### PR TITLE
qpack: AVX2 VPSLLVQ encode for FOR widths 10/12/14/20

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,7 +694,7 @@ QPack codecs, and a 128-bit sliding-window bit-unpacker for FOR / Delta+FOR.
 | Tag             | Effect                                                                                                  | Build prerequisite |
 | --------------- | ------------------------------------------------------------------------------------------------------- | ------------------ |
 | `qdf_reflect2`  | Swap `reflect.MakeSlice` / `MakeMapWithSize` for `modern-go/reflect2` unsafe equivalents. Smaller decode allocations on map / slice heavy workloads. | none — pure Go     |
-| `qdf_simd`      | AVX2 fast paths for the QPack integer/bool codecs: decode at bits ∈ {8,16,32} (`VPMOVZX`) and every width 1–28 (`VPBROADCASTQ`+`VPSRLVQ`), encode at {8,16,32} (`VPSHUFB`), `[]bool` pack. ~3-11× over the pure-Go path on those widths. Output byte-identical to scalar. Runtime CPUID gate via `golang.org/x/sys/cpu`; older amd64 without AVX2 falls back transparently; non-amd64 targets compile a stub. See `docs/USAGE.md` for when to use it. | amd64; AVX2 detected at run time |
+| `qdf_simd`      | AVX2 fast paths for the QPack integer/bool codecs: decode at bits ∈ {8,16,32} (`VPMOVZX`) and every width 1–28 (`VPBROADCASTQ`+`VPSRLVQ`), encode at {8,16,32} (`VPSHUFB`) and {10,12,14,20} (`VPSLLVQ`+lane-OR), `[]bool` pack. ~3-11× over the pure-Go path on those widths. Output byte-identical to scalar. Runtime CPUID gate via `golang.org/x/sys/cpu`; older amd64 without AVX2 falls back transparently; non-amd64 targets compile a stub. See `docs/USAGE.md` for when to use it. | amd64; AVX2 detected at run time |
 
 ```bash
 go build -tags qdf_reflect2 ./...

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -590,8 +590,10 @@ inner loops, both directions:
   `b ≤ 14` (`7 + 4·14 < 64`), 2 values/iter for `15 ≤ b ≤ 28`
   (`7 + 2·28 < 64`). Fixed-shift kernels handle the hot `{10,12,14,20}`.
   Widths 29–31 and 33–56 stay on the scalar window.
-- **Encode** (`VPSHUFB` byte-gather) at `{8, 16, 32}` — the mirror of
-  the decode fast path.
+- **Encode** at `{8, 16, 32}` (`VPSHUFB` byte-gather) and `{10,12,14,20}`
+  (`VPSLLVQ` shifts each value to its slot, then a lane-OR reduction folds
+  the group into one byte-aligned chunk). Odd / wider encode widths stay
+  scalar (they would need cross-chunk byte merging).
 - `[]bool` pack (`VPSLLW` + `VPMOVMSKB`).
 
 Widths not listed (odd widths, ≥ ~24 non-aligned) and the float
@@ -805,7 +807,7 @@ payloads.
 
 | Tag             | Effect                                                                                                                                                                                                                                                                                | Platform                              |
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| `qdf_simd`      | AVX2 for the QPack integer/bool codecs: decode at every `bits ∈ 1..28` plus `32`, encode at `{8,16,32}`, `[]bool` pack. Output byte-identical to scalar. Runtime CPUID gate; non-AVX2 amd64 falls back transparently; other arches compile a stub. See docs/USAGE.md for when to use it. | amd64; AVX2 detected at run time      |
+| `qdf_simd`      | AVX2 for the QPack integer/bool codecs: decode at every `bits ∈ 1..28` plus `32`, encode at `{8,10,12,14,16,20,32}`, `[]bool` pack. Output byte-identical to scalar. Runtime CPUID gate; non-AVX2 amd64 falls back transparently; other arches compile a stub. See docs/USAGE.md for when to use it. | amd64; AVX2 detected at run time      |
 | `qdf_reflect2`  | Swap `reflect.MakeSlice` / `MakeMapWithSize` / `reflect.New` for `modern-go/reflect2` unsafe equivalents.                                                                                                                                                                             | none — pure Go                        |
 
 Combine freely:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -257,6 +257,7 @@ Only the QPack codecs that pack fixed-width integers and booleans:
 | Integer **decode** (FOR) | 1–14 (4 values/iter, `VPSRLVQ`) | ~7–11× |
 | Integer **decode** (FOR) | 15–28 (2 values/iter, `VPSRLVQ`) | ~5–7× |
 | Integer **encode** (FOR) | 8, 16, 32 (`VPSHUFB`) | ~2–5× |
+| Integer **encode** (FOR) | 10, 12, 14, 20 (`VPSLLVQ` + lane-OR) | ~4–5.5× |
 | `[]bool` pack | — | large |
 
 Decode is the most broadly accelerated: every bit width from 1 to 28 (plus

--- a/qpack_for.go
+++ b/qpack_for.go
@@ -224,12 +224,28 @@ func bitPackChunkInto(out []byte, vals []uint64, bitsPer int, elemOff int) {
 	// store with no cross-byte accumulator. These dedicated packers mirror
 	// the byte-aligned unpack fast paths and get a SIMD variant under
 	// qdf_simd.
+	// elemOff is always a multiple of the 64-element chunk size, so bitOff
+	// is byte-aligned for every width below (64*b is a multiple of 8). The
+	// dedicated packers write whole-byte chunks with a SIMD variant under
+	// qdf_simd; 10/12/14/20 use VPSLLVQ + lane-OR, 8/16/32 use VPSHUFB.
 	switch bitsPer {
 	case 8:
 		packBits8(out[bitOff>>3:], vals)
 		return
+	case 10:
+		packBits10(out[bitOff>>3:], vals)
+		return
+	case 12:
+		packBits12(out[bitOff>>3:], vals)
+		return
+	case 14:
+		packBits14(out[bitOff>>3:], vals)
+		return
 	case 16:
 		packBits16(out[bitOff>>3:], vals)
+		return
+	case 20:
+		packBits20(out[bitOff>>3:], vals)
 		return
 	case 32:
 		packBits32(out[bitOff>>3:], vals)

--- a/qpack_pack12_test.go
+++ b/qpack_pack12_test.go
@@ -1,0 +1,62 @@
+package qdf
+
+import (
+	"bytes"
+	"testing"
+)
+
+func dispatchPack(out []byte, vals []uint64, bitsPer int) {
+	switch bitsPer {
+	case 10:
+		packBits10(out, vals)
+	case 12:
+		packBits12(out, vals)
+	case 14:
+		packBits14(out, vals)
+	case 20:
+		packBits20(out, vals)
+	default:
+		bitPackU64LE(out, vals, bitsPer)
+	}
+}
+
+// TestPackVarWidth_MatchesReference checks each VPSLLVQ-specialized encode
+// width against the scalar accumulator packer, byte-for-byte.
+func TestPackVarWidth_MatchesReference(t *testing.T) {
+	widths := []int{10, 12, 14, 20}
+	sizes := []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 64, 100, 257, 1000}
+	for _, b := range widths {
+		mask := uint64(1)<<uint(b) - 1
+		for _, n := range sizes {
+			vals := make([]uint64, n)
+			for i := range vals {
+				vals[i] = uint64(i*2654435761+11) & mask
+			}
+			got := make([]byte, (n*b+7)/8)
+			dispatchPack(got, vals, b)
+			want := make([]byte, (n*b+7)/8)
+			bitPackU64LE(want, vals, b)
+			if !bytes.Equal(got, want) {
+				t.Fatalf("b=%d n=%d: packBits mismatch\n got=%v\nwant=%v", b, n, got, want)
+			}
+		}
+	}
+}
+
+func benchPackWidth(b *testing.B, bitsPer int) {
+	vals := make([]uint64, 1024)
+	mask := uint64(1)<<uint(bitsPer) - 1
+	for i := range vals {
+		vals[i] = uint64(i*2654435761+11) & mask
+	}
+	out := make([]byte, (1024*bitsPer+7)/8)
+	b.SetBytes(1024 * 8)
+	for b.Loop() {
+		dispatchPack(out, vals, bitsPer)
+	}
+}
+
+func BenchmarkPackWidth10(b *testing.B) { benchPackWidth(b, 10) }
+func BenchmarkPackWidth12(b *testing.B) { benchPackWidth(b, 12) }
+func BenchmarkPackWidth14(b *testing.B) { benchPackWidth(b, 14) }
+func BenchmarkPackWidth20(b *testing.B) { benchPackWidth(b, 20) }

--- a/qpack_simd_amd64.go
+++ b/qpack_simd_amd64.go
@@ -29,6 +29,81 @@ func packBoolsAVX2Block32(out []byte, in []bool, blocks int)
 func packBits8AVX2(out []byte, vals []uint64, n int)
 
 //go:noescape
+func packBits12AVX2(out []byte, vals []uint64, groups int)
+
+//go:noescape
+func packBits10AVX2(out []byte, vals []uint64, groups int)
+
+//go:noescape
+func packBits14AVX2(out []byte, vals []uint64, groups int)
+
+//go:noescape
+func packBits20AVX2(out []byte, vals []uint64, pairs int)
+
+// packBits10 packs width-10 values, 4 per byte-aligned 40-bit chunk (5
+// bytes); trailing values use the scalar accumulator on a byte boundary.
+func packBits10(out []byte, vals []uint64) {
+	n := len(vals)
+	groups := 0
+	if hasAVX2 {
+		groups = n / 4
+		if groups > 0 {
+			packBits10AVX2(out, vals, groups)
+		}
+	}
+	if done := 4 * groups; done < n {
+		bitPackU64LE(out[5*groups:], vals[done:], 10)
+	}
+}
+
+// packBits14 packs width-14 values, 4 per byte-aligned 56-bit chunk (7 bytes).
+func packBits14(out []byte, vals []uint64) {
+	n := len(vals)
+	groups := 0
+	if hasAVX2 {
+		groups = n / 4
+		if groups > 0 {
+			packBits14AVX2(out, vals, groups)
+		}
+	}
+	if done := 4 * groups; done < n {
+		bitPackU64LE(out[7*groups:], vals[done:], 14)
+	}
+}
+
+// packBits20 packs width-20 values, 2 per byte-aligned 40-bit chunk (5 bytes).
+func packBits20(out []byte, vals []uint64) {
+	n := len(vals)
+	pairs := 0
+	if hasAVX2 {
+		pairs = n / 2
+		if pairs > 0 {
+			packBits20AVX2(out, vals, pairs)
+		}
+	}
+	if done := 2 * pairs; done < n {
+		bitPackU64LE(out[5*pairs:], vals[done:], 20)
+	}
+}
+
+// packBits12 packs width-12 values, 4 per byte-aligned 48-bit chunk (6
+// bytes) via VPSLLVQ + lane OR; trailing values use the scalar accumulator
+// on a byte boundary (4 values = 6 bytes).
+func packBits12(out []byte, vals []uint64) {
+	n := len(vals)
+	groups := 0
+	if hasAVX2 {
+		groups = n / 4
+		if groups > 0 {
+			packBits12AVX2(out, vals, groups)
+		}
+	}
+	if done := 4 * groups; done < n {
+		bitPackU64LE(out[6*groups:], vals[done:], 12)
+	}
+}
+
+//go:noescape
 func packBits16AVX2(out []byte, vals []uint64, n int)
 
 //go:noescape

--- a/qpack_simd_amd64.s
+++ b/qpack_simd_amd64.s
@@ -524,3 +524,177 @@ loop_vw:
 done_vw:
 	VZEROUPPER
 	RET
+
+// shift12pk/mask12pk: encode width-12 — four values per byte-aligned 48-bit
+// chunk (6 bytes) at offsets 0,12,24,36.
+DATA shift12pk<>+0(SB)/8,  $0x0000000000000000
+DATA shift12pk<>+8(SB)/8,  $0x000000000000000C
+DATA shift12pk<>+16(SB)/8, $0x0000000000000018
+DATA shift12pk<>+24(SB)/8, $0x0000000000000024
+GLOBL shift12pk<>(SB), RODATA|NOPTR, $32
+DATA mask12pk<>+0(SB)/8,  $0x0000000000000FFF
+DATA mask12pk<>+8(SB)/8,  $0x0000000000000FFF
+DATA mask12pk<>+16(SB)/8, $0x0000000000000FFF
+DATA mask12pk<>+24(SB)/8, $0x0000000000000FFF
+GLOBL mask12pk<>(SB), RODATA|NOPTR, $32
+
+// func packBits12AVX2(out []byte, vals []uint64, groups int)
+//
+// Packs `groups` chunks of four 12-bit values into byte-aligned 48-bit
+// chunks. Each group loads four uint64s, masks to 12 bits, VPSLLVQ by
+// 0/12/24/36, ORs the four lanes into one 48-bit word, and writes 6 bytes.
+// Caller guarantees len(out) >= 6*groups, len(vals) >= 4*groups, AVX2.
+TEXT ·packBits12AVX2(SB), NOSPLIT, $0-56
+	MOVQ    out_base+0(FP), DI
+	MOVQ    vals_base+24(FP), SI
+	MOVQ    groups+48(FP), CX
+	VMOVDQU shift12pk<>(SB), Y1
+	VMOVDQU mask12pk<>(SB), Y2
+
+loop_e12:
+	TESTQ        CX, CX
+	JZ           done_e12
+	VMOVDQU      (SI), Y0
+	VPAND        Y2, Y0, Y0
+	VPSLLVQ      Y1, Y0, Y0
+	VEXTRACTI128 $1, Y0, X3
+	VPOR         X3, X0, X0
+	VMOVQ        X0, AX
+	VPEXTRQ      $1, X0, DX
+	ORQ          DX, AX
+	MOVL         AX, (DI)
+	SHRQ         $32, AX
+	MOVW         AX, 4(DI)
+	ADDQ         $32, SI
+	ADDQ         $6, DI
+	DECQ         CX
+	JMP          loop_e12
+
+done_e12:
+	VZEROUPPER
+	RET
+
+// encode width-10: four values per byte-aligned 40-bit chunk (5 bytes).
+DATA shift10pk<>+0(SB)/8,  $0x0000000000000000
+DATA shift10pk<>+8(SB)/8,  $0x000000000000000A
+DATA shift10pk<>+16(SB)/8, $0x0000000000000014
+DATA shift10pk<>+24(SB)/8, $0x000000000000001E
+GLOBL shift10pk<>(SB), RODATA|NOPTR, $32
+DATA mask10pk<>+0(SB)/8,  $0x00000000000003FF
+DATA mask10pk<>+8(SB)/8,  $0x00000000000003FF
+DATA mask10pk<>+16(SB)/8, $0x00000000000003FF
+DATA mask10pk<>+24(SB)/8, $0x00000000000003FF
+GLOBL mask10pk<>(SB), RODATA|NOPTR, $32
+
+// func packBits10AVX2(out []byte, vals []uint64, groups int)
+TEXT ·packBits10AVX2(SB), NOSPLIT, $0-56
+	MOVQ    out_base+0(FP), DI
+	MOVQ    vals_base+24(FP), SI
+	MOVQ    groups+48(FP), CX
+	VMOVDQU shift10pk<>(SB), Y1
+	VMOVDQU mask10pk<>(SB), Y2
+
+loop_e10:
+	TESTQ        CX, CX
+	JZ           done_e10
+	VMOVDQU      (SI), Y0
+	VPAND        Y2, Y0, Y0
+	VPSLLVQ      Y1, Y0, Y0
+	VEXTRACTI128 $1, Y0, X3
+	VPOR         X3, X0, X0
+	VMOVQ        X0, AX
+	VPEXTRQ      $1, X0, DX
+	ORQ          DX, AX
+	MOVL         AX, (DI)
+	SHRQ         $32, AX
+	MOVB         AL, 4(DI)
+	ADDQ         $32, SI
+	ADDQ         $5, DI
+	DECQ         CX
+	JMP          loop_e10
+
+done_e10:
+	VZEROUPPER
+	RET
+
+// encode width-14: four values per byte-aligned 56-bit chunk (7 bytes).
+DATA shift14pk<>+0(SB)/8,  $0x0000000000000000
+DATA shift14pk<>+8(SB)/8,  $0x000000000000000E
+DATA shift14pk<>+16(SB)/8, $0x000000000000001C
+DATA shift14pk<>+24(SB)/8, $0x000000000000002A
+GLOBL shift14pk<>(SB), RODATA|NOPTR, $32
+DATA mask14pk<>+0(SB)/8,  $0x0000000000003FFF
+DATA mask14pk<>+8(SB)/8,  $0x0000000000003FFF
+DATA mask14pk<>+16(SB)/8, $0x0000000000003FFF
+DATA mask14pk<>+24(SB)/8, $0x0000000000003FFF
+GLOBL mask14pk<>(SB), RODATA|NOPTR, $32
+
+// func packBits14AVX2(out []byte, vals []uint64, groups int)
+TEXT ·packBits14AVX2(SB), NOSPLIT, $0-56
+	MOVQ    out_base+0(FP), DI
+	MOVQ    vals_base+24(FP), SI
+	MOVQ    groups+48(FP), CX
+	VMOVDQU shift14pk<>(SB), Y1
+	VMOVDQU mask14pk<>(SB), Y2
+
+loop_e14:
+	TESTQ        CX, CX
+	JZ           done_e14
+	VMOVDQU      (SI), Y0
+	VPAND        Y2, Y0, Y0
+	VPSLLVQ      Y1, Y0, Y0
+	VEXTRACTI128 $1, Y0, X3
+	VPOR         X3, X0, X0
+	VMOVQ        X0, AX
+	VPEXTRQ      $1, X0, DX
+	ORQ          DX, AX
+	MOVL         AX, (DI)
+	SHRQ         $32, AX
+	MOVW         AX, 4(DI)
+	SHRQ         $16, AX
+	MOVB         AL, 6(DI)
+	ADDQ         $32, SI
+	ADDQ         $7, DI
+	DECQ         CX
+	JMP          loop_e14
+
+done_e14:
+	VZEROUPPER
+	RET
+
+// encode width-20: two values per byte-aligned 40-bit chunk (5 bytes).
+DATA shift20pk<>+0(SB)/8, $0x0000000000000000
+DATA shift20pk<>+8(SB)/8, $0x0000000000000014
+GLOBL shift20pk<>(SB), RODATA|NOPTR, $16
+DATA mask20pk<>+0(SB)/8, $0x00000000000FFFFF
+DATA mask20pk<>+8(SB)/8, $0x00000000000FFFFF
+GLOBL mask20pk<>(SB), RODATA|NOPTR, $16
+
+// func packBits20AVX2(out []byte, vals []uint64, pairs int)
+TEXT ·packBits20AVX2(SB), NOSPLIT, $0-56
+	MOVQ    out_base+0(FP), DI
+	MOVQ    vals_base+24(FP), SI
+	MOVQ    pairs+48(FP), CX
+	VMOVDQU shift20pk<>(SB), X1
+	VMOVDQU mask20pk<>(SB), X2
+
+loop_e20:
+	TESTQ   CX, CX
+	JZ      done_e20
+	VMOVDQU (SI), X0
+	VPAND   X2, X0, X0
+	VPSLLVQ X1, X0, X0
+	VMOVQ   X0, AX
+	VPEXTRQ $1, X0, DX
+	ORQ     DX, AX
+	MOVL    AX, (DI)
+	SHRQ    $32, AX
+	MOVB    AL, 4(DI)
+	ADDQ    $16, SI
+	ADDQ    $5, DI
+	DECQ    CX
+	JMP     loop_e20
+
+done_e20:
+	VZEROUPPER
+	RET

--- a/qpack_simd_stub.go
+++ b/qpack_simd_stub.go
@@ -47,6 +47,12 @@ func packBits32(out []byte, vals []uint64) {
 	}
 }
 
+// packBits10/12/14/20 fallbacks: scalar accumulator packer.
+func packBits10(out []byte, vals []uint64) { bitPackU64LE(out, vals, 10) }
+func packBits12(out []byte, vals []uint64) { bitPackU64LE(out, vals, 12) }
+func packBits14(out []byte, vals []uint64) { bitPackU64LE(out, vals, 14) }
+func packBits20(out []byte, vals []uint64) { bitPackU64LE(out, vals, 20) }
+
 // unpackBitsVar / unpackBitsVarWide fallbacks: scalar sliding window.
 func unpackBitsVar(out []uint64, in []byte, bitsPer int) {
 	bitUnpackU64LEFast(out, in, bitsPer)


### PR DESCRIPTION
## Summary

Extends SIMD FOR **encode** past the byte-aligned 8/16/32 (`VPSHUFB`) set to
the common non-byte-aligned widths. For 10/12/14/20 a small group of values
forms a byte-aligned chunk that fits a single 64-bit word, so the group can be
packed branch-free:

- mask each value to `b` bits,
- `VPSLLVQ` shift each value to its slot (`0, b, 2b, 3b`),
- fold the lanes into one chunk word (`VEXTRACTI128` + `VPOR` + a scalar OR),
- write the exact chunk bytes.

4 values/group for 10/12/14 (40/48/56-bit chunks), 2 for 20 (40-bit).
Trailing values use the scalar accumulator on a byte boundary.
`bitPackChunkInto` dispatches 10/12/14/20 to the new packers.

Odd and wider encode widths stay scalar — they would need cross-chunk byte
merging (a value straddling two output chunks), which the byte-aligned-chunk
widths avoid by construction.

Encode-only; decoder and wire format untouched; output **bit-identical** to
the scalar packer.

## Wire-format impact

- [x] None. Encode-speed change only; the emitted bytes are identical.

## Bench evidence

Microbench, 1024 elements, `-count=5`, i7-9750H. Scalar → AVX2:

| width | scalar | AVX2 | speedup |
| ----: | -----: | ---: | ------- |
| 10    | ~2070  | ~460 | ~4.5×   |
| 12    | ~1850  | ~440 | ~4.2×   |
| 14    | ~2240  | ~405 | ~5.5×   |
| 20    | ~3270  | ~660 | ~5.0×   |

## Checklist

- [x] `go test -race -count=1 ./...` (default) passes.
- [x] `GOEXPERIMENT=simd go test -tags qdf_simd -race -count=1 .` passes.
- [x] Parity tests (widths 10/12/14/20 vs the scalar accumulator packer) pass
      under both build configs across many sizes.
- [x] Golden fixtures unchanged (encode output bit-identical).
- [x] `golangci-lint run ./...` (v2.12.2) — 0 issues.
- [x] Docs (USAGE/GUIDE/README) updated.

## Notes / scoped-but-not-done

Odd encode widths (9/11/13) and wide non-aligned (15–28) need cross-chunk byte
merging — left scalar for now. AVX-512 VBMI remains a separate future lever.

## Linked issues

<!-- Closes #..., Refs #... -->
