### PR TITLE
docs: plain-language `qdf_simd` guide + sync SIMD coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,7 +694,7 @@ QPack codecs, and a 128-bit sliding-window bit-unpacker for FOR / Delta+FOR.
 | Tag             | Effect                                                                                                  | Build prerequisite |
 | --------------- | ------------------------------------------------------------------------------------------------------- | ------------------ |
 | `qdf_reflect2`  | Swap `reflect.MakeSlice` / `MakeMapWithSize` for `modern-go/reflect2` unsafe equivalents. Smaller decode allocations on map / slice heavy workloads. | none — pure Go     |
-| `qdf_simd`      | AVX2 fast path for QPack bit-unpack at bits ∈ {8, 16, 32}. 22-53× over the pure-Go path on those widths (≈ 50 GB/s, memory-bandwidth bound). Runtime CPUID gate via `golang.org/x/sys/cpu`; older amd64 without AVX2 transparently falls back to the scalar zero-extend. Non-amd64 targets compile a stub. | amd64; AVX2 detected at run time |
+| `qdf_simd`      | AVX2 fast paths for the QPack integer/bool codecs: decode at bits ∈ {8,16,32} (`VPMOVZX`) and {10,12,14,20} (`VPBROADCASTQ`+`VPSRLVQ`), encode at {8,16,32} (`VPSHUFB`), `[]bool` pack. ~3-11× over the pure-Go path on those widths. Output byte-identical to scalar. Runtime CPUID gate via `golang.org/x/sys/cpu`; older amd64 without AVX2 falls back transparently; non-amd64 targets compile a stub. See `docs/USAGE.md` for when to use it. | amd64; AVX2 detected at run time |
 
 ```bash
 go build -tags qdf_reflect2 ./...
@@ -702,10 +702,10 @@ go build -tags qdf_simd ./...
 go build -tags "qdf_simd qdf_reflect2" ./...   # combined
 ```
 
-The `qdf_simd` path only changes behaviour for QPack-encoded numeric
-slices whose chosen codec is FOR or Delta+FOR at one of the byte-aligned
-bit widths; other widths and other codecs run the pure-Go path
-unchanged.
+The `qdf_simd` path only changes the speed of QPack-encoded numeric and
+bool slices at the accelerated widths; string / map / struct paths, the
+float codecs, and other bit widths run the pure-Go path unchanged. It is
+a pure speed switch — the wire format and output are identical.
 
 ---
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -580,13 +580,22 @@ encoder calls them once per slice and picks the smallest.
 
 #### SIMD AVX2 (`qdf_simd` build tag)
 
-`qpack_simd_amd64.s` is hand-rolled AVX2 for the bit-unpack inner
-loop at `bitsPer ∈ {8, 16, 32}`. 22–53× faster than the scalar
-fallback at memory-bandwidth saturation (~50 GB/s on
-i7-9750H). CPUID-gated at runtime; non-amd64 builds compile a stub.
+`qpack_simd_amd64.s` is hand-rolled AVX2 for the QPack integer/bool
+inner loops, both directions:
 
-Encode-side SIMD is not yet implemented — the encode
-inner loop is still scalar today.
+- **Decode** (`VPMOVZX*`) at byte-aligned `bitsPer ∈ {8, 16, 32}`,
+  and (`VPBROADCASTQ` + `VPSRLVQ`) at the common non-byte-aligned
+  widths `{10, 12, 14, 20}` — each group of values shares one
+  byte-aligned chunk that fits a 64-bit broadcast, shifted per-lane.
+- **Encode** (`VPSHUFB` byte-gather) at `{8, 16, 32}` — the mirror of
+  the decode fast path.
+- `[]bool` pack (`VPSLLW` + `VPMOVMSKB`).
+
+Widths not listed (odd widths, ≥ ~24 non-aligned) and the float
+codecs stay on the scalar path. CPUID-gated at runtime; non-amd64
+builds compile a scalar stub. Output is byte-identical to scalar —
+the tag is a pure speed switch. See `docs/USAGE.md` for a
+plain-language "when to use it" guide.
 
 ### reflect2 swap (`qdf_reflect2` build tag)
 
@@ -793,7 +802,7 @@ payloads.
 
 | Tag             | Effect                                                                                                                                                                                                                                                                                | Platform                              |
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| `qdf_simd`      | AVX2 bit-unpack at `bits ∈ {8, 16, 32}`. 22–53× over scalar. Runtime CPUID gate; non-AVX2 amd64 falls back transparently. Other arches compile a stub. | amd64; AVX2 detected at run time      |
+| `qdf_simd`      | AVX2 for the QPack integer/bool codecs: decode at `bits ∈ {8,16,32,10,12,14,20}`, encode at `{8,16,32}`, `[]bool` pack. Output byte-identical to scalar. Runtime CPUID gate; non-AVX2 amd64 falls back transparently; other arches compile a stub. See docs/USAGE.md for when to use it. | amd64; AVX2 detected at run time      |
 | `qdf_reflect2`  | Swap `reflect.MakeSlice` / `MakeMapWithSize` / `reflect.New` for `modern-go/reflect2` unsafe equivalents.                                                                                                                                                                             | none — pure Go                        |
 
 Combine freely:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -227,5 +227,72 @@ wg.Wait()
   `MarshalQDF`/`UnmarshalQDF` methods that bypass reflect entirely.
   Worth it for hot paths encoding the same struct type millions of
   times — typically 30–60% faster than the reflect path on encode.
-- Build with `-tags qdf_simd` on amd64 to enable AVX2-accelerated
-  bit-unpack for QPack codecs (~50 GB/s, runtime CPUID-gated).
+- Build with `-tags qdf_simd` on amd64 to accelerate the numeric-slice
+  codecs with AVX2. It is opt-in and changes nothing else — see the
+  section below for when it actually helps.
+
+---
+
+## SIMD acceleration (`qdf_simd` build tag)
+
+`qdf_simd` is an **opt-in build tag** that swaps hand-written AVX2 assembly
+into the inner loops of the numeric-slice (QPack) codecs:
+
+```bash
+go build -tags qdf_simd ./...
+go test  -tags qdf_simd ./...
+```
+
+It is **off by default**. Turning it on does **not** change the wire format,
+the API, or the output — encoded bytes are byte-for-byte identical with and
+without the tag. It is purely a speed switch, safe to flip.
+
+### What it speeds up
+
+Only the QPack codecs that pack fixed-width integers and booleans:
+
+| Operation | Accelerated widths | Typical speedup vs scalar |
+| --------- | ------------------ | ------------------------- |
+| Integer **decode** (FOR) | 8, 16, 32 (byte-aligned) | ~3–8× |
+| Integer **decode** (FOR) | 10, 12, 14, 20 (common packed widths) | ~7–11× |
+| Integer **encode** (FOR) | 8, 16, 32 | ~2–5× |
+| `[]bool` pack | — | large |
+
+Everything else runs the same scalar code whether or not the tag is set:
+strings, maps, struct shapes, varints, the Gorilla and ALP float codecs, and
+integer widths not listed above. The tag simply doesn't touch them.
+
+### When it helps
+
+- Payloads dominated by **large numeric or boolean slices** that go through
+  QPack/FOR: metrics, counters, sensor batches, columnar numeric rows,
+  integer-quantized embeddings. The bigger the slices, the bigger the win —
+  it is a per-element inner-loop speedup, so fixed overhead dominates on small
+  slices.
+
+### When it does *not* help
+
+- Small payloads, single objects, config-shaped data (few or short slices) —
+  the overhead swamps any gain.
+- String-heavy, map-heavy, or struct-shape-heavy payloads — those paths are
+  scalar regardless of the tag.
+- Float time-series (Gorilla / ALP) — not SIMD-accelerated yet.
+
+### Architectures
+
+- **amd64 with AVX2** is the only accelerated target. A runtime CPUID check
+  gates the asm: on a CPU without AVX2 it transparently falls back to scalar,
+  so the binary still runs correctly everywhere.
+- **Other architectures** (arm64, etc.) compile a scalar stub — building with
+  the tag is safe but gives no speedup. (arm64 NEON is a possible future
+  addition, not implemented today.)
+- No special environment is required — plain `-tags qdf_simd` is enough.
+
+### Recommendation
+
+Use the default build unless profiling shows that encode/decode of numeric
+slices is a hot spot **and** your payloads carry big integer/bool slices. In
+that case enable `qdf_simd` and measure on your real data
+(`go test -bench` with and without the tag) — if your data is string- or
+struct-heavy, expect little change. Because the output is identical and the
+fallback is automatic, it is safe to enable broadly; worst case it is a no-op.


### PR DESCRIPTION
Documentation only — no code, no wire change.

- **New dev-facing section in `docs/USAGE.md`:** "When to use the `qdf_simd`
  build tag." Explains, for app developers, what the tag accelerates (the
  QPack integer/bool codecs), which data shapes actually benefit (large
  numeric/bool slices — metrics, counters, columnar rows, int embeddings) vs
  which don't (small payloads, string/map/struct-heavy data, float codecs),
  the supported architectures (amd64 + AVX2, runtime CPUID fallback, scalar
  stub elsewhere, plain `-tags qdf_simd` with no `GOEXPERIMENT` needed), and a
  concrete recommendation with a "measure on your data" note.
- **Fixed stale SIMD docs in `docs/GUIDE.md` and `README.md`.** Both claimed
  decode-only bit-unpack at `{8,16,32}` and "encode-side SIMD is not yet
  implemented." Updated to what actually ships: encode `VPSHUFB` at
  `{8,16,32}`, decode at `{8,16,32}` (`VPMOVZX`) and `{10,12,14,20}`
  (`VPBROADCASTQ`+`VPSRLVQ`), `[]bool` pack — and that output is byte-identical
  to the scalar path.

## Wire-format impact

- [x] None. Docs only.

## Checklist

- [x] `go build -tags qdf_simd ./...` confirmed to work without
      `GOEXPERIMENT` (documented form is accurate).
- [x] No code touched; README / GUIDE / USAGE describe the shipped SIMD set.

## Linked issues

<!-- Closes #..., Refs #... -->
