### PR TITLE
qpack: AVX2 VPSRLVQ decode for wide FOR widths 15–28

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,7 +694,7 @@ QPack codecs, and a 128-bit sliding-window bit-unpacker for FOR / Delta+FOR.
 | Tag             | Effect                                                                                                  | Build prerequisite |
 | --------------- | ------------------------------------------------------------------------------------------------------- | ------------------ |
 | `qdf_reflect2`  | Swap `reflect.MakeSlice` / `MakeMapWithSize` for `modern-go/reflect2` unsafe equivalents. Smaller decode allocations on map / slice heavy workloads. | none — pure Go     |
-| `qdf_simd`      | AVX2 fast paths for the QPack integer/bool codecs: decode at bits ∈ {8,16,32} (`VPMOVZX`) and every width 1–14 plus 20 (`VPBROADCASTQ`+`VPSRLVQ`), encode at {8,16,32} (`VPSHUFB`), `[]bool` pack. ~3-11× over the pure-Go path on those widths. Output byte-identical to scalar. Runtime CPUID gate via `golang.org/x/sys/cpu`; older amd64 without AVX2 falls back transparently; non-amd64 targets compile a stub. See `docs/USAGE.md` for when to use it. | amd64; AVX2 detected at run time |
+| `qdf_simd`      | AVX2 fast paths for the QPack integer/bool codecs: decode at bits ∈ {8,16,32} (`VPMOVZX`) and every width 1–28 (`VPBROADCASTQ`+`VPSRLVQ`), encode at {8,16,32} (`VPSHUFB`), `[]bool` pack. ~3-11× over the pure-Go path on those widths. Output byte-identical to scalar. Runtime CPUID gate via `golang.org/x/sys/cpu`; older amd64 without AVX2 falls back transparently; non-amd64 targets compile a stub. See `docs/USAGE.md` for when to use it. | amd64; AVX2 detected at run time |
 
 ```bash
 go build -tags qdf_reflect2 ./...

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -584,11 +584,12 @@ encoder calls them once per slice and picks the smallest.
 inner loops, both directions:
 
 - **Decode** (`VPMOVZX*`) at byte-aligned `bitsPer ∈ {8, 16, 32}`,
-  and (`VPBROADCASTQ` + `VPSRLVQ`) at every width `1..14` plus `20` —
-  fixed-shift kernels for `{10,12,14,20}`, and a general kernel
-  (table-indexed per-group offset) for the rest, including odd widths.
-  Each group of four values fits one 64-bit broadcast (`7 + 4*14 < 64`),
-  shifted per-lane and masked.
+  and (`VPBROADCASTQ` + `VPSRLVQ`) at every width `1..28`. Two general
+  kernels load one 8-byte window per group and shift each lane by a
+  per-group offset selected from a small table: 4 values/iter for
+  `b ≤ 14` (`7 + 4·14 < 64`), 2 values/iter for `15 ≤ b ≤ 28`
+  (`7 + 2·28 < 64`). Fixed-shift kernels handle the hot `{10,12,14,20}`.
+  Widths 29–31 and 33–56 stay on the scalar window.
 - **Encode** (`VPSHUFB` byte-gather) at `{8, 16, 32}` — the mirror of
   the decode fast path.
 - `[]bool` pack (`VPSLLW` + `VPMOVMSKB`).
@@ -804,7 +805,7 @@ payloads.
 
 | Tag             | Effect                                                                                                                                                                                                                                                                                | Platform                              |
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| `qdf_simd`      | AVX2 for the QPack integer/bool codecs: decode at every `bits ∈ 1..14` plus `{16,20,32}`, encode at `{8,16,32}`, `[]bool` pack. Output byte-identical to scalar. Runtime CPUID gate; non-AVX2 amd64 falls back transparently; other arches compile a stub. See docs/USAGE.md for when to use it. | amd64; AVX2 detected at run time      |
+| `qdf_simd`      | AVX2 for the QPack integer/bool codecs: decode at every `bits ∈ 1..28` plus `32`, encode at `{8,16,32}`, `[]bool` pack. Output byte-identical to scalar. Runtime CPUID gate; non-AVX2 amd64 falls back transparently; other arches compile a stub. See docs/USAGE.md for when to use it. | amd64; AVX2 detected at run time      |
 | `qdf_reflect2`  | Swap `reflect.MakeSlice` / `MakeMapWithSize` / `reflect.New` for `modern-go/reflect2` unsafe equivalents.                                                                                                                                                                             | none — pure Go                        |
 
 Combine freely:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -254,12 +254,14 @@ Only the QPack codecs that pack fixed-width integers and booleans:
 | Operation | Accelerated widths | Typical speedup vs scalar |
 | --------- | ------------------ | ------------------------- |
 | Integer **decode** (FOR) | 8, 16, 32 (byte-aligned, `VPMOVZX`) | ~3–8× |
-| Integer **decode** (FOR) | all widths 1–14, plus 20 (`VPSRLVQ`) | ~7–11× |
+| Integer **decode** (FOR) | 1–14 (4 values/iter, `VPSRLVQ`) | ~7–11× |
+| Integer **decode** (FOR) | 15–28 (2 values/iter, `VPSRLVQ`) | ~5–7× |
 | Integer **encode** (FOR) | 8, 16, 32 (`VPSHUFB`) | ~2–5× |
 | `[]bool` pack | — | large |
 
-Decode is the most broadly accelerated: every width up to 14 bits per value
-(the common range for packed FOR deltas) plus 16/20/32 has a SIMD path.
+Decode is the most broadly accelerated: every bit width from 1 to 28 (plus
+32) has a SIMD path. Only widths 29–31 and 33–56 still run the scalar
+window — uncommon for real FOR deltas.
 
 Everything else runs the same scalar code whether or not the tag is set:
 strings, maps, struct shapes, varints, the Gorilla and ALP float codecs, and

--- a/qpack_for.go
+++ b/qpack_for.go
@@ -77,10 +77,15 @@ func bitUnpackU64LE(out []uint64, in []byte, bitsPer int) {
 		return
 	}
 	// Remaining small widths (1-7, 9, 11, 13) go through the general
-	// VPSRLVQ kernel under qdf_simd; it falls back to the scalar window
-	// on non-SIMD builds or non-AVX2 CPUs.
+	// 4-value VPSRLVQ kernel; the wider non-aligned widths (15, 17-19,
+	// 21-28) use the 2-value kernel. Both fall back to the scalar window
+	// on non-SIMD builds or non-AVX2 CPUs. Widths >= 29 stay scalar.
 	if bitsPer <= 14 {
 		unpackBitsVar(out, in, bitsPer)
+		return
+	}
+	if bitsPer <= 28 {
+		unpackBitsVarWide(out, in, bitsPer)
 		return
 	}
 	bitUnpackU64LEFast(out, in, bitsPer)

--- a/qpack_simd_amd64.go
+++ b/qpack_simd_amd64.go
@@ -116,6 +116,47 @@ func unpackBitsVar(out []uint64, in []byte, b int) {
 	}
 }
 
+//go:noescape
+func unpackBitsVarWide2AVX2(out []uint64, in []byte, pairs int, twoB int, shifts *[16]uint64, mask uint64)
+
+// unpackBitsVarWide decodes a width b in [15,28] — too wide for four values
+// in a 64-bit window, but two values fit (7 + 2*28 < 64). It processes 2
+// values per VPSRLVQ iteration with a per-pair in-byte offset; `shifts`
+// holds the 8 possible 2-lane shift vectors (one per offset 0..7). pairs is
+// bounded by read headroom (each pair loads 8 bytes) and by a byte-aligned
+// handoff so the scalar tail resumes on a byte boundary.
+func unpackBitsVarWide(out []uint64, in []byte, b int) {
+	n := len(out)
+	if n == 0 {
+		return
+	}
+	pairs := 0
+	if hasAVX2 && b >= 15 && b <= 28 {
+		var shifts [16]uint64
+		for off := 0; off < 8; off++ {
+			shifts[off*2+0] = uint64(off)
+			shifts[off*2+1] = uint64(off + b)
+		}
+		mask := uint64(1)<<uint(b) - 1
+		pairs = n / 2
+		// Last pair's VPBROADCASTQ reads 8 bytes at ((pairs-1)*2b)>>3.
+		for pairs > 0 && ((pairs-1)*2*b)/8+8 > len(in) {
+			pairs--
+		}
+		// The scalar tail resumes at bit 2*pairs*b, which must be a whole
+		// number of bytes.
+		for pairs > 0 && (2*pairs*b)%8 != 0 {
+			pairs--
+		}
+		if pairs > 0 {
+			unpackBitsVarWide2AVX2(out[:2*pairs], in, pairs, 2*b, &shifts, mask)
+		}
+	}
+	if done := 2 * pairs; done < n {
+		bitUnpackU64LEFast(out[done:], in[(2*pairs*b)/8:], b)
+	}
+}
+
 // unpackBits10 decodes a width-10 FOR stream: 4 values per byte-aligned
 // 5-byte chunk via VPSRLVQ, scalar tail for the remainder.
 func unpackBits10(out []uint64, in []byte) {

--- a/qpack_simd_amd64.s
+++ b/qpack_simd_amd64.s
@@ -482,3 +482,45 @@ loop_var:
 done_var:
 	VZEROUPPER
 	RET
+
+// func unpackBitsVarWide2AVX2(out []uint64, in []byte, pairs int, twoB int, shifts *[16]uint64, mask uint64)
+//
+// General width-b decoder for b in [15,28]: two values per iteration. Two
+// consecutive values plus the worst in-byte offset fit a single 64-bit
+// window (7 + 2*28 = 63 < 64), so each pair loads 8 bytes at its start
+// byte, VPBROADCASTQ to both 128-bit lanes, then VPSRLVQ by per-pair shift
+// [off, off+b] and AND mask. `shifts` is a caller-built table of those
+// 2-lane vectors indexed by off (0..7); `twoB` is 2*b. The caller bounds
+// pairs by read headroom and a byte-aligned handoff. mask = (1<<b)-1.
+TEXT ·unpackBitsVarWide2AVX2(SB), NOSPLIT, $0-80
+	MOVQ         out_base+0(FP), DI
+	MOVQ         in_base+24(FP), BX
+	MOVQ         pairs+48(FP), R10
+	MOVQ         twoB+56(FP), R9
+	MOVQ         shifts+64(FP), R11
+	MOVQ         mask+72(FP), AX
+	MOVQ         AX, X2
+	VPBROADCASTQ X2, X2
+	XORQ         R8, R8
+
+loop_vw:
+	TESTQ        R10, R10
+	JZ           done_vw
+	MOVQ         R8, AX
+	MOVQ         R8, DX
+	SHRQ         $3, AX
+	ANDQ         $7, DX
+	VPBROADCASTQ (BX)(AX*1), X0
+	SHLQ         $4, DX
+	VMOVDQU      (R11)(DX*1), X1
+	VPSRLVQ      X1, X0, X0
+	VPAND        X2, X0, X0
+	VMOVDQU      X0, (DI)
+	ADDQ         R9, R8
+	ADDQ         $16, DI
+	DECQ         R10
+	JMP          loop_vw
+
+done_vw:
+	VZEROUPPER
+	RET

--- a/qpack_simd_stub.go
+++ b/qpack_simd_stub.go
@@ -47,8 +47,12 @@ func packBits32(out []byte, vals []uint64) {
 	}
 }
 
-// unpackBitsVar fallback: scalar sliding window for an arbitrary width.
+// unpackBitsVar / unpackBitsVarWide fallbacks: scalar sliding window.
 func unpackBitsVar(out []uint64, in []byte, bitsPer int) {
+	bitUnpackU64LEFast(out, in, bitsPer)
+}
+
+func unpackBitsVarWide(out []uint64, in []byte, bitsPer int) {
 	bitUnpackU64LEFast(out, in, bitsPer)
 }
 

--- a/qpack_unpack_bench_test.go
+++ b/qpack_unpack_bench_test.go
@@ -57,6 +57,25 @@ func BenchmarkUnpackVar9(b *testing.B)  { benchUnpackVar(b, 9) }
 func BenchmarkUnpackVar11(b *testing.B) { benchUnpackVar(b, 11) }
 func BenchmarkUnpackVar13(b *testing.B) { benchUnpackVar(b, 13) }
 
+func benchUnpackWide(b *testing.B, bitsPer int) {
+	vals := make([]uint64, unpackBenchN)
+	mask := uint64(1)<<uint(bitsPer) - 1
+	for i := range vals {
+		vals[i] = uint64(i*2654435761+11) & mask
+	}
+	body := make([]byte, (unpackBenchN*bitsPer+7)/8)
+	bitPackU64LE(body, vals, bitsPer)
+	out := make([]uint64, unpackBenchN)
+	b.SetBytes(int64(unpackBenchN * 8))
+	for b.Loop() {
+		unpackBitsVarWide(out, body, bitsPer)
+	}
+}
+
+func BenchmarkUnpackWide17(b *testing.B) { benchUnpackWide(b, 17) }
+func BenchmarkUnpackWide23(b *testing.B) { benchUnpackWide(b, 23) }
+func BenchmarkUnpackWide28(b *testing.B) { benchUnpackWide(b, 28) }
+
 // BenchmarkUnpack12Direct exercises unpackBits12 (the VPSRLVQ path under
 // qdf_simd, scalar otherwise) directly, isolating the width-12 codec from
 // the bitUnpackU64LE dispatch.

--- a/qpack_unpack_wide_test.go
+++ b/qpack_unpack_wide_test.go
@@ -1,0 +1,33 @@
+package qdf
+
+import "testing"
+
+// TestUnpackBitsVarWide_MatchesReference checks the general 15<=b<=28
+// VPSRLVQ kernel (2 values per 64-bit window) against the byte-at-a-time
+// scalar decoder, bit-for-bit, across sizes that hit the SIMD body, the
+// read-headroom guard, the byte-alignment trim, and the scalar tail.
+func TestUnpackBitsVarWide_MatchesReference(t *testing.T) {
+	widths := []int{15, 17, 18, 19, 21, 23, 24, 28}
+	sizes := []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 64, 100, 257, 1000}
+	for _, b := range widths {
+		mask := uint64(1)<<uint(b) - 1
+		for _, n := range sizes {
+			vals := make([]uint64, n)
+			for i := range vals {
+				vals[i] = uint64(i*2654435761+11) & mask
+			}
+			body := make([]byte, (n*b+7)/8)
+			bitPackU64LE(body, vals, b)
+
+			want := make([]uint64, n)
+			bitUnpackU64LEScalar(want, body, b)
+			got := make([]uint64, n)
+			unpackBitsVarWide(got, body, b)
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("b=%d n=%d i=%d: got %d want %d", b, n, i, got[i], want[i])
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Extends SIMD FOR **decode** past the 4-values-per-window range, so every
common FOR width now has a SIMD path. For `15 ≤ b ≤ 28`, four values overflow
a single 64-bit window, but **two** fit even at the worst in-byte offset
(`7 + 2·28 = 63 < 64`). A 2-value/iter kernel handles them:

- `VPBROADCASTQ` the 8-byte window at the pair's start byte to both lanes,
- `VPSRLVQ` by a per-pair shift `[off, off+b]` taken from an offset-indexed
  table,
- `VPAND` the width mask.

`bitUnpackU64LE` routes `15 ≤ b ≤ 28` (those not already special-cased)
through it; widths 29+ stay on the scalar window. A byte-aligned handoff and
an 8-byte read-headroom bound cap the group count; the tail is scalar.

Decode-only; wire format and output unchanged — **bit-identical** to scalar.

## Wire-format impact

- [x] None. Decode-speed change only.

## Bench evidence

Microbench, 1024 elements, `-count=5`, i7-9750H. Scalar → AVX2:

| width | scalar | AVX2 | speedup |
| ----: | -----: | ---: | ------- |
| 17    | ~3650  | ~750 | ~4.9×   |
| 23    | ~3900  | ~750 | ~5.2×   |
| 28    | ~4760  | ~690 | ~6.9×   |

With this, every FOR width **1–28 plus 32** has a SIMD decode path; only
29–31 and 33–56 (uncommon for real FOR deltas) remain scalar.

## Checklist

- [x] `go test -race -count=1 ./...` (default) passes.
- [x] `GOEXPERIMENT=simd go test -tags qdf_simd -race -count=1 .` passes.
- [x] Parity tests (widths 15/17/18/19/21/23/24/28 vs the byte-at-a-time
      scalar decoder) pass under both build configs, across sizes hitting the
      SIMD body, the headroom guard, the alignment trim, and the scalar tail.
- [x] Golden fixtures unchanged (decode output bit-identical).
- [x] `golangci-lint run ./...` (v2.12.2) — 0 issues.
- [x] Docs (USAGE/GUIDE/README) updated to the 1–28 + 32 decode coverage.

## Notes / scoped-but-not-done

Widths 29–56 need either a two-load window (29–32) or are rare enough to skip;
left scalar for now. Encode-side arbitrary widths and AVX-512 VBMI remain
separate future levers.

## Linked issues

<!-- Closes #..., Refs #... -->
