### PR TITLE
ci: raise bench-trend alert threshold to 200%

### DIFF
--- a/.github/workflows/bench-trend.yml
+++ b/.github/workflows/bench-trend.yml
@@ -83,7 +83,7 @@ jobs:
           benchmark-data-dir-path: dev/bench
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
-          alert-threshold: "150%"
+          alert-threshold: "200%"
           comment-on-alert: false
           fail-on-alert: false
 
@@ -116,7 +116,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: false
           save-data-file: false
-          alert-threshold: "150%"
+          alert-threshold: "200%"
           comment-on-alert: true
           fail-on-alert: false
           summary-always: true


### PR DESCRIPTION
Shared GitHub runners vary ~1.5-1.6x run-to-run (uniform across all benchmarks, including the third-party json/msgpack ones the repo does not touch), so a 150% threshold fired comment-only false alerts on nearly every push. Raise to 200%. Single-shot cross-runner comparison cannot reliably detect sub-2x regressions anyway — the trend dashboard is the real signal; the alert is just a coarse comment-only tripwire for gross regressions.

<!-- Thanks for opening a PR against qdf. -->

## Summary

<!-- 1-3 sentences. What does this change do and why? -->

## Wire-format impact

<!-- Tick exactly one. -->

- [ ] Wire-compatible. Existing buffers still decode; new buffers
      still decode through older readers that ignore unknown tags.
- [ ] Adds a new tag. Old decoders will surface `ErrBadTag` rather
      than mis-decoding. Tag value chosen from the reserved range
      documented in `wire.go`.
- [ ] Breaks the wire. Requires a version bump in `Version1` /
      header byte. Migration plan: <describe>.

## Checklist

- [ ] `go test -race -count=1 ./...` passes locally.
- [ ] Relevant `-tags qdf_simd` and `-tags qdf_reflect2` builds tested
      (skip if change does not touch the affected paths).
- [ ] Golden fixtures regenerated (`go test -run TestGolden -update`)
      if the change is intentional.
- [ ] Bench numbers refreshed in `docs/BENCH.md` if the hot path
      changed measurably.
- [ ] Fuzz corpus + property fuzzers run for ≥30 s if the decoder
      surface area changed.
- [ ] README or `docs/BENCH.md` updated for any user-facing API
      change.

## Linked issues

<!-- Closes #..., Refs #... -->
