### PR TITLE
qpack: AVX2 VPSRLVQ decode for non-byte-aligned FOR widths 10/12/14/20

### DIFF
--- a/.github/workflows/bench-trend.yml
+++ b/.github/workflows/bench-trend.yml
@@ -61,7 +61,11 @@ jobs:
             tmp="$(mktemp -d)"
             git -C "$tmp" init -q
             git -C "$tmp" checkout -q --orphan gh-pages
-            git -C "$tmp" commit -q --allow-empty -m "init gh-pages"
+            # The runner has no global git identity; set one for this commit.
+            git -C "$tmp" \
+              -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -q --allow-empty -m "init gh-pages"
             git -C "$tmp" push -q \
               "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
               gh-pages

--- a/qpack_for.go
+++ b/qpack_for.go
@@ -57,8 +57,20 @@ func bitUnpackU64LE(out []uint64, in []byte, bitsPer int) {
 	case 8:
 		unpackBits8(out, in)
 		return
+	case 10:
+		unpackBits10(out, in)
+		return
+	case 12:
+		unpackBits12(out, in)
+		return
+	case 14:
+		unpackBits14(out, in)
+		return
 	case 16:
 		unpackBits16(out, in)
+		return
+	case 20:
+		unpackBits20(out, in)
 		return
 	case 32:
 		unpackBits32(out, in)

--- a/qpack_simd_amd64.go
+++ b/qpack_simd_amd64.go
@@ -34,6 +34,111 @@ func packBits16AVX2(out []byte, vals []uint64, n int)
 //go:noescape
 func packBits32AVX2(out []byte, vals []uint64, n int)
 
+//go:noescape
+func unpackBits12AVX2(out []uint64, in []byte, groups int)
+
+// unpackBits12 decodes a width-12 FOR stream: 4 values per byte-aligned
+// 6-byte chunk via VPBROADCASTQ + VPSRLVQ; the remainder (and the last
+// chunk, which lacks 8-byte read headroom) falls back to the scalar
+// sliding window. Byte-aligned handoff: 4*groups values consume exactly
+// 6*groups bytes.
+func unpackBits12(out []uint64, in []byte) {
+	n := len(out)
+	if n == 0 {
+		return
+	}
+	groups := 0
+	if hasAVX2 {
+		groups = n / 4
+		// The last chunk's VPBROADCASTQ reads in[6*(groups-1) : +8]; keep
+		// that read inside the buffer.
+		for groups > 0 && 6*(groups-1)+8 > len(in) {
+			groups--
+		}
+		if groups > 0 {
+			unpackBits12AVX2(out[:4*groups], in, groups)
+		}
+	}
+	if done := 4 * groups; done < n {
+		bitUnpackU64LEFast(out[done:], in[6*groups:], 12)
+	}
+}
+
+//go:noescape
+func unpackBits10AVX2(out []uint64, in []byte, groups int)
+
+//go:noescape
+func unpackBits14AVX2(out []uint64, in []byte, groups int)
+
+//go:noescape
+func unpackBits20AVX2(out []uint64, in []byte, pairs int)
+
+// unpackBits10 decodes a width-10 FOR stream: 4 values per byte-aligned
+// 5-byte chunk via VPSRLVQ, scalar tail for the remainder.
+func unpackBits10(out []uint64, in []byte) {
+	n := len(out)
+	if n == 0 {
+		return
+	}
+	groups := 0
+	if hasAVX2 {
+		groups = n / 4
+		for groups > 0 && 5*(groups-1)+8 > len(in) {
+			groups--
+		}
+		if groups > 0 {
+			unpackBits10AVX2(out[:4*groups], in, groups)
+		}
+	}
+	if done := 4 * groups; done < n {
+		bitUnpackU64LEFast(out[done:], in[5*groups:], 10)
+	}
+}
+
+// unpackBits14 decodes a width-14 FOR stream: 4 values per byte-aligned
+// 7-byte chunk.
+func unpackBits14(out []uint64, in []byte) {
+	n := len(out)
+	if n == 0 {
+		return
+	}
+	groups := 0
+	if hasAVX2 {
+		groups = n / 4
+		for groups > 0 && 7*(groups-1)+8 > len(in) {
+			groups--
+		}
+		if groups > 0 {
+			unpackBits14AVX2(out[:4*groups], in, groups)
+		}
+	}
+	if done := 4 * groups; done < n {
+		bitUnpackU64LEFast(out[done:], in[7*groups:], 14)
+	}
+}
+
+// unpackBits20 decodes a width-20 FOR stream: 2 values per byte-aligned
+// 5-byte chunk.
+func unpackBits20(out []uint64, in []byte) {
+	n := len(out)
+	if n == 0 {
+		return
+	}
+	pairs := 0
+	if hasAVX2 {
+		pairs = n / 2
+		for pairs > 0 && 5*(pairs-1)+8 > len(in) {
+			pairs--
+		}
+		if pairs > 0 {
+			unpackBits20AVX2(out[:2*pairs], in, pairs)
+		}
+	}
+	if done := 2 * pairs; done < n {
+		bitUnpackU64LEFast(out[done:], in[5*pairs:], 20)
+	}
+}
+
 // packBits8 writes the low byte of each value contiguously. With AVX2 it
 // dispatches to a Plan9-asm VPSHUFB gather (4 values -> 4 bytes per iter);
 // the tail (n%4) uses a scalar loop. Encode inverse of unpackBits8.

--- a/qpack_simd_amd64.s
+++ b/qpack_simd_amd64.s
@@ -281,3 +281,160 @@ loop4_p32:
 done_p32:
 	VZEROUPPER
 	RET
+
+// shift12/mask12: four 12-bit values share a byte-aligned 48-bit chunk
+// (6 bytes) at offsets 0,12,24,36 — all within a single 64-bit broadcast.
+DATA shift12<>+0(SB)/8,  $0x0000000000000000
+DATA shift12<>+8(SB)/8,  $0x000000000000000C
+DATA shift12<>+16(SB)/8, $0x0000000000000018
+DATA shift12<>+24(SB)/8, $0x0000000000000024
+GLOBL shift12<>(SB), RODATA|NOPTR, $32
+DATA mask12<>+0(SB)/8,  $0x0000000000000FFF
+DATA mask12<>+8(SB)/8,  $0x0000000000000FFF
+DATA mask12<>+16(SB)/8, $0x0000000000000FFF
+DATA mask12<>+24(SB)/8, $0x0000000000000FFF
+GLOBL mask12<>(SB), RODATA|NOPTR, $32
+
+// func unpackBits12AVX2(out []uint64, in []byte, groups int)
+//
+// Decodes `groups` chunks of four 12-bit LSB-first values. Each chunk is
+// byte-aligned (48 bits = 6 bytes); VPBROADCASTQ loads the 8 bytes at the
+// chunk start (overreads 2) into all four lanes, VPSRLVQ shifts by
+// 0/12/24/36, then AND 0xFFF isolates each value. Writes 4 uint64 per
+// chunk, advances 6 input bytes. Caller guarantees len(out) >= 4*groups,
+// 6*(groups-1)+8 <= len(in), AVX2 available.
+TEXT ·unpackBits12AVX2(SB), NOSPLIT, $0-56
+	MOVQ    out_base+0(FP), DI
+	MOVQ    in_base+24(FP), SI
+	MOVQ    groups+48(FP), CX
+	VMOVDQU shift12<>(SB), Y1
+	VMOVDQU mask12<>(SB), Y2
+
+loop_p12:
+	TESTQ        CX, CX
+	JZ           done_p12
+	VPBROADCASTQ (SI), Y0
+	VPSRLVQ      Y1, Y0, Y0
+	VPAND        Y2, Y0, Y0
+	VMOVDQU      Y0, (DI)
+	ADDQ         $6, SI
+	ADDQ         $32, DI
+	DECQ         CX
+	JMP          loop_p12
+
+done_p12:
+	VZEROUPPER
+	RET
+
+// width-10: four 10-bit values share a byte-aligned 40-bit chunk (5 bytes)
+// at offsets 0,10,20,30. Four lanes -> 256-bit.
+DATA shift10<>+0(SB)/8,  $0x0000000000000000
+DATA shift10<>+8(SB)/8,  $0x000000000000000A
+DATA shift10<>+16(SB)/8, $0x0000000000000014
+DATA shift10<>+24(SB)/8, $0x000000000000001E
+GLOBL shift10<>(SB), RODATA|NOPTR, $32
+DATA mask10<>+0(SB)/8,  $0x00000000000003FF
+DATA mask10<>+8(SB)/8,  $0x00000000000003FF
+DATA mask10<>+16(SB)/8, $0x00000000000003FF
+DATA mask10<>+24(SB)/8, $0x00000000000003FF
+GLOBL mask10<>(SB), RODATA|NOPTR, $32
+
+// func unpackBits10AVX2(out []uint64, in []byte, groups int)
+// Each group: 4 values from a 5-byte chunk. VPBROADCASTQ the 8 bytes at
+// the chunk start (overreads 3) to all four lanes, VPSRLVQ by 0/10/20/30,
+// AND 0x3FF. Caller guarantees len(out) >= 4*groups, 5*(groups-1)+8 <=
+// len(in), AVX2 available.
+TEXT ·unpackBits10AVX2(SB), NOSPLIT, $0-56
+	MOVQ    out_base+0(FP), DI
+	MOVQ    in_base+24(FP), SI
+	MOVQ    groups+48(FP), CX
+	VMOVDQU shift10<>(SB), Y1
+	VMOVDQU mask10<>(SB), Y2
+
+loop_p10:
+	TESTQ        CX, CX
+	JZ           done_p10
+	VPBROADCASTQ (SI), Y0
+	VPSRLVQ      Y1, Y0, Y0
+	VPAND        Y2, Y0, Y0
+	VMOVDQU      Y0, (DI)
+	ADDQ         $5, SI
+	ADDQ         $32, DI
+	DECQ         CX
+	JMP          loop_p10
+
+done_p10:
+	VZEROUPPER
+	RET
+
+// width-14: four 14-bit values share a byte-aligned 56-bit chunk (7 bytes)
+// at offsets 0,14,28,42.
+DATA shift14<>+0(SB)/8,  $0x0000000000000000
+DATA shift14<>+8(SB)/8,  $0x000000000000000E
+DATA shift14<>+16(SB)/8, $0x000000000000001C
+DATA shift14<>+24(SB)/8, $0x000000000000002A
+GLOBL shift14<>(SB), RODATA|NOPTR, $32
+DATA mask14<>+0(SB)/8,  $0x0000000000003FFF
+DATA mask14<>+8(SB)/8,  $0x0000000000003FFF
+DATA mask14<>+16(SB)/8, $0x0000000000003FFF
+DATA mask14<>+24(SB)/8, $0x0000000000003FFF
+GLOBL mask14<>(SB), RODATA|NOPTR, $32
+
+// func unpackBits14AVX2(out []uint64, in []byte, groups int)
+// Each group: 4 values from a 7-byte chunk (overreads 1).
+TEXT ·unpackBits14AVX2(SB), NOSPLIT, $0-56
+	MOVQ    out_base+0(FP), DI
+	MOVQ    in_base+24(FP), SI
+	MOVQ    groups+48(FP), CX
+	VMOVDQU shift14<>(SB), Y1
+	VMOVDQU mask14<>(SB), Y2
+
+loop_p14:
+	TESTQ        CX, CX
+	JZ           done_p14
+	VPBROADCASTQ (SI), Y0
+	VPSRLVQ      Y1, Y0, Y0
+	VPAND        Y2, Y0, Y0
+	VMOVDQU      Y0, (DI)
+	ADDQ         $7, SI
+	ADDQ         $32, DI
+	DECQ         CX
+	JMP          loop_p14
+
+done_p14:
+	VZEROUPPER
+	RET
+
+// width-20: two 20-bit values share a byte-aligned 40-bit chunk (5 bytes)
+// at offsets 0,20. Two lanes -> 128-bit.
+DATA shift20<>+0(SB)/8, $0x0000000000000000
+DATA shift20<>+8(SB)/8, $0x0000000000000014
+GLOBL shift20<>(SB), RODATA|NOPTR, $16
+DATA mask20<>+0(SB)/8, $0x00000000000FFFFF
+DATA mask20<>+8(SB)/8, $0x00000000000FFFFF
+GLOBL mask20<>(SB), RODATA|NOPTR, $16
+
+// func unpackBits20AVX2(out []uint64, in []byte, pairs int)
+// Each pair: 2 values from a 5-byte chunk (overreads 3).
+TEXT ·unpackBits20AVX2(SB), NOSPLIT, $0-56
+	MOVQ    out_base+0(FP), DI
+	MOVQ    in_base+24(FP), SI
+	MOVQ    pairs+48(FP), CX
+	VMOVDQU shift20<>(SB), X1
+	VMOVDQU mask20<>(SB), X2
+
+loop_p20:
+	TESTQ        CX, CX
+	JZ           done_p20
+	VPBROADCASTQ (SI), X0
+	VPSRLVQ      X1, X0, X0
+	VPAND        X2, X0, X0
+	VMOVDQU      X0, (DI)
+	ADDQ         $5, SI
+	ADDQ         $16, DI
+	DECQ         CX
+	JMP          loop_p20
+
+done_p20:
+	VZEROUPPER
+	RET

--- a/qpack_simd_stub.go
+++ b/qpack_simd_stub.go
@@ -47,6 +47,12 @@ func packBits32(out []byte, vals []uint64) {
 	}
 }
 
+// unpackBits10/12/14/20 fallbacks: the scalar sliding-window decoder.
+func unpackBits10(out []uint64, in []byte) { bitUnpackU64LEFast(out, in, 10) }
+func unpackBits12(out []uint64, in []byte) { bitUnpackU64LEFast(out, in, 12) }
+func unpackBits14(out []uint64, in []byte) { bitUnpackU64LEFast(out, in, 14) }
+func unpackBits20(out []uint64, in []byte) { bitUnpackU64LEFast(out, in, 20) }
+
 // packBoolsBitsLSB fallback: plain scalar bit-by-bit pack.
 func packBoolsBitsLSB(dst []byte, src []bool, n int) {
 	for i := range n {

--- a/qpack_unpack12_test.go
+++ b/qpack_unpack12_test.go
@@ -1,0 +1,51 @@
+package qdf
+
+import (
+	"testing"
+)
+
+// dispatchUnpack routes to the width-specialized decoder under test.
+func dispatchUnpack(out []uint64, in []byte, bitsPer int) {
+	switch bitsPer {
+	case 10:
+		unpackBits10(out, in)
+	case 12:
+		unpackBits12(out, in)
+	case 14:
+		unpackBits14(out, in)
+	case 20:
+		unpackBits20(out, in)
+	default:
+		bitUnpackU64LEFast(out, in, bitsPer)
+	}
+}
+
+// TestUnpackVarWidth_MatchesReference checks each VPSRLVQ-specialized
+// width against the byte-at-a-time scalar decoder, bit-for-bit, across
+// sizes that exercise the SIMD body, the read-headroom guard, and the
+// scalar tail.
+func TestUnpackVarWidth_MatchesReference(t *testing.T) {
+	widths := []int{10, 12, 14, 20}
+	sizes := []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 64, 100, 1000}
+	for _, bitsPer := range widths {
+		mask := uint64(1)<<uint(bitsPer) - 1
+		for _, n := range sizes {
+			vals := make([]uint64, n)
+			for i := range vals {
+				vals[i] = uint64(i*2654435761+11) & mask
+			}
+			body := make([]byte, (n*bitsPer+7)/8)
+			bitPackU64LE(body, vals, bitsPer)
+
+			want := make([]uint64, n)
+			bitUnpackU64LEScalar(want, body, bitsPer)
+			got := make([]uint64, n)
+			dispatchUnpack(got, body, bitsPer)
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("bits=%d n=%d i=%d: got %d want %d", bitsPer, n, i, got[i], want[i])
+				}
+			}
+		}
+	}
+}

--- a/qpack_unpack_bench_test.go
+++ b/qpack_unpack_bench_test.go
@@ -1,0 +1,56 @@
+package qdf
+
+import "testing"
+
+// Decode-side SIMD headroom probe. bitUnpackU64LE dispatches to the
+// VPMOVZX asm under qdf_simd for byte-aligned widths and to the scalar
+// 128-bit sliding window for the rest. Comparing the same benchmark
+// across default and qdf_simd builds shows how much the simple byte-
+// aligned SIMD actually buys on the expanding decode path — a cheap
+// proxy for whether the much harder arbitrary-width SIMD unpack is worth
+// the per-width asm.
+
+const unpackBenchN = 1024
+
+func benchUnpack(b *testing.B, bitsPer int) {
+	vals := make([]uint64, unpackBenchN)
+	mask := uint64(1)<<uint(bitsPer) - 1
+	for i := range vals {
+		vals[i] = uint64(i*2654435761+11) & mask
+	}
+	body := make([]byte, (unpackBenchN*bitsPer+7)/8)
+	bitPackU64LE(body, vals, bitsPer)
+	out := make([]uint64, unpackBenchN)
+	b.SetBytes(int64(unpackBenchN * 8))
+	for b.Loop() {
+		bitUnpackU64LE(out, body, bitsPer)
+	}
+}
+
+func BenchmarkUnpack8(b *testing.B)  { benchUnpack(b, 8) }
+func BenchmarkUnpack16(b *testing.B) { benchUnpack(b, 16) }
+func BenchmarkUnpack32(b *testing.B) { benchUnpack(b, 32) }
+
+// Arbitrary (non-byte-aligned) widths — always the scalar sliding window
+// today. Baseline a SIMD VPSRLVQ unpack would have to beat.
+func BenchmarkUnpack10(b *testing.B) { benchUnpack(b, 10) }
+func BenchmarkUnpack12(b *testing.B) { benchUnpack(b, 12) }
+func BenchmarkUnpack14(b *testing.B) { benchUnpack(b, 14) }
+func BenchmarkUnpack20(b *testing.B) { benchUnpack(b, 20) }
+
+// BenchmarkUnpack12Direct exercises unpackBits12 (the VPSRLVQ path under
+// qdf_simd, scalar otherwise) directly, isolating the width-12 codec from
+// the bitUnpackU64LE dispatch.
+func BenchmarkUnpack12Direct(b *testing.B) {
+	vals := make([]uint64, unpackBenchN)
+	for i := range vals {
+		vals[i] = uint64(i*2654435761+11) & 0xFFF
+	}
+	body := make([]byte, (unpackBenchN*12+7)/8)
+	bitPackU64LE(body, vals, 12)
+	out := make([]uint64, unpackBenchN)
+	b.SetBytes(int64(unpackBenchN * 8))
+	for b.Loop() {
+		unpackBits12(out, body)
+	}
+}


### PR DESCRIPTION
## Summary

Speeds up FOR-codec **decode** for the common non-byte-aligned bit widths.
Byte-aligned widths (8/16/32) already had AVX2 `VPMOVZX` fast paths, but every
other width fell back to the scalar 128-bit sliding window (~4 dependent ops
per element, ~2.5 GB/s) — about **20–30× slower** than the byte-aligned SIMD.
Real FOR deltas frequently land at 10–20 bits (telemetry/counter ranges), so
this was the slowest decode path in regular use.

Adds per-width `VPSRLVQ` kernels under `qdf_simd`. The key idea: a small group
of values shares one **byte-aligned** chunk (`lcm(bits, 8)` bits) that fits in
a single 64-bit word, so

- `VPBROADCASTQ` loads the chunk into every 64-bit lane,
- `VPSRLVQ` shifts each lane by its in-chunk bit offset (a constant per width),
- `VPAND` with the width mask isolates each value.

Widths 10/12/14 decode 4 values per iteration (256-bit, offsets like
`0/12/24/36`); width 20 does 2 (128-bit — 4 values would exceed the 64-bit
broadcast window). The final chunk and any remainder use the scalar window
(the broadcast overreads a few bytes, so the last chunk lacks read headroom),
handed off on a byte boundary.

Decode-only change; the encoder and wire format are untouched, and output is
**bit-identical** to the scalar decoder.

## Wire-format impact

- [x] None. Pure decode-speed change. The same bytes decode to the same values;
      encoders and golden fixtures are unaffected.

## Bench evidence

Microbench, 1024 elements, `-count=5`, i7-9750H. Scalar (default build) → AVX2
(`qdf_simd`):

| width | scalar | AVX2 VPSRLVQ | speedup | lanes |
| ----: | -----: | -----------: | ------- | ----- |
| 10    | ~3200  | ~300         | ~10.6×  | 4     |
| 12    | ~3300  | ~310         | ~10.7×  | 4     |
| 14    | ~3340  | ~300         | ~11×    | 4     |
| 20    | ~3740  | ~555         | ~6.7×   | 2     |

For reference, the existing byte-aligned SIMD decode runs ~150 ns; these widths
now land in the same order of magnitude instead of 20–30× behind.

## Checklist

- [x] `go test -race -count=1 ./...` (default) passes.
- [x] `GOEXPERIMENT=simd go test -tags qdf_simd -race -count=1 .` passes.
- [x] Parity tests (widths 10/12/14/20 vs the byte-at-a-time scalar decoder)
      pass under both build configs, across sizes that hit the SIMD body, the
      read-headroom guard, and the scalar tail.
- [x] Golden fixtures unchanged (decode output bit-identical).
- [x] `golangci-lint run ./...` (v2.12.2) — 0 issues.

## Notes / scoped-but-not-done

This covers the single-load widths whose group fits one 64-bit broadcast
(10/12/14/20). Wider or odd widths (e.g. 9/11/18/24+) need a two-load or
gather kernel and are left on the scalar window for now; encode-side arbitrary
widths and AVX-512 VBMI remain separate future levers.

## Also in this PR: bench-trend CI fix

The gh-pages bootstrap step (added earlier) ran `git commit` with no git
identity configured on the runner, failing with `empty ident name` (exit 128)
on push to `main`. Set an explicit `github-actions[bot]` identity on that
commit. `main`'s bench-trend run goes green once this PR merges.

## Linked issues

<!-- Closes #..., Refs #... -->
