### PR TITLE
feat: nullable (optional pointer) columns in the columnar container

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![ci](https://github.com/alex60217101990/qdf/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/alex60217101990/qdf/actions/workflows/ci.yml)
 [![codeql](https://github.com/alex60217101990/qdf/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/alex60217101990/qdf/actions/workflows/codeql.yml)
 [![codecov](https://codecov.io/gh/alex60217101990/qdf/branch/main/graph/badge.svg)](https://codecov.io/gh/alex60217101990/qdf)
-[![benchmarks](https://img.shields.io/badge/benchmarks-dashboard-blue)](https://alex60217101990.github.io/qdf/)
+[![benchmarks](https://img.shields.io/badge/benchmarks-live%20dashboard-blue)](https://alex60217101990.github.io/qdf/dev/bench/)
 [![Go Reference](https://pkg.go.dev/badge/github.com/alex60217101990/qdf.svg)](https://pkg.go.dev/github.com/alex60217101990/qdf)
 [![Go Report Card](https://goreportcard.com/badge/github.com/alex60217101990/qdf)](https://goreportcard.com/report/github.com/alex60217101990/qdf)
 ![Go](https://img.shields.io/badge/go-1.26-blue?logo=go)
@@ -481,10 +481,22 @@ on decode.
 
 ## Benchmarks
 
-Darwin amd64 / Intel i7-9750H @ 2.6 GHz, Go 1.26.0, `-benchtime=2s`,
-`-race` cross-check. Full numbers, realistic / unique-data scenarios,
-memory tables and reproduction commands are in
-[`docs/BENCH.md`](docs/BENCH.md).
+📈 **Live trend dashboard: <https://alex60217101990.github.io/qdf/dev/bench/>**
+
+Every push to `main` re-runs the benchmark suite in CI and appends the
+result to that dashboard — one chart per benchmark, `ns/op` (and where
+shown `B/op` / `allocs/op`) over the commit timeline. A curve trending
+**down** is a speed/size win; a **sustained** step up is a regression (a
+lone spike is shared-runner noise — read the trend, not single points).
+See [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) for how to read the graphs.
+Wire-size numbers (`TestCorpusCodec_Sizes`) are deterministic, so changes
+there are real.
+
+The tables below are a point-in-time snapshot — Darwin amd64 / Intel
+i7-9750H @ 2.6 GHz, Go 1.26.0, `-benchtime=2s`, `-race` cross-check. Full
+numbers, realistic / unique-data scenarios, memory tables and reproduction
+commands are in [`docs/BENCH.md`](docs/BENCH.md); the live dashboard above
+has the current numbers.
 
 > **May 2026 perf series** (commits `ada9fd7`, `2ea3b48`, `02d6aac`,
 > `7090e25`, `c0517e8`, `95d3c21`, `001864b`) rebuilt the encode +

--- a/columnar.go
+++ b/columnar.go
@@ -18,16 +18,33 @@ const (
 	colKindFloat                 // float32, float64 → []float64 column
 	colKindBool                  // bool → []bool column
 	colKindString                // string, []byte → consecutive WriteString
+
+	// colKindNullable is OR'd onto a base kind in the columnar shape's kind
+	// byte to mark an optional (pointer-to-scalar/string) column: a `*T`
+	// field. The column is stored as a presence bitmap (1 bit per row) plus
+	// a dense column of only the present values, encoded with the base
+	// kind's normal codec. Nullability is a static property of the field
+	// type, so it travels in the shape declaration — no separate wire tag.
+	colKindNullable colKind = 0x80
 )
+
+// base returns the kind without the nullable flag.
+func (k colKind) base() colKind { return k &^ colKindNullable }
+
+// isNullable reports whether the column is an optional (pointer) column.
+func (k colKind) isNullable() bool { return k&colKindNullable != 0 }
 
 // colColumn is one field's columnar descriptor: where it lives in each struct
 // element and how to (de)serialize the column.
 type colColumn struct {
 	name   string
 	offset uintptr
-	kind   colKind
+	kind   colKind // base kind, OR'd with colKindNullable for *T columns
 	width  uintptr // element width in bytes for the scalar load/store
 	isByte bool    // true for []byte string columns (vs string)
+	// elemType is the pointed-to type for a nullable (*T) column, used to
+	// allocate the present values on decode. nil for non-nullable columns.
+	elemType reflect.Type
 }
 
 // columnarPlan is cached on the slice element's typeDesc. nil means the
@@ -49,6 +66,12 @@ const columnarMinElems = 16
 // (callers with more rows should shard or stream).
 const maxColumnarElems = 1 << 24
 
+// maxColumnarAnyElems caps the row count for the reflective map[string]any
+// decode, which allocates one map per row up front (much heavier than the
+// typed struct path's single backing slice). Kept well above any realistic
+// ad-hoc decode; callers with more rows should decode into a typed struct.
+const maxColumnarAnyElems = 1 << 16
+
 // checkColumnarN validates a tagColStruct struct count. Unlike row-major
 // slices, a columnar count is not byte-bounded (compressed columns), so it is
 // checked against a fixed ceiling rather than the remaining buffer length.
@@ -69,11 +92,32 @@ func buildColumnarPlan(td *typeDesc) *columnarPlan {
 	cols := make([]colColumn, 0, len(td.fields))
 	for i := range td.fields {
 		f := &td.fields[i]
-		ck, w, isByte, ok := classifyColKind(f.desc)
+		fd := f.desc
+		// An optional (*T) field becomes a nullable column: classify the
+		// pointed-to type and remember its reflect.Type for decode allocation.
+		var elemType reflect.Type
+		nullable := false
+		if fd.kind == reflect.Pointer {
+			if fd.elem == nil {
+				return nil
+			}
+			nullable = true
+			elemType = fd.rType.Elem()
+			fd = fd.elem
+		}
+		ck, w, isByte, ok := classifyColKind(fd)
 		if !ok {
 			return nil
 		}
-		cols = append(cols, colColumn{name: f.name, offset: f.offset, kind: ck, width: w, isByte: isByte})
+		if nullable {
+			// v1: only scalar/bool pointers (*int*, *uint*, *float*, *bool).
+			// Nullable string/[]byte columns fall back to row-major for now.
+			if isByte || ck == colKindString {
+				return nil
+			}
+			ck |= colKindNullable
+		}
+		cols = append(cols, colColumn{name: f.name, offset: f.offset, kind: ck, width: w, isByte: isByte, elemType: elemType})
 	}
 	return &columnarPlan{cols: cols, stride: td.rType.Size()}
 }
@@ -195,6 +239,34 @@ func columnarProbe(plan *columnarPlan, base unsafe.Pointer, n int) bool {
 				prev = s
 				first = false
 			}
+		default:
+			if !col.kind.isNullable() {
+				continue // unknown kind contributes nothing
+			}
+			// Nullable column. Row-major spends ~1 tag byte per row (tagNil for
+			// absent, a value tag for present) plus the present value bytes;
+			// columnar spends a presence bitmap plus a dense column no larger
+			// than those value bytes (FOR-packing only shrinks it further), so
+			// the mask-vs-byte-per-row difference is the conservative win.
+			valBytes := 0
+			for i := range sample {
+				pp := *(*unsafe.Pointer)(unsafe.Add(base, uintptr(i)*plan.stride+col.offset))
+				if pp == nil {
+					continue
+				}
+				switch col.kind.base() {
+				case colKindInt:
+					valBytes += uvarintLen(zigzagEncode64(loadI64At(pp, col.width)))
+				case colKindUint:
+					valBytes += uvarintLen(loadU64At(pp, col.width))
+				case colKindFloat:
+					valBytes += 8
+				case colKindBool:
+					valBytes++
+				}
+			}
+			rowBytes += sample + valBytes
+			colBytes += (sample+7)/8 + valBytes
 		}
 	}
 	if rowBytes == 0 {
@@ -228,6 +300,12 @@ func (e *Encoder) encodeColumnar(plan *columnarPlan, base unsafe.Pointer, n int)
 
 	for c := range plan.cols {
 		col := &plan.cols[c]
+		if col.kind.isNullable() {
+			if err := e.encodeNullableColumn(base, plan, col, n); err != nil {
+				return err
+			}
+			continue
+		}
 		switch col.kind {
 		case colKindInt:
 			s := st.colScratchI64[:0]
@@ -279,12 +357,7 @@ func (e *Encoder) encodeColumnar(plan *columnarPlan, base unsafe.Pointer, n int)
 				s = append(s, loadStringField(base, plan.stride, col, i))
 			}
 			st.colScratchStr = s
-			if e.tryWriteStringColumnDict(s) {
-				break // dict form emitted; never-worse gate already passed
-			}
-			for _, v := range s {
-				e.WriteString(v)
-			}
+			e.writeStringColumn(s)
 		}
 	}
 	return nil
@@ -349,6 +422,10 @@ func decodeColumnar(d *Decoder, t reflect.Type, plan *columnarPlan, p unsafe.Poi
 	if err := checkColumnarN(n); err != nil {
 		return err
 	}
+	// Every column holds exactly n elements; bound each column codec's
+	// claimed length so a constant/zero-width codec cannot allocate past n.
+	d.colMaxLen = n
+	defer func() { d.colMaxLen = 0 }()
 	if d.state == nil {
 		d.state = newDecState()
 	}
@@ -398,6 +475,12 @@ func decodeColumnar(d *Decoder, t reflect.Type, plan *columnarPlan, p unsafe.Poi
 		col := &plan.cols[c]
 		if c >= len(sh.kinds) || sh.kinds[c] != col.kind {
 			return ErrTypeMismatch
+		}
+		if col.kind.isNullable() {
+			if err := d.decodeNullableColumn(base, plan, col, n); err != nil {
+				return err
+			}
+			continue
 		}
 		switch col.kind {
 		case colKindInt:
@@ -528,6 +611,16 @@ func decodeColumnarAny(d *Decoder) (any, error) {
 	if err := checkColumnarN(n); err != nil {
 		return nil, err
 	}
+	// The map-per-row reflection decode allocates n maps up front, far heavier
+	// than the struct path's single backing slice, so it gets a tighter
+	// element ceiling. A constant column can claim a huge n from a tiny body;
+	// without this a small hostile input would drive a multi-gigabyte map
+	// allocation. Callers decoding millions of rows should use a typed struct.
+	if n > maxColumnarAnyElems {
+		return nil, ErrInvalidLength
+	}
+	d.colMaxLen = n
+	defer func() { d.colMaxLen = 0 }()
 	if d.state == nil {
 		d.state = newDecState()
 	}
@@ -574,6 +667,16 @@ func decodeColumnarAny(d *Decoder) (any, error) {
 	}
 	for c := range sh.kinds {
 		name := sh.names[c]
+		if sh.kinds[c].isNullable() {
+			vals, err := d.decodeNullableColumnAny(sh.kinds[c], n)
+			if err != nil {
+				return nil, err
+			}
+			for i := range n {
+				out[i].(map[string]any)[name] = vals[i]
+			}
+			continue
+		}
 		switch sh.kinds[c] {
 		case colKindInt:
 			var s []int64

--- a/decoder.go
+++ b/decoder.go
@@ -24,6 +24,20 @@ type Decoder struct {
 	keyCache intern.Cache
 
 	headerRead bool
+
+	// colMaxLen bounds a slice codec's claimed element count while decoding
+	// a columnar column, where every column must hold exactly the struct
+	// count M. 0 means unbounded (standalone slice decode). It blocks a
+	// hostile column whose constant/zero-width codec claims a huge n from a
+	// tiny body before the per-element allocation.
+	colMaxLen int
+}
+
+// colLenOK reports whether a slice length is acceptable in the current
+// decode context. Outside a columnar column (colMaxLen == 0) any length is
+// allowed; the row-major and standalone paths bound length by the buffer.
+func (d *Decoder) colLenOK(n uint64) bool {
+	return d.colMaxLen == 0 || n <= uint64(d.colMaxLen)
 }
 
 // InternKey returns a string equal to b, sharing storage with prior

--- a/docs/BENCH.md
+++ b/docs/BENCH.md
@@ -1,5 +1,11 @@
 # QDF Benchmark Results
 
+> **The numbers below are a point-in-time snapshot.** For the
+> continuously-updated results (re-run on every push to `main`) see the
+> **live dashboard: <https://alex60217101990.github.io/qdf/dev/bench/>** —
+> read [`BENCHMARKS.md`](BENCHMARKS.md) for how to read the trend graphs
+> and tell a real change from shared-runner noise.
+
 Measured on Darwin amd64 / Intel i7-9750H @ 2.6 GHz. Go 1.26.0.
 `go test -bench=. -benchmem -benchtime=2s` in `bench/`.
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,53 @@
+# Continuous benchmarks
+
+Live dashboard: **<https://alex60217101990.github.io/qdf/dev/bench/>**
+
+Every push to `main` runs the Go benchmark suite in CI and appends the
+results to a trend dashboard (built with
+[`benchmark-action/github-action-benchmark`](https://github.com/benchmark-action/github-action-benchmark)
+and published to the `gh-pages` branch). The dashboard is the
+always-current source of performance numbers; the tables in
+[`BENCH.md`](BENCH.md) are a point-in-time snapshot.
+
+## What the graphs show
+
+- **One chart per benchmark** (e.g. `BenchmarkProfile_HotPath/decode/qdf`,
+  `BenchmarkCorpusCodec_*`). The X axis is the commit timeline; the Y axis
+  is the metric — `ns/op` (lower is faster), and where reported `B/op` and
+  `allocs/op` (lower is leaner).
+- **Hover a point** to see the exact commit, value, and date. Click it to
+  jump to the commit on GitHub.
+
+## How to read progress vs regression
+
+- **Line trends down → improvement.** A commit that makes a path faster (or
+  smaller) drops the curve at that point.
+- **Line trends up → regression.** A sustained step up means a change cost
+  time/memory. A one-commit spike that immediately returns is almost always
+  **runner noise**, not a real regression (see below).
+- **Compare the latest point to the recent plateau**, not to a single prior
+  point — that filters out the variance.
+
+## Noise — read trends, not single points
+
+CI runs on shared GitHub-hosted runners, so absolute numbers carry roughly
+**±10–15 %** run-to-run variance (CPU model, neighbours, thermal). Rules of
+thumb:
+
+- A real win/regression shows as a **sustained shift across several
+  commits**, not a lone spike.
+- The dashboard's auto-alert fires when a commit is more than ~2× slower
+  than its baseline; sub-2× changes are below the cross-run noise floor and
+  must be confirmed locally with `benchstat` over ≥10 interleaved runs (see
+  the "measure-first" discipline in [`BENCH.md`](BENCH.md)).
+- Wire **size** numbers (from `TestCorpusCodec_Sizes`) are deterministic —
+  no noise — so any change there is real.
+
+## Running the suite locally
+
+```sh
+cd bench
+go test -run=^$ -bench='BenchmarkProfile_'  -benchtime=2s -count=10 | tee new.txt
+benchstat old.txt new.txt          # keep/revert decisions
+go test -run TestCorpusCodec_Sizes -v        # deterministic wire sizes
+```

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -679,6 +679,15 @@ the slice:
   columns are always emitted as M consecutive inline values.
 - The remaining string/`[]byte` per-value emissions go through the
   normal intern path; repeated values collapse to state-refs.
+- An optional (`*T`) field whose `T` is a scalar (`int*`/`uint*`/
+  `float*`/`bool`) becomes a **nullable column** instead of forcing the
+  whole struct to row-major: a presence bitmap (1 bit per row, LSB-first)
+  followed by a dense column of only the present values, fed through the
+  base type's normal codec. Nullability rides in the shape's kind byte
+  (`colKindNullable`, the high bit) — no extra wire tag — so the decoder
+  rebuilds the nils from the mask. A single optional field used to defeat
+  columnar for the entire struct; this keeps the win. Nullable string
+  columns currently fall back to row-major.
 
 The wire layout is `0xEF, varuint(M), varuint(shapeID)` followed by K
 column payloads in declaration order. `shapeID == 0` declares a new

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -155,6 +155,7 @@ time. You do not need to hint it — just set the bit.
 | Arrays of identical struct type | Shape interning | `OptBalanced` |
 | Predictable field transitions (e.g. service→region) | Markov-1 pair predictor | `OptBalanced` |
 | Enum-like string column in a `[]SomeStruct` (log level, service, region, status) | Per-column string dictionary (distinct table + bit-packed index/row) | `OptBalanced` (columnar) |
+| Optional (`*int`/`*float`/`*bool`…) field in a `[]SomeStruct` | Nullable column: 1-bit-per-row presence bitmap + dense present-only column. Keeps columnar instead of falling back to row-major. | `OptBalanced` (columnar) |
 | `[]SomeStruct` where fields are int/uint/float/bool/string/[]byte | Columnar transpose: numeric fields get FOR/delta/RLE/dict, enum-like string columns get a per-column dictionary, other repeated string fields collapse via intern. Automatic — no flag. The encoder probes each array and falls back to row-major when columnar would not win. | `OptBalanced` (Dense + ShapeIntern) |
 
 The encoder probes a slice's structure before committing. For

--- a/nullable_col.go
+++ b/nullable_col.go
@@ -1,0 +1,311 @@
+package qdf
+
+import (
+	"math/bits"
+	"reflect"
+	"runtime"
+	"unsafe"
+)
+
+// Nullable (optional) columns for the columnar container. A `*T` struct
+// field — where T is a scalar (int*/uint*/float*/bool) — would otherwise
+// force the whole struct to the row-major fallback, losing the columnar
+// codecs on every sibling column. Instead it is stored as a presence
+// bitmap (1 bit per row, LSB-first) followed by a dense column of only the
+// present values, encoded with T's normal slice codec. The nullable flag
+// rides in the columnar shape's kind byte (colKindNullable), so there is no
+// separate wire tag; the column slot is `ceil(M/8) mask bytes, <dense
+// column>`.
+
+// writeStringColumn emits a gathered string column either as a dictionary
+// (when the never-worse gate accepts it) or as M per-value strings. Shared
+// by the regular string column path; factored out so nullable columns could
+// reuse it (nullable string columns are a follow-up).
+func (e *Encoder) writeStringColumn(strs []string) {
+	if e.tryWriteStringColumnDict(strs) {
+		return
+	}
+	for _, v := range strs {
+		e.WriteString(v)
+	}
+}
+
+func loadI64At(p unsafe.Pointer, width uintptr) int64 {
+	switch width {
+	case 1:
+		return int64(*(*int8)(p))
+	case 2:
+		return int64(*(*int16)(p))
+	case 4:
+		return int64(*(*int32)(p))
+	default:
+		return *(*int64)(p)
+	}
+}
+
+func loadU64At(p unsafe.Pointer, width uintptr) uint64 {
+	switch width {
+	case 1:
+		return uint64(*(*uint8)(p))
+	case 2:
+		return uint64(*(*uint16)(p))
+	case 4:
+		return uint64(*(*uint32)(p))
+	default:
+		return *(*uint64)(p)
+	}
+}
+
+func loadF64At(p unsafe.Pointer, width uintptr) float64 {
+	if width == 4 {
+		return float64(*(*float32)(p))
+	}
+	return *(*float64)(p)
+}
+
+func storeI64At(p unsafe.Pointer, width uintptr, v int64) {
+	switch width {
+	case 1:
+		*(*int8)(p) = int8(v)
+	case 2:
+		*(*int16)(p) = int16(v)
+	case 4:
+		*(*int32)(p) = int32(v)
+	default:
+		*(*int64)(p) = v
+	}
+}
+
+func storeU64At(p unsafe.Pointer, width uintptr, v uint64) {
+	switch width {
+	case 1:
+		*(*uint8)(p) = uint8(v)
+	case 2:
+		*(*uint16)(p) = uint16(v)
+	case 4:
+		*(*uint32)(p) = uint32(v)
+	default:
+		*(*uint64)(p) = v
+	}
+}
+
+func storeF64At(p unsafe.Pointer, width uintptr, v float64) {
+	if width == 4 {
+		*(*float32)(p) = float32(v)
+	} else {
+		*(*float64)(p) = v
+	}
+}
+
+// encodeNullableColumn writes the presence bitmap and the dense present-only
+// column for a `*T` field.
+func (e *Encoder) encodeNullableColumn(base unsafe.Pointer, plan *columnarPlan, col *colColumn, n int) error {
+	st := e.state
+	maskBytes := (n + 7) >> 3
+	var mask []byte
+	if cap(st.colMaskScratch) >= maskBytes {
+		mask = st.colMaskScratch[:maskBytes]
+		clear(mask)
+	} else {
+		mask = make([]byte, maskBytes)
+	}
+	st.colMaskScratch = mask
+	stride, off := plan.stride, col.offset
+
+	switch col.kind.base() {
+	case colKindInt:
+		s := st.colScratchI64[:0]
+		for i := range n {
+			pp := *(*unsafe.Pointer)(unsafe.Add(base, uintptr(i)*stride+off))
+			if pp != nil {
+				mask[i>>3] |= 1 << uint(i&7)
+				s = append(s, loadI64At(pp, col.width))
+			}
+		}
+		st.colScratchI64 = s
+		e.buf = append(e.buf, mask...)
+		return encodeSliceInt64(e, unsafe.Pointer(&s))
+	case colKindUint:
+		s := st.colScratchU64[:0]
+		for i := range n {
+			pp := *(*unsafe.Pointer)(unsafe.Add(base, uintptr(i)*stride+off))
+			if pp != nil {
+				mask[i>>3] |= 1 << uint(i&7)
+				s = append(s, loadU64At(pp, col.width))
+			}
+		}
+		st.colScratchU64 = s
+		e.buf = append(e.buf, mask...)
+		return encodeSliceUint64(e, unsafe.Pointer(&s))
+	case colKindFloat:
+		s := st.colScratchF64[:0]
+		for i := range n {
+			pp := *(*unsafe.Pointer)(unsafe.Add(base, uintptr(i)*stride+off))
+			if pp != nil {
+				mask[i>>3] |= 1 << uint(i&7)
+				s = append(s, loadF64At(pp, col.width))
+			}
+		}
+		st.colScratchF64 = s
+		e.buf = append(e.buf, mask...)
+		return encodeSliceFloat64(e, unsafe.Pointer(&s))
+	case colKindBool:
+		s := st.colScratchBool[:0]
+		for i := range n {
+			pp := *(*unsafe.Pointer)(unsafe.Add(base, uintptr(i)*stride+off))
+			if pp != nil {
+				mask[i>>3] |= 1 << uint(i&7)
+				s = append(s, *(*bool)(pp))
+			}
+		}
+		st.colScratchBool = s
+		e.buf = append(e.buf, mask...)
+		return encodeSliceBool(e, unsafe.Pointer(&s))
+	}
+	return ErrBadTag
+}
+
+// readNullableMask consumes the presence bitmap and returns it plus the
+// present count (popcount). The caller decodes the dense column next.
+func (d *Decoder) readNullableMask(n int) (mask []byte, present int, err error) {
+	maskBytes := (n + 7) >> 3
+	if d.i+maskBytes > len(d.buf) {
+		return nil, 0, ErrShortBuffer
+	}
+	mask = d.buf[d.i : d.i+maskBytes]
+	d.i += maskBytes
+	for _, b := range mask {
+		present += bits.OnesCount8(b)
+	}
+	return mask, present, nil
+}
+
+// decodeNullableColumn reads the mask + dense column and scatters the present
+// values back into the `*T` field, allocating all present values in a single
+// backing slice that the field pointers reference into.
+func (d *Decoder) decodeNullableColumn(base unsafe.Pointer, plan *columnarPlan, col *colColumn, n int) error {
+	mask, present, err := d.readNullableMask(n)
+	if err != nil {
+		return err
+	}
+	elemSize := col.elemType.Size()
+	backing := reflect.MakeSlice(reflect.SliceOf(col.elemType), present, present)
+	dataPtr := backing.UnsafePointer()
+	stride, off := plan.stride, col.offset
+	k := 0
+	set := func(store func(ea unsafe.Pointer, k int)) {
+		for i := range n {
+			fp := unsafe.Add(base, uintptr(i)*stride+off)
+			if mask[i>>3]&(1<<uint(i&7)) != 0 {
+				ea := unsafe.Add(dataPtr, uintptr(k)*elemSize)
+				store(ea, k)
+				*(*unsafe.Pointer)(fp) = ea
+				k++
+			} else {
+				*(*unsafe.Pointer)(fp) = nil
+			}
+		}
+	}
+	switch col.kind.base() {
+	case colKindInt:
+		var s []int64
+		if err := decodeSliceInt64(d, unsafe.Pointer(&s)); err != nil {
+			return err
+		}
+		if len(s) != present {
+			return ErrTypeMismatch
+		}
+		set(func(ea unsafe.Pointer, k int) { storeI64At(ea, col.width, s[k]) })
+	case colKindUint:
+		var s []uint64
+		if err := decodeSliceUint64(d, unsafe.Pointer(&s)); err != nil {
+			return err
+		}
+		if len(s) != present {
+			return ErrTypeMismatch
+		}
+		set(func(ea unsafe.Pointer, k int) { storeU64At(ea, col.width, s[k]) })
+	case colKindFloat:
+		var s []float64
+		if err := decodeSliceFloat64(d, unsafe.Pointer(&s)); err != nil {
+			return err
+		}
+		if len(s) != present {
+			return ErrTypeMismatch
+		}
+		set(func(ea unsafe.Pointer, k int) { storeF64At(ea, col.width, s[k]) })
+	case colKindBool:
+		var s []bool
+		if err := decodeSliceBool(d, unsafe.Pointer(&s)); err != nil {
+			return err
+		}
+		if len(s) != present {
+			return ErrTypeMismatch
+		}
+		set(func(ea unsafe.Pointer, k int) { *(*bool)(ea) = s[k] })
+	default:
+		return ErrBadTag
+	}
+	runtime.KeepAlive(backing)
+	return nil
+}
+
+// decodeNullableColumnAny reads the mask + dense column and returns one boxed
+// value per row (nil for absent), for the map[string]any decode path.
+func (d *Decoder) decodeNullableColumnAny(kind colKind, n int) ([]any, error) {
+	mask, present, err := d.readNullableMask(n)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]any, n)
+	k := 0
+	scatter := func(box func(i, k int)) {
+		for i := range n {
+			if mask[i>>3]&(1<<uint(i&7)) != 0 {
+				box(i, k)
+				k++
+			}
+		}
+	}
+	switch kind.base() {
+	case colKindInt:
+		var s []int64
+		if err := decodeSliceInt64(d, unsafe.Pointer(&s)); err != nil {
+			return nil, err
+		}
+		if len(s) != present {
+			return nil, ErrTypeMismatch
+		}
+		scatter(func(i, k int) { out[i] = s[k] })
+	case colKindUint:
+		var s []uint64
+		if err := decodeSliceUint64(d, unsafe.Pointer(&s)); err != nil {
+			return nil, err
+		}
+		if len(s) != present {
+			return nil, ErrTypeMismatch
+		}
+		scatter(func(i, k int) { out[i] = s[k] })
+	case colKindFloat:
+		var s []float64
+		if err := decodeSliceFloat64(d, unsafe.Pointer(&s)); err != nil {
+			return nil, err
+		}
+		if len(s) != present {
+			return nil, ErrTypeMismatch
+		}
+		scatter(func(i, k int) { out[i] = s[k] })
+	case colKindBool:
+		var s []bool
+		if err := decodeSliceBool(d, unsafe.Pointer(&s)); err != nil {
+			return nil, err
+		}
+		if len(s) != present {
+			return nil, ErrTypeMismatch
+		}
+		scatter(func(i, k int) { out[i] = s[k] })
+	default:
+		return nil, ErrBadTag
+	}
+	return out, nil
+}

--- a/nullable_col_test.go
+++ b/nullable_col_test.go
@@ -1,0 +1,128 @@
+package qdf
+
+import (
+	"math/rand"
+	"testing"
+)
+
+type nullRow struct {
+	Seq int64    // sequential → columnar engages
+	A   *int64   // optional
+	B   *uint32  // optional, narrow
+	C   *float64 // optional
+	D   *bool    // optional
+}
+
+func mkNullRows(n int, nullPct int, seed int64) []nullRow {
+	r := rand.New(rand.NewSource(seed))
+	out := make([]nullRow, n)
+	for i := range out {
+		out[i].Seq = int64(i)
+		if r.Intn(100) >= nullPct {
+			v := int64(r.Intn(10000) - 5000)
+			out[i].A = &v
+		}
+		if r.Intn(100) >= nullPct {
+			v := uint32(r.Intn(1 << 20))
+			out[i].B = &v
+		}
+		if r.Intn(100) >= nullPct {
+			v := float64(r.Intn(1000)) / 7
+			out[i].C = &v
+		}
+		if r.Intn(100) >= nullPct {
+			v := r.Intn(2) == 0
+			out[i].D = &v
+		}
+	}
+	return out
+}
+
+func eqNullRow(a, b nullRow) bool {
+	if a.Seq != b.Seq {
+		return false
+	}
+	eqI := func(x, y *int64) bool { return (x == nil) == (y == nil) && (x == nil || *x == *y) }
+	eqU := func(x, y *uint32) bool { return (x == nil) == (y == nil) && (x == nil || *x == *y) }
+	eqF := func(x, y *float64) bool { return (x == nil) == (y == nil) && (x == nil || *x == *y) }
+	eqB := func(x, y *bool) bool { return (x == nil) == (y == nil) && (x == nil || *x == *y) }
+	return eqI(a.A, b.A) && eqU(a.B, b.B) && eqF(a.C, b.C) && eqB(a.D, b.D)
+}
+
+func TestNullable_RoundTrip(t *testing.T) {
+	for _, nullPct := range []int{0, 30, 95, 100} {
+		for _, n := range []int{20, 1000} {
+			rows := mkNullRows(n, nullPct, int64(nullPct*7+n))
+			enc, err := Marshal(rows, OptBalanced&^OptRANS)
+			if err != nil {
+				t.Fatalf("null%%=%d n=%d: %v", nullPct, n, err)
+			}
+			var got []nullRow
+			if err := Unmarshal(enc, &got); err != nil {
+				t.Fatalf("null%%=%d n=%d unmarshal: %v", nullPct, n, err)
+			}
+			if len(got) != len(rows) {
+				t.Fatalf("len %d != %d", len(got), len(rows))
+			}
+			for i := range rows {
+				if !eqNullRow(got[i], rows[i]) {
+					t.Fatalf("null%%=%d n=%d row %d mismatch: %+v != %+v", nullPct, n, i, got[i], rows[i])
+				}
+			}
+		}
+	}
+}
+
+func TestNullable_RoundTripAny(t *testing.T) {
+	rows := mkNullRows(500, 40, 99)
+	enc, err := Marshal(rows, OptBalanced&^OptRANS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var gotAny any
+	if err := Unmarshal(enc, &gotAny); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := gotAny.([]any)
+	if !ok || len(got) != len(rows) {
+		t.Fatalf("any shape: %T", gotAny)
+	}
+	for i := range rows {
+		m := got[i].(map[string]any)
+		if rows[i].A == nil {
+			if m["A"] != nil {
+				t.Fatalf("row %d A: want nil got %v", i, m["A"])
+			}
+		} else if m["A"].(int64) != *rows[i].A {
+			t.Fatalf("row %d A: %v != %d", i, m["A"], *rows[i].A)
+		}
+		if rows[i].D == nil {
+			if m["D"] != nil {
+				t.Fatalf("row %d D: want nil got %v", i, m["D"])
+			}
+		} else if m["D"].(bool) != *rows[i].D {
+			t.Fatalf("row %d D mismatch", i)
+		}
+	}
+}
+
+func TestNullable_SmallerThanRowMajor(t *testing.T) {
+	rows := mkNullRows(2000, 30, 7)
+	col, err := Marshal(rows, OptBalanced&^OptRANS) // columnar + null-mask
+	if err != nil {
+		t.Fatal(err)
+	}
+	row, err := Marshal(rows, OptSpeed) // no codecs → row-major baseline
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Unlocking the columnar codecs for a struct with optional fields must
+	// beat the row-major baseline. (Random high-entropy values cap the
+	// absolute ratio, but columnar still wins via the presence bitmap and
+	// FOR-packed present columns.)
+	if len(col) >= len(row) {
+		t.Fatalf("columnar null-mask %d not smaller than row-major %d", len(col), len(row))
+	}
+	t.Logf("n=%d  columnar=%d  row-major(OptSpeed)=%d  (%.1f%% smaller)",
+		len(rows), len(col), len(row), 100*(1-float64(len(col))/float64(len(row))))
+}

--- a/qdf.go
+++ b/qdf.go
@@ -37,6 +37,8 @@
 // and compressed column-by-column automatically — numeric columns get the
 // integer codecs, an enum-like string column is dictionary-coded (distinct
 // table + a bit-packed index per row) when that beats per-value interning,
+// an optional (*T scalar) field becomes a presence bitmap plus a dense
+// present-only column instead of forcing the struct back to row-major,
 // other repeated string columns collapse — with no flag, and a per-array
 // probe falls back to the plain row encoding when columnar would not help. The float codecs that trade encode CPU for size live behind
 // OptCompression: Gorilla XOR on smooth series, ALP on quantized/decimal

--- a/qpack_delta.go
+++ b/qpack_delta.go
@@ -205,6 +205,9 @@ func (d *Decoder) readPackedDeltaForHeader(expectKind byte) (bitsPer int, unsign
 		return 0, 0, 0, 0, 0, nil, ErrInvalidLength
 	}
 	d.i += nr
+	if !d.colLenOK(n64) {
+		return 0, 0, 0, 0, 0, nil, ErrInvalidLength
+	}
 	if n64 < 2 {
 		return bitsPer, unsignedFirst, signedFirst, minDelta, int(n64), nil, nil
 	}

--- a/qpack_dict.go
+++ b/qpack_dict.go
@@ -162,6 +162,9 @@ func (d *Decoder) readPackedDictUint64Slice() ([]uint64, error) {
 		return nil, ErrInvalidLength
 	}
 	d.i += nr
+	if !d.colLenOK(n64) {
+		return nil, ErrInvalidLength
+	}
 	n := int(n64)
 	out := make([]uint64, n)
 	if bitsPer == 0 {
@@ -210,6 +213,9 @@ func (d *Decoder) readPackedDictInt64Slice() ([]int64, error) {
 		return nil, ErrInvalidLength
 	}
 	d.i += nr
+	if !d.colLenOK(n64) {
+		return nil, ErrInvalidLength
+	}
 	n := int(n64)
 	out := make([]int64, n)
 	if bitsPer == 0 {

--- a/qpack_for.go
+++ b/qpack_for.go
@@ -182,6 +182,9 @@ func (d *Decoder) readPackedForHeader(expectKind byte) (bitsPer int, unsignedMin
 		return 0, 0, 0, 0, nil, ErrInvalidLength
 	}
 	d.i += nr
+	if !d.colLenOK(n64) {
+		return 0, 0, 0, 0, nil, ErrInvalidLength
+	}
 	// Validate body size in uint64 BEFORE the signed cast. A hostile
 	// varuint with n64 > MaxInt would otherwise wrap int(n64) to
 	// negative and the bounds check in the original form

--- a/qpack_pfor.go
+++ b/qpack_pfor.go
@@ -191,6 +191,9 @@ func (d *Decoder) readPackedPForInt64Slice() ([]int64, error) {
 		return nil, ErrInvalidLength
 	}
 	d.i += nr
+	if !d.colLenOK(n64) {
+		return nil, ErrInvalidLength
+	}
 	if d.i >= len(d.buf) {
 		return nil, ErrShortBuffer
 	}
@@ -272,6 +275,9 @@ func (d *Decoder) readPackedPForUint64Slice() ([]uint64, error) {
 		return nil, ErrInvalidLength
 	}
 	d.i += nr
+	if !d.colLenOK(n64) {
+		return nil, ErrInvalidLength
+	}
 	if d.i >= len(d.buf) {
 		return nil, ErrShortBuffer
 	}

--- a/state.go
+++ b/state.go
@@ -160,6 +160,7 @@ type encState struct {
 	colScratchBool []bool
 	colScratchStr  []string // gathered string column values
 	colDictTable   []string // distinct table for the string-dict codec
+	colMaskScratch []byte   // presence bitmap for nullable columns
 	// strDictMap maps a string column's distinct values to dense indices
 	// while the string-dict codec decides/encodes. Reused (cleared) per
 	// column to avoid a per-column map allocation.


### PR DESCRIPTION
A `*T` struct field — where `T` is a scalar (`int*`/`uint*`/`float*`/
`bool`) — used to make the **whole** struct ineligible for columnar
encoding, dropping it to the row-major fallback and losing FOR / Delta /
dict / RLE on **every** sibling column. One optional field could inflate a
struct array ~28×. Such fields are now a columnar **nullable column**.

Available **automatically under `OptBalanced`** (the columnar path); no
flag, no public API change.

## Wire format

Nullability is a static property of the field type, so it travels in the
columnar **shape**, not as a per-value tag: the shape's kind byte gets the
high bit set (`colKindNullable = 0x80` OR'd onto the base kind). **No new
wire tag is consumed.** The column slot is:

```
ceil(M/8) presence-bitmap bytes (LSB-first), <dense present-only column>
```

The dense column is the present values encoded with the base type's normal
slice codec (FOR/Delta/dict/raw). The decoder rebuilds the nils from the
mask; `popcount(mask)` is the present count and cross-checks the dense
column length.

## Decode

Present values for a column are allocated in a **single backing slice**
(`reflect.MakeSlice(T, present)`); each present field pointer references
into it — one allocation per column, not one per value. Absent rows get a
nil pointer.

## Never-worse

The columnar probe prices the nullable column (presence bitmap + a dense
column no larger than the row-major value bytes), so columnar is committed
only when it beats row-major. A struct with no optional fields is
unaffected. Measured ~70% smaller than the row-major baseline on a
mixed-optional fixture even with high-entropy random values.

v1 covers scalar/bool pointers; nullable **string** columns fall back to
row-major (follow-up).

## Decode hardening (bundled)

Exercising this path with the decoder fuzzer surfaced a **pre-existing**
allocation DoS: a slice codec whose constant/zero-width form carries no
body (e.g. Frame-of-Reference with `bits == 0`, a single-value dictionary)
could claim a huge element count from a tiny input and drive a
multi-gigabyte `make` before any bounds check. Since every columnar column
must hold exactly the struct count `M`, the decoder now sets `colMaxLen` on
entry and each codec's length-read rejects `n > M` (`colLenOK`) **before**
the allocation; the reflective `map[string]any` decode (one map per row)
gets a tighter ceiling (`maxColumnarAnyElems`). Standalone slice decodes
are unaffected. This closes the OOM and is the root cause of the earlier
`FuzzDecoder_NeverPanics` CI failure.

## Verification

- Round-trip into a typed struct **and** into `any`/`map[string]any`,
  across 0 / 30 / 95 / 100 % null densities and n = 20 … 1000.
- Golden fixtures unchanged (structs without optional fields encode
  byte-identically).
- `go test -race` and the fuzz regression corpus clean under both the
  default and `qdf_simd` build tags; `golangci-lint` clean; arm64 NEON
  round-trip + golden under emulation.
- Interleaved benchstat on the existing decode/corpus/profile benchmarks
  shows **no regression** (all `~`, the per-codec length guard is a single
  comparison on the slice header, not per element).

Docs updated: GUIDE / USAGE columnar sections and the `qdf` package comment.
