### PR TITLE
feat: price the string dictionary in the columnar probe

### DIFF
--- a/columnar.go
+++ b/columnar.go
@@ -189,7 +189,11 @@ func columnarProbe(plan *columnarPlan, base unsafe.Pointer, n int) bool {
 		switch col.kind {
 		case colKindInt, colKindUint:
 			var mn, mx uint64 = ^uint64(0), 0
-			distinct := map[uint64]struct{}{}
+			// Distinct values bounded to 17 (cardinality > 16 disables the dict
+			// estimate) tracked in a stack array with a linear scan — no map
+			// allocation per probed column.
+			var seen [17]uint64
+			ndistinct := 0
 			for i := range sample {
 				v := loadScalarU64(base, plan.stride, col, i)
 				if v < mn {
@@ -198,8 +202,18 @@ func columnarProbe(plan *columnarPlan, base unsafe.Pointer, n int) bool {
 				if v > mx {
 					mx = v
 				}
-				if len(distinct) <= 16 {
-					distinct[v] = struct{}{}
+				if ndistinct <= 16 {
+					found := false
+					for j := 0; j < ndistinct; j++ {
+						if seen[j] == v {
+							found = true
+							break
+						}
+					}
+					if !found {
+						seen[ndistinct] = v
+						ndistinct++
+					}
 				}
 				rowBytes += uvarintLen(v) // row-major: one varint per value
 			}
@@ -211,12 +225,12 @@ func columnarProbe(plan *columnarPlan, base unsafe.Pointer, n int) bool {
 			}
 			forEst := 3 + (bits*sample+7)/8
 			dictEst := 1 << 30
-			if len(distinct) <= 16 {
+			if ndistinct <= 16 {
 				idxBits := 0
-				for (1 << idxBits) < len(distinct) {
+				for (1 << idxBits) < ndistinct {
 					idxBits++
 				}
-				dictEst = 3 + len(distinct)*8 + (idxBits*sample+7)/8
+				dictEst = 3 + ndistinct*8 + (idxBits*sample+7)/8
 			}
 			colBytes += min(forEst, dictEst)
 		case colKindFloat:
@@ -226,19 +240,46 @@ func columnarProbe(plan *columnarPlan, base unsafe.Pointer, n int) bool {
 			rowBytes += sample
 			colBytes += (sample + 7) / 8
 		case colKindString:
+			// Estimate the column two ways over the sample and keep the
+			// cheaper, mirroring the encoder: per-value (with consecutive-repeat
+			// collapse) OR a string dictionary (distinct table + ceil(log2
+			// distinct) bits/row). Without the dictionary term the probe would
+			// decline columnar for a low-cardinality string column that never
+			// repeats consecutively, even though the dictionary crushes it.
+			//
+			// Distinct values are tracked in a stack array with a linear scan,
+			// not a map: the sample is <= columnarProbeSample, so the set is
+			// tiny and a map would heap-allocate buckets on every probed column.
+			var seen [columnarProbeSample]string
+			nseen := 0
+			var tableBytes, perValue int
 			prev := ""
 			first := true
 			for i := range sample {
 				s := loadStringField(base, plan.stride, col, i)
+				fresh := true
+				for j := 0; j < nseen; j++ {
+					if seen[j] == s {
+						fresh = false
+						break
+					}
+				}
+				if fresh && nseen < len(seen) {
+					seen[nseen] = s
+					nseen++
+					tableBytes += 2 + len(s)
+				}
 				if !first && s == prev {
-					colBytes += 1 // tagStateRepeat
+					perValue += 1 // tagStateRepeat
 				} else {
-					colBytes += 2 + len(s)
+					perValue += 2 + len(s)
 				}
 				rowBytes += 2 + len(s)
 				prev = s
 				first = false
 			}
+			dictBytes := tableBytes + (sample*bitsForDistinct(nseen)+7)/8
+			colBytes += min(perValue, dictBytes)
 		default:
 			if !col.kind.isNullable() {
 				continue // unknown kind contributes nothing

--- a/columnar_probe_strdict_test.go
+++ b/columnar_probe_strdict_test.go
@@ -1,0 +1,56 @@
+package qdf
+
+import (
+	"testing"
+)
+
+// RED until columnarProbe prices the string dictionary: a struct whose
+// fields are ALL enum-like strings (no numeric column to tip the probe)
+// must still commit to columnar so the per-column string dictionary fires.
+// Today the probe estimates string columns at per-value/repeat cost only,
+// so it declines columnar and the struct stays row-major (≈10× larger).
+func TestColumnarProbe_PricesStringDict(t *testing.T) {
+	type dimRow struct {
+		Level   string
+		Service string
+		Region  string
+	}
+	levels := []string{"INFO", "WARN", "ERROR", "DEBUG"}
+	services := []string{"api", "auth", "billing", "user"}
+	regions := []string{"us-east-1", "eu-west-1", "ap-south-1"}
+	n := 1000
+	rows := make([]dimRow, n)
+	// Strictly cycling — low cardinality but NO consecutive repeats, so the
+	// probe's repeat heuristic sees no columnar gain and declines today, even
+	// though the string dictionary would crush these columns.
+	for i := range rows {
+		rows[i] = dimRow{
+			Level:   levels[i%len(levels)],
+			Service: services[(i+1)%len(services)],
+			Region:  regions[(i+2)%len(regions)],
+		}
+	}
+
+	enc, err := Marshal(rows, OptBalanced&^OptRANS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []dimRow
+	if err := Unmarshal(enc, &got); err != nil {
+		t.Fatal(err)
+	}
+	for i := range rows {
+		if got[i] != rows[i] {
+			t.Fatalf("row %d mismatch", i)
+		}
+	}
+
+	// With columnar + the string dictionary, three low-cardinality columns
+	// over n rows cost roughly the distinct tables plus ~2 bits/row each —
+	// well under one byte per row total. Row-major (the current behaviour)
+	// spends several bytes per row, so this threshold separates the two.
+	if len(enc) >= n {
+		t.Fatalf("pure-string-enum struct encoded to %d bytes for %d rows (>= 1 byte/row) — columnar string-dict did not engage", len(enc), n)
+	}
+	t.Logf("n=%d wire=%d (%.2f bytes/row)", n, len(enc), float64(len(enc))/float64(n))
+}

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -656,10 +656,13 @@ one generates per-user-type marshalers in the user's package.
 When the encoder sees a `[]SomeStruct` under `OptBalanced`
 (Dense + ShapeIntern), it checks whether the element type is a flat,
 homogeneous struct — fields of kind `int*`, `uint*`, `float*`, `bool`,
-`string`, or `[]byte`, no custom marshalers, no nested structs. If it
-is, a per-array probe samples up to 16 elements and estimates the
-columnar wire size vs row-major. On a commit the encoder transposes
-the slice:
+`string`, `[]byte`, or an optional pointer to a scalar/string (`*int`,
+`*string`, …), no custom marshalers, no nested structs. If it is, a
+per-array probe samples up to 32 elements and estimates the columnar
+wire size vs row-major — pricing each string column with the dictionary
+(distinct table + bit-packed index), so a struct of nothing but
+low-cardinality string columns still commits to columnar. On a commit
+the encoder transposes the slice:
 
 - Numeric (`int*`/`uint*`) and bool columns are gathered into a
   scratch slice and passed through the existing QPack codec selector


### PR DESCRIPTION
The per-array probe that decides columnar-vs-row-major estimated string
columns at **per-value / consecutive-repeat** cost only. So a struct whose
fields are all low-cardinality strings that never repeat consecutively (a
cyclic enum) saw no columnar gain and stayed row-major — even though the
per-column **string dictionary** would crush it (the encoder's own
never-worse gate was never given the chance to fire).

The probe now also estimates the dictionary form per string column
(distinct table + `ceil(log2 distinct)`-bit index) and keeps the cheaper of
the two, so these all-string structs commit to columnar and the dictionary
engages.

## Leaner probe (no map allocation)

Distinct tracking in the probe — both the new string estimate and the
existing integer-column estimate — now uses a small **stack array with a
linear scan** instead of a `map`. The sample is bounded (`<= 32`), so the
distinct set is tiny; a map only added a heap allocation per probed column
for a handful of short values. Escape analysis confirms the arrays stay on
the stack.

## Effect

- **Traces corpus: encode 16.7% faster and ~9.6% smaller** at
  `OptBalanced` — its `service` / `operation` string columns now go
  columnar + dictionary instead of row-major.
- Every other corpus is byte-identical; all other benchmarks are within
  noise (interleaved benchstat n=10, geomean **-3.45%**, every non-traces
  bench `~`). No CPU or wire regression.

## Verification

- TDD: a struct of three cyclic low-cardinality string columns dropped from
  8594 bytes (row-major) to 874 (columnar + dict) for 1000 rows, with exact
  round-trip; the existing string-dict / nullable / golden tests stay green.
- Golden fixtures unchanged; `go test -race` and the fuzz regression corpus
  clean under both default and `qdf_simd` build tags; `golangci-lint`
  clean; arm64 NEON + golden under emulation.

Docs: GUIDE columnar-probe section updated (sample size, string-dictionary
pricing, optional-pointer field kinds).
