### PR TITLE
perf: columnar string-column decode reuses the intern cache

### DIFF
--- a/bench/query_test.go
+++ b/bench/query_test.go
@@ -87,6 +87,21 @@ func BenchmarkQueryOrNot(b *testing.B) {
 	}
 }
 
+// BenchmarkColumnarFullDecode measures a plain full decode of a batch with a
+// low-cardinality string column (lvl: long runs that fall below the dict gate).
+func BenchmarkColumnarFullDecode(b *testing.B) {
+	rows := mkWide(2000, 100) // 1% ERROR, long INFO runs
+	enc, _ := qdf.Marshal(rows, qdf.OptBalanced|qdf.OptColumnIndex)
+	b.ReportAllocs()
+
+	for b.Loop() {
+		var all []wideRow
+		if err := qdf.Unmarshal(enc, &all); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // BenchmarkQuery_VsFullManual compares pushdown against full decode + manual filter.
 func BenchmarkQuery_VsFullManual(b *testing.B) {
 	rows := mkWide(2000, 100)

--- a/columnar.go
+++ b/columnar.go
@@ -1109,16 +1109,23 @@ func (d *Decoder) decodeColumnInto(base unsafe.Pointer, plan *columnarPlan, col 
 			break
 		}
 		for i := range n {
-			sb, err := d.readStringBytes()
+			dp := unsafe.Add(base, uintptr(i)*plan.stride+col.offset)
+			if col.isByte {
+				sb, err := d.readStringBytes()
+				if err != nil {
+					return err
+				}
+				*(*[]byte)(dp) = append([]byte(nil), sb...)
+				continue
+			}
+			// ReadString shares repeated values via the decode-side intern
+			// cache, so a low-cardinality string column that fell below the dict
+			// gate scatters to ~distinct allocs, not one per row.
+			str, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			dp := unsafe.Add(base, uintptr(i)*plan.stride+col.offset)
-			if col.isByte {
-				*(*[]byte)(dp) = append([]byte(nil), sb...)
-			} else {
-				*(*string)(dp) = string(sb)
-			}
+			*(*string)(dp) = str
 		}
 	}
 	return nil

--- a/columnar.go
+++ b/columnar.go
@@ -681,11 +681,14 @@ func (d *Decoder) decodeColumnVals(kind colKind, n int, isByte bool) (colVals, e
 		}
 		s := make([]string, n)
 		for i := range n {
-			sb, err := d.readStringBytes()
+			// ReadString shares repeated values via the decode-side intern
+			// cache (and aliases under noCopy), so a low-cardinality column that
+			// fell below the dict gate decodes to ~distinct allocs, not n.
+			str, err := d.ReadString()
 			if err != nil {
 				return cv, err
 			}
-			s[i] = string(sb)
+			s[i] = str
 		}
 		cv.s = s
 	default:


### PR DESCRIPTION
A columnar string column whose values repeat (low cardinality, long runs, or a
single value) is stored on the wire by the per-value path with state-repeat /
intern references — compact. But the **decode** materialised a fresh
`string([]byte)` for every row, allocating `n` strings even when only a handful
were distinct. The normal interning reader (`ReadString`) already shares
repeated values through the decode-side intern cache; the two columnar
hot-decode loops just didn't use it — they called `readStringBytes` + `string`
directly.

Both now route the non-`[]byte` string case through `ReadString`, so a repeated
column decodes to ~distinct allocations instead of one per row. `[]byte` columns
keep their copy semantics (callers may mutate them).

This only matters when the per-column string **dictionary** declines (the
never-worse dict gate rejects it when the per-value RLE wire is already smaller —
i.e. exactly the long-run / single-value columns this fix targets). Where the
dict fires, decode was already allocation-light and is unchanged.

## How it was found

A headroom probe for a *different* idea (element-addressable seek) decomposed a
pushdown query and surfaced ~2000 allocations per call at 1% selectivity on a
batch with only two distinct values in the filter column — a string column
decoding one allocation per row. (Element-seek itself was measured NO-GO: the
projected-column decode it would shrink is a small, bandwidth-bound fraction;
whole-column decode and per-row materialisation dominate.)

## Result

Intel i7-9750H, interleaved base/head, `benchstat` n=12 (p=0.000 throughout):

| benchmark | sec/op | allocs/op |
| --- | ---: | ---: |
| query, 1% selectivity | **−36%** | 2024 → 26 (−98.7%) |
| query, 100% selectivity | **−24%** | 2032 → 33 |
| pushdown vs full-decode | **−40%** | 2024 → 26 |
| **full struct decode** | **−24%** | 2015 → 17 (−99.2%) |

No change where the dict already fires (50% selectivity, distinct alternating)
or for non-string filters. A `[]map[string]any` decode was deliberately **not**
changed: there the per-row `any` boxing and map insertion dominate, so the
string-sharing saving is marginal and showed no wall-clock win — left as-is to
avoid a speculative change.

## Considered, not pursued

- **Map (`[]map[string]any`) path** — left unchanged: per-row `any` boxing plus
  map insertion dominate, so string-sharing is marginal and showed no
  wall-clock win.
- **Byte-arena for decoded strings** — packing distinct strings into one `[]byte`
  would cut the *allocation count* on a high-cardinality column, but the copy
  work is unchanged (same bytes moved), so the wall-clock effect is the classic
  arena trap (fewer allocs, flat time). For callers that actually want
  zero-allocation high-cardinality decode, `noCopy` already aliases the input
  buffer directly. Not worth a speculative arena; would gate on a benchmark
  first if revisited.

## Verification

- `go test -race` and golden clean under both default and `qdf_simd`; `gofmt`
  clean. Output strings are owned copies (default decode is not `noCopy`), so
  the shared-from-cache strings are safe to return.
- Speed-only change: produces identical decoded values; golden fixtures
  unchanged.
- New `BenchmarkColumnarFullDecode` pins the full-decode regression.