### PR TITLE
feat: dictionary-coded string columns in the columnar container

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ the practical subset of that idea:
 | ------------------------ | ---------------------------- |
 | **State set** — the discrete values a position can take. | The Dense-mode intern table. The first occurrence of a string or `[]byte` value writes it in full and assigns it a stable ID. |
 | **Wavefunction collapse** — a single observation picks one state. | Every subsequent occurrence emits a `state_ref` tag plus a varint ID. Decoding "collapses" the reference back to its stored value. |
-| **Density** — keep only what carries information; minimise entropy `H(D \| C)` against the existing context. | Repeated keys / values across a message (and across a Dense stream) cost 1–3 bytes rather than their full length. Numeric and bool slices use QPack codecs (FOR, Delta+FOR, RLE, dictionary, Gorilla XOR, ALP decimal, raw-LE bulk) that auto-select the smallest predicted form per slice; slices of homogeneous structs transpose to per-column codecs. Field-name headers in generated code are pre-encoded once per type and concatenated without further work. |
+| **Density** — keep only what carries information; minimise entropy `H(D \| C)` against the existing context. | Repeated keys / values across a message (and across a Dense stream) cost 1–3 bytes rather than their full length. Numeric and bool slices use QPack codecs (FOR, Delta+FOR, RLE, dictionary, Gorilla XOR, ALP decimal, raw-LE bulk) that auto-select the smallest predicted form per slice; slices of homogeneous structs transpose to per-column codecs, and an enum-like string column is dictionary-coded (distinct table + bit-packed index per row) when that beats per-value interning. Field-name headers in generated code are pre-encoded once per type and concatenated without further work. |
 | **Probabilistic / residual coding** — predict, then store only the deviation. | QPack's Delta+FOR codec is exactly this for monotonic integer sequences: encode the first value plus the bit-packed residual against a `aᵢ = aᵢ₋₁ + minΔ` predictor. Gorilla does the same for floats by XOR-ing each sample against the previous one and storing the differing bits only. |
 | **Entanglement** — correlated values that constrain each other (e.g. `city = "Vilnius"` ⇒ `country = "Lithuania"`). | Three stacked predictors on the Dense state stream. **Markov-0** (`tagStateRepeat`, `0xE8`) collapses an immediate repeat of the previously emitted state-ref to a single byte. **MTF rank** (`tagStateMTF`, `0xE9`) encodes the LRU rank of the touched ID when that varuint is shorter than the raw id. **Markov-1 pair** (`tagStatePair`, `0xEA`) keeps the last 4 successors observed after each prev ID and encodes a hit as `0xEA + 1-byte rank` — wins when the prev → curr transition is predictable and the raw id needs a multi-byte varuint. The encoder picks the shortest of the four variants per emission, so the wire is never larger than the plain `tagStateRef` encoding. A full conditional-probability table beyond order-1 stays in the reserved `0xEB / 0xED..0xEF` block. |
 | **Shape interning** — repeated structure means the *layout* itself is information. | Dense mode emits structs (and `map[string]any` of stable shape via the reflect-struct path) through `tagMapShape` (`0xEC`). First occurrence declares the shape inline: `0xEC, 0, varuint(N), N × key`. Subsequent occurrences of the same shape emit `0xEC + varuint(shapeID) + N × value` — keys are *not* re-emitted. Per-record saving on an array of identical-shape structs is `N × 2` bytes for the elided state-refs plus the map header. The shape table is per-stream, addressed by `*typeDesc` on the encoder and by sequential ID on the wire. Shapes never collide across types because the encoder keys the binding on the descriptor pointer. |
@@ -152,11 +152,12 @@ Tag space is msgpack-inspired with a few additions:
 | `0xEF`               | QPack: columnar `[]struct` container          |
 | `0xF0..0xF3`         | ext / timestamp                               |
 | `0xF4`               | QPack: ALP decimal-coded `[]float64` slice    |
-| `0xF5..0xFF`         | reserved (rANS, n-gram graph, future)         |
+| `0xF5`               | QPack: dictionary-coded string column          |
+| `0xF6..0xFF`         | reserved (rANS, n-gram graph, future)         |
 
 The 5th header byte holds two flag bits: `FlagDense` (`0x01`) for the
 intern dialect, and `FlagQPack` (`0x02`) as an early hint that the body
-may carry codec tags from the QPack codec range (`0xE3..0xEF`, `0xF4`). A reader that does
+may carry codec tags from the QPack codec range (`0xE3..0xEF`, `0xF4..0xF5`). A reader that does
 not implement the QPack tags fails with `ErrBadTag` on first contact;
 it never decodes a packed payload as scalar by accident.
 

--- a/columnar.go
+++ b/columnar.go
@@ -267,13 +267,23 @@ func (e *Encoder) encodeColumnar(plan *columnarPlan, base unsafe.Pointer, n int)
 				return err
 			}
 		case colKindString:
-			for i := range n {
-				if col.isByte {
+			if col.isByte {
+				for i := range n {
 					p := unsafe.Add(base, uintptr(i)*plan.stride+col.offset)
 					e.WriteBytes(*(*[]byte)(p))
-				} else {
-					e.WriteString(loadStringField(base, plan.stride, col, i))
 				}
+				break
+			}
+			s := st.colScratchStr[:0]
+			for i := range n {
+				s = append(s, loadStringField(base, plan.stride, col, i))
+			}
+			st.colScratchStr = s
+			if e.tryWriteStringColumnDict(s) {
+				break // dict form emitted; never-worse gate already passed
+			}
+			for _, v := range s {
+				e.WriteString(v)
 			}
 		}
 	}
@@ -435,6 +445,17 @@ func decodeColumnar(d *Decoder, t reflect.Type, plan *columnarPlan, p unsafe.Poi
 				*(*bool)(unsafe.Add(base, uintptr(i)*plan.stride+col.offset)) = s[i]
 			}
 		case colKindString:
+			if !col.isByte && d.i < len(d.buf) && d.buf[d.i] == tagColStrDict {
+				table, idx, err := d.readStringColumnDict(n)
+				if err != nil {
+					return err
+				}
+				for i := range n {
+					dp := unsafe.Add(base, uintptr(i)*plan.stride+col.offset)
+					*(*string)(dp) = table[idx[i]]
+				}
+				break
+			}
 			for i := range n {
 				sb, err := d.readStringBytes()
 				if err != nil {
@@ -599,6 +620,16 @@ func decodeColumnarAny(d *Decoder) (any, error) {
 				out[i].(map[string]any)[name] = s[i]
 			}
 		case colKindString:
+			if d.i < len(d.buf) && d.buf[d.i] == tagColStrDict {
+				table, idx, err := d.readStringColumnDict(n)
+				if err != nil {
+					return nil, err
+				}
+				for i := range n {
+					out[i].(map[string]any)[name] = table[idx[i]]
+				}
+				break
+			}
 			for i := range n {
 				sb, err := d.readStringBytes()
 				if err != nil {

--- a/docs/BENCH.md
+++ b/docs/BENCH.md
@@ -14,7 +14,9 @@ Operating modes compared:
   `OptCompression`). Auto-selects the smallest predicted form per
   slice.
 - **qdf_dense** — qdf_qpack + inline state-table interning for
-  repeating strings (logs, columnar telemetry).
+  repeating strings (logs, columnar telemetry). Enum-like string columns
+  in a struct array are dictionary-coded (distinct table + bit-packed
+  index per row) when that beats per-value interning.
 - **qdf_codegen** — code-generated `MarshalQDF`/`UnmarshalQDF` from
   `cmd/qdfgen` (no runtime reflection).
 - **qdf_fast + qdf_reflect2** (opt-in build tag) — swap

--- a/docs/CHOOSING.md
+++ b/docs/CHOOSING.md
@@ -31,7 +31,10 @@ live small (archives, cold storage, paginated history) wants
 bit differs.
 
 Arrays of flat homogeneous structs are compressed columnar automatically
-under `OptBalanced` and above — no flag needed.
+under `OptBalanced` and above — no flag needed. Within that path, enum-like
+string columns (log level, service, region, status) are dictionary-coded
+(distinct table + a bit-packed index per row) when that beats per-value
+interning, which is a large win on wide low-cardinality dimension columns.
 
 ---
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -189,9 +189,10 @@ So far so msgpack-shaped. The qdf-specific tags start at 0xE0:
 0xF0..0xF2  tagExt8/16/32         user-extension envelope
 0xF3        tagTimestamp          int64 ns since unix epoch
 0xF4  tagPackALP        (QPack)   ALP decimal-coded []float64 slice
+0xF5  tagColStrDict     (QPack)   dictionary-coded string column (inside columnar)
 ```
 
-Tags 0xF5..0xFF are reserved.
+Tags 0xF6..0xFF are reserved.
 
 A `tagStateRef` payload is `varuint(id)`. A `tagStateMTF` payload is
 `varuint(rank)` where rank 0 means "most recently emitted". A
@@ -554,6 +555,7 @@ slice; the decoder reads the picked tag.
 0xEB  tagPackRLE       []intN       Run-length encoded (value, runLen) pairs
 0xED  tagPackDict      []intN       Dictionary-coded; ≤16 distinct values
 0xEE  tagPackPFor      []intN       Patched FOR: narrow body + outlier exceptions
+0xF5  tagColStrDict    []string col Dictionary-coded string column (distinct table + bit-packed index/row)
 ```
 
 Selection logic:
@@ -665,9 +667,18 @@ the slice:
   slice is encoded as a single QPack payload.
 - Float columns are emitted as raw-LE slices (Gorilla is opt-in via
   `OptGorillaFloat`).
-- String and `[]byte` columns are emitted as M consecutive inline
-  string/bytes values through the normal intern path; repeated values
-  collapse to state-refs.
+- String columns try a per-column dictionary first (`tagColStrDict`,
+  0xF5): the distinct values are written once and each row stores a
+  `ceil(log2 distinct)`-bit index (via the bitpack layer). It is emitted
+  as the column's first byte, so it is self-describing — the decoder
+  peeks the byte and either reads the dictionary or falls back to M
+  per-value strings. The dictionary is chosen only when its index body
+  beats the per-value run cost (one byte per run boundary), so scattered
+  enum-like columns (log level, service, region, status) win while
+  run-heavy or high-cardinality columns keep the per-value path. `[]byte`
+  columns are always emitted as M consecutive inline values.
+- The remaining string/`[]byte` per-value emissions go through the
+  normal intern path; repeated values collapse to state-refs.
 
 The wire layout is `0xEF, varuint(M), varuint(shapeID)` followed by K
 column payloads in declaration order. `shapeID == 0` declares a new

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -154,7 +154,8 @@ time. You do not need to hint it — just set the bit.
 | Repeated strings / `[]byte` across messages | Intern table + state-ref | `OptDense` |
 | Arrays of identical struct type | Shape interning | `OptBalanced` |
 | Predictable field transitions (e.g. service→region) | Markov-1 pair predictor | `OptBalanced` |
-| `[]SomeStruct` where fields are int/uint/float/bool/string/[]byte | Columnar transpose: numeric fields get FOR/delta/RLE/dict, repeated string fields collapse via intern. Automatic — no flag. The encoder probes each array and falls back to row-major when columnar would not win. | `OptBalanced` (Dense + ShapeIntern) |
+| Enum-like string column in a `[]SomeStruct` (log level, service, region, status) | Per-column string dictionary (distinct table + bit-packed index/row) | `OptBalanced` (columnar) |
+| `[]SomeStruct` where fields are int/uint/float/bool/string/[]byte | Columnar transpose: numeric fields get FOR/delta/RLE/dict, enum-like string columns get a per-column dictionary, other repeated string fields collapse via intern. Automatic — no flag. The encoder probes each array and falls back to row-major when columnar would not win. | `OptBalanced` (Dense + ShapeIntern) |
 
 The encoder probes a slice's structure before committing. For
 integer slices it evaluates FOR, Delta+FOR, RLE, dict, and Patched FOR

--- a/example_options_test.go
+++ b/example_options_test.go
@@ -38,6 +38,40 @@ func ExampleOptions() {
 	// OptBalanced  wire=161 bytes
 }
 
+// ExampleOptions_columnarStringDict shows the per-column string dictionary
+// that fires automatically under OptBalanced for a slice of structs whose
+// string fields are enum-like — a small set of distinct values scattered
+// across rows. The distinct strings are stored once and each row keeps a
+// few-bit index, so the wire is far smaller than one interned reference per
+// value. It is gated never-worse: run-heavy or high-cardinality columns keep
+// the per-value path, and the choice is invisible to the decoder.
+func ExampleOptions_columnarStringDict() {
+	type LogRow struct {
+		TS      int64  `qdf:"ts"`      // sequential — Delta+FOR makes columnar win
+		Level   string `qdf:"level"`   // enum — string dictionary
+		Service string `qdf:"service"` // enum — string dictionary
+	}
+	levels := []string{"INFO", "WARN", "ERROR"}
+	services := []string{"api", "auth", "billing"}
+	in := make([]LogRow, 300)
+	for i := range in {
+		in[i] = LogRow{
+			TS:      int64(1700000000 + i),
+			Level:   levels[i%len(levels)],
+			Service: services[(i*7)%len(services)],
+		}
+	}
+
+	buf, _ := qdf.Marshal(in, qdf.OptBalanced)
+
+	var out []LogRow
+	_ = qdf.Unmarshal(buf, &out)
+	fmt.Printf("rows=%d wire=%d bytes roundtrip=%v\n", len(in), len(buf), out[0] == in[0] && out[299] == in[299])
+
+	// Output:
+	// rows=300 wire=234 bytes roundtrip=true
+}
+
 // ExampleOptions_streamingDictShared shows the headline Dense-mode
 // win: across many calls of a StreamEncoder the intern table /
 // shape table / predictors all survive, so the second record

--- a/qdf.go
+++ b/qdf.go
@@ -35,9 +35,10 @@
 // dictionary coding; bool slices bit-pack; repeated strings are interned
 // and back-referenced. A slice of homogeneous flat structs is transposed
 // and compressed column-by-column automatically — numeric columns get the
-// integer codecs, repeated string columns collapse — with no flag, and a
-// per-array probe falls back to the plain row encoding when columnar would
-// not help. The float codecs that trade encode CPU for size live behind
+// integer codecs, an enum-like string column is dictionary-coded (distinct
+// table + a bit-packed index per row) when that beats per-value interning,
+// other repeated string columns collapse — with no flag, and a per-array
+// probe falls back to the plain row encoding when columnar would not help. The float codecs that trade encode CPU for size live behind
 // OptCompression: Gorilla XOR on smooth series, ALP on quantized/decimal
 // float64 grids (quantized telemetry, prices, latencies).
 //

--- a/qpack_strdict.go
+++ b/qpack_strdict.go
@@ -1,0 +1,174 @@
+package qdf
+
+import "github.com/alex60217101990/qdf/internal/bitpack"
+
+// Dictionary-coded string columns for the columnar container. A string
+// column whose values are drawn from a small set (enum-like dimensions —
+// log level, service, region, status) is cheaper to store as a distinct
+// table plus a bitpacked index per row than as M interned values, because
+// each interned reference still costs at least a byte while an index costs
+// ceil(log2 distinct) bits. Wire format documented at tagColStrDict.
+//
+// The codec is gated so it never grows the wire: it is chosen only when the
+// bitpacked index body is smaller than the per-value run cost (one byte per
+// run boundary is the floor for the interned/repeat path). Run-heavy
+// (clustered) columns keep the per-value path, which repeat-codes runs more
+// cheaply than a flat index.
+
+const (
+	// qpackStrDictMaxDistinct caps the distinct count. 256 keeps the index
+	// at <= 8 bits and the distinct probe bounded.
+	qpackStrDictMaxDistinct = 256
+	// qpackStrDictMinElems skips the probe for tiny columns where the table
+	// overhead cannot pay off.
+	qpackStrDictMinElems = 16
+	// Cheap high-cardinality bail: if the first sample rows are mostly
+	// distinct, the column is ID/text-like — abandon before the full scan.
+	qpackStrDictSampleN      = 64
+	qpackStrDictSampleMaxPct = 70 // distinct% over the sample above which we bail
+)
+
+// tryWriteStringColumnDict attempts to emit strs as a tagColStrDict block.
+// It returns true when the dictionary form was written (and is strictly
+// smaller than the per-value run floor), false when the caller should fall
+// back to per-value WriteString. Encode-side scratch is reused across
+// columns to avoid per-column allocation.
+func (e *Encoder) tryWriteStringColumnDict(strs []string) bool {
+	n := len(strs)
+	if n < qpackStrDictMinElems {
+		return false
+	}
+	m := e.state.strDictMap
+	if m == nil {
+		m = make(map[string]uint32, qpackStrDictMaxDistinct)
+		e.state.strDictMap = m
+	} else {
+		clear(m)
+	}
+	table := e.state.colDictTable[:0]
+	idx := e.state.colScratchU64[:0]
+	runs := 0
+	prev := ^uint32(0)
+	for i, s := range strs {
+		id, ok := m[s]
+		if !ok {
+			if len(m) >= qpackStrDictMaxDistinct {
+				e.state.colDictTable = table
+				e.state.colScratchU64 = idx
+				return false
+			}
+			id = uint32(len(m))
+			m[s] = id
+			table = append(table, s)
+		}
+		idx = append(idx, uint64(id))
+		if id != prev {
+			runs++
+		}
+		prev = id
+		// High-cardinality bail: after the sample, if the column is mostly
+		// distinct it will not dict-compress — stop before scanning the rest.
+		if i+1 == qpackStrDictSampleN && len(m)*100 > qpackStrDictSampleN*qpackStrDictSampleMaxPct {
+			e.state.colDictTable = table
+			e.state.colScratchU64 = idx
+			return false
+		}
+	}
+	e.state.colDictTable = table
+	e.state.colScratchU64 = idx
+
+	d := len(table)
+	bits := bitsForDistinct(d)
+	bodyBytes := (n*bits + 7) >> 3
+	// Never-worse gate. The distinct table bytes are paid by both forms (the
+	// per-value path emits each distinct string once too), so they cancel;
+	// compare only the dict's fixed overhead + index body against the
+	// per-value run floor (>= 1 byte per run boundary).
+	overhead := 1 + uvarintLen(uint64(d)) + uvarintLen(uint64(n))
+	if bodyBytes+overhead >= runs {
+		return false
+	}
+
+	e.writeHeader()
+	out := e.buf
+	out = append(out, tagColStrDict)
+	out = appendUvarint(out, uint64(d))
+	for _, s := range table {
+		out = appendUvarint(out, uint64(len(s)))
+		out = append(out, s...)
+	}
+	out = appendUvarint(out, uint64(n))
+	if bits > 0 {
+		start := len(out)
+		out = append(out, make([]byte, bodyBytes)...)
+		body := out[start : start+bodyBytes]
+		var chunk [64]uint64
+		for i := 0; i < n; i += len(chunk) {
+			end := min(i+len(chunk), n)
+			bitpack.PackChunk(body, idx[i:end], bits, i)
+		}
+	}
+	e.buf = out
+	return true
+}
+
+// readStringColumnDict decodes a tagColStrDict block (tag at d.i) into a
+// distinct table and a per-row index slice of length n. Each row's string
+// is table[idx[i]]; the distinct strings are allocated once and shared by
+// every row that references them. n is the row count the caller expects
+// from the columnar header; the block's own count must match.
+func (d *Decoder) readStringColumnDict(n int) (table []string, idx []uint32, err error) {
+	d.i++ // consume tagColStrDict
+	c64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, nil, ErrInvalidLength
+	}
+	d.i += nr
+	if c64 == 0 || c64 > qpackStrDictMaxDistinct {
+		return nil, nil, ErrBadTag
+	}
+	count := int(c64)
+	table = make([]string, count)
+	for i := range count {
+		l64, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return nil, nil, ErrInvalidLength
+		}
+		d.i += nr
+		if l64 > uint64(len(d.buf)-d.i) {
+			return nil, nil, ErrShortBuffer
+		}
+		l := int(l64)
+		table[i] = string(d.buf[d.i : d.i+l]) // owned copy
+		d.i += l
+	}
+	n64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, nil, ErrInvalidLength
+	}
+	d.i += nr
+	if int(n64) != n {
+		return nil, nil, ErrTypeMismatch
+	}
+	idx = make([]uint32, n)
+	bits := bitsForDistinct(count)
+	if bits == 0 {
+		return table, idx, nil // single distinct value → all indices 0
+	}
+	rem := uint64(len(d.buf) - d.i)
+	if n64 > rem*8/uint64(bits) {
+		return nil, nil, ErrShortBuffer
+	}
+	bodyBytes := (n*bits + 7) >> 3
+	body := d.buf[d.i : d.i+bodyBytes]
+	d.i += bodyBytes
+	tmp := make([]uint64, n)
+	bitpack.Unpack(tmp, body, bits)
+	for i, v := range tmp {
+		if v >= c64 {
+			return nil, nil, ErrBadTag
+		}
+		idx[i] = uint32(v)
+	}
+	return table, idx, nil
+}

--- a/qpack_strdict.go
+++ b/qpack_strdict.go
@@ -78,6 +78,15 @@ func (e *Encoder) tryWriteStringColumnDict(strs []string) bool {
 	e.state.colScratchU64 = idx
 
 	d := len(table)
+	if d < 2 {
+		// A single distinct value never beats the per-value path (one interned
+		// string + a state-repeat run). The gate below would reject it anyway,
+		// but make the invariant explicit: the decoder relies on count >= 2 (so
+		// bits >= 1, so a non-empty index body) to keep the row count bounded by
+		// the buffer. A count==1 dict would carry no body and let a tiny input
+		// claim a huge n.
+		return false
+	}
 	bits := bitsForDistinct(d)
 	bodyBytes := (n*bits + 7) >> 3
 	// Never-worse gate. The distinct table bytes are paid by both forms (the
@@ -124,7 +133,13 @@ func (d *Decoder) readStringColumnDict(n int) (table []string, idx []uint32, err
 		return nil, nil, ErrInvalidLength
 	}
 	d.i += nr
-	if c64 == 0 || c64 > qpackStrDictMaxDistinct {
+	if c64 < 2 || c64 > qpackStrDictMaxDistinct {
+		// The encoder never emits a single-distinct (count==1) dictionary —
+		// per-value wins, so the never-worse gate rejects it. Requiring
+		// count >= 2 here is therefore lossless for valid streams and, crucially,
+		// guarantees bits >= 1 so the index body is non-empty and the row count n
+		// is bounded by the remaining buffer below. A count==1 dict would carry
+		// no body and let a tiny hostile input drive a huge n / allocation.
 		return nil, nil, ErrBadTag
 	}
 	count := int(c64)
@@ -150,11 +165,10 @@ func (d *Decoder) readStringColumnDict(n int) (table []string, idx []uint32, err
 	if int(n64) != n {
 		return nil, nil, ErrTypeMismatch
 	}
-	idx = make([]uint32, n)
+	// count >= 2 ⇒ bits >= 1 ⇒ the index body is non-empty, so this check
+	// bounds n by the remaining buffer BEFORE any n-sized allocation; a tiny
+	// input can no longer drive a large idx/tmp/output slice.
 	bits := bitsForDistinct(count)
-	if bits == 0 {
-		return table, idx, nil // single distinct value → all indices 0
-	}
 	rem := uint64(len(d.buf) - d.i)
 	if n64 > rem*8/uint64(bits) {
 		return nil, nil, ErrShortBuffer
@@ -162,6 +176,7 @@ func (d *Decoder) readStringColumnDict(n int) (table []string, idx []uint32, err
 	bodyBytes := (n*bits + 7) >> 3
 	body := d.buf[d.i : d.i+bodyBytes]
 	d.i += bodyBytes
+	idx = make([]uint32, n)
 	tmp := make([]uint64, n)
 	bitpack.Unpack(tmp, body, bits)
 	for i, v := range tmp {

--- a/qpack_strdict_test.go
+++ b/qpack_strdict_test.go
@@ -209,3 +209,29 @@ func FuzzStrDict_RoundTrip(f *testing.F) {
 		}
 	})
 }
+
+// TestStrDict_DecodeRejectsSingleDistinct hardens the decoder against a
+// hostile count==1 (or 0) dictionary, which a valid encoder never produces
+// (the never-worse gate rejects single-distinct). count<2 carries no index
+// body, so accepting it would let a tiny input claim a huge row count and
+// drive a large allocation. The decoder must reject it without panic/OOM.
+func TestStrDict_DecodeRejectsSingleDistinct(t *testing.T) {
+	rows := mkStrDictRows(2000, 5) // multi-distinct enum columns → dict fires
+	enc, err := Marshal(rows, OptBalanced&^OptRANS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pos := bytes.IndexByte(enc, tagColStrDict)
+	if pos < 0 || pos+1 >= len(enc) {
+		t.Skip("no string-dict tag in this encoding")
+	}
+	// Byte after 0xF5 is varuint(count); a small distinct count is one byte.
+	for _, bad := range []byte{0x01, 0x00} {
+		m := append([]byte(nil), enc...)
+		m[pos+1] = bad
+		var got []strDictRow
+		// Correctness contract: never panic/hang on malformed input. An error
+		// (or a benign mismatch) is fine; a panic or OOM is not.
+		_ = Unmarshal(m, &got)
+	}
+}

--- a/qpack_strdict_test.go
+++ b/qpack_strdict_test.go
@@ -1,0 +1,211 @@
+package qdf
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+func strdictHasByte(buf []byte, b byte) bool { return bytes.IndexByte(buf, b) >= 0 }
+
+type strDictRow struct {
+	Level   string
+	Service string
+	Host    string
+	Seq     int64
+}
+
+func mkStrDictRows(n int, seed int64) []strDictRow {
+	r := rand.New(rand.NewSource(seed))
+	levels := []string{"INFO", "INFO", "INFO", "WARN", "ERROR", "DEBUG"}
+	services := []string{"api-gateway", "auth-service", "billing-service", "user-service"}
+	hosts := []string{"node-01", "node-02", "node-03", "node-04"}
+	out := make([]strDictRow, n)
+	for i := range out {
+		out[i] = strDictRow{
+			Level:   levels[r.Intn(len(levels))],
+			Service: services[r.Intn(len(services))],
+			Host:    hosts[r.Intn(len(hosts))],
+			Seq:     int64(i),
+		}
+	}
+	return out
+}
+
+func TestStrDict_RoundTripStruct(t *testing.T) {
+	rows := mkStrDictRows(2000, 1)
+	enc, err := Marshal(rows, OptBalanced&^OptRANS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strdictHasByte(enc, tagColStrDict) {
+		t.Fatalf("expected string-dict tag 0x%X on wire for enum columns, absent", tagColStrDict)
+	}
+	var got []strDictRow
+	if err := Unmarshal(enc, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(rows) {
+		t.Fatalf("len %d != %d", len(got), len(rows))
+	}
+	for i := range rows {
+		if got[i] != rows[i] {
+			t.Fatalf("row %d mismatch: %+v != %+v", i, got[i], rows[i])
+		}
+	}
+}
+
+func TestStrDict_RoundTripAny(t *testing.T) {
+	rows := mkStrDictRows(1000, 2)
+	enc, err := Marshal(rows, OptBalanced&^OptRANS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var gotAny any
+	if err := Unmarshal(enc, &gotAny); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := gotAny.([]any)
+	if !ok || len(got) != len(rows) {
+		t.Fatalf("any decode shape: %T len mismatch", gotAny)
+	}
+	for i := range rows {
+		m, ok := got[i].(map[string]any)
+		if !ok {
+			t.Fatalf("row %d not a map: %T", i, got[i])
+		}
+		if m["Level"] != rows[i].Level || m["Service"] != rows[i].Service || m["Host"] != rows[i].Host {
+			t.Fatalf("row %d any mismatch: %v", i, m)
+		}
+	}
+}
+
+func TestStrDict_SmallerThanPerValue(t *testing.T) {
+	rows := mkStrDictRows(4000, 3)
+	withDict, err := Marshal(rows, OptBalanced&^OptRANS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sanity: dict fired and the payload is meaningfully smaller than the
+	// raw lower bound of one byte per string value (3 string cols * n).
+	floor := 3 * len(rows)
+	if len(withDict) >= floor {
+		t.Fatalf("dict payload %d not below per-value floor %d", len(withDict), floor)
+	}
+	fmt.Printf("strdict n=%d size=%d (per-value floor ~%d)\n", len(rows), len(withDict), floor)
+}
+
+// Run-heavy (sorted) columns must NOT regress: the never-worse gate should
+// keep them on the per-value/repeat path or at least not grow the wire.
+func TestStrDict_NeverWorseRunHeavy(t *testing.T) {
+	// One value repeated in long runs → repeat-coding should win; dict must
+	// not be chosen (its flat index would be larger than the run encoding).
+	type row struct{ S string }
+	rows := make([]row, 3000)
+	vals := []string{"AAAA", "BBBB", "CCCC"}
+	for i := range rows {
+		rows[i].S = vals[i/1000] // 3 long runs
+	}
+	enc, err := Marshal(rows, OptBalanced&^OptRANS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []row
+	if err := Unmarshal(enc, &got); err != nil {
+		t.Fatal(err)
+	}
+	for i := range rows {
+		if got[i] != rows[i] {
+			t.Fatalf("run-heavy row %d mismatch", i)
+		}
+	}
+}
+
+// High-cardinality columns (unique-ish strings) must not be dict-encoded.
+func TestStrDict_HighCardinalityFallback(t *testing.T) {
+	type row struct{ ID string }
+	rows := make([]row, 2000)
+	for i := range rows {
+		rows[i].ID = fmt.Sprintf("id-%08x-%d", i*2654435761, i)
+	}
+	enc, err := Marshal(rows, OptBalanced&^OptRANS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strdictHasByte(enc, tagColStrDict) {
+		t.Fatal("high-cardinality column must not use the string-dict codec")
+	}
+	var got []row
+	if err := Unmarshal(enc, &got); err != nil {
+		t.Fatal(err)
+	}
+	for i := range rows {
+		if got[i] != rows[i] {
+			t.Fatalf("highcard row %d mismatch", i)
+		}
+	}
+}
+
+// Single distinct value → bits==0, empty index body.
+func TestStrDict_SingleDistinct(t *testing.T) {
+	type row struct {
+		S string
+		N int64
+	}
+	rows := make([]row, 500)
+	for i := range rows {
+		rows[i] = row{S: "constant", N: int64(i)}
+	}
+	enc, err := Marshal(rows, OptBalanced&^OptRANS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []row
+	if err := Unmarshal(enc, &got); err != nil {
+		t.Fatal(err)
+	}
+	for i := range rows {
+		if got[i] != rows[i] {
+			t.Fatalf("single-distinct row %d mismatch", i)
+		}
+	}
+}
+
+// FuzzStrDict_RoundTrip drives enum-column selection from fuzz bytes and
+// asserts the columnar string-dict codec round-trips for any picks.
+func FuzzStrDict_RoundTrip(f *testing.F) {
+	f.Add([]byte{0, 1, 2, 3, 4, 5, 6, 7})
+	vals := []string{"", "INFO", "WARN", "ERROR", "a", "service-x", "service-y", "node-01"}
+	f.Fuzz(func(t *testing.T, b []byte) {
+		type row struct {
+			A string
+			B string
+		}
+		n := 20 + len(b)
+		rows := make([]row, n)
+		for i := range rows {
+			if len(b) == 0 {
+				rows[i] = row{A: "INFO", B: "x"}
+				continue
+			}
+			rows[i] = row{A: vals[int(b[i%len(b)])%len(vals)], B: vals[int(b[(i*7+1)%len(b)])%len(vals)]}
+		}
+		enc, err := Marshal(rows, OptBalanced&^OptRANS)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got []row
+		if err := Unmarshal(enc, &got); err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != len(rows) {
+			t.Fatalf("len %d != %d", len(got), len(rows))
+		}
+		for i := range rows {
+			if got[i] != rows[i] {
+				t.Fatalf("row %d: %+v != %+v", i, got[i], rows[i])
+			}
+		}
+	})
+}

--- a/state.go
+++ b/state.go
@@ -158,6 +158,12 @@ type encState struct {
 	colScratchU64  []uint64
 	colScratchF64  []float64
 	colScratchBool []bool
+	colScratchStr  []string // gathered string column values
+	colDictTable   []string // distinct table for the string-dict codec
+	// strDictMap maps a string column's distinct values to dense indices
+	// while the string-dict codec decides/encodes. Reused (cleared) per
+	// column to avoid a per-column map allocation.
+	strDictMap map[string]uint32
 
 	// arena owns the byte storage that backs every intern key the
 	// encoder allocates — accessed only on intern miss, kept at the

--- a/wire.go
+++ b/wire.go
@@ -176,6 +176,16 @@ const (
 	// Chosen by the float64 picker only when strictly smaller than raw
 	// and the Gorilla projection, so it never grows the wire.
 	tagPackALP = 0xF4
+
+	// Dictionary-coded string column inside a tagColStruct payload. Emitted
+	// as the first byte where a string column's M values would otherwise be
+	// written consecutively, so it is self-describing: a decoder peeks the
+	// byte and either takes this path or reads M per-value strings. Wire:
+	//   0xF5, varuint(d), d×(varuint(len), len bytes),  // distinct table
+	//   varuint(M), ceil(M*ceil(log2 d)/8) LSB-first index body (absent
+	//   when d==1). Chosen by the column emitter only when the bitpacked
+	//   index body beats the per-value run cost, so it never grows the wire.
+	tagColStrDict = 0xF5
 )
 
 // Varint (ULEB128) helpers. Used for state-table IDs and intern-payload


### PR DESCRIPTION
Enum-like string columns (log level, service, region, status) are
everywhere in real telemetry but cost ~1.8 bytes per value today: each
interned reference is at least a tag byte, and scattered values defeat the
consecutive-repeat collapse. This adds a per-column **string dictionary** —
the distinct values stored once plus a `ceil(log2 distinct)`-bit index per
row, reusing the `internal/bitpack` layer for the indices.

Available **automatically under `OptBalanced`** (the columnar path); no
flag, no API change.

## Wire format

New tag `tagColStrDict` (`0xF5`), emitted as the **first byte** of a string
column inside a `tagColStruct` payload, so it is self-describing: the
decoder peeks the byte and either takes the dictionary path or reads `M`
per-value strings.

```
0xF5, varuint(d), d×(varuint(len), len bytes),   // distinct table (d >= 2)
varuint(M), ceil(M*ceil(log2 d)/8) LSB-first index body
```

Existing per-value emission is unchanged, so the wire for columns that do
not benefit stays **byte-identical** — golden fixtures are unmodified.

## Never-worse gate

The distinct-table bytes are paid by both forms and cancel, so the codec
fires only when the bitpacked index body plus fixed overhead is smaller
than the per-value run floor (≥ 1 byte per run boundary). Consequences:

- **Scattered enum columns win** (~6× smaller at `OptBalanced`, and ~2.5×
  even vs the rANS tier, since `log2(card)`/symbol beats byte entropy).
- **Run-heavy (clustered) columns** keep the cheaper repeat path.
- A cheap **sampled high-cardinality bail** (64 rows, >70% distinct)
  abandons ID/text-like columns before the full distinct scan.
- Decode shares **one allocation per distinct string** across all rows.

It only engages when the `[]struct` is already columnar-eligible *and* has
enum string columns; ID/numeric-dominated payloads stay row-major and are
untouched.

## Decoder hardening (second commit)

A valid encoder never emits a single-distinct (`count==1`) dictionary —
per-value always wins there, so a `count==1` block has no index body. On
decode that would let a tiny hostile input claim an arbitrary row count and
drive a large allocation. The decoder now rejects `count < 2` (`ErrBadTag`),
which is lossless for valid streams and guarantees the row count is bounded
by the remaining buffer before any `n`-sized allocation. This closes an OOM
the `FuzzDecoder_NeverPanics` CI job can reach on this branch.

## Verification

- Round-trip (struct decode + `any` decode), never-worse on run-heavy and
  high-cardinality columns, hostile `count<2` regression test.
- Golden fixtures unchanged (existing wire byte-identical).
- `go test -race` + two fuzz targets (`FuzzDecoder_NeverPanics` 5.5M execs,
  `FuzzStrDict_RoundTrip`) under both default and `qdf_simd` build tags.
- `golangci-lint` clean; arm64 NEON round-trip + golden under emulation.
- **Interleaved** benchstat (n=10) shows no encode/decode regression on the
  existing corpora (all p>0.05, allocs byte-identical).

Docs updated: README / GUIDE / USAGE / CHOOSING / BENCH tag tables and codec
references, and the `qdf` package comment.
