### PR TITLE
qpack: Patched Frame-of-Reference (PFOR) integer codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,11 @@ Tag space is msgpack-inspired with a few additions:
 | `0xEB`               | QPack: run-length encoded integer slice       |
 | `0xEC`               | Dense: struct/map shape declare / reuse       |
 | `0xED`               | QPack: dictionary-coded integer slice         |
+| `0xEE`               | QPack: Patched FOR integer slice (outliers)   |
 | `0xEF`               | QPack: columnar `[]struct` container          |
 | `0xF0..0xF3`         | ext / timestamp                               |
 | `0xF4`               | QPack: ALP decimal-coded `[]float64` slice    |
-| `0xEE`, `0xF5..0xFF` | reserved (rANS, n-gram graph, future)         |
+| `0xF5..0xFF`         | reserved (rANS, n-gram graph, future)         |
 
 The 5th header byte holds two flag bits: `FlagDense` (`0x01`) for the
 intern dialect, and `FlagQPack` (`0x02`) as an early hint that the body
@@ -387,6 +388,7 @@ floats).
 | Raw-LE     | numeric slice, large delta range                   | Unsafe-slice cast → single `memmove` of LE bytes. 10-50× faster.      |
 | FOR        | numeric slice, clustered values                    | Frame-of-Reference: store `min` and `ceil(log₂(max-min+1))`-bit deltas.|
 | Delta+FOR  | monotonic / near-monotonic integers                | Δᵢ = aᵢ - aᵢ₋₁, zigzag bias, FOR over the deltas.                     |
+| Patched FOR| integer slice with rare outliers (latency spikes)  | FOR body at a reduced width `b` + an exception list for the few values that don't fit. ~50% smaller than FOR on spiky columns. |
 | Gorilla    | float slices (explicit opt-in via low-level API)   | XOR with previous, run-length leading/meaningful-bit window. (Facebook VLDB 2015.) |
 
 Head-to-head on a mixed 256-bool / 512-monotonic-u64 / 512-i64 / 256-f64

--- a/bench/corpus_codec_test.go
+++ b/bench/corpus_codec_test.go
@@ -232,6 +232,29 @@ func mkMetricQuantColumn(n int) metricQuantColumn {
 	return metricQuantColumn{Name: "billing.amount.usd", Values: v}
 }
 
+// latencySpikesColumn is the shape PFOR was built for: a latency column of
+// mostly sub-millisecond values (microseconds) with a rare ~1% tail of large
+// spikes (slow requests, GC pauses, lock contention). The spikes force plain
+// FOR to a wide bit count for every slot; PFOR packs the common case narrow
+// and patches the few outliers from an exception list.
+type latencySpikesColumn struct {
+	Name   string   `qdf:"name"   json:"name"   msgpack:"name"`
+	Values []uint64 `qdf:"values" json:"values" msgpack:"values"`
+}
+
+func mkLatencySpikesColumn(n int) latencySpikesColumn {
+	rnd := rand.New(rand.NewSource(909))
+	v := make([]uint64, n)
+	for i := range v {
+		if rnd.Intn(1000) < 10 { // ~1% spikes
+			v[i] = 50_000 + uint64(rnd.Intn(950_000)) // 50ms..1s in us
+		} else {
+			v[i] = uint64(rnd.Intn(500)) // sub-millisecond
+		}
+	}
+	return latencySpikesColumn{Name: "http.request.latency.us", Values: v}
+}
+
 // TestCorpusCodec_Sizes prints a wire-size table covering the new
 // corpus across OptSpeed / OptBalanced / OptCompression. Run with
 // `go test -C bench -run TestCorpusCodec_Sizes -v` and copy the
@@ -249,6 +272,7 @@ func TestCorpusCodec_Sizes(t *testing.T) {
 		{"metric_quant_1024", mkMetricQuantColumn(1024)},
 		{"status_1024", mkStatusBatch(1024)},
 		{"spread_enum_1024", mkSpreadEnumColumn(1024)},
+		{"latency_spikes_1024", mkLatencySpikesColumn(1024)},
 		{"logentries_1024", logEntriesBatch(1024)},
 		{"events_1024", eventsBatch(1024)},
 	}
@@ -290,6 +314,31 @@ func TestALPCorpusSizes(t *testing.T) {
 	// stays <= Balanced (ALP either wins or is not chosen).
 	if len(sComp) > len(sBal) {
 		t.Errorf("smooth: OptCompression (%d B) regressed past OptBalanced (%d B)", len(sComp), len(sBal))
+	}
+}
+
+// TestPForCorpusSize asserts PFOR crushes the outlier-heavy latency column.
+// A 1024-sample column whose common case is sub-millisecond but whose 1% tail
+// spikes to ~1s forces plain FOR to ~20 bits/value (raw ≈ 8 KB, FOR ≈ 2.5 KB).
+// PFOR packs the common case at ~9 bits and patches the spikes, landing well
+// under the FOR size.
+func TestPForCorpusSize(t *testing.T) {
+	col := mkLatencySpikesColumn(1024)
+	qBal, _ := qdf.Marshal(col, qdf.OptBalanced)
+	// FOR would need ~20 bits * 1024 / 8 ≈ 2560 B for the body alone; PFOR
+	// must land comfortably below that (it measured ≈ 1.2 KB).
+	if len(qBal) > 1800 {
+		t.Errorf("latency_spikes: OptBalanced size %d B larger than expected (PFOR likely not chosen)", len(qBal))
+	}
+	// Round-trips.
+	var got latencySpikesColumn
+	if err := qdf.Unmarshal(qBal, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for i := range col.Values {
+		if got.Values[i] != col.Values[i] {
+			t.Fatalf("round-trip mismatch at %d", i)
+		}
 	}
 }
 

--- a/decoder.go
+++ b/decoder.go
@@ -1186,6 +1186,63 @@ func (d *Decoder) Skip() error {
 		}
 		d.i += int((n64*uint64(bp) + 7) / 8)
 		return nil
+	case tagPackPFor:
+		d.i++
+		if d.i >= len(d.buf) {
+			return ErrShortBuffer
+		}
+		k := d.buf[d.i]
+		d.i++
+		if k != qpackKindUint64 && k != qpackKindInt64 {
+			return ErrBadTag
+		}
+		n64, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += nr
+		if d.i >= len(d.buf) {
+			return ErrShortBuffer
+		}
+		b := int(d.buf[d.i])
+		d.i++
+		if b > qpackForMaxBits {
+			return ErrBadTag
+		}
+		// min varuint
+		if _, nr := readUvarint(d.buf[d.i:]); nr <= 0 {
+			return ErrInvalidLength
+		} else {
+			d.i += nr
+		}
+		// body: n*b bits
+		rem := uint64(len(d.buf) - d.i)
+		if b > 0 && n64 > rem*8/uint64(b) {
+			return ErrShortBuffer
+		}
+		d.i += int((n64*uint64(b) + 7) / 8)
+		// exception list: excN pairs of (dPos, delta) varuints
+		excN64, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += nr
+		if excN64 > n64 {
+			return ErrInvalidLength
+		}
+		for range excN64 {
+			if _, nr := readUvarint(d.buf[d.i:]); nr <= 0 {
+				return ErrInvalidLength
+			} else {
+				d.i += nr
+			}
+			if _, nr := readUvarint(d.buf[d.i:]); nr <= 0 {
+				return ErrInvalidLength
+			} else {
+				d.i += nr
+			}
+		}
+		return nil
 	}
 	return ErrBadTag
 }

--- a/docs/BENCH.md
+++ b/docs/BENCH.md
@@ -9,8 +9,8 @@ Operating modes compared:
   paths for common slice (`[]string`, `[]int*`, `[]uint*`,
   `[]float32/64`, `[]bool`) and map types.
 - **qdf_qpack** — Fast mode + QPack codecs (bit-packed bool, raw-LE,
-  Frame-of-Reference, Delta+FOR, RLE, dictionary for numeric/bool
-  slices; Gorilla XOR and ALP decimal for float64 under
+  Frame-of-Reference, Delta+FOR, RLE, dictionary, Patched FOR for
+  numeric/bool slices; Gorilla XOR and ALP decimal for float64 under
   `OptCompression`). Auto-selects the smallest predicted form per
   slice.
 - **qdf_dense** — qdf_qpack + inline state-table interning for
@@ -227,10 +227,10 @@ Payload: 256 booleans, 512 monotonic `uint64` (timestamps), 512 `int64`,
 
 QPack auto-selects, per slice, by predicted wire size: bit-packed
 bool, raw-LE bulk, Frame-of-Reference + bit-pack, Delta + zigzag +
-FOR, run-length, and a low-cardinality dictionary codec for integer
-slices. Float slices add two codecs under `OptCompression` — Gorilla
-XOR for smooth series and ALP decimal for quantized/decimal grids —
-picked against raw-LE only when strictly smaller, since their
+FOR, run-length, a low-cardinality dictionary codec, and Patched FOR
+for integer slices. Float slices add two codecs under `OptCompression`
+— Gorilla XOR for smooth series and ALP decimal for quantized/decimal
+grids — picked against raw-LE only when strictly smaller, since their
 bit-level work costs CPU that pays off only when size matters more.
 On a 2-decimal `metric_quant_1024` fixture ALP brings `OptCompression`
 to 2 592 B versus 8 238 B at `OptBalanced` (3.2× smaller).
@@ -238,6 +238,14 @@ to 2 592 B versus 8 238 B at `OptBalanced` (3.2× smaller).
 On a 1024-element monotonic Unix-second timestamp vector the Delta+FOR
 codec collapses the wire from 8 201 bytes (raw) to **16 bytes** —
 a 512× reduction.
+
+On a `latency_spikes_1024` fixture (sub-millisecond latencies with a
+~1 % tail of large spikes) Patched FOR packs the common case at 9 bits
+and patches the outliers from an exception list, landing at 1 215 B
+versus 2 566 B for plain FOR — **~53 % smaller**. Plain FOR loses here
+because the rare spikes force every slot to ~20 bits. The picker uses a
+conservative cost upper bound, so PFOR is chosen only when strictly
+smaller — clean columns keep FOR with a byte-identical wire.
 
 ## QPack micro-benchmarks (in-package, `qdf_simd` tag where noted)
 

--- a/docs/CHOOSING.md
+++ b/docs/CHOOSING.md
@@ -158,6 +158,28 @@ run-fraction probe over the first 32 elements and only commits to
 RLE if the win is real, so unrelated random `[]int` columns stay
 on raw / FOR without paying the estimator cost.
 
+### Latency / outlier-heavy int column
+
+A long `[]int`/`[]uint64` that is mostly small but carries a rare
+tail of large values — request latencies in microseconds with the
+occasional slow request, byte counters with the odd jumbo payload,
+counters that reset. The spikes are what kill plain Frame-of-Reference:
+a handful of large values force every slot to a wide bit count.
+
+**Recipe:** `qdf.OptQPack`
+
+```go
+b, err := qdf.Marshal(batch, qdf.OptQPack)
+```
+
+The picker evaluates Patched FOR (`tagPackPFor`): it packs the common
+case at a reduced bit width and stores the few outliers in an exception
+list. On a 1024-element latency column with ~1 % spikes this lands at
+**1 215 bytes** versus 2 566 for plain FOR (~53 % smaller). The PFOR
+cost estimate uses a conservative upper bound, so it is chosen only
+when strictly smaller than every other codec — a clean, tightly-ranged
+column keeps FOR and the wire is byte-identical.
+
 ### Embedding vector / dense float array
 
 Single `[]float32` or `[]float64` of 100s–1000s of elements. The
@@ -261,7 +283,7 @@ Compile-time switches, orthogonal to runtime `Options`. Build with
 
 | Tag           | What it does                                                          | When to use                                                   |
 | ------------- | --------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `qdf_simd`    | Compiles in AVX2 bit-unpack for FOR / Delta+FOR codecs (decode side). | amd64, large numeric payloads under `OptQPack` or `OptBalanced`. CPUID-gated at runtime — safe to ship even if the target doesn't have AVX2 (falls back to scalar). |
+| `qdf_simd`    | Compiles in AVX2/NEON bit-unpack shared by every bit-packed integer codec (FOR, Delta+FOR, dict, Patched FOR) on the decode side. | amd64 (AVX2, CPUID-gated) or arm64 (NEON, baseline), large numeric payloads under `OptQPack` or `OptBalanced`. Safe to ship even without AVX2 (falls back to scalar). |
 | `qdf_reflect2`| Swaps the reflect-based allocator for `github.com/modern-go/reflect2`. | Profile shows `reflect.MakeSlice` / `reflect.MakeMap` on the decode hot path. Otherwise leave off. |
 
 These tags affect linked binary contents (different SIMD code paths,

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -184,13 +184,14 @@ So far so msgpack-shaped. The qdf-specific tags start at 0xE0:
 0xEB  tagPackRLE        (QPack)   run-length encoded integer slice
 0xEC  tagMapShape       (Dense)   struct shape table reference
 0xED  tagPackDict       (QPack)   dictionary-coded integer slice
+0xEE  tagPackPFor       (QPack)   Patched FOR integer slice (rare outliers)
 0xEF  tagColStruct      (QPack)   columnar container for []struct; see below
 0xF0..0xF2  tagExt8/16/32         user-extension envelope
 0xF3        tagTimestamp          int64 ns since unix epoch
 0xF4  tagPackALP        (QPack)   ALP decimal-coded []float64 slice
 ```
 
-Tags 0xEE, 0xF5..0xFF are reserved.
+Tags 0xF5..0xFF are reserved.
 
 A `tagStateRef` payload is `varuint(id)`. A `tagStateMTF` payload is
 `varuint(rank)` where rank 0 means "most recently emitted". A
@@ -552,6 +553,7 @@ slice; the decoder reads the picked tag.
 0xE7  tagPackGorilla   []float64    Gorilla XOR coding
 0xEB  tagPackRLE       []intN       Run-length encoded (value, runLen) pairs
 0xED  tagPackDict      []intN       Dictionary-coded; ≤16 distinct values
+0xEE  tagPackPFor      []intN       Patched FOR: narrow body + outlier exceptions
 ```
 
 Selection logic:
@@ -566,7 +568,13 @@ Selection logic:
   probe over the first 32 elements decides whether to compute the
   full RLE size. For small distinct cardinality (≤ 16) with a wide
   spread where FOR can't pack tightly, the picker evaluates dict
-  (`tagPackDict`). The winning estimator wins.
+  (`tagPackDict`). For columns whose values are mostly small but carry
+  a rare tail of large outliers (latency spikes, counters with resets),
+  the picker evaluates Patched FOR (`tagPackPFor`): a FOR body at a
+  reduced width plus an exception list for the few values that don't
+  fit. Its size estimate uses a conservative upper bound on the
+  exception bytes, so it is chosen only when strictly smaller than every
+  other codec. The winning estimator wins.
 - **Float slice**: by default, raw. Gorilla is opt-in via
   `OptGorillaFloat` (bundled into `OptCompression`). When the bit is
   set, `pickF64Codec` probes the first 32 consecutive XOR pairs; if

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -148,6 +148,7 @@ time. You do not need to hint it — just set the bit.
 | `[]int64`/`[]uint64`, monotonic or time-series | Delta+FOR | `OptQPack` |
 | `[]intN`, run-heavy (status codes, enum-like, sparse counters) | RLE (value, runLen pairs) | `OptQPack` |
 | `[]intN`, small distinct cardinality (≤16), wide value range | Dictionary codec | `OptQPack` |
+| `[]intN`/`[]uintN`, mostly small with rare large outliers (latency spikes, counter resets) | Patched FOR (narrow body + exception list) | `OptQPack` |
 | `[]float64`/`[]float32`, smooth time-series | Gorilla XOR | `OptCompression` (or `OptGorillaFloat`) |
 | `[]float64`, quantized/decimal grid (prices, percentages, latencies) | ALP decimal (integer-mantissa FOR + exception list) | `OptCompression` |
 | Repeated strings / `[]byte` across messages | Intern table + state-ref | `OptDense` |
@@ -156,8 +157,8 @@ time. You do not need to hint it — just set the bit.
 | `[]SomeStruct` where fields are int/uint/float/bool/string/[]byte | Columnar transpose: numeric fields get FOR/delta/RLE/dict, repeated string fields collapse via intern. Automatic — no flag. The encoder probes each array and falls back to row-major when columnar would not win. | `OptBalanced` (Dense + ShapeIntern) |
 
 The encoder probes a slice's structure before committing. For
-integer slices it evaluates FOR, Delta+FOR, RLE, and dict by
-predicted wire size and picks the smallest. For `[]float64` under
+integer slices it evaluates FOR, Delta+FOR, RLE, dict, and Patched FOR
+by predicted wire size and picks the smallest. For `[]float64` under
 `OptCompression` it picks the smallest of raw-LE, a Gorilla XOR
 projection (32-sample probe), and an ALP decimal estimate; the ALP
 estimate is a conservative upper bound, so ALP is chosen only when it
@@ -167,7 +168,11 @@ FOR/Delta+FOR win on tight or monotonic integer ranges. RLE wins when
 a handful of distinct values repeat in long runs. Dict wins when the
 cardinality is small but values are spread wide (e.g. HTTP status
 codes 200/301/404/500 scattered randomly — no long runs, not a tight
-range). Gorilla wins on smooth sensor data; it loses on white noise.
+range). Patched FOR wins when the column is mostly small but a rare
+tail of large values would otherwise force FOR to a wide bit count —
+it packs the common case narrow and patches the outliers (≈50% smaller
+than FOR on a latency column with ~1% spikes). Gorilla wins on smooth
+sensor data; it loses on white noise.
 ALP wins on quantized/decimal streams (2-decimal metrics, prices,
 latencies) that sit on a fixed grid Gorilla cannot exploit.
 

--- a/qpack.go
+++ b/qpack.go
@@ -243,6 +243,7 @@ const (
 	qpackGorilla
 	qpackRLE
 	qpackDict
+	qpackPFor
 )
 
 // qpackDictMaxDistinct caps the dictionary codec: a slice with more

--- a/qpack.go
+++ b/qpack.go
@@ -50,7 +50,7 @@ func qpackRawWidthBytes(kind byte) int {
 // pickU64Codec analyses a []uint64 and decides which QPack codec yields
 // the smallest wire form. Cost of the scan is O(n) (min/max + delta
 // stats + RLE probe), which is dominated by the encode itself.
-func pickU64Codec(s []uint64) (codec qpackCodec, mn uint64, forBits int, first uint64, minDelta int64, deltaBits int) {
+func pickU64Codec(s []uint64) (codec qpackCodec, mn uint64, forBits int, first uint64, minDelta int64, deltaBits int, pforBits int) {
 	n := len(s)
 	codec = qpackRaw
 	if n == 0 {
@@ -117,9 +117,17 @@ func pickU64Codec(s []uint64) (codec qpackCodec, mn uint64, forBits int, first u
 		if count, ok := probeDistinctU64(s, &table); ok && count > 0 {
 			c := qpackDictSizeU64(table[:count], n)
 			if c < bestCost {
+				bestCost = c
 				codec = qpackDict
 			}
 		}
+	}
+	// PFOR: wins on outlier-heavy slices where plain FOR is forced wide by a
+	// few large values. Conservative cost estimate (maxDelta upper bound) keeps
+	// it never-worse: chosen only when strictly smaller than every other codec.
+	if pb, pc, okp := pforPlanUnsigned(s, mn, forBits); okp && pc < bestCost {
+		codec = qpackPFor
+		pforBits = pb
 	}
 	return
 }
@@ -168,7 +176,7 @@ func qpackRLESizeI64(s []int64, n int) int {
 	return hdr + body
 }
 
-func pickI64Codec(s []int64) (codec qpackCodec, mn int64, forBits int, first int64, minDelta int64, deltaBits int) {
+func pickI64Codec(s []int64) (codec qpackCodec, mn int64, forBits int, first int64, minDelta int64, deltaBits int, pforBits int) {
 	n := len(s)
 	codec = qpackRaw
 	if n == 0 {
@@ -226,9 +234,14 @@ func pickI64Codec(s []int64) (codec qpackCodec, mn int64, forBits int, first int
 		if count, ok := probeDistinctI64(s, &table); ok && count > 0 {
 			c := qpackDictSizeI64(table[:count], n)
 			if c < bestCost {
+				bestCost = c
 				codec = qpackDict
 			}
 		}
+	}
+	if pb, pc, okp := pforPlanSigned(s, mn, forBits); okp && pc < bestCost {
+		codec = qpackPFor
+		pforBits = pb
 	}
 	return
 }

--- a/qpack_dict_test.go
+++ b/qpack_dict_test.go
@@ -73,7 +73,7 @@ func TestDict_PickerHitsSpreadValues(t *testing.T) {
 	for i := range s {
 		s[i] = dictVals[i%4]
 	}
-	codec, _, _, _, _, _ := pickU64Codec(s)
+	codec, _, _, _, _, _, _ := pickU64Codec(s)
 	if codec != qpackDict {
 		t.Fatalf("u64 picker: got codec %d, want qpackDict (%d) on 4-distinct/wide-range input", codec, qpackDict)
 	}
@@ -83,7 +83,7 @@ func TestDict_PickerHitsSpreadValues(t *testing.T) {
 	for i := range si {
 		si[i] = dictI[i%4]
 	}
-	codec, _, _, _, _, _ = pickI64Codec(si)
+	codec, _, _, _, _, _, _ = pickI64Codec(si)
 	if codec != qpackDict {
 		t.Fatalf("i64 picker: got codec %d, want qpackDict (%d) on 4-distinct/wide-range input", codec, qpackDict)
 	}
@@ -96,7 +96,7 @@ func TestDict_PickerSkipsHighCardinality(t *testing.T) {
 	for i := range s {
 		s[i] = uint64(i * 113) // 64 unique values, well above cap
 	}
-	codec, _, _, _, _, _ := pickU64Codec(s)
+	codec, _, _, _, _, _, _ := pickU64Codec(s)
 	if codec == qpackDict {
 		t.Fatalf("u64 picker: returned qpackDict on >cap distinct (=%d), want fallback", len(s))
 	}

--- a/qpack_pfor.go
+++ b/qpack_pfor.go
@@ -1,6 +1,9 @@
 package qdf
 
-import "math/bits"
+import (
+	"math/bits"
+	"slices"
+)
 
 // Patched Frame-of-Reference. Packs (v-min) at a reduced width b chosen so
 // that the few values that don't fit (outliers) are cheaper to store in an
@@ -51,7 +54,8 @@ func (e *Encoder) writePackedPForUint64Slice(s []uint64, mn uint64, b int) {
 	n := len(s)
 	mask := uint64(1)<<uint(b) - 1
 	bodyBytes := (n*b + 7) >> 3
-	out := append(e.buf, tagPackPFor, qpackKindUint64)
+	out := slices.Grow(e.buf, 3+10+10+bodyBytes)
+	out = append(out, tagPackPFor, qpackKindUint64)
 	out = appendUvarint(out, uint64(n))
 	out = append(out, byte(b))
 	out = appendUvarint(out, mn)
@@ -137,7 +141,8 @@ func (e *Encoder) writePackedPForInt64Slice(s []int64, mn int64, b int) {
 	mnU := uint64(mn)
 	mask := uint64(1)<<uint(b) - 1
 	bodyBytes := (n*b + 7) >> 3
-	out := append(e.buf, tagPackPFor, qpackKindInt64)
+	out := slices.Grow(e.buf, 3+10+10+bodyBytes)
+	out = append(out, tagPackPFor, qpackKindInt64)
 	out = appendUvarint(out, uint64(n))
 	out = append(out, byte(b))
 	out = appendUvarint(out, zigzagEncode64(mn))

--- a/qpack_pfor.go
+++ b/qpack_pfor.go
@@ -94,6 +94,156 @@ func pforIsException(d uint64, b int) bool {
 	return b == 0 || d>>uint(b) != 0
 }
 
+// pforPlanSigned mirrors pforPlanUnsigned for int64 (deltas computed in
+// wrapping uint64 space relative to min, min stored zigzag).
+func pforPlanSigned(s []int64, mn int64, forBits int) (b int, cost int, ok bool) {
+	n := len(s)
+	if n < 8 || forBits < 2 || forBits > qpackForMaxBits {
+		return 0, 0, false
+	}
+	mnU := uint64(mn)
+	var hist [65]int
+	var maxDelta uint64
+	for _, v := range s {
+		d := uint64(v) - mnU
+		hist[bits.Len64(d)]++
+		if d > maxDelta {
+			maxDelta = d
+		}
+	}
+	valLen := uvarintLen(maxDelta)
+	hdr := 3 + uvarintLen(uint64(n)) + uvarintLen(zigzagEncode64(mn))
+	bestB, bestCost := -1, int(^uint(0)>>1)
+	suffix := 0
+	for cand := forBits - 1; cand >= 0; cand-- {
+		suffix += hist[cand+1]
+		body := (n*cand + 7) >> 3
+		c := hdr + body + uvarintLen(uint64(suffix)) + suffix*(1+valLen)
+		if c < bestCost {
+			bestCost, bestB = c, cand
+		}
+	}
+	if bestB < 0 {
+		return 0, 0, false
+	}
+	return bestB, bestCost, true
+}
+
+// writePackedPForInt64Slice emits s as a tagPackPFor payload at width b.
+// mn must equal the slice min; b must come from pforPlanSigned.
+func (e *Encoder) writePackedPForInt64Slice(s []int64, mn int64, b int) {
+	e.writeHeader()
+	n := len(s)
+	mnU := uint64(mn)
+	mask := uint64(1)<<uint(b) - 1
+	bodyBytes := (n*b + 7) >> 3
+	out := append(e.buf, tagPackPFor, qpackKindInt64)
+	out = appendUvarint(out, uint64(n))
+	out = append(out, byte(b))
+	out = appendUvarint(out, zigzagEncode64(mn))
+	start := len(out)
+	out = append(out, make([]byte, bodyBytes)...)
+	body := out[start : start+bodyBytes]
+	var chunk [64]uint64
+	for i := 0; i < n; i += len(chunk) {
+		end := min(i+len(chunk), n)
+		for j, v := range s[i:end] {
+			chunk[j] = (uint64(v) - mnU) & mask
+		}
+		bitPackChunkInto(body, chunk[:end-i], b, i)
+	}
+	excN := 0
+	for _, v := range s {
+		if pforIsException(uint64(v)-mnU, b) {
+			excN++
+		}
+	}
+	out = appendUvarint(out, uint64(excN))
+	prev := 0
+	for i, v := range s {
+		d := uint64(v) - mnU
+		if pforIsException(d, b) {
+			out = appendUvarint(out, uint64(i-prev))
+			out = appendUvarint(out, d)
+			prev = i
+		}
+	}
+	e.buf = out
+}
+
+// readPackedPForInt64Slice decodes a tagPackPFor int64 payload (tag already
+// consumed) into a []int64.
+func (d *Decoder) readPackedPForInt64Slice() ([]int64, error) {
+	if d.i+1 > len(d.buf) || d.buf[d.i] != qpackKindInt64 {
+		return nil, ErrTypeMismatch
+	}
+	d.i++
+	n64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, ErrInvalidLength
+	}
+	d.i += nr
+	if d.i >= len(d.buf) {
+		return nil, ErrShortBuffer
+	}
+	b := int(d.buf[d.i])
+	d.i++
+	if b > qpackForMaxBits {
+		return nil, ErrBadTag
+	}
+	mz, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, ErrInvalidLength
+	}
+	d.i += nr
+	mnU := uint64(zigzagDecode64(mz))
+	rem := uint64(len(d.buf) - d.i)
+	if b > 0 && n64 > rem*8/uint64(b) {
+		return nil, ErrShortBuffer
+	}
+	n := int(n64)
+	bodyBytes := (n*b + 7) >> 3
+	if d.i+bodyBytes > len(d.buf) {
+		return nil, ErrShortBuffer
+	}
+	tmp := make([]uint64, n)
+	if b > 0 {
+		bitUnpackU64LE(tmp, d.buf[d.i:d.i+bodyBytes], b)
+	}
+	d.i += bodyBytes
+	out := make([]int64, n)
+	for k := range out {
+		out[k] = int64(mnU + tmp[k])
+	}
+	excN64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, ErrInvalidLength
+	}
+	d.i += nr
+	if excN64 > n64 {
+		return nil, ErrInvalidLength
+	}
+	pos := 0
+	for j := uint64(0); j < excN64; j++ {
+		dp, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return nil, ErrInvalidLength
+		}
+		d.i += nr
+		delta, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return nil, ErrInvalidLength
+		}
+		d.i += nr
+		pos += int(dp)
+		if pos < 0 || pos >= n {
+			return nil, ErrInvalidLength
+		}
+		out[pos] = int64(mnU + delta)
+	}
+	return out, nil
+}
+
 // readPackedPForUint64Slice decodes a tagPackPFor payload (tag already
 // consumed) into a []uint64.
 func (d *Decoder) readPackedPForUint64Slice() ([]uint64, error) {

--- a/qpack_pfor.go
+++ b/qpack_pfor.go
@@ -229,7 +229,7 @@ func (d *Decoder) readPackedPForInt64Slice() ([]int64, error) {
 		return nil, ErrInvalidLength
 	}
 	pos := 0
-	for j := uint64(0); j < excN64; j++ {
+	for range excN64 {
 		dp, nr := readUvarint(d.buf[d.i:])
 		if nr <= 0 {
 			return nil, ErrInvalidLength
@@ -306,7 +306,7 @@ func (d *Decoder) readPackedPForUint64Slice() ([]uint64, error) {
 		return nil, ErrInvalidLength
 	}
 	pos := 0
-	for j := uint64(0); j < excN64; j++ {
+	for range excN64 {
 		dp, nr := readUvarint(d.buf[d.i:])
 		if nr <= 0 {
 			return nil, ErrInvalidLength

--- a/qpack_pfor.go
+++ b/qpack_pfor.go
@@ -1,0 +1,172 @@
+package qdf
+
+import "math/bits"
+
+// Patched Frame-of-Reference. Packs (v-min) at a reduced width b chosen so
+// that the few values that don't fit (outliers) are cheaper to store in an
+// exception list than to widen every slot. Selected by the picker only when
+// strictly smaller than every other codec, so it never regresses.
+
+// pforPlanUnsigned scans s (min already known, forBits = plain-FOR width) and
+// returns the bit width b that minimizes the PFOR wire cost, that cost, and
+// whether PFOR is a sensible candidate (ok=false for n<8 or forBits<2, where
+// there is no room to patch). The exception value byte cost uses maxDelta as a
+// conservative UPPER bound, so PFOR is never chosen when it would be larger.
+func pforPlanUnsigned(s []uint64, mn uint64, forBits int) (b int, cost int, ok bool) {
+	n := len(s)
+	if n < 8 || forBits < 2 || forBits > qpackForMaxBits {
+		return 0, 0, false
+	}
+	var hist [65]int
+	var maxDelta uint64
+	for _, v := range s {
+		d := v - mn
+		hist[bits.Len64(d)]++
+		if d > maxDelta {
+			maxDelta = d
+		}
+	}
+	valLen := uvarintLen(maxDelta) // conservative upper bound per exception value
+	hdr := 3 + uvarintLen(uint64(n)) + uvarintLen(mn)
+	bestB, bestCost := -1, int(^uint(0)>>1)
+	suffix := 0 // number of values with width > cand, accumulated as cand descends
+	for cand := forBits - 1; cand >= 0; cand-- {
+		suffix += hist[cand+1]
+		body := (n*cand + 7) >> 3
+		c := hdr + body + uvarintLen(uint64(suffix)) + suffix*(1+valLen)
+		if c < bestCost {
+			bestCost, bestB = c, cand
+		}
+	}
+	if bestB < 0 {
+		return 0, 0, false
+	}
+	return bestB, bestCost, true
+}
+
+// writePackedPForUint64Slice emits s as a tagPackPFor payload at width b.
+// mn must equal the slice min; b must come from pforPlanUnsigned.
+func (e *Encoder) writePackedPForUint64Slice(s []uint64, mn uint64, b int) {
+	e.writeHeader()
+	n := len(s)
+	mask := uint64(1)<<uint(b) - 1
+	bodyBytes := (n*b + 7) >> 3
+	out := append(e.buf, tagPackPFor, qpackKindUint64)
+	out = appendUvarint(out, uint64(n))
+	out = append(out, byte(b))
+	out = appendUvarint(out, mn)
+	start := len(out)
+	out = append(out, make([]byte, bodyBytes)...)
+	body := out[start : start+bodyBytes]
+	var chunk [64]uint64
+	for i := 0; i < n; i += len(chunk) {
+		end := min(i+len(chunk), n)
+		for j, v := range s[i:end] {
+			chunk[j] = (v - mn) & mask
+		}
+		bitPackChunkInto(body, chunk[:end-i], b, i)
+	}
+	excN := 0
+	for _, v := range s {
+		if pforIsException(v-mn, b) {
+			excN++
+		}
+	}
+	out = appendUvarint(out, uint64(excN))
+	prev := 0
+	for i, v := range s {
+		d := v - mn
+		if pforIsException(d, b) {
+			out = appendUvarint(out, uint64(i-prev))
+			out = appendUvarint(out, d)
+			prev = i
+		}
+	}
+	e.buf = out
+}
+
+// pforIsException reports whether delta d does not fit in b bits (and so must
+// be patched). d==0 never needs patching (it fits any width, including b==0).
+func pforIsException(d uint64, b int) bool {
+	if d == 0 {
+		return false
+	}
+	return b == 0 || d>>uint(b) != 0
+}
+
+// readPackedPForUint64Slice decodes a tagPackPFor payload (tag already
+// consumed) into a []uint64.
+func (d *Decoder) readPackedPForUint64Slice() ([]uint64, error) {
+	if d.i+1 > len(d.buf) {
+		return nil, ErrShortBuffer
+	}
+	if d.buf[d.i] != qpackKindUint64 {
+		return nil, ErrTypeMismatch
+	}
+	d.i++
+	n64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, ErrInvalidLength
+	}
+	d.i += nr
+	if d.i >= len(d.buf) {
+		return nil, ErrShortBuffer
+	}
+	b := int(d.buf[d.i])
+	d.i++
+	if b > qpackForMaxBits {
+		return nil, ErrBadTag
+	}
+	mn, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, ErrInvalidLength
+	}
+	d.i += nr
+	rem := uint64(len(d.buf) - d.i)
+	if b > 0 && n64 > rem*8/uint64(b) {
+		return nil, ErrShortBuffer
+	}
+	n := int(n64)
+	bodyBytes := (n*b + 7) >> 3
+	if d.i+bodyBytes > len(d.buf) {
+		return nil, ErrShortBuffer
+	}
+	body := d.buf[d.i : d.i+bodyBytes]
+	d.i += bodyBytes
+	out := make([]uint64, n)
+	if b > 0 {
+		bitUnpackU64LE(out, body, b)
+	}
+	if mn != 0 {
+		for k := range out {
+			out[k] += mn
+		}
+	}
+	excN64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, ErrInvalidLength
+	}
+	d.i += nr
+	if excN64 > n64 {
+		return nil, ErrInvalidLength
+	}
+	pos := 0
+	for j := uint64(0); j < excN64; j++ {
+		dp, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return nil, ErrInvalidLength
+		}
+		d.i += nr
+		delta, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return nil, ErrInvalidLength
+		}
+		d.i += nr
+		pos += int(dp)
+		if pos < 0 || pos >= n {
+			return nil, ErrInvalidLength
+		}
+		out[pos] = mn + delta
+	}
+	return out, nil
+}

--- a/qpack_pfor_test.go
+++ b/qpack_pfor_test.go
@@ -1,6 +1,7 @@
 package qdf
 
 import (
+	"encoding/binary"
 	"math/rand"
 	"testing"
 )
@@ -118,4 +119,46 @@ func TestPFor_RoundTripU64(t *testing.T) {
 			}
 		}
 	}
+}
+
+func FuzzPForRoundTrip(f *testing.F) {
+	f.Add([]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	f.Add(make([]byte, 256))
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		n := len(raw) / 8
+		if n == 0 {
+			return
+		}
+		s := make([]uint64, n)
+		for i := range s {
+			s[i] = binary.LittleEndian.Uint64(raw[i*8:])
+		}
+		mn, mx := minMaxU64(s)
+		forBits := bitsForDelta(mx - mn)
+		b, _, ok := pforPlanUnsigned(s, mn, forBits)
+		if !ok {
+			return
+		}
+		var e Encoder
+		e.writePackedPForUint64Slice(s, mn, b)
+		var d Decoder
+		d.buf = e.buf
+		d.i = 0
+		if err := d.readHeader(); err != nil {
+			t.Fatalf("header: %v", err)
+		}
+		d.i++ // tag
+		got, err := d.readPackedPForUint64Slice()
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(got) != len(s) {
+			t.Fatalf("len %d != %d", len(got), len(s))
+		}
+		for i := range s {
+			if got[i] != s[i] {
+				t.Fatalf("i=%d got %d want %d", i, got[i], s[i])
+			}
+		}
+	})
 }

--- a/qpack_pfor_test.go
+++ b/qpack_pfor_test.go
@@ -26,6 +26,62 @@ func pforTestSlicesU64() [][]uint64 {
 	}
 }
 
+func pforTestSlicesI64() [][]int64 {
+	r := rand.New(rand.NewSource(2))
+	mk := func(n int, base int64, spikePct int, spike int64) []int64 {
+		s := make([]int64, n)
+		for i := range s {
+			if spikePct > 0 && r.Intn(100) < spikePct {
+				s[i] = spike + int64(r.Intn(1000))
+			} else {
+				s[i] = base + int64(r.Intn(16))
+			}
+		}
+		return s
+	}
+	return [][]int64{
+		mk(100, -1000, 1, 1<<40),    // negative min, rare huge spikes
+		mk(1000, -50, 3, -(1 << 20)), // 3% negative spikes
+		mk(257, 7, 0, 0),             // no spikes
+		mk(512, -(1 << 30), 2, 1<<45),
+	}
+}
+
+func TestPFor_RoundTripI64(t *testing.T) {
+	for ci, s := range pforTestSlicesI64() {
+		mn, mx := minMaxI64(s)
+		forBits := bitsForDelta(uint64(mx) - uint64(mn))
+		b, _, ok := pforPlanSigned(s, mn, forBits)
+		if !ok {
+			continue
+		}
+		var e Encoder
+		e.writePackedPForInt64Slice(s, mn, b)
+		var d Decoder
+		d.buf = e.buf
+		d.i = 0
+		if err := d.readHeader(); err != nil {
+			t.Fatalf("case %d header: %v", ci, err)
+		}
+		if d.buf[d.i] != tagPackPFor {
+			t.Fatalf("case %d: expected tagPackPFor", ci)
+		}
+		d.i++
+		got, err := d.readPackedPForInt64Slice()
+		if err != nil {
+			t.Fatalf("case %d decode: %v", ci, err)
+		}
+		if len(got) != len(s) {
+			t.Fatalf("case %d len %d != %d", ci, len(got), len(s))
+		}
+		for i := range s {
+			if got[i] != s[i] {
+				t.Fatalf("case %d i=%d: got %d want %d", ci, i, got[i], s[i])
+			}
+		}
+	}
+}
+
 func TestPFor_RoundTripU64(t *testing.T) {
 	for ci, s := range pforTestSlicesU64() {
 		if len(s) == 0 {

--- a/qpack_pfor_test.go
+++ b/qpack_pfor_test.go
@@ -1,0 +1,65 @@
+package qdf
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func pforTestSlicesU64() [][]uint64 {
+	r := rand.New(rand.NewSource(1))
+	mk := func(n int, base uint64, spikePct int, spike uint64) []uint64 {
+		s := make([]uint64, n)
+		for i := range s {
+			if spikePct > 0 && r.Intn(100) < spikePct {
+				s[i] = spike + uint64(r.Intn(1000))
+			} else {
+				s[i] = base + uint64(r.Intn(16))
+			}
+		}
+		return s
+	}
+	return [][]uint64{
+		{}, {5}, {5, 5, 5},
+		mk(100, 1000, 1, 1<<40), // rare huge spikes
+		mk(1000, 200, 3, 1<<20), // 3% spikes
+		mk(257, 0, 0, 0),        // no spikes
+	}
+}
+
+func TestPFor_RoundTripU64(t *testing.T) {
+	for ci, s := range pforTestSlicesU64() {
+		if len(s) == 0 {
+			continue
+		}
+		mn, mx := minMaxU64(s)
+		forBits := bitsForDelta(mx - mn)
+		b, _, ok := pforPlanUnsigned(s, mn, forBits)
+		if !ok {
+			continue // PFOR not applicable for this slice
+		}
+		var e Encoder
+		e.writePackedPForUint64Slice(s, mn, b)
+		var d Decoder
+		d.buf = e.buf
+		d.i = 0
+		if err := d.readHeader(); err != nil {
+			t.Fatalf("case %d header: %v", ci, err)
+		}
+		if d.buf[d.i] != tagPackPFor {
+			t.Fatalf("case %d: expected tagPackPFor", ci)
+		}
+		d.i++
+		got, err := d.readPackedPForUint64Slice()
+		if err != nil {
+			t.Fatalf("case %d decode: %v", ci, err)
+		}
+		if len(got) != len(s) {
+			t.Fatalf("case %d len %d != %d", ci, len(got), len(s))
+		}
+		for i := range s {
+			if got[i] != s[i] {
+				t.Fatalf("case %d i=%d: got %d want %d", ci, i, got[i], s[i])
+			}
+		}
+	}
+}

--- a/qpack_pfor_test.go
+++ b/qpack_pfor_test.go
@@ -41,7 +41,7 @@ func pforTestSlicesI64() [][]int64 {
 		return s
 	}
 	return [][]int64{
-		mk(100, -1000, 1, 1<<40),    // negative min, rare huge spikes
+		mk(100, -1000, 1, 1<<40),     // negative min, rare huge spikes
 		mk(1000, -50, 3, -(1 << 20)), // 3% negative spikes
 		mk(257, 7, 0, 0),             // no spikes
 		mk(512, -(1 << 30), 2, 1<<45),
@@ -161,4 +161,73 @@ func FuzzPForRoundTrip(f *testing.F) {
 			}
 		}
 	})
+}
+
+type pforProbe struct {
+	V []uint64
+}
+
+// containsTagKind reports whether b carries an integer-slice payload framed by
+// the two-byte structural header {tag, kind}. A bare byte-scan would yield
+// false positives against arbitrary data bytes.
+func containsTagKind(b []byte, tag, kind byte) bool {
+	for i := 0; i+1 < len(b); i++ {
+		if b[i] == tag && b[i+1] == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPFor_PickerChoosesByData(t *testing.T) {
+	r := rand.New(rand.NewSource(7))
+	// Outlier-heavy: mostly tiny values, ~1% huge spikes -> plain FOR forced wide.
+	spikes := make([]uint64, 1024)
+	for i := range spikes {
+		if r.Intn(100) < 1 {
+			spikes[i] = 1<<40 + uint64(r.Intn(1000))
+		} else {
+			spikes[i] = uint64(r.Intn(16))
+		}
+	}
+	// Clean: uniform small values -> FOR already optimal, PFOR must not fire.
+	clean := make([]uint64, 1024)
+	for i := range clean {
+		clean[i] = 1000 + uint64(r.Intn(16))
+	}
+
+	// Inspect the raw wire; exclude rANS (it wraps the body and hides the tag).
+	opts := OptBalanced &^ OptRANS
+	encSpikes, err := Marshal(pforProbe{V: spikes}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encClean, err := Marshal(pforProbe{V: clean}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !containsTagKind(encSpikes, tagPackPFor, qpackKindUint64) {
+		t.Errorf("outlier-heavy data: expected PFOR tag on wire, not found")
+	}
+	if containsTagKind(encClean, tagPackPFor, qpackKindUint64) {
+		t.Errorf("clean data: PFOR should lose to FOR, but PFOR tag present")
+	}
+
+	// Round-trips regardless of codec choice.
+	for name, enc := range map[string][]byte{"spikes": encSpikes, "clean": encClean} {
+		var got pforProbe
+		if err := Unmarshal(enc, &got); err != nil {
+			t.Fatalf("%s: unmarshal: %v", name, err)
+		}
+	}
+	var gotS pforProbe
+	if err := Unmarshal(encSpikes, &gotS); err != nil {
+		t.Fatal(err)
+	}
+	for i := range spikes {
+		if gotS.V[i] != spikes[i] {
+			t.Fatalf("spikes round-trip mismatch at %d: %d != %d", i, gotS.V[i], spikes[i])
+		}
+	}
 }

--- a/qpack_pfor_test.go
+++ b/qpack_pfor_test.go
@@ -231,3 +231,50 @@ func TestPFor_PickerChoosesByData(t *testing.T) {
 		}
 	}
 }
+
+// TestPFor_CorpusGate is the measure-first gate: on a realistic latency column
+// (microsecond latencies with ~1% large spikes) PFOR must beat plain FOR by a
+// meaningful margin, and the codec must round-trip. The never-worse picker
+// guarantees no other workload regresses; this asserts the win actually exists.
+func TestPFor_CorpusGate(t *testing.T) {
+	r := rand.New(rand.NewSource(99))
+	const n = 1024
+	s := make([]uint64, n)
+	for i := range s {
+		if r.Intn(1000) < 10 { // ~1% spikes
+			s[i] = 50_000 + uint64(r.Intn(950_000)) // 50ms..1s spike (in us)
+		} else {
+			s[i] = uint64(r.Intn(500)) // sub-millisecond latency
+		}
+	}
+	mn, mx := minMaxU64(s)
+	forBits := bitsForDelta(mx - mn)
+	forSize := qpackForSizeUnsigned(n, forBits, mn)
+	b, pforCost, ok := pforPlanUnsigned(s, mn, forBits)
+	if !ok {
+		t.Fatalf("PFOR not applicable (forBits=%d)", forBits)
+	}
+	t.Logf("latency_spikes_1024: FOR=%d B (bits=%d), PFOR=%d B (bits=%d) -> %.1f%% smaller",
+		forSize, forBits, pforCost, b, 100*(1-float64(pforCost)/float64(forSize)))
+	if pforCost >= forSize*9/10 {
+		t.Fatalf("PFOR not >=10%% smaller than FOR: PFOR=%d FOR=%d", pforCost, forSize)
+	}
+	// Round-trip the actual encoded payload.
+	var e Encoder
+	e.writePackedPForUint64Slice(s, mn, b)
+	var d Decoder
+	d.buf = e.buf
+	if err := d.readHeader(); err != nil {
+		t.Fatal(err)
+	}
+	d.i++ // tag
+	got, err := d.readPackedPForUint64Slice()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range s {
+		if got[i] != s[i] {
+			t.Fatalf("round-trip mismatch at %d", i)
+		}
+	}
+}

--- a/qpack_rle_test.go
+++ b/qpack_rle_test.go
@@ -89,7 +89,7 @@ func TestRLE_PickerHitsHighRepeat(t *testing.T) {
 	for i := 96; i < 128; i++ {
 		u[i] = 404
 	}
-	if got, _, _, _, _, _ := pickU64Codec(u); got != qpackRLE {
+	if got, _, _, _, _, _, _ := pickU64Codec(u); got != qpackRLE {
 		t.Fatalf("u64 picker: got codec %d, want qpackRLE (%d)", got, qpackRLE)
 	}
 
@@ -106,7 +106,7 @@ func TestRLE_PickerHitsHighRepeat(t *testing.T) {
 	for i := 96; i < 128; i++ {
 		s[i] = -2
 	}
-	if got, _, _, _, _, _ := pickI64Codec(s); got != qpackRLE {
+	if got, _, _, _, _, _, _ := pickI64Codec(s); got != qpackRLE {
 		t.Fatalf("i64 picker: got codec %d, want qpackRLE (%d)", got, qpackRLE)
 	}
 }
@@ -122,7 +122,7 @@ func TestRLE_PickerSkipsHighEntropy(t *testing.T) {
 	for i := range u {
 		u[i] = uint64(i*7919 + 1)
 	}
-	got, _, _, _, _, _ := pickU64Codec(u)
+	got, _, _, _, _, _, _ := pickU64Codec(u)
 	if got == qpackRLE {
 		t.Fatalf("u64 picker: returned qpackRLE on high-entropy input")
 	}

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -91,7 +91,7 @@ func encodeSliceInt(e *Encoder, p unsafe.Pointer) error {
 		// so the dead branch is eliminated.
 		if unsafe.Sizeof(int(0)) == 8 {
 			s64 := unsafe.Slice((*int64)(unsafe.Pointer(unsafe.SliceData(s))), len(s))
-			codec, mn, forBits, first, minDelta, deltaBits := pickI64Codec(s64)
+			codec, mn, forBits, first, minDelta, deltaBits, pforBits := pickI64Codec(s64)
 			switch codec {
 			case qpackFor:
 				e.writePackedForInt64Slice(s64, mn, forBits)
@@ -101,6 +101,8 @@ func encodeSliceInt(e *Encoder, p unsafe.Pointer) error {
 				e.writePackedRLEInt64Slice(s64)
 			case qpackDict:
 				e.writePackedDictInt64Slice(s64)
+			case qpackPFor:
+				e.writePackedPForInt64Slice(s64, mn, pforBits)
 			default:
 				e.writePackedInt64Slice(s64)
 			}
@@ -122,7 +124,7 @@ func decodeSliceInt(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	switch t {
-	case tagPackRaw, tagPackFor, tagPackDeltaFor, tagPackRLE, tagPackDict:
+	case tagPackRaw, tagPackFor, tagPackDeltaFor, tagPackRLE, tagPackDict, tagPackPFor:
 		if unsafe.Sizeof(int(0)) == 8 {
 			var dest []int64
 			if err := decodeSliceInt64(d, unsafe.Pointer(&dest)); err != nil {
@@ -205,7 +207,7 @@ func decodeSliceInt32(d *Decoder, p unsafe.Pointer) error {
 func encodeSliceInt64(e *Encoder, p unsafe.Pointer) error {
 	s := *(*[]int64)(p)
 	if e.qpack {
-		codec, mn, forBits, first, minDelta, deltaBits := pickI64Codec(s)
+		codec, mn, forBits, first, minDelta, deltaBits, pforBits := pickI64Codec(s)
 		switch codec {
 		case qpackFor:
 			e.writePackedForInt64Slice(s, mn, forBits)
@@ -215,6 +217,8 @@ func encodeSliceInt64(e *Encoder, p unsafe.Pointer) error {
 			e.writePackedRLEInt64Slice(s)
 		case qpackDict:
 			e.writePackedDictInt64Slice(s)
+		case qpackPFor:
+			e.writePackedPForInt64Slice(s, mn, pforBits)
 		default:
 			e.writePackedInt64Slice(s)
 		}
@@ -267,6 +271,14 @@ func decodeSliceInt64(d *Decoder, p unsafe.Pointer) error {
 	case tagPackDict:
 		d.i++
 		v, err := d.readPackedDictInt64Slice()
+		if err != nil {
+			return err
+		}
+		*(*[]int64)(p) = v
+		return nil
+	case tagPackPFor:
+		d.i++
+		v, err := d.readPackedPForInt64Slice()
 		if err != nil {
 			return err
 		}
@@ -338,7 +350,7 @@ func decodeSliceUint32(d *Decoder, p unsafe.Pointer) error {
 func encodeSliceUint64(e *Encoder, p unsafe.Pointer) error {
 	s := *(*[]uint64)(p)
 	if e.qpack {
-		codec, mn, forBits, first, minDelta, deltaBits := pickU64Codec(s)
+		codec, mn, forBits, first, minDelta, deltaBits, pforBits := pickU64Codec(s)
 		switch codec {
 		case qpackFor:
 			e.writePackedForUint64Slice(s, mn, forBits)
@@ -348,6 +360,8 @@ func encodeSliceUint64(e *Encoder, p unsafe.Pointer) error {
 			e.writePackedRLEUint64Slice(s)
 		case qpackDict:
 			e.writePackedDictUint64Slice(s)
+		case qpackPFor:
+			e.writePackedPForUint64Slice(s, mn, pforBits)
 		default:
 			e.writePackedUint64Slice(s)
 		}
@@ -400,6 +414,14 @@ func decodeSliceUint64(d *Decoder, p unsafe.Pointer) error {
 	case tagPackDict:
 		d.i++
 		v, err := d.readPackedDictUint64Slice()
+		if err != nil {
+			return err
+		}
+		*(*[]uint64)(p) = v
+		return nil
+	case tagPackPFor:
+		d.i++
+		v, err := d.readPackedPForUint64Slice()
 		if err != nil {
 			return err
 		}

--- a/wire.go
+++ b/wire.go
@@ -123,6 +123,17 @@ const (
 	//                    bitsPer is implicit (derivable from distinct);
 	//                    distinct == 1 emits a zero-width body and the
 	//                    decoder broadcasts the single value.
+	tagPackPFor = 0xEE // Patched Frame-of-Reference integer slice. The FOR
+	//                    body is bit-packed at a reduced width b chosen so the
+	//                    few values that don't fit (outliers) go to an
+	//                    exception list instead of widening every slot. Wire:
+	//                       tag, kind, varuint(n), b(1 byte), <min>,
+	//                       body (n*b bits, LSB-first, (delta & mask)),
+	//                       varuint(excN),
+	//                       excN x ( varuint(dPos), varuint(delta) ).
+	//                    <min> is varuint (unsigned kinds) or zigzag-varuint
+	//                    (signed). Selected only when strictly smaller than
+	//                    every other codec, so the wire never grows.
 	tagStatePair = 0xEA // Markov-1 predictor for Dense state-refs.
 	//                    Conditioned on the previously emitted state-ref ID
 	//                    (lastID), the encoder maintains a small ring of the


### PR DESCRIPTION
## Summary

Adds a picker-gated **Patched Frame-of-Reference (PFOR)** integer codec
(`tagPackPFor = 0xEE`) for `[]intN`/`[]uintN` slices that are mostly small
but carry a rare tail of large outliers (latency spikes, counter resets).
Plain FOR is forced to a wide bit count by those few values; PFOR packs the
common case at a reduced width `b` and stores the outliers in an exception
list.

It is **never-worse**: `pickU64Codec`/`pickI64Codec` evaluate PFOR as a final
candidate using a conservative upper bound on exception bytes (`maxDelta`), so
it is chosen only when strictly smaller than every other codec. Clean / tight
columns keep FOR and the wire is byte-identical to before. Benefits standalone
integer slices and columnar struct-array numeric columns (shared picker).

### Wire format
`0xEE, kind, varuint(n), b(1), <min>, body(n*b bits LSB-first), varuint(excN), excN×(varuint dPos, varuint delta)`
— `<min>` is varuint (unsigned) / zigzag-varuint (signed). The body reuses the
existing SIMD-accelerated `bitPackChunkInto`/`bitUnpackU64LE`.

### Results (1024-sample corpus)
- `latency_spikes_1024`: FOR 2566 B -> PFOR 1215 B (**~53% smaller**).
- Also shrinks real corpora: `webreq` 8759->8668 B, `counters` 569->464 B.
- Every other corpus fixture is **byte-identical** (verified vs `origin/main`).

### Safety
Decode validates `b <= 56`, `n` bounded against the remaining buffer, `excN <= n`,
and each exception `pos < n`; truncated streams fail cleanly. Old decoders see
`0xEE` as an unknown tag -> `ErrBadTag`. `Skip()` handles the full payload.

## Test Plan
- [x] `go test -race -count=1 ./...` green (root + internal modules)
- [x] uint64 + int64 round-trip across no/one/many/all-outlier and negative-min patterns
- [x] `FuzzPForRoundTrip` 20s, 1.7M execs clean
- [x] Picker assertion: PFOR fires on outlier-heavy data, absent on clean data
- [x] In-package size gate (FOR vs PFOR) + bench size guard
- [x] Golden fixtures unchanged; `golangci-lint` 0 issues