### PR TITLE
qdf: grow intern table at 3/4 load instead of 1/2

### DIFF
--- a/state.go
+++ b/state.go
@@ -534,7 +534,7 @@ func (e *encState) lookupOrAssignSlow(h uint64, key string, startIdx uint64) (ui
 // installInternSlot writes a fresh entry into slot, copies the key
 // into the encoder arena (so it survives the caller's buffer
 // lifetime), bumps the LRU + intern counters, and grows the table
-// when the load crosses 0.5. The slot pointer can be invalidated
+// when the load crosses 3/4. The slot pointer can be invalidated
 // by the grow; callers must not touch it after this returns.
 func (e *encState) installInternSlot(slot *internSlot, h uint64, key string) uint32 {
 	id := e.internLoad
@@ -550,16 +550,22 @@ func (e *encState) installInternSlot(slot *internSlot, h uint64, key string) uin
 	slot.id = id
 	e.internLoad++
 	e.lruAddFresh(id)
-	if e.internLoad*2 >= uint32(len(e.internTable)) {
+	// Grow at 3/4 load, not 1/2. A denser table is smaller (better cache)
+	// and rehashes less often; with the well-distributed maphash the longer
+	// linear-probe chains cost less than the cache + rehash savings.
+	// Measured -12.6% encode on the large-payload Archive profile (thousands
+	// of interned strings), neutral on small/medium payloads, wire unchanged.
+	if e.internLoad*4 >= uint32(len(e.internTable))*3 {
 		e.internTableGrow()
 	}
 	return id
 }
 
 // internTableGrow doubles the flat hash table and rehashes every
-// occupied slot. Called from lookupOrAssign when the load factor
-// reaches 0.5, so amortised insert cost stays O(1) and the typical
-// probe chain remains short (≤ 2 hops).
+// occupied slot. Called from installInternSlot when the load factor
+// reaches 3/4. Amortised insert stays O(1); the denser table trades
+// slightly longer probe chains for fewer rehashes and a smaller cache
+// footprint (a net encode win on large, intern-heavy payloads).
 func (e *encState) internTableGrow() {
 	old := e.internTable
 	newSize := len(old) * 2


### PR DESCRIPTION
## Summary

One-constant change to the encoder's open-addressed intern table: grow it when
it crosses **3/4** full instead of **1/2** (`internLoad*2 >= len` →
`internLoad*4 >= len*3`).

A denser table is smaller (better cache behaviour) and rehashes/doubles less
often. With the well-distributed `maphash` the slightly longer linear-probe
chains cost less than the cache + rehash savings, so it is a net win on
intern-heavy encodes — and the smaller backing array also slashes allocations.

## Wire-format impact

- [x] None. Intern IDs and emission order are unchanged, so the encoded bytes
      are byte-identical. Golden and corpus-size tests pass unmodified.

## Bench evidence

Interleaved benchstat, n=10, `-benchtime=2s`, i7-9750H, vs current `main`:

| benchmark | sec/op | B/op |
| --------- | -----: | ---: |
| `Profile_Archive/encode/qdf` | **−17.1%** (p=0.000) | **−69%** (1483→457 KiB) |
| `LargePayload_Encode/qdf_fast` | −8.9% (p=0.000) | — |
| `LargePayload_Encode/qdf_qpack` | −2.7% (p=0.035) | — |
| `LargePayload_Encode/qdf_dense` | −2.6% (p=0.004) | −8.7% B/op |

The change is **encode-side only** (`encState.installInternSlot`); decode uses
a separate `decState` and is untouched. A small decode move seen in one run is
cross-session runner variance (third-party json/msgpack decode drifted the
same way).

## Checklist

- [x] `go test -race -count=1 ./...` passes.
- [x] Golden fixtures unchanged (wire byte-identical).
- [x] `golangci-lint run ./...` (v2.12.2) — 0 issues.
- [x] Win re-verified on current `main` (numbers above), not just the original
      branch baseline.

## Linked issues

<!-- Closes #..., Refs #... -->
