### PR TITLE
feat: nullable string columns in the columnar container

### DIFF
--- a/columnar.go
+++ b/columnar.go
@@ -110,9 +110,9 @@ func buildColumnarPlan(td *typeDesc) *columnarPlan {
 			return nil
 		}
 		if nullable {
-			// v1: only scalar/bool pointers (*int*, *uint*, *float*, *bool).
-			// Nullable string/[]byte columns fall back to row-major for now.
-			if isByte || ck == colKindString {
+			// Nullable scalar/bool/string pointers are columnar; nullable
+			// []byte still falls back to row-major.
+			if isByte { // nullable []byte still unsupported; nullable string now allowed
 				return nil
 			}
 			ck |= colKindNullable

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -680,14 +680,15 @@ the slice:
 - The remaining string/`[]byte` per-value emissions go through the
   normal intern path; repeated values collapse to state-refs.
 - An optional (`*T`) field whose `T` is a scalar (`int*`/`uint*`/
-  `float*`/`bool`) becomes a **nullable column** instead of forcing the
-  whole struct to row-major: a presence bitmap (1 bit per row, LSB-first)
-  followed by a dense column of only the present values, fed through the
-  base type's normal codec. Nullability rides in the shape's kind byte
+  `float*`/`bool`) or a `string` becomes a **nullable column** instead of
+  forcing the whole struct to row-major: a presence bitmap (1 bit per row,
+  LSB-first) followed by a dense column of only the present values, fed
+  through the base type's normal codec (the string dictionary applies to a
+  nullable string column too). Nullability rides in the shape's kind byte
   (`colKindNullable`, the high bit) — no extra wire tag — so the decoder
   rebuilds the nils from the mask. A single optional field used to defeat
-  columnar for the entire struct; this keeps the win. Nullable string
-  columns currently fall back to row-major.
+  columnar for the entire struct; this keeps the win. (`*[]byte` still
+  falls back to row-major.)
 
 The wire layout is `0xEF, varuint(M), varuint(shapeID)` followed by K
 column payloads in declaration order. `shapeID == 0` declares a new

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -155,7 +155,7 @@ time. You do not need to hint it — just set the bit.
 | Arrays of identical struct type | Shape interning | `OptBalanced` |
 | Predictable field transitions (e.g. service→region) | Markov-1 pair predictor | `OptBalanced` |
 | Enum-like string column in a `[]SomeStruct` (log level, service, region, status) | Per-column string dictionary (distinct table + bit-packed index/row) | `OptBalanced` (columnar) |
-| Optional (`*int`/`*float`/`*bool`…) field in a `[]SomeStruct` | Nullable column: 1-bit-per-row presence bitmap + dense present-only column. Keeps columnar instead of falling back to row-major. | `OptBalanced` (columnar) |
+| Optional (`*int`/`*float`/`*bool`/`*string`…) field in a `[]SomeStruct` | Nullable column: 1-bit-per-row presence bitmap + dense present-only column (the present strings still get the string dictionary). Keeps columnar instead of falling back to row-major. | `OptBalanced` (columnar) |
 | `[]SomeStruct` where fields are int/uint/float/bool/string/[]byte | Columnar transpose: numeric fields get FOR/delta/RLE/dict, enum-like string columns get a per-column dictionary, other repeated string fields collapse via intern. Automatic — no flag. The encoder probes each array and falls back to row-major when columnar would not win. | `OptBalanced` (Dense + ShapeIntern) |
 
 The encoder probes a slice's structure before committing. For

--- a/nullable_col.go
+++ b/nullable_col.go
@@ -161,6 +161,19 @@ func (e *Encoder) encodeNullableColumn(base unsafe.Pointer, plan *columnarPlan, 
 		st.colScratchBool = s
 		e.buf = append(e.buf, mask...)
 		return encodeSliceBool(e, unsafe.Pointer(&s))
+	case colKindString:
+		s := st.colScratchStr[:0]
+		for i := range n {
+			pp := *(*unsafe.Pointer)(unsafe.Add(base, uintptr(i)*stride+off))
+			if pp != nil {
+				mask[i>>3] |= 1 << uint(i&7)
+				s = append(s, *(*string)(pp))
+			}
+		}
+		st.colScratchStr = s
+		e.buf = append(e.buf, mask...)
+		e.writeStringColumn(s)
+		return nil
 	}
 	return ErrBadTag
 }
@@ -243,6 +256,23 @@ func (d *Decoder) decodeNullableColumn(base unsafe.Pointer, plan *columnarPlan, 
 			return ErrTypeMismatch
 		}
 		set(func(ea unsafe.Pointer, k int) { *(*bool)(ea) = s[k] })
+	case colKindString:
+		strs, err := d.readStringColumn(present)
+		if err != nil {
+			return err
+		}
+		k := 0
+		for i := range n {
+			fp := unsafe.Add(base, uintptr(i)*stride+off)
+			if mask[i>>3]&(1<<uint(i&7)) != 0 {
+				*(*unsafe.Pointer)(fp) = unsafe.Pointer(&strs[k])
+				k++
+			} else {
+				*(*unsafe.Pointer)(fp) = nil
+			}
+		}
+		runtime.KeepAlive(strs)
+		return nil
 	default:
 		return ErrBadTag
 	}
@@ -304,6 +334,12 @@ func (d *Decoder) decodeNullableColumnAny(kind colKind, n int) ([]any, error) {
 			return nil, ErrTypeMismatch
 		}
 		scatter(func(i, k int) { out[i] = s[k] })
+	case colKindString:
+		strs, err := d.readStringColumn(present)
+		if err != nil {
+			return nil, err
+		}
+		scatter(func(i, k int) { out[i] = strs[k] })
 	default:
 		return nil, ErrBadTag
 	}

--- a/nullable_string_test.go
+++ b/nullable_string_test.go
@@ -1,0 +1,119 @@
+package qdf
+
+import (
+	"math/rand"
+	"testing"
+)
+
+type nullStrRow struct {
+	Seq   int64   // sequential → columnar engages
+	Label *string // optional enum-ish string
+	Note  *string // optional, higher cardinality
+}
+
+func mkNullStrRows(n, nullPct int, seed int64) []nullStrRow {
+	r := rand.New(rand.NewSource(seed))
+	labels := []string{"INFO", "WARN", "ERROR", "DEBUG"}
+	out := make([]nullStrRow, n)
+	for i := range out {
+		out[i].Seq = int64(i)
+		if r.Intn(100) >= nullPct {
+			v := labels[r.Intn(len(labels))]
+			out[i].Label = &v
+		}
+		if r.Intn(100) >= nullPct {
+			v := "note-" + labels[r.Intn(len(labels))]
+			out[i].Note = &v
+		}
+	}
+	return out
+}
+
+func eqNullStrRow(a, b nullStrRow) bool {
+	if a.Seq != b.Seq {
+		return false
+	}
+	eq := func(x, y *string) bool { return (x == nil) == (y == nil) && (x == nil || *x == *y) }
+	return eq(a.Label, b.Label) && eq(a.Note, b.Note)
+}
+
+// RED until nullable string columns ship: a struct with optional string
+// fields must use the columnar path (presence bitmap + dense string column)
+// and come out far smaller than the row-major baseline, while round-tripping
+// nils and values exactly.
+func TestNullableString_RoundTripAndSmaller(t *testing.T) {
+	for _, nullPct := range []int{0, 40, 100} {
+		rows := mkNullStrRows(2000, nullPct, int64(nullPct+1))
+		col, err := Marshal(rows, OptBalanced&^OptRANS)
+		if err != nil {
+			t.Fatalf("null%%=%d: %v", nullPct, err)
+		}
+		var got []nullStrRow
+		if err := Unmarshal(col, &got); err != nil {
+			t.Fatalf("null%%=%d unmarshal: %v", nullPct, err)
+		}
+		if len(got) != len(rows) {
+			t.Fatalf("len %d != %d", len(got), len(rows))
+		}
+		for i := range rows {
+			if !eqNullStrRow(got[i], rows[i]) {
+				t.Fatalf("null%%=%d row %d mismatch: %+v != %+v", nullPct, i, got[i], rows[i])
+			}
+		}
+		// Discriminator: the same data with the string fields made non-optional
+		// (value, not pointer) is columnar-eligible today and encodes tightly.
+		// The optional version must come within a small factor of it — proving
+		// nullable string columns engage instead of falling back to row-major
+		// (where it is ~10× larger). OptBalanced-Dense already beats OptSpeed via
+		// interning even when row-major, so OptSpeed is NOT a valid baseline here.
+		type vrow struct {
+			Seq   int64
+			Label string
+			Note  string
+		}
+		vr := make([]vrow, len(rows))
+		for i := range rows {
+			vr[i].Seq = rows[i].Seq
+			if rows[i].Label != nil {
+				vr[i].Label = *rows[i].Label
+			}
+			if rows[i].Note != nil {
+				vr[i].Note = *rows[i].Note
+			}
+		}
+		ref, err := Marshal(vr, OptBalanced&^OptRANS)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(col) >= 4*len(ref) {
+			t.Fatalf("null%%=%d: nullable-string columnar %d not within 4x of value-string columnar %d (row-major fallback?)", nullPct, len(col), len(ref))
+		}
+		t.Logf("null%%=%d nullable=%d value-columnar=%d", nullPct, len(col), len(ref))
+	}
+}
+
+func TestNullableString_Any(t *testing.T) {
+	rows := mkNullStrRows(500, 40, 9)
+	enc, err := Marshal(rows, OptBalanced&^OptRANS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var a any
+	if err := Unmarshal(enc, &a); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := a.([]any)
+	if !ok || len(got) != len(rows) {
+		t.Fatalf("any shape %T", a)
+	}
+	for i := range rows {
+		m := got[i].(map[string]any)
+		if rows[i].Label == nil {
+			if m["Label"] != nil {
+				t.Fatalf("row %d Label want nil got %v", i, m["Label"])
+			}
+		} else if m["Label"].(string) != *rows[i].Label {
+			t.Fatalf("row %d Label %v != %s", i, m["Label"], *rows[i].Label)
+		}
+	}
+}

--- a/qdf.go
+++ b/qdf.go
@@ -37,8 +37,9 @@
 // and compressed column-by-column automatically — numeric columns get the
 // integer codecs, an enum-like string column is dictionary-coded (distinct
 // table + a bit-packed index per row) when that beats per-value interning,
-// an optional (*T scalar) field becomes a presence bitmap plus a dense
-// present-only column instead of forcing the struct back to row-major,
+// an optional (*T, T a scalar or string) field becomes a presence bitmap
+// plus a dense present-only column instead of forcing the struct back to
+// row-major,
 // other repeated string columns collapse — with no flag, and a per-array
 // probe falls back to the plain row encoding when columnar would not help. The float codecs that trade encode CPU for size live behind
 // OptCompression: Gorilla XOR on smooth series, ALP on quantized/decimal

--- a/qpack_strdict.go
+++ b/qpack_strdict.go
@@ -121,6 +121,30 @@ func (e *Encoder) tryWriteStringColumnDict(strs []string) bool {
 	return true
 }
 
+// readStringColumn decodes a string column of n values written by
+// writeStringColumn: a tagColStrDict dictionary block, or n per-value strings.
+func (d *Decoder) readStringColumn(n int) ([]string, error) {
+	out := make([]string, n)
+	if n > 0 && d.i < len(d.buf) && d.buf[d.i] == tagColStrDict {
+		table, idx, err := d.readStringColumnDict(n)
+		if err != nil {
+			return nil, err
+		}
+		for i := range n {
+			out[i] = table[idx[i]]
+		}
+		return out, nil
+	}
+	for i := range n {
+		sb, err := d.readStringBytes()
+		if err != nil {
+			return nil, err
+		}
+		out[i] = string(sb) // owned copy
+	}
+	return out, nil
+}
+
 // readStringColumnDict decodes a tagColStrDict block (tag at d.i) into a
 // distinct table and a per-row index slice of length n. Each row's string
 // is table[idx[i]]; the distinct strings are allocated once and shared by


### PR DESCRIPTION
Follow-up to the nullable (optional pointer) columns feature: extends it
to optional **`*string`** fields.

An optional string field used to make the whole struct fall back to
row-major — ~10–16× larger than the columnar form. It is now a columnar
**nullable column** like the scalar optionals: a presence bitmap (1 bit
per row, LSB-first) followed by a dense column of only the present strings,
which still go through the per-column **string dictionary** when that wins.

Available automatically under `OptBalanced` (the columnar path); no flag,
no new wire tag — nullability rides in the shape's kind byte
(`colKindNullable`).

## Changes

- `buildColumnarPlan` accepts `*string` (only `*[]byte` stays row-major).
- `encodeNullableColumn` gathers the present strings and emits them through
  the shared `writeStringColumn` (dictionary-or-per-value).
- A new `readStringColumn(n)` decode helper mirrors the writer; the typed
  decode points each present `*string` field into the decoded backing slice
  (one allocation, GC-kept via `runtime.KeepAlive`), nil for absent rows;
  the `any` decode boxes present strings and nil otherwise.

## Verification

- TDD: the size discriminator (an optional-string struct now lands within a
  small factor of the equivalent value-string columnar form, not ~16×
  larger) plus nil/value round-trip for typed **and** `any` decode across
  0 / 40 / 100 % null densities.
- Golden fixtures unchanged; `go test -race` and the fuzz regression corpus
  clean under both default and `qdf_simd` build tags; `golangci-lint`
  clean; arm64 NEON round-trip + golden under emulation.
- Interleaved benchstat vs the merged scalar-nullable baseline shows no
  regression (the new code paths are reached only for `*string` columns).

Docs updated: GUIDE / USAGE columnar sections and the `qdf` package comment.
