### PR TITLE
ci: published bench-trend + coverage dashboard (GitHub Pages)

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>qdf — benchmarks & coverage</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { font: 16px/1.6 system-ui, sans-serif; max-width: 48rem; margin: 3rem auto; padding: 0 1.25rem; }
+    h1 { margin-bottom: 0.25rem; }
+    p.sub { color: #888; margin-top: 0; }
+    ul { list-style: none; padding: 0; }
+    li { margin: 0.75rem 0; }
+    a.card { display: block; padding: 1rem 1.25rem; border: 1px solid #8884; border-radius: 10px; text-decoration: none; }
+    a.card:hover { border-color: #888; }
+    a.card b { display: block; font-size: 1.1rem; }
+    a.card span { color: #888; font-size: 0.9rem; }
+    .note { font-size: 0.85rem; color: #888; border-left: 3px solid #8884; padding-left: 0.75rem; }
+  </style>
+</head>
+<body>
+  <h1>qdf</h1>
+  <p class="sub">compact, streaming-friendly binary serialization for Go</p>
+
+  <ul>
+    <li><a class="card" href="./dev/bench/">
+      <b>Benchmark trends &rarr;</b>
+      <span>per-commit ns/op, B/op, allocs/op with regression alerts</span>
+    </a></li>
+    <li><a class="card" href="./coverage.html">
+      <b>Coverage snapshot &rarr;</b>
+      <span>latest <code>go tool cover</code> HTML report</span>
+    </a></li>
+    <li><a class="card" href="https://codecov.io/gh/alex60217101990/qdf">
+      <b>Codecov &rarr;</b>
+      <span>coverage history, sunburst, file-level view</span>
+    </a></li>
+    <li><a class="card" href="https://github.com/alex60217101990/qdf">
+      <b>Repository &rarr;</b>
+      <span>source, README, wire-format docs</span>
+    </a></li>
+  </ul>
+
+  <p class="note">
+    Benchmark numbers come from shared GitHub-hosted runners and are meaningful
+    as a <em>relative trend</em>, not as absolute performance. Headline numbers
+    in the README are measured on dedicated hardware.
+  </p>
+</body>
+</html>

--- a/.github/workflows/bench-trend.yml
+++ b/.github/workflows/bench-trend.yml
@@ -1,0 +1,101 @@
+name: bench-trend
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# contents:write — push history to gh-pages. pull-requests:write — post the alert comment.
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: bench-trend-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bench:
+    name: bench-trend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            bench/go.sum
+
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: gocache-benchtrend-${{ runner.os }}-${{ hashFiles('**/go.sum', '**/*.go') }}
+          restore-keys: |
+            gocache-benchtrend-${{ runner.os }}-
+
+      - name: run benchmarks (default tags)
+        working-directory: bench
+        run: |
+          set -euo pipefail
+          go test -bench=. -benchmem -run=^$ -benchtime=2s -count=1 -timeout=15m | tee output.txt
+
+      # --- main: append to history + publish the trend dashboard ---
+      - name: store benchmark result (push to gh-pages)
+        if: github.event_name == 'push'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: qdf Go Benchmarks
+          tool: go
+          output-file-path: bench/output.txt
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: "150%"
+          comment-on-alert: false
+          fail-on-alert: false
+
+      # --- PR: comment-only regression alert, never push, never fail ---
+      - name: compare benchmark result (PR alert)
+        if: github.event_name == 'pull_request'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: qdf Go Benchmarks
+          tool: go
+          output-file-path: bench/output.txt
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: false
+          save-data-file: false
+          alert-threshold: "150%"
+          comment-on-alert: true
+          fail-on-alert: false
+          summary-always: true
+
+      # --- main: coverage snapshot + landing, staged into ./public ---
+      - name: coverage snapshot
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+          go test -coverprofile=coverage.out -covermode=atomic ./...
+          go tool cover -html=coverage.out -o coverage.html
+          mkdir -p public
+          cp coverage.html public/coverage.html
+          cp .github/pages/index.html public/index.html
+
+      # Runs AFTER the benchmark action's push, so the two gh-pages writes are
+      # sequenced. keep_files:true preserves dev/bench/ that the action wrote.
+      - name: publish landing + coverage to gh-pages
+        if: github.event_name == 'push'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./public
+          keep_files: true

--- a/.github/workflows/bench-trend.yml
+++ b/.github/workflows/bench-trend.yml
@@ -60,9 +60,25 @@ jobs:
           comment-on-alert: false
           fail-on-alert: false
 
+      # The PR alert path fetches gh-pages to read the baseline and hard-fails
+      # (git exit 128) if the branch does not exist yet. On a fresh repo the
+      # first main run creates gh-pages; until then, skip the comparison —
+      # there is no baseline to compare against anyway.
+      - name: check gh-pages branch exists
+        id: ghpages
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::gh-pages branch does not exist yet; PR baseline comparison skipped until the first main run creates it."
+          fi
+
       # --- PR: comment-only regression alert, never push, never fail ---
       - name: compare benchmark result (PR alert)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.ghpages.outputs.exists == 'true'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: qdf Go Benchmarks

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![ci](https://github.com/alex60217101990/qdf/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/alex60217101990/qdf/actions/workflows/ci.yml)
 [![codeql](https://github.com/alex60217101990/qdf/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/alex60217101990/qdf/actions/workflows/codeql.yml)
+[![codecov](https://codecov.io/gh/alex60217101990/qdf/branch/main/graph/badge.svg)](https://codecov.io/gh/alex60217101990/qdf)
+[![benchmarks](https://img.shields.io/badge/benchmarks-dashboard-blue)](https://alex60217101990.github.io/qdf/)
 [![Go Reference](https://pkg.go.dev/badge/github.com/alex60217101990/qdf.svg)](https://pkg.go.dev/github.com/alex60217101990/qdf)
 [![Go Report Card](https://goreportcard.com/badge/github.com/alex60217101990/qdf)](https://goreportcard.com/report/github.com/alex60217101990/qdf)
 ![Go](https://img.shields.io/badge/go-1.26-blue?logo=go)


### PR DESCRIPTION
## Summary
- New `bench-trend.yml`: runs the default-tag bench suite, publishes a
  `github-action-benchmark` trend dashboard to the orphan `gh-pages` branch,
  plus a `go tool cover` coverage snapshot and a landing page.
- PR runs post a **comment-only** regression alert (threshold 150%, never
  fails CI) — shared runners are too noisy to gate on.
- Landing template at `.github/pages/index.html`.
- README: Codecov badge + dashboard link.

`main` only gains the workflow YAML + the landing template; all generated HTML
lives on the orphan `gh-pages` branch.

## One-time Pages setup (after this merges)
The `gh-pages` branch is created automatically by the first `bench-trend` run
on `main`. Then, in **Settings → Pages**:
- Source: **Deploy from a branch**
- Branch: **`gh-pages`**, Folder: **`/(root)`**
- Save

URLs once live:
- Landing: `https://alex60217101990.github.io/qdf/`
- Trends: `https://alex60217101990.github.io/qdf/dev/bench/`
- Coverage: `https://alex60217101990.github.io/qdf/coverage.html`

Settings → Actions → General → Workflow permissions must allow
"Read and write permissions" so the action can push `gh-pages`.

## Test Plan
- [x] actionlint clean on the workflow.
- [ ] After merge to `main`: first `bench-trend` run creates `gh-pages`.
- [ ] Enable Pages per the steps above; landing/trends/coverage URLs render.
- [ ] Throwaway PR with an intentional slowdown → comment appears, CI stays green.