### PR TITLE
qpack: faster FOR encode — byte-aligned scalar fast path + AVX2 VPSHUFB bitpack

### DIFF
--- a/.github/workflows/bench-trend.yml
+++ b/.github/workflows/bench-trend.yml
@@ -44,6 +44,29 @@ jobs:
           set -euo pipefail
           go test -bench=. -benchmem -run=^$ -benchtime=2s -count=1 -timeout=15m | tee output.txt
 
+      # github-action-benchmark fetches gh-pages before writing and hard-fails
+      # (git exit 128) when the branch is absent — it does not bootstrap it.
+      # Create an empty orphan gh-pages on the first main run so the store step
+      # below has a branch to fetch and append to.
+      - name: ensure gh-pages branch exists
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            echo "gh-pages already exists"
+          else
+            echo "creating empty gh-pages branch"
+            tmp="$(mktemp -d)"
+            git -C "$tmp" init -q
+            git -C "$tmp" checkout -q --orphan gh-pages
+            git -C "$tmp" commit -q --allow-empty -m "init gh-pages"
+            git -C "$tmp" push -q \
+              "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+              gh-pages
+          fi
+
       # --- main: append to history + publish the trend dashboard ---
       - name: store benchmark result (push to gh-pages)
         if: github.event_name == 'push'

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ profile.out
 # Local concept notes — kept on disk, excluded from the PR.
 qdf.md
 qdf-*.md
+docs/PLAN*.md
+docs/superpowers

--- a/qpack_for.go
+++ b/qpack_for.go
@@ -194,8 +194,24 @@ func bitPackChunkInto(out []byte, vals []uint64, bitsPer int, elemOff int) {
 	if bitsPer == 0 || len(vals) == 0 {
 		return
 	}
-	mask := uint64(1)<<uint(bitsPer) - 1
 	bitOff := elemOff * bitsPer
+	// Byte-aligned widths land on whole-byte boundaries (bitsPer multiple
+	// of 8 ⇒ bitOff multiple of 8), so each value is an independent LE
+	// store with no cross-byte accumulator. These dedicated packers mirror
+	// the byte-aligned unpack fast paths and get a SIMD variant under
+	// qdf_simd.
+	switch bitsPer {
+	case 8:
+		packBits8(out[bitOff>>3:], vals)
+		return
+	case 16:
+		packBits16(out[bitOff>>3:], vals)
+		return
+	case 32:
+		packBits32(out[bitOff>>3:], vals)
+		return
+	}
+	mask := uint64(1)<<uint(bitsPer) - 1
 	pos := bitOff >> 3
 	bitInByte := uint(bitOff & 7)
 	var acc uint64

--- a/qpack_pack_test.go
+++ b/qpack_pack_test.go
@@ -1,0 +1,123 @@
+package qdf
+
+import (
+	"bytes"
+	"testing"
+)
+
+func benchPackVals(n int, mask uint64) []uint64 {
+	vals := make([]uint64, n)
+	for i := range vals {
+		vals[i] = uint64(i*2654435761+11) & mask
+	}
+	return vals
+}
+
+func BenchmarkPack8_Accumulator(b *testing.B) {
+	vals := benchPackVals(1024, 0xFF)
+	out := make([]byte, 1024)
+	b.SetBytes(1024)
+	for b.Loop() {
+		bitPackU64LE(out, vals, 8)
+	}
+}
+
+func BenchmarkPack8_Fast(b *testing.B) {
+	vals := benchPackVals(1024, 0xFF)
+	out := make([]byte, 1024)
+	b.SetBytes(1024)
+	for b.Loop() {
+		packBits8(out, vals)
+	}
+}
+
+func BenchmarkPack16_Accumulator(b *testing.B) {
+	vals := benchPackVals(1024, 0xFFFF)
+	out := make([]byte, 1024*2)
+	b.SetBytes(1024 * 2)
+	for b.Loop() {
+		bitPackU64LE(out, vals, 16)
+	}
+}
+
+func BenchmarkPack16_Fast(b *testing.B) {
+	vals := benchPackVals(1024, 0xFFFF)
+	out := make([]byte, 1024*2)
+	b.SetBytes(1024 * 2)
+	for b.Loop() {
+		packBits16(out, vals)
+	}
+}
+
+func BenchmarkPack32_Accumulator(b *testing.B) {
+	vals := benchPackVals(1024, 0xFFFFFFFF)
+	out := make([]byte, 1024*4)
+	b.SetBytes(1024 * 4)
+	for b.Loop() {
+		bitPackU64LE(out, vals, 32)
+	}
+}
+
+func BenchmarkPack32_Fast(b *testing.B) {
+	vals := benchPackVals(1024, 0xFFFFFFFF)
+	out := make([]byte, 1024*4)
+	b.SetBytes(1024 * 4)
+	for b.Loop() {
+		packBits32(out, vals)
+	}
+}
+
+// packReference packs vals at bitsPer using the general accumulator packer,
+// the source of truth the byte-aligned fast paths must match byte-for-byte.
+func packReference(vals []uint64, bitsPer int) []byte {
+	out := make([]byte, (len(vals)*bitsPer+7)/8)
+	bitPackU64LE(out, vals, bitsPer)
+	return out
+}
+
+var packSizes = []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 100, 1000}
+
+func TestPackBits8_MatchesReference(t *testing.T) {
+	for _, n := range packSizes {
+		vals := make([]uint64, n)
+		for i := range vals {
+			vals[i] = uint64(i*7+3) & 0xFF
+		}
+		got := make([]byte, n)
+		packBits8(got, vals)
+		want := packReference(vals, 8)
+		if !bytes.Equal(got, want) {
+			t.Fatalf("n=%d: packBits8 mismatch\n got=%v\nwant=%v", n, got, want)
+		}
+	}
+}
+
+func TestPackBits16_MatchesReference(t *testing.T) {
+	for _, n := range packSizes {
+		vals := make([]uint64, n)
+		for i := range vals {
+			vals[i] = uint64(i*1337+9) & 0xFFFF
+		}
+		got := make([]byte, n*2)
+		packBits16(got, vals)
+		want := packReference(vals, 16)
+		if !bytes.Equal(got, want) {
+			t.Fatalf("n=%d: packBits16 mismatch\n got=%v\nwant=%v", n, got, want)
+		}
+	}
+}
+
+func TestPackBits32_MatchesReference(t *testing.T) {
+	for _, n := range packSizes {
+		vals := make([]uint64, n)
+		for i := range vals {
+			vals[i] = uint64(i*2654435761+11) & 0xFFFFFFFF
+		}
+		got := make([]byte, n*4)
+		packBits32(got, vals)
+		want := packReference(vals, 32)
+		if !bytes.Equal(got, want) {
+			t.Fatalf("n=%d: packBits32 mismatch\n got=%v\nwant=%v", n, got, want)
+		}
+	}
+}

--- a/qpack_pack_test.go
+++ b/qpack_pack_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 )
 
-func benchPackVals(n int, mask uint64) []uint64 {
-	vals := make([]uint64, n)
+const benchPackN = 1024
+
+func benchPackVals(mask uint64) []uint64 {
+	vals := make([]uint64, benchPackN)
 	for i := range vals {
 		vals[i] = uint64(i*2654435761+11) & mask
 	}
@@ -14,7 +16,7 @@ func benchPackVals(n int, mask uint64) []uint64 {
 }
 
 func BenchmarkPack8_Accumulator(b *testing.B) {
-	vals := benchPackVals(1024, 0xFF)
+	vals := benchPackVals(0xFF)
 	out := make([]byte, 1024)
 	b.SetBytes(1024)
 	for b.Loop() {
@@ -23,7 +25,7 @@ func BenchmarkPack8_Accumulator(b *testing.B) {
 }
 
 func BenchmarkPack8_Fast(b *testing.B) {
-	vals := benchPackVals(1024, 0xFF)
+	vals := benchPackVals(0xFF)
 	out := make([]byte, 1024)
 	b.SetBytes(1024)
 	for b.Loop() {
@@ -32,7 +34,7 @@ func BenchmarkPack8_Fast(b *testing.B) {
 }
 
 func BenchmarkPack16_Accumulator(b *testing.B) {
-	vals := benchPackVals(1024, 0xFFFF)
+	vals := benchPackVals(0xFFFF)
 	out := make([]byte, 1024*2)
 	b.SetBytes(1024 * 2)
 	for b.Loop() {
@@ -41,7 +43,7 @@ func BenchmarkPack16_Accumulator(b *testing.B) {
 }
 
 func BenchmarkPack16_Fast(b *testing.B) {
-	vals := benchPackVals(1024, 0xFFFF)
+	vals := benchPackVals(0xFFFF)
 	out := make([]byte, 1024*2)
 	b.SetBytes(1024 * 2)
 	for b.Loop() {
@@ -50,7 +52,7 @@ func BenchmarkPack16_Fast(b *testing.B) {
 }
 
 func BenchmarkPack32_Accumulator(b *testing.B) {
-	vals := benchPackVals(1024, 0xFFFFFFFF)
+	vals := benchPackVals(0xFFFFFFFF)
 	out := make([]byte, 1024*4)
 	b.SetBytes(1024 * 4)
 	for b.Loop() {
@@ -59,7 +61,7 @@ func BenchmarkPack32_Accumulator(b *testing.B) {
 }
 
 func BenchmarkPack32_Fast(b *testing.B) {
-	vals := benchPackVals(1024, 0xFFFFFFFF)
+	vals := benchPackVals(0xFFFFFFFF)
 	out := make([]byte, 1024*4)
 	b.SetBytes(1024 * 4)
 	for b.Loop() {

--- a/qpack_simd_amd64.go
+++ b/qpack_simd_amd64.go
@@ -25,6 +25,61 @@ func unpackBits8AVX2(out []uint64, in []byte, n int)
 //go:noescape
 func packBoolsAVX2Block32(out []byte, in []bool, blocks int)
 
+//go:noescape
+func packBits8AVX2(out []byte, vals []uint64, n int)
+
+//go:noescape
+func packBits16AVX2(out []byte, vals []uint64, n int)
+
+//go:noescape
+func packBits32AVX2(out []byte, vals []uint64, n int)
+
+// packBits8 writes the low byte of each value contiguously. With AVX2 it
+// dispatches to a Plan9-asm VPSHUFB gather (4 values -> 4 bytes per iter);
+// the tail (n%4) uses a scalar loop. Encode inverse of unpackBits8.
+func packBits8(out []byte, vals []uint64) {
+	n := len(vals)
+	off := 0
+	if hasAVX2 && n >= 4 {
+		blocks := n &^ 3
+		packBits8AVX2(out[:blocks], vals[:blocks], blocks)
+		off = blocks
+	}
+	for i := off; i < n; i++ {
+		out[i] = byte(vals[i])
+	}
+}
+
+// packBits16 writes the low 2 bytes LE per value. AVX2 VPSHUFB gather
+// (4 values -> 8 bytes per iter) with a scalar n%4 tail.
+func packBits16(out []byte, vals []uint64) {
+	n := len(vals)
+	off := 0
+	if hasAVX2 && n >= 4 {
+		blocks := n &^ 3
+		packBits16AVX2(out[:blocks*2], vals[:blocks], blocks)
+		off = blocks
+	}
+	for i := off; i < n; i++ {
+		binary.LittleEndian.PutUint16(out[i*2:], uint16(vals[i]))
+	}
+}
+
+// packBits32 writes the low 4 bytes LE per value. AVX2 VPSHUFB gather
+// (4 values -> 16 bytes per iter) with a scalar n%4 tail.
+func packBits32(out []byte, vals []uint64) {
+	n := len(vals)
+	off := 0
+	if hasAVX2 && n >= 4 {
+		blocks := n &^ 3
+		packBits32AVX2(out[:blocks*4], vals[:blocks], blocks)
+		off = blocks
+	}
+	for i := off; i < n; i++ {
+		binary.LittleEndian.PutUint32(out[i*4:], uint32(vals[i]))
+	}
+}
+
 // packBoolsBitsLSB writes n booleans from src as ceil(n/8) bytes into
 // dst, LSB-first (bool i -> bit (i%8) of dst[i/8]). dst must have
 // length ceil(n/8) and be cleared. With qdf_simd and AVX2, blocks of

--- a/qpack_simd_amd64.s
+++ b/qpack_simd_amd64.s
@@ -153,3 +153,131 @@ loop32_bp:
 done_bp:
 	VZEROUPPER
 	RET
+
+// packlow8mask is the per-128-bit-lane VPSHUFB control that gathers the
+// low byte of each of two uint64 lanes to byte positions 0 and 1, zeroing
+// the rest (0x80 high bit ⇒ output 0). Replicated across both 128-bit
+// lanes so one VPSHUFB handles four uint64s.
+DATA packlow8mask<>+0(SB)/8,  $0x8080808080800800
+DATA packlow8mask<>+8(SB)/8,  $0x8080808080808080
+DATA packlow8mask<>+16(SB)/8, $0x8080808080800800
+DATA packlow8mask<>+24(SB)/8, $0x8080808080808080
+GLOBL packlow8mask<>(SB), RODATA|NOPTR, $32
+
+// func packBits8AVX2(out []byte, vals []uint64, n int)
+//
+// Packs the low byte of each of n uint64 values into n contiguous bytes
+// of out (the encode inverse of unpackBits8AVX2). Equivalent to:
+//
+//	for i := 0; i < n; i++ {
+//	    out[i] = byte(vals[i])
+//	}
+//
+// Loads 4 uint64s (32 bytes), VPSHUFB-gathers the four low bytes to
+// positions 0,1 of each 128-bit lane, then writes 2 bytes from the low
+// lane and 2 from the high lane. Caller guarantees len(out) >= n,
+// len(vals) >= n, n a multiple of 4, and AVX2 available.
+TEXT ·packBits8AVX2(SB), NOSPLIT, $0-56
+	MOVQ    out_base+0(FP), DI
+	MOVQ    vals_base+24(FP), SI
+	MOVQ    n+48(FP), CX
+	VMOVDQU packlow8mask<>(SB), Y2
+
+loop4_p8:
+	CMPQ         CX, $4
+	JL           done_p8
+	VMOVDQU      (SI), Y0
+	VPSHUFB      Y2, Y0, Y0
+	VMOVD        X0, AX
+	MOVW         AX, (DI)
+	VEXTRACTI128 $1, Y0, X1
+	VMOVD        X1, BX
+	MOVW         BX, 2(DI)
+	ADDQ         $32, SI
+	ADDQ         $4, DI
+	SUBQ         $4, CX
+	JMP          loop4_p8
+
+done_p8:
+	VZEROUPPER
+	RET
+
+// packlow16mask gathers the low 2 bytes of each of two uint64 lanes to
+// byte positions 0..3 of each 128-bit lane.
+DATA packlow16mask<>+0(SB)/8,  $0x8080808009080100
+DATA packlow16mask<>+8(SB)/8,  $0x8080808080808080
+DATA packlow16mask<>+16(SB)/8, $0x8080808009080100
+DATA packlow16mask<>+24(SB)/8, $0x8080808080808080
+GLOBL packlow16mask<>(SB), RODATA|NOPTR, $32
+
+// func packBits16AVX2(out []byte, vals []uint64, n int)
+//
+// Packs the low 2 bytes (LE) of each of n uint64 values into 2*n bytes of
+// out. Loads 4 uint64s, VPSHUFB-gathers each lane's low 2 bytes to the
+// front of its 128-bit lane, writes 4 bytes from the low lane and 4 from
+// the high lane. Caller guarantees len(out) >= 2*n, len(vals) >= n, n a
+// multiple of 4, AVX2 available.
+TEXT ·packBits16AVX2(SB), NOSPLIT, $0-56
+	MOVQ    out_base+0(FP), DI
+	MOVQ    vals_base+24(FP), SI
+	MOVQ    n+48(FP), CX
+	VMOVDQU packlow16mask<>(SB), Y2
+
+loop4_p16:
+	CMPQ         CX, $4
+	JL           done_p16
+	VMOVDQU      (SI), Y0
+	VPSHUFB      Y2, Y0, Y0
+	VMOVD        X0, AX
+	MOVL         AX, (DI)
+	VEXTRACTI128 $1, Y0, X1
+	VMOVD        X1, BX
+	MOVL         BX, 4(DI)
+	ADDQ         $32, SI
+	ADDQ         $8, DI
+	SUBQ         $4, CX
+	JMP          loop4_p16
+
+done_p16:
+	VZEROUPPER
+	RET
+
+// packlow32mask gathers the low 4 bytes of each of two uint64 lanes to
+// byte positions 0..7 of each 128-bit lane.
+DATA packlow32mask<>+0(SB)/8,  $0x0b0a090803020100
+DATA packlow32mask<>+8(SB)/8,  $0x8080808080808080
+DATA packlow32mask<>+16(SB)/8, $0x0b0a090803020100
+DATA packlow32mask<>+24(SB)/8, $0x8080808080808080
+GLOBL packlow32mask<>(SB), RODATA|NOPTR, $32
+
+// func packBits32AVX2(out []byte, vals []uint64, n int)
+//
+// Packs the low 4 bytes (LE) of each of n uint64 values into 4*n bytes of
+// out. Loads 4 uint64s, VPSHUFB-gathers each lane's low 4 bytes to the
+// front of its 128-bit lane, writes 8 bytes from the low lane and 8 from
+// the high lane. Caller guarantees len(out) >= 4*n, len(vals) >= n, n a
+// multiple of 4, AVX2 available.
+TEXT ·packBits32AVX2(SB), NOSPLIT, $0-56
+	MOVQ    out_base+0(FP), DI
+	MOVQ    vals_base+24(FP), SI
+	MOVQ    n+48(FP), CX
+	VMOVDQU packlow32mask<>(SB), Y2
+
+loop4_p32:
+	CMPQ         CX, $4
+	JL           done_p32
+	VMOVDQU      (SI), Y0
+	VPSHUFB      Y2, Y0, Y0
+	VMOVQ        X0, AX
+	MOVQ         AX, (DI)
+	VEXTRACTI128 $1, Y0, X1
+	VMOVQ        X1, BX
+	MOVQ         BX, 8(DI)
+	ADDQ         $32, SI
+	ADDQ         $16, DI
+	SUBQ         $4, CX
+	JMP          loop4_p32
+
+done_p32:
+	VZEROUPPER
+	RET

--- a/qpack_simd_stub.go
+++ b/qpack_simd_stub.go
@@ -26,6 +26,27 @@ func unpackBits8(out []uint64, in []byte) {
 	}
 }
 
+// packBits8 fallback: low byte of each value, contiguous.
+func packBits8(out []byte, vals []uint64) {
+	for i, v := range vals {
+		out[i] = byte(v)
+	}
+}
+
+// packBits16 fallback: low 2 bytes LE per value.
+func packBits16(out []byte, vals []uint64) {
+	for i, v := range vals {
+		binary.LittleEndian.PutUint16(out[i*2:], uint16(v))
+	}
+}
+
+// packBits32 fallback: low 4 bytes LE per value.
+func packBits32(out []byte, vals []uint64) {
+	for i, v := range vals {
+		binary.LittleEndian.PutUint32(out[i*4:], uint32(v))
+	}
+}
+
 // packBoolsBitsLSB fallback: plain scalar bit-by-bit pack.
 func packBoolsBitsLSB(dst []byte, src []bool, n int) {
 	for i := range n {


### PR DESCRIPTION
## Summary

Speeds up FOR-codec encoding for byte-aligned bit widths (8/16/32), closing an
asymmetry with the decoder. The encoder ran **every** width through the general
bit-accumulator (`shift | or` + inner byte-drain), even widths that land on
whole-byte boundaries — while the decoder already fast-paths 8/16/32 via
zero-extend. Two layers:

- **Scalar fast path (default build).** `packBits8/16/32` emit one plain LE
  store per value; `bitPackChunkInto` dispatches to them when `bitsPer` is
  byte-aligned. No asm, no build tag — every consumer gets it.
- **AVX2 SIMD (`qdf_simd`).** `packBits8/16/32` dispatch to Plan9 asm that
  loads 4 uint64s and `VPSHUFB`-gathers each lane's low 1/2/4 bytes to the
  front of its 128-bit lane, then writes the low and high lanes (4 values per
  iteration, scalar `n%4` tail). This is the encode mirror of the existing
  `VPMOVZX` unpack fast paths; the bitmask/shuffle-driven byte-gather is the
  same primitive simdjson uses in its compaction kernels.

Output is **byte-identical** to the old packer — golden fixtures unchanged,
parity tests pass under both build configs. The SIMD path is opt-in; the
default build keeps the scalar fast path.

## Wire-format impact

- [x] None. Pure encode-speed change; the emitted bytes are identical for
      every width. Decoders are untouched.

## Bench evidence

Microbench, 1024 elements, `-count=8`, i7-9750H. Times are ns/op; ratios are
vs the scalar fast path / vs the original accumulator.

| width | accumulator | scalar fast | AVX2 SIMD | SIMD vs scalar / vs accum |
| ----: | ----------: | ----------: | --------: | ------------------------- |
| 8     | ~1800       | ~430        | ~230      | ~1.9× / ~7.8×             |
| 16    | ~2275       | ~980        | ~225      | ~4.3× / ~10×              |
| 32    | ~3900       | ~1030       | ~210      | ~4.9× / ~18×              |

The scalar fast path alone (no asm) is ~2.3–3.7× over the accumulator; the
SIMD path adds another ~1.9–4.9× on top under `qdf_simd`.

## Checklist

- [x] `go test -race -count=1 ./...` (default) passes.
- [x] `GOEXPERIMENT=simd go test -tags qdf_simd -race -count=1 .` passes.
- [x] Parity tests (`packBits{8,16,32}` vs the accumulator) pass under both
      build configs.
- [x] Golden fixtures unchanged (byte-identical output).
- [x] `golangci-lint run ./...` (v2.12.2) — 0 issues.

## Notes / scoped-but-not-done

Larger SIMD levers were deliberately left out (each its own measure-first
gate): arbitrary non-byte-aligned widths via `VPSRLVQ` (wider coverage, higher
asm risk), AVX-512 VBMI `VPMULTISHIFTQB` (new ISA path), and a vectorized ALP
exception scan.

## Also in this PR: bench-trend CI fix

The `bench-trend` workflow (merged earlier) failed on push to `main` with
`fatal: couldn't find remote ref gh-pages` — `github-action-benchmark` fetches
`gh-pages` before writing and hard-fails when the branch is absent instead of
creating it. Added a push-only step that bootstraps an empty orphan `gh-pages`
when missing, so the first `main` run can create the history and publish.
`main`'s bench-trend run goes green once this PR merges.

## Linked issues

<!-- Closes #..., Refs #... -->