### PR TITLE
ci: on-demand release workflow + pkg.go.dev doc refresh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: release
+
+# Releases are cut on demand, never on a plain merge to main:
+#   - push a semver tag:   git tag v0.1.0 && git push origin v0.1.0
+#   - or run this workflow from the Actions tab and type the version
+#     (the tag is created and pushed for you).
+on:
+  push:
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version, e.g. v0.1.0 (tag is created + pushed)"
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # create the GitHub release and (on dispatch) push the tag
+
+env:
+  GO_VERSION: "1.26"
+  GOEXPERIMENT: simd
+  MODULE: github.com/alex60217101990/qdf
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags for --generate-notes
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Resolve and validate version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME}"
+          fi
+          if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::'$VERSION' is not a vMAJOR.MINOR.PATCH[-prerelease] tag"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify at the release commit
+        run: |
+          go vet ./...
+          go test -race -count=1 -timeout=10m ./...
+
+      - name: Create and push tag (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "::error::tag $VERSION already exists on origin"
+            exit 1
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --generate-notes \
+            --verify-tag
+
+      - name: Warm pkg.go.dev via the module proxy
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          # Fetching the version through the public proxy triggers
+          # indexing on pkg.go.dev. Best-effort: the proxy can lag a
+          # few minutes behind the tag, so a miss here is not fatal.
+          curl -fsS "https://proxy.golang.org/${MODULE}/@v/${VERSION}.info" || true

--- a/qdf.go
+++ b/qdf.go
@@ -9,8 +9,7 @@
 //
 //	OptSpeed       — Fast mode, no codecs (matches encoding/json shape)
 //	OptBalanced    — Dense + QPack + shape interning + Markov-1 + MTF
-//	OptCompression — OptBalanced + Gorilla XOR for float slices +
-//	                 column-repeat codec for repeating struct fields
+//	OptCompression — OptBalanced + Gorilla XOR for float slices
 //	                 (~70 % wire reduction on smooth time-series at
 //	                 ~10× CPU per slice; future heavy codecs land here)
 //
@@ -28,6 +27,30 @@
 //
 // Marshal returns a freshly-allocated slice owned by the caller.
 // AppendMarshal is the zero-extra-copy variant.
+//
+// # Data shapes and codecs
+//
+// Under OptBalanced the encoder picks a codec per slice from the data
+// itself: integer slices use Frame-of-Reference, delta, run-length or
+// dictionary coding; bool slices bit-pack; repeated strings are interned
+// and back-referenced. A slice of homogeneous flat structs is transposed
+// and compressed column-by-column automatically — numeric columns get the
+// integer codecs, repeated string columns collapse — with no flag, and a
+// per-array probe falls back to the plain row encoding when columnar would
+// not help. Gorilla float coding is the one codec that trades CPU for
+// size, so it lives behind OptCompression.
+//
+// # Concurrency
+//
+// Marshal, Unmarshal and AppendMarshal are safe for concurrent use: each
+// call leases its own encoder/decoder from a pool. A single Encoder,
+// Decoder or StreamEncoder value is not safe to share across goroutines —
+// use one per goroutine. A Dense document is a sequential stream, so one
+// document cannot be encoded or decoded in parallel; to parallelize a
+// large dataset, split it into independent shards and Marshal each
+// separately.
+//
+// See docs/USAGE.md in the repository for a fuller guide.
 //
 // # Public API surface
 //


### PR DESCRIPTION
## Summary

Follow-up to the columnar work. Two changes:

- **On-demand release workflow** (`.github/workflows/release.yml`). Cut a
  release by pushing a semver tag (`git tag v0.1.0 && git push origin v0.1.0`)
  or from the Actions tab via "Run workflow" (it creates and pushes the tag).
  The job validates the version, runs vet + race tests at the tagged commit,
  creates a GitHub release with generated notes, and warms pkg.go.dev through
  the module proxy. Releases are decoupled from merges to main — they happen
  only when a tag is cut.
- **Package doc refresh** (`qdf.go`). The package doc comment renders on
  pkg.go.dev; it still referenced the removed col-repeat codec. Drop that, and
  document the columnar struct-array codec and the concurrency contract
  (pool-safe top-level calls; one Encoder/Decoder per goroutine; shard a large
  dataset for parallelism).

No production code changes — CI config and a doc comment only.

## Wire-format impact

- [x] Wire-compatible. Existing buffers still decode; new buffers still decode
      through older readers. (No code or wire change in this PR.)

## Checklist

- [x] `go test -race -count=1 ./...` passes locally.
- [ ] `-tags qdf_simd` / `-tags qdf_reflect2` builds — n/a (no code change).
- [ ] Golden fixtures — n/a.
- [ ] Bench numbers — n/a.
- [ ] Fuzz — n/a (decoder surface unchanged).
- [x] Docs updated (package doc comment; `docs/USAGE.md` shipped separately).

## Linked issues

<!-- Closes #..., Refs #... -->