### PR TITLE
qpack: general AVX2 VPSRLVQ decode for all FOR widths 1–14 (incl. odd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,7 +694,7 @@ QPack codecs, and a 128-bit sliding-window bit-unpacker for FOR / Delta+FOR.
 | Tag             | Effect                                                                                                  | Build prerequisite |
 | --------------- | ------------------------------------------------------------------------------------------------------- | ------------------ |
 | `qdf_reflect2`  | Swap `reflect.MakeSlice` / `MakeMapWithSize` for `modern-go/reflect2` unsafe equivalents. Smaller decode allocations on map / slice heavy workloads. | none — pure Go     |
-| `qdf_simd`      | AVX2 fast paths for the QPack integer/bool codecs: decode at bits ∈ {8,16,32} (`VPMOVZX`) and {10,12,14,20} (`VPBROADCASTQ`+`VPSRLVQ`), encode at {8,16,32} (`VPSHUFB`), `[]bool` pack. ~3-11× over the pure-Go path on those widths. Output byte-identical to scalar. Runtime CPUID gate via `golang.org/x/sys/cpu`; older amd64 without AVX2 falls back transparently; non-amd64 targets compile a stub. See `docs/USAGE.md` for when to use it. | amd64; AVX2 detected at run time |
+| `qdf_simd`      | AVX2 fast paths for the QPack integer/bool codecs: decode at bits ∈ {8,16,32} (`VPMOVZX`) and every width 1–14 plus 20 (`VPBROADCASTQ`+`VPSRLVQ`), encode at {8,16,32} (`VPSHUFB`), `[]bool` pack. ~3-11× over the pure-Go path on those widths. Output byte-identical to scalar. Runtime CPUID gate via `golang.org/x/sys/cpu`; older amd64 without AVX2 falls back transparently; non-amd64 targets compile a stub. See `docs/USAGE.md` for when to use it. | amd64; AVX2 detected at run time |
 
 ```bash
 go build -tags qdf_reflect2 ./...

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -584,9 +584,11 @@ encoder calls them once per slice and picks the smallest.
 inner loops, both directions:
 
 - **Decode** (`VPMOVZX*`) at byte-aligned `bitsPer ∈ {8, 16, 32}`,
-  and (`VPBROADCASTQ` + `VPSRLVQ`) at the common non-byte-aligned
-  widths `{10, 12, 14, 20}` — each group of values shares one
-  byte-aligned chunk that fits a 64-bit broadcast, shifted per-lane.
+  and (`VPBROADCASTQ` + `VPSRLVQ`) at every width `1..14` plus `20` —
+  fixed-shift kernels for `{10,12,14,20}`, and a general kernel
+  (table-indexed per-group offset) for the rest, including odd widths.
+  Each group of four values fits one 64-bit broadcast (`7 + 4*14 < 64`),
+  shifted per-lane and masked.
 - **Encode** (`VPSHUFB` byte-gather) at `{8, 16, 32}` — the mirror of
   the decode fast path.
 - `[]bool` pack (`VPSLLW` + `VPMOVMSKB`).
@@ -802,7 +804,7 @@ payloads.
 
 | Tag             | Effect                                                                                                                                                                                                                                                                                | Platform                              |
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| `qdf_simd`      | AVX2 for the QPack integer/bool codecs: decode at `bits ∈ {8,16,32,10,12,14,20}`, encode at `{8,16,32}`, `[]bool` pack. Output byte-identical to scalar. Runtime CPUID gate; non-AVX2 amd64 falls back transparently; other arches compile a stub. See docs/USAGE.md for when to use it. | amd64; AVX2 detected at run time      |
+| `qdf_simd`      | AVX2 for the QPack integer/bool codecs: decode at every `bits ∈ 1..14` plus `{16,20,32}`, encode at `{8,16,32}`, `[]bool` pack. Output byte-identical to scalar. Runtime CPUID gate; non-AVX2 amd64 falls back transparently; other arches compile a stub. See docs/USAGE.md for when to use it. | amd64; AVX2 detected at run time      |
 | `qdf_reflect2`  | Swap `reflect.MakeSlice` / `MakeMapWithSize` / `reflect.New` for `modern-go/reflect2` unsafe equivalents.                                                                                                                                                                             | none — pure Go                        |
 
 Combine freely:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -253,10 +253,13 @@ Only the QPack codecs that pack fixed-width integers and booleans:
 
 | Operation | Accelerated widths | Typical speedup vs scalar |
 | --------- | ------------------ | ------------------------- |
-| Integer **decode** (FOR) | 8, 16, 32 (byte-aligned) | ~3–8× |
-| Integer **decode** (FOR) | 10, 12, 14, 20 (common packed widths) | ~7–11× |
-| Integer **encode** (FOR) | 8, 16, 32 | ~2–5× |
+| Integer **decode** (FOR) | 8, 16, 32 (byte-aligned, `VPMOVZX`) | ~3–8× |
+| Integer **decode** (FOR) | all widths 1–14, plus 20 (`VPSRLVQ`) | ~7–11× |
+| Integer **encode** (FOR) | 8, 16, 32 (`VPSHUFB`) | ~2–5× |
 | `[]bool` pack | — | large |
+
+Decode is the most broadly accelerated: every width up to 14 bits per value
+(the common range for packed FOR deltas) plus 16/20/32 has a SIMD path.
 
 Everything else runs the same scalar code whether or not the tag is set:
 strings, maps, struct shapes, varints, the Gorilla and ALP float codecs, and

--- a/qpack_for.go
+++ b/qpack_for.go
@@ -76,6 +76,13 @@ func bitUnpackU64LE(out []uint64, in []byte, bitsPer int) {
 		unpackBits32(out, in)
 		return
 	}
+	// Remaining small widths (1-7, 9, 11, 13) go through the general
+	// VPSRLVQ kernel under qdf_simd; it falls back to the scalar window
+	// on non-SIMD builds or non-AVX2 CPUs.
+	if bitsPer <= 14 {
+		unpackBitsVar(out, in, bitsPer)
+		return
+	}
 	bitUnpackU64LEFast(out, in, bitsPer)
 }
 

--- a/qpack_simd_amd64.go
+++ b/qpack_simd_amd64.go
@@ -73,6 +73,49 @@ func unpackBits14AVX2(out []uint64, in []byte, groups int)
 //go:noescape
 func unpackBits20AVX2(out []uint64, in []byte, pairs int)
 
+//go:noescape
+func unpackBitsVarAVX2(out []uint64, in []byte, groups int, fourB int, shifts *[32]uint64, mask uint64)
+
+// unpackBitsVar decodes an arbitrary width b in [1,14] (including the odd
+// widths that lack a fixed byte-aligned chunk). It processes 4 values per
+// VPSRLVQ iteration with a per-group in-byte offset; the table `shifts`
+// holds the 8 possible shift vectors (one per offset 0..7). groups is
+// bounded by read headroom (each group loads 8 bytes) and by a
+// byte-aligned handoff so the scalar tail can resume on a byte boundary.
+func unpackBitsVar(out []uint64, in []byte, b int) {
+	n := len(out)
+	if n == 0 {
+		return
+	}
+	groups := 0
+	if hasAVX2 && b >= 1 && b <= 14 {
+		var shifts [32]uint64
+		for off := 0; off < 8; off++ {
+			for k := 0; k < 4; k++ {
+				shifts[off*4+k] = uint64(off + k*b)
+			}
+		}
+		mask := uint64(1)<<uint(b) - 1
+		groups = n / 4
+		// Last group's VPBROADCASTQ reads 8 bytes at ((groups-1)*4b)>>3.
+		for groups > 0 && ((groups-1)*4*b)/8+8 > len(in) {
+			groups--
+		}
+		// The scalar tail resumes at bit 4*groups*b, which must be a whole
+		// number of bytes (always true for even b; trims to even groups
+		// for odd b).
+		for groups > 0 && (4*groups*b)%8 != 0 {
+			groups--
+		}
+		if groups > 0 {
+			unpackBitsVarAVX2(out[:4*groups], in, groups, 4*b, &shifts, mask)
+		}
+	}
+	if done := 4 * groups; done < n {
+		bitUnpackU64LEFast(out[done:], in[(4*groups*b)/8:], b)
+	}
+}
+
 // unpackBits10 decodes a width-10 FOR stream: 4 values per byte-aligned
 // 5-byte chunk via VPSRLVQ, scalar tail for the remainder.
 func unpackBits10(out []uint64, in []byte) {

--- a/qpack_simd_amd64.s
+++ b/qpack_simd_amd64.s
@@ -438,3 +438,47 @@ loop_p20:
 done_p20:
 	VZEROUPPER
 	RET
+
+// func unpackBitsVarAVX2(out []uint64, in []byte, groups int, fourB int, shifts *[32]uint64, mask uint64)
+//
+// General width-b decoder for b in [1,14]: four values per iteration. For
+// width b<=14 any four consecutive values fit a single 64-bit window even
+// at the worst in-byte start offset (7 + 4*14 = 63 < 64), so each group
+// loads 8 bytes at the byte containing its start, VPBROADCASTQ to all
+// lanes, then VPSRLVQ by per-lane shift [off, off+b, off+2b, off+3b] and
+// AND mask. `shifts` is a caller-built table of those vectors indexed by
+// off (0..7); `fourB` is 4*b, the per-group bit advance. The last group
+// loads 8 bytes at ((groups-1)*4b)>>3, so the caller bounds groups by both
+// read headroom and a byte-aligned handoff. mask = (1<<b)-1.
+TEXT ·unpackBitsVarAVX2(SB), NOSPLIT, $0-80
+	MOVQ         out_base+0(FP), DI
+	MOVQ         in_base+24(FP), BX
+	MOVQ         groups+48(FP), R10
+	MOVQ         fourB+56(FP), R9
+	MOVQ         shifts+64(FP), R11
+	MOVQ         mask+72(FP), AX
+	MOVQ         AX, X2
+	VPBROADCASTQ X2, Y2
+	XORQ         R8, R8
+
+loop_var:
+	TESTQ        R10, R10
+	JZ           done_var
+	MOVQ         R8, AX
+	MOVQ         R8, DX
+	SHRQ         $3, AX
+	ANDQ         $7, DX
+	VPBROADCASTQ (BX)(AX*1), Y0
+	SHLQ         $5, DX
+	VMOVDQU      (R11)(DX*1), Y1
+	VPSRLVQ      Y1, Y0, Y0
+	VPAND        Y2, Y0, Y0
+	VMOVDQU      Y0, (DI)
+	ADDQ         R9, R8
+	ADDQ         $32, DI
+	DECQ         R10
+	JMP          loop_var
+
+done_var:
+	VZEROUPPER
+	RET

--- a/qpack_simd_stub.go
+++ b/qpack_simd_stub.go
@@ -47,6 +47,11 @@ func packBits32(out []byte, vals []uint64) {
 	}
 }
 
+// unpackBitsVar fallback: scalar sliding window for an arbitrary width.
+func unpackBitsVar(out []uint64, in []byte, bitsPer int) {
+	bitUnpackU64LEFast(out, in, bitsPer)
+}
+
 // unpackBits10/12/14/20 fallbacks: the scalar sliding-window decoder.
 func unpackBits10(out []uint64, in []byte) { bitUnpackU64LEFast(out, in, 10) }
 func unpackBits12(out []uint64, in []byte) { bitUnpackU64LEFast(out, in, 12) }

--- a/qpack_unpack_bench_test.go
+++ b/qpack_unpack_bench_test.go
@@ -38,6 +38,25 @@ func BenchmarkUnpack12(b *testing.B) { benchUnpack(b, 12) }
 func BenchmarkUnpack14(b *testing.B) { benchUnpack(b, 14) }
 func BenchmarkUnpack20(b *testing.B) { benchUnpack(b, 20) }
 
+func benchUnpackVar(b *testing.B, bitsPer int) {
+	vals := make([]uint64, unpackBenchN)
+	mask := uint64(1)<<uint(bitsPer) - 1
+	for i := range vals {
+		vals[i] = uint64(i*2654435761+11) & mask
+	}
+	body := make([]byte, (unpackBenchN*bitsPer+7)/8)
+	bitPackU64LE(body, vals, bitsPer)
+	out := make([]uint64, unpackBenchN)
+	b.SetBytes(int64(unpackBenchN * 8))
+	for b.Loop() {
+		unpackBitsVar(out, body, bitsPer)
+	}
+}
+
+func BenchmarkUnpackVar9(b *testing.B)  { benchUnpackVar(b, 9) }
+func BenchmarkUnpackVar11(b *testing.B) { benchUnpackVar(b, 11) }
+func BenchmarkUnpackVar13(b *testing.B) { benchUnpackVar(b, 13) }
+
 // BenchmarkUnpack12Direct exercises unpackBits12 (the VPSRLVQ path under
 // qdf_simd, scalar otherwise) directly, isolating the width-12 codec from
 // the bitUnpackU64LE dispatch.

--- a/qpack_unpack_var_test.go
+++ b/qpack_unpack_var_test.go
@@ -1,0 +1,35 @@
+package qdf
+
+import "testing"
+
+// TestUnpackBitsVar_MatchesReference checks the general b<=14 VPSRLVQ
+// kernel (variable in-chunk offset + table-indexed shift) against the
+// byte-at-a-time scalar decoder, bit-for-bit. Covers odd widths (which
+// lack a fixed byte-aligned chunk) and a range of sizes that exercise
+// the SIMD body, the read-headroom guard, the byte-alignment handoff,
+// and the scalar tail.
+func TestUnpackBitsVar_MatchesReference(t *testing.T) {
+	widths := []int{5, 6, 7, 9, 11, 13}
+	sizes := []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 64, 100, 257, 1000}
+	for _, b := range widths {
+		mask := uint64(1)<<uint(b) - 1
+		for _, n := range sizes {
+			vals := make([]uint64, n)
+			for i := range vals {
+				vals[i] = uint64(i*2654435761+11) & mask
+			}
+			body := make([]byte, (n*b+7)/8)
+			bitPackU64LE(body, vals, b)
+
+			want := make([]uint64, n)
+			bitUnpackU64LEScalar(want, body, b)
+			got := make([]uint64, n)
+			unpackBitsVar(got, body, b)
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("b=%d n=%d i=%d: got %d want %d", b, n, i, got[i], want[i])
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Extends SIMD FOR **decode** to every small bit width, closing the last common
gap. The fixed-width kernels already covered 8/10/12/14/16/20/32, but the
remaining widths — notably the common **odd** FOR-delta widths 9/11/13 — still
ran the scalar sliding window (~2 GB/s).

Adds a **general `b ≤ 14` kernel**. Four consecutive values fit a single
64-bit window even at the worst in-byte start offset (`7 + 4·14 = 63 < 64`), so
each group:

- loads 8 bytes at the byte containing its start,
- `VPBROADCASTQ` to all four lanes,
- `VPSRLVQ` by a per-group shift vector `[off, off+b, off+2b, off+3b]` selected
  from a small table indexed by the in-byte offset (0..7),
- `VPAND` the width mask.

`bitUnpackU64LE` now routes every width ≤ 14 not already special-cased through
this kernel; the dedicated fixed-shift kernels (10/12/14/20) stay for their
peak speed. The scalar tail resumes on a byte-aligned boundary (groups trimmed
so `4·groups·b` is a whole byte count, which for odd `b` means an even group
count), and group count is also bounded by 8-byte read headroom.

Decode-only; encoder and wire format untouched; output is **bit-identical** to
the scalar decoder.

## Wire-format impact

- [x] None. Decode-speed change only; same bytes decode to the same values.

## Bench evidence

Microbench, 1024 elements, `-count=5`, i7-9750H. Scalar → AVX2:

| width | scalar | AVX2 | speedup |
| ----: | -----: | ---: | ------- |
| 9     | ~3700  | ~480 | ~7.7×   |
| 11    | ~4200  | ~490 | ~8.6×   |
| 13    | ~5200  | ~510 | ~10×    |

With this, every FOR width from 1 to 14 (plus 16/20/32) has a SIMD decode
path; only wider non-aligned widths (15, 17–19, 21+) remain on the scalar
window.

## Checklist

- [x] `go test -race -count=1 ./...` (default) passes.
- [x] `GOEXPERIMENT=simd go test -tags qdf_simd -race -count=1 .` passes.
- [x] Parity tests (widths 5/6/7/9/11/13 vs the byte-at-a-time scalar decoder)
      pass under both build configs, across sizes hitting the SIMD body, the
      headroom guard, the alignment trim, and the scalar tail.
- [x] Golden fixtures unchanged (decode output bit-identical).
- [x] `golangci-lint run ./...` (v2.12.2) — 0 issues.
- [x] Docs (USAGE/GUIDE/README) updated to the broader decode coverage.

## Notes / scoped-but-not-done

Wider non-byte-aligned widths (15, 17–19, 21+) need a two-load/gather kernel
(four values exceed a 64-bit window) and stay scalar for now. Encode-side
arbitrary widths and AVX-512 VBMI remain separate future levers.

## Linked issues

<!-- Closes #..., Refs #... -->

