### PR TITLE
perf: route `[]uint32` / `[]int32` through the QPack codec picker

### DIFF
--- a/docs/CHOOSING.md
+++ b/docs/CHOOSING.md
@@ -142,7 +142,7 @@ intern-table CPU for zero wire benefit — skip it.
 
 ### Status-code / enum-like int column
 
-A long `[]int` (or `[]int64`) dominated by a handful of distinct
+A long `[]int` (or `[]int32`/`[]int64`) dominated by a handful of distinct
 values — HTTP status codes, log severities encoded as ints, sparse
 counter snapshots, finite-state-machine traces. Long stretches of
 the same value with short bursts of others is the canonical shape.
@@ -164,7 +164,7 @@ on raw / FOR without paying the estimator cost.
 
 ### Latency / outlier-heavy int column
 
-A long `[]int`/`[]uint64` that is mostly small but carries a rare
+A long `[]int`/`[]uint32`/`[]uint64` that is mostly small but carries a rare
 tail of large values — request latencies in microseconds with the
 occasional slow request, byte counters with the odd jumbo payload,
 counters that reset. The spikes are what kill plain Frame-of-Reference:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -145,7 +145,7 @@ time. You do not need to hint it — just set the bit.
 |---|---|---|
 | `[]bool` | bit-pack (1 bit/elem) | `OptQPack` |
 | `[]intN`/`[]uintN`, clustered range | Frame-of-Reference (FOR) | `OptQPack` |
-| `[]int64`/`[]uint64`, monotonic or time-series | Delta+FOR | `OptQPack` |
+| `[]int`/`[]int32`/`[]int64`/`[]uint`/`[]uint32`/`[]uint64`, monotonic or time-series | Delta+FOR | `OptQPack` |
 | `[]intN`, run-heavy (status codes, enum-like, sparse counters) | RLE (value, runLen pairs) | `OptQPack` |
 | `[]intN`, small distinct cardinality (≤16), wide value range | Dictionary codec | `OptQPack` |
 | `[]intN`/`[]uintN`, mostly small with rare large outliers (latency spikes, counter resets) | Patched FOR (narrow body + exception list) | `OptQPack` |

--- a/qdf.go
+++ b/qdf.go
@@ -211,7 +211,10 @@ const (
 	OptDense Options = 1 << iota
 
 	// OptQPack enables the numeric / boolean slice codecs. Bools
-	// bit-pack; integer slices try Frame-of-Reference and Delta+FOR;
+	// bit-pack; 32- and 64-bit integer slices ([]int/int32/int64,
+	// []uint/uint32/uint64) run the codec picker — Frame-of-Reference,
+	// Delta+FOR, RLE, dictionary, and Patched FOR — widening 32-bit
+	// values to 64-bit for selection and narrowing back on decode;
 	// float slices stay on raw-LE. Auto-selected per slice; the
 	// encoder falls back to raw-LE when nothing wins. Gorilla XOR
 	// for floats lives behind OptGorillaFloat (bit 5) — see

--- a/qpack.go
+++ b/qpack.go
@@ -51,7 +51,7 @@ func qpackRawWidthBytes(kind byte) int {
 // pickU64Codec analyses a []uint64 and decides which QPack codec yields
 // the smallest wire form. Cost of the scan is O(n) (min/max + delta
 // stats + RLE probe), which is dominated by the encode itself.
-func pickU64Codec(s []uint64) (codec qpackCodec, mn uint64, forBits int, first uint64, minDelta int64, deltaBits int, pforBits int) {
+func pickU64Codec(s []uint64) (codec qpackCodec, mn uint64, forBits int, first uint64, minDelta int64, deltaBits int, pforBits int, bestCost int) {
 	n := len(s)
 	codec = qpackRaw
 	if n == 0 {
@@ -63,7 +63,7 @@ func pickU64Codec(s []uint64) (codec qpackCodec, mn uint64, forBits int, first u
 	var mx uint64
 	mn, mx = minMaxU64(s)
 	forBits = bitpack.BitsForDelta(mx - mn)
-	bestCost := rawCost
+	bestCost = rawCost
 	if forBits <= qpackForMaxBits {
 		c := qpackForSizeUnsigned(n, forBits, mn)
 		if c < bestCost {
@@ -177,7 +177,7 @@ func qpackRLESizeI64(s []int64, n int) int {
 	return hdr + body
 }
 
-func pickI64Codec(s []int64) (codec qpackCodec, mn int64, forBits int, first int64, minDelta int64, deltaBits int, pforBits int) {
+func pickI64Codec(s []int64) (codec qpackCodec, mn int64, forBits int, first int64, minDelta int64, deltaBits int, pforBits int, bestCost int) {
 	n := len(s)
 	codec = qpackRaw
 	if n == 0 {
@@ -188,7 +188,7 @@ func pickI64Codec(s []int64) (codec qpackCodec, mn int64, forBits int, first int
 	var mx int64
 	mn, mx = minMaxI64(s)
 	forBits = bitpack.BitsForDelta(uint64(mx) - uint64(mn))
-	bestCost := rawCost
+	bestCost = rawCost
 	if forBits <= qpackForMaxBits {
 		c := qpackForSizeSigned(n, forBits, mn)
 		if c < bestCost {

--- a/qpack_dict_test.go
+++ b/qpack_dict_test.go
@@ -73,7 +73,7 @@ func TestDict_PickerHitsSpreadValues(t *testing.T) {
 	for i := range s {
 		s[i] = dictVals[i%4]
 	}
-	codec, _, _, _, _, _, _ := pickU64Codec(s)
+	codec, _, _, _, _, _, _, _ := pickU64Codec(s)
 	if codec != qpackDict {
 		t.Fatalf("u64 picker: got codec %d, want qpackDict (%d) on 4-distinct/wide-range input", codec, qpackDict)
 	}
@@ -83,7 +83,7 @@ func TestDict_PickerHitsSpreadValues(t *testing.T) {
 	for i := range si {
 		si[i] = dictI[i%4]
 	}
-	codec, _, _, _, _, _, _ = pickI64Codec(si)
+	codec, _, _, _, _, _, _, _ = pickI64Codec(si)
 	if codec != qpackDict {
 		t.Fatalf("i64 picker: got codec %d, want qpackDict (%d) on 4-distinct/wide-range input", codec, qpackDict)
 	}
@@ -96,7 +96,7 @@ func TestDict_PickerSkipsHighCardinality(t *testing.T) {
 	for i := range s {
 		s[i] = uint64(i * 113) // 64 unique values, well above cap
 	}
-	codec, _, _, _, _, _, _ := pickU64Codec(s)
+	codec, _, _, _, _, _, _, _ := pickU64Codec(s)
 	if codec == qpackDict {
 		t.Fatalf("u64 picker: returned qpackDict on >cap distinct (=%d), want fallback", len(s))
 	}

--- a/qpack_rle_test.go
+++ b/qpack_rle_test.go
@@ -89,7 +89,7 @@ func TestRLE_PickerHitsHighRepeat(t *testing.T) {
 	for i := 96; i < 128; i++ {
 		u[i] = 404
 	}
-	if got, _, _, _, _, _, _ := pickU64Codec(u); got != qpackRLE {
+	if got, _, _, _, _, _, _, _ := pickU64Codec(u); got != qpackRLE {
 		t.Fatalf("u64 picker: got codec %d, want qpackRLE (%d)", got, qpackRLE)
 	}
 
@@ -106,7 +106,7 @@ func TestRLE_PickerHitsHighRepeat(t *testing.T) {
 	for i := 96; i < 128; i++ {
 		s[i] = -2
 	}
-	if got, _, _, _, _, _, _ := pickI64Codec(s); got != qpackRLE {
+	if got, _, _, _, _, _, _, _ := pickI64Codec(s); got != qpackRLE {
 		t.Fatalf("i64 picker: got codec %d, want qpackRLE (%d)", got, qpackRLE)
 	}
 }
@@ -122,7 +122,7 @@ func TestRLE_PickerSkipsHighEntropy(t *testing.T) {
 	for i := range u {
 		u[i] = uint64(i*7919 + 1)
 	}
-	got, _, _, _, _, _, _ := pickU64Codec(u)
+	got, _, _, _, _, _, _, _ := pickU64Codec(u)
 	if got == qpackRLE {
 		t.Fatalf("u64 picker: returned qpackRLE on high-entropy input")
 	}

--- a/slices_32bit_test.go
+++ b/slices_32bit_test.go
@@ -1,0 +1,158 @@
+package qdf
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestQPack32BitCompresses(t *testing.T) {
+	const N = 1024
+	// monotonic uint32 — must compress far below raw 4*N via delta/FOR
+	u := make([]uint32, N)
+	for i := range u {
+		u[i] = uint32(1_000_000 + i)
+	}
+	enc, err := Marshal(u, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(enc) > 512 {
+		t.Fatalf("uint32 monotonic not compressed: %d B (want << 4096)", len(enc))
+	}
+	var back []uint32
+	if err := Unmarshal(enc, &back); err != nil {
+		t.Fatal(err)
+	}
+	if len(back) != N {
+		t.Fatalf("len %d != %d", len(back), N)
+	}
+	for i := range u {
+		if back[i] != u[i] {
+			t.Fatalf("u32 roundtrip row %d: %d != %d", i, back[i], u[i])
+		}
+	}
+
+	// int32 with negatives, low cardinality
+	s := make([]int32, N)
+	for i := range s {
+		s[i] = int32(-5 + i%4)
+	}
+	enc2, err := Marshal(s, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(enc2) > 512 {
+		t.Fatalf("int32 low-card not compressed: %d B", len(enc2))
+	}
+	var back2 []int32
+	if err := Unmarshal(enc2, &back2); err != nil {
+		t.Fatal(err)
+	}
+	for i := range s {
+		if back2[i] != s[i] {
+			t.Fatalf("i32 roundtrip row %d: %d != %d", i, back2[i], s[i])
+		}
+	}
+
+	// edge: full-range uint32 values (max) must round-trip exactly (no truncation bug)
+	w := []uint32{0, 1, 4294967295, 2147483648, 42}
+	enc3, _ := Marshal(w, OptBalanced)
+	var back3 []uint32
+	if err := Unmarshal(enc3, &back3); err != nil {
+		t.Fatal(err)
+	}
+	for i := range w {
+		if back3[i] != w[i] {
+			t.Fatalf("u32 max roundtrip %d: %d != %d", i, back3[i], w[i])
+		}
+	}
+
+	// edge: int32 min/max
+	wi := []int32{-2147483648, 2147483647, 0, -1, 1}
+	enc4, _ := Marshal(wi, OptBalanced)
+	var back4 []int32
+	if err := Unmarshal(enc4, &back4); err != nil {
+		t.Fatal(err)
+	}
+	for i := range wi {
+		if back4[i] != wi[i] {
+			t.Fatalf("i32 min/max %d: %d != %d", i, back4[i], wi[i])
+		}
+	}
+
+	// empty + single
+	for _, e := range [][]uint32{{}, {7}} {
+		eb, _ := Marshal(e, OptBalanced)
+		var bk []uint32
+		if err := Unmarshal(eb, &bk); err != nil {
+			t.Fatal(err)
+		}
+		if len(bk) != len(e) {
+			t.Fatalf("empty/single u32")
+		}
+	}
+}
+
+// TestQPack32BitNeverWorse: incompressible full-range 32-bit data must not
+// exceed the native 4 B/elem raw form — widening to 64-bit must never inflate.
+func TestQPack32BitNeverWorse(t *testing.T) {
+	const N = 1024
+	r := rand.New(rand.NewSource(1))
+	u := make([]uint32, N)
+	for i := range u {
+		u[i] = r.Uint32()
+	}
+	enc, _ := Marshal(u, OptBalanced)
+	if len(enc) > 4*N+16 { // 4 B/elem + small header, never the 8 B/elem widened form
+		t.Fatalf("incompressible uint32 inflated to %d B (native floor ~%d)", len(enc), 4*N)
+	}
+	var back []uint32
+	if err := Unmarshal(enc, &back); err != nil {
+		t.Fatal(err)
+	}
+	for i := range u {
+		if back[i] != u[i] {
+			t.Fatalf("u32 nw roundtrip %d", i)
+		}
+	}
+	s := make([]int32, N)
+	for i := range s {
+		s[i] = int32(r.Uint32())
+	}
+	enc2, _ := Marshal(s, OptBalanced)
+	if len(enc2) > 4*N+16 {
+		t.Fatalf("incompressible int32 inflated to %d B", len(enc2))
+	}
+
+	// Small-N adversarial: alternating near-max-range values where a widened
+	// DeltaFor would be chosen over FOR yet still exceed native 4 B/elem raw.
+	for _, small := range [][]uint32{
+		{1450029205, 1650547297, 1650967836, 2572537883, 3887843792, 3947857014, 4268614616},
+		{0, 2147483648, 0, 2147483648, 0, 2147483648, 0},
+	} {
+		eb, _ := Marshal(small, OptBalanced)
+		// native total = 5B message header + tag(1)+kind(1)+nVarUint+4n.
+		native := 5 + 2 + 1 + 4*len(small)
+		if len(eb) > native {
+			t.Fatalf("small-N uint32 inflated to %d B (native %d)", len(eb), native)
+		}
+		var bk []uint32
+		if err := Unmarshal(eb, &bk); err != nil {
+			t.Fatal(err)
+		}
+		for i := range small {
+			if bk[i] != small[i] {
+				t.Fatalf("small-N u32 roundtrip %d", i)
+			}
+		}
+	}
+	var back2 []int32
+	if err := Unmarshal(enc2, &back2); err != nil {
+		t.Fatal(err)
+	}
+	for i := range s {
+		if back2[i] != s[i] {
+			t.Fatalf("i32 nw roundtrip %d", i)
+		}
+	}
+}

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -80,6 +80,58 @@ func decodeSliceString(d *Decoder, p unsafe.Pointer) error {
 	return nil
 }
 
+// ----- QPack codec helpers shared by 64-bit and widened 32-bit paths -----
+
+// writeQPackUint64 runs the codec picker over s and writes the chosen QPack form.
+func (e *Encoder) writeQPackUint64(s []uint64) {
+	codec, mn, forBits, first, minDelta, deltaBits, pforBits, _ := pickU64Codec(s)
+	e.emitQPackUint64(s, codec, mn, forBits, first, minDelta, deltaBits, pforBits)
+}
+
+// emitQPackUint64 writes s in the already-chosen codec form (picker output passed
+// in, so a caller that needs to inspect the choice does not pick twice).
+func (e *Encoder) emitQPackUint64(s []uint64, codec qpackCodec, mn uint64, forBits int, first uint64, minDelta int64, deltaBits, pforBits int) {
+	switch codec {
+	case qpackFor:
+		e.writePackedForUint64Slice(s, mn, forBits)
+	case qpackDeltaFor:
+		e.writePackedDeltaForUint64Slice(s, first, minDelta, deltaBits)
+	case qpackRLE:
+		e.writePackedRLEUint64Slice(s)
+	case qpackDict:
+		e.writePackedDictUint64Slice(s)
+	case qpackPFor:
+		e.writePackedPForUint64Slice(s, mn, pforBits)
+	default:
+		e.writePackedUint64Slice(s)
+	}
+}
+
+// writeQPackInt64 runs the codec picker over s and writes the chosen QPack form.
+func (e *Encoder) writeQPackInt64(s []int64) {
+	codec, mn, forBits, first, minDelta, deltaBits, pforBits, _ := pickI64Codec(s)
+	e.emitQPackInt64(s, codec, mn, forBits, first, minDelta, deltaBits, pforBits)
+}
+
+// emitQPackInt64 writes s in the already-chosen codec form (picker output passed
+// in, so a caller that needs to inspect the choice does not pick twice).
+func (e *Encoder) emitQPackInt64(s []int64, codec qpackCodec, mn int64, forBits int, first int64, minDelta int64, deltaBits, pforBits int) {
+	switch codec {
+	case qpackFor:
+		e.writePackedForInt64Slice(s, mn, forBits)
+	case qpackDeltaFor:
+		e.writePackedDeltaForInt64Slice(s, first, minDelta, deltaBits)
+	case qpackRLE:
+		e.writePackedRLEInt64Slice(s)
+	case qpackDict:
+		e.writePackedDictInt64Slice(s)
+	case qpackPFor:
+		e.writePackedPForInt64Slice(s, mn, pforBits)
+	default:
+		e.writePackedInt64Slice(s)
+	}
+}
+
 // ----- []int / []int32 / []int64 / []uint32 / []uint64 -----
 
 func encodeSliceInt(e *Encoder, p unsafe.Pointer) error {
@@ -91,21 +143,7 @@ func encodeSliceInt(e *Encoder, p unsafe.Pointer) error {
 		// so the dead branch is eliminated.
 		if unsafe.Sizeof(int(0)) == 8 {
 			s64 := unsafe.Slice((*int64)(unsafe.Pointer(unsafe.SliceData(s))), len(s))
-			codec, mn, forBits, first, minDelta, deltaBits, pforBits := pickI64Codec(s64)
-			switch codec {
-			case qpackFor:
-				e.writePackedForInt64Slice(s64, mn, forBits)
-			case qpackDeltaFor:
-				e.writePackedDeltaForInt64Slice(s64, first, minDelta, deltaBits)
-			case qpackRLE:
-				e.writePackedRLEInt64Slice(s64)
-			case qpackDict:
-				e.writePackedDictInt64Slice(s64)
-			case qpackPFor:
-				e.writePackedPForInt64Slice(s64, mn, pforBits)
-			default:
-				e.writePackedInt64Slice(s64)
-			}
+			e.writeQPackInt64(s64)
 			return nil
 		}
 		s32 := unsafe.Slice((*int32)(unsafe.Pointer(unsafe.SliceData(s))), len(s))
@@ -163,7 +201,19 @@ func decodeSliceInt(d *Decoder, p unsafe.Pointer) error {
 func encodeSliceInt32(e *Encoder, p unsafe.Pointer) error {
 	s := *(*[]int32)(p)
 	if e.qpack {
-		e.writePackedInt32Slice(s)
+		w := make([]int64, len(s))
+		for i, v := range s {
+			w[i] = int64(v)
+		}
+		codec, mn, forBits, first, minDelta, deltaBits, pforBits, bestCost := pickI64Codec(w)
+		// Never-worse floor: native int32-raw is 4 B/elem vs the picker's 8 B/elem
+		// uint64-raw baseline. Emit the widened codec only when it beats native
+		// int32-raw; else native raw so incompressible 32-bit data isn't inflated.
+		if bestCost >= 2+uvarintLen(uint64(len(s)))+4*len(s) {
+			e.writePackedInt32Slice(s)
+			return nil
+		}
+		e.emitQPackInt64(w, codec, mn, forBits, first, minDelta, deltaBits, pforBits)
 		return nil
 	}
 	e.WriteArrayHeader(len(s))
@@ -172,18 +222,89 @@ func encodeSliceInt32(e *Encoder, p unsafe.Pointer) error {
 	}
 	return nil
 }
+
+// readQPackUint64 consumes a QPack uint64 codec body whose tag t was peeked.
+// The caller must have already peeked (not consumed) the tag; this function
+// increments d.i to consume it before reading the payload.
+func (d *Decoder) readQPackUint64(t byte) ([]uint64, error) {
+	d.i++
+	switch t {
+	case tagPackRaw:
+		return d.readPackedUint64Slice()
+	case tagPackFor:
+		return d.readPackedForUint64Slice()
+	case tagPackDeltaFor:
+		return d.readPackedDeltaForUint64Slice()
+	case tagPackRLE:
+		return d.readPackedRLEUint64Slice()
+	case tagPackDict:
+		return d.readPackedDictUint64Slice()
+	case tagPackPFor:
+		return d.readPackedPForUint64Slice()
+	}
+	return nil, ErrBadTag
+}
+
+// readQPackInt64 consumes a QPack int64 codec body whose tag t was peeked.
+// The caller must have already peeked (not consumed) the tag; this function
+// increments d.i to consume it before reading the payload.
+func (d *Decoder) readQPackInt64(t byte) ([]int64, error) {
+	d.i++
+	switch t {
+	case tagPackRaw:
+		return d.readPackedInt64Slice()
+	case tagPackFor:
+		return d.readPackedForInt64Slice()
+	case tagPackDeltaFor:
+		return d.readPackedDeltaForInt64Slice()
+	case tagPackRLE:
+		return d.readPackedRLEInt64Slice()
+	case tagPackDict:
+		return d.readPackedDictInt64Slice()
+	case tagPackPFor:
+		return d.readPackedPForInt64Slice()
+	}
+	return nil, ErrBadTag
+}
+
 func decodeSliceInt32(d *Decoder, p unsafe.Pointer) error {
 	t, err := d.peekTag()
 	if err != nil {
 		return err
 	}
-	if t == tagPackRaw {
+	switch t {
+	case tagPackRaw:
+		// Could be qpackKindInt32 (legacy raw) or qpackKindInt64 (new QPack path).
+		// Peek the kind byte (one position ahead of the tag) to decide.
+		if d.i+1 < len(d.buf) && d.buf[d.i+1] == qpackKindInt64 {
+			v64, err := d.readQPackInt64(t)
+			if err != nil {
+				return err
+			}
+			out := make([]int32, len(v64))
+			for i, x := range v64 {
+				out[i] = int32(x)
+			}
+			*(*[]int32)(p) = out
+			return nil
+		}
 		d.i++
 		v, err := d.readPackedInt32Slice()
 		if err != nil {
 			return err
 		}
 		*(*[]int32)(p) = v
+		return nil
+	case tagPackFor, tagPackDeltaFor, tagPackRLE, tagPackDict, tagPackPFor:
+		v64, err := d.readQPackInt64(t)
+		if err != nil {
+			return err
+		}
+		out := make([]int32, len(v64))
+		for i, x := range v64 {
+			out[i] = int32(x)
+		}
+		*(*[]int32)(p) = out
 		return nil
 	}
 	n, err := d.ReadArrayHeader()
@@ -207,21 +328,7 @@ func decodeSliceInt32(d *Decoder, p unsafe.Pointer) error {
 func encodeSliceInt64(e *Encoder, p unsafe.Pointer) error {
 	s := *(*[]int64)(p)
 	if e.qpack {
-		codec, mn, forBits, first, minDelta, deltaBits, pforBits := pickI64Codec(s)
-		switch codec {
-		case qpackFor:
-			e.writePackedForInt64Slice(s, mn, forBits)
-		case qpackDeltaFor:
-			e.writePackedDeltaForInt64Slice(s, first, minDelta, deltaBits)
-		case qpackRLE:
-			e.writePackedRLEInt64Slice(s)
-		case qpackDict:
-			e.writePackedDictInt64Slice(s)
-		case qpackPFor:
-			e.writePackedPForInt64Slice(s, mn, pforBits)
-		default:
-			e.writePackedInt64Slice(s)
-		}
+		e.writeQPackInt64(s)
 		return nil
 	}
 	e.WriteArrayHeader(len(s))
@@ -306,7 +413,20 @@ func decodeSliceInt64(d *Decoder, p unsafe.Pointer) error {
 func encodeSliceUint32(e *Encoder, p unsafe.Pointer) error {
 	s := *(*[]uint32)(p)
 	if e.qpack {
-		e.writePackedUint32Slice(s)
+		w := make([]uint64, len(s))
+		for i, v := range s {
+			w[i] = uint64(v)
+		}
+		codec, mn, forBits, first, minDelta, deltaBits, pforBits, bestCost := pickU64Codec(w)
+		// Never-worse floor: the picker scores codecs against the uint64-raw
+		// 8 B/elem baseline, but the native form for a uint32 is 4 B/elem. Emit
+		// the widened codec only when its cost beats native uint32-raw; otherwise
+		// fall back to native raw so incompressible 32-bit data is never inflated.
+		if bestCost >= 2+uvarintLen(uint64(len(s)))+4*len(s) {
+			e.writePackedUint32Slice(s)
+			return nil
+		}
+		e.emitQPackUint64(w, codec, mn, forBits, first, minDelta, deltaBits, pforBits)
 		return nil
 	}
 	e.WriteArrayHeader(len(s))
@@ -320,13 +440,39 @@ func decodeSliceUint32(d *Decoder, p unsafe.Pointer) error {
 	if err != nil {
 		return err
 	}
-	if t == tagPackRaw {
+	switch t {
+	case tagPackRaw:
+		// Could be qpackKindUint32 (legacy raw) or qpackKindUint64 (new QPack path).
+		// Peek the kind byte (one position ahead of the tag) to decide.
+		if d.i+1 < len(d.buf) && d.buf[d.i+1] == qpackKindUint64 {
+			v64, err := d.readQPackUint64(t)
+			if err != nil {
+				return err
+			}
+			out := make([]uint32, len(v64))
+			for i, x := range v64 {
+				out[i] = uint32(x)
+			}
+			*(*[]uint32)(p) = out
+			return nil
+		}
 		d.i++
 		v, err := d.readPackedUint32Slice()
 		if err != nil {
 			return err
 		}
 		*(*[]uint32)(p) = v
+		return nil
+	case tagPackFor, tagPackDeltaFor, tagPackRLE, tagPackDict, tagPackPFor:
+		v64, err := d.readQPackUint64(t)
+		if err != nil {
+			return err
+		}
+		out := make([]uint32, len(v64))
+		for i, x := range v64 {
+			out[i] = uint32(x)
+		}
+		*(*[]uint32)(p) = out
 		return nil
 	}
 	n, err := d.ReadArrayHeader()
@@ -350,21 +496,7 @@ func decodeSliceUint32(d *Decoder, p unsafe.Pointer) error {
 func encodeSliceUint64(e *Encoder, p unsafe.Pointer) error {
 	s := *(*[]uint64)(p)
 	if e.qpack {
-		codec, mn, forBits, first, minDelta, deltaBits, pforBits := pickU64Codec(s)
-		switch codec {
-		case qpackFor:
-			e.writePackedForUint64Slice(s, mn, forBits)
-		case qpackDeltaFor:
-			e.writePackedDeltaForUint64Slice(s, first, minDelta, deltaBits)
-		case qpackRLE:
-			e.writePackedRLEUint64Slice(s)
-		case qpackDict:
-			e.writePackedDictUint64Slice(s)
-		case qpackPFor:
-			e.writePackedPForUint64Slice(s, mn, pforBits)
-		default:
-			e.writePackedUint64Slice(s)
-		}
+		e.writeQPackUint64(s)
 		return nil
 	}
 	e.WriteArrayHeader(len(s))


### PR DESCRIPTION
Standalone `[]uint32`/`[]int32` slices (and row-major struct fields of those
types) emitted **raw little-endian** under `OptQPack` / `OptBalanced` — they
skipped the whole codec picker, so FOR / Delta+FOR / RLE / dictionary / PFOR
never fired on 32-bit integer data. The `[]uint64`/`[]int64` paths already run
the picker. (Columnar `uint32` *columns* were already covered — the columnar
gather widens into the `uint64` scratch before encoding; this is the
standalone-slice / row-major gap.)

Fix: widen the 32-bit slice to `[]uint64`/`[]int64`, run the existing picker,
and on decode read the chosen codec and narrow back.

## Headroom (1024-element `[]uint32`, OptBalanced)

| data | before (raw) | after | factor |
| --- | ---: | ---: | ---: |
| monotonic | 4105 B | **14 B** | 293× |
| low-cardinality | 4105 B | 274 B | 15× |
| small-range (10-bit) | 4105 B | 1291 B | 3.2× |

## Never-worse floor (exact)

The picker scores codecs against the `uint64`-raw **8 B/elem** baseline, but the
native form for a `uint32` is **4 B/elem**. Without a floor, a codec that beats
8N but not 4N (e.g. a small-N alternating-near-max slice picking Delta+FOR/FOR at
the full 32-bit width) would *inflate* 32-bit data. So `pickU64Codec` /
`pickI64Codec` now also return the chosen `bestCost`, and the 32-bit encoder
emits the widened codec **only when `bestCost` beats native `uint32`/`int32`-raw**
— otherwise it falls back to the native 4 B/elem raw form. Incompressible
full-range `uint32` stays at the pre-feature size (4105 B for N=1024); a small-N
adversarial case is pinned in the test.

## Notes

- 64-bit paths refactored into shared `writeQPack`/`emitQPack` helpers (split
  pick vs emit so the 32-bit caller can inspect the choice without picking
  twice). Behaviour byte-identical — 64-bit golden unchanged, interleaved
  `benchstat` over the Profile matrix shows geomean −0.23% (noise, all p > 0.18).
- Decode disambiguates the `tagPackRaw` form by peeking the kind byte: legacy
  `uint32`-raw → `readPackedUint32Slice`; new widened `uint64`-raw → widen-narrow
  path. Narrowing `uint32(x)`/`int32(x)` is exact for valid streams (encoder only
  emits in-range values; full-range min/max round-trip is tested) and, on hostile
  input, truncates consistently with the pre-existing array-header fallback —
  bounded by the existing `CheckLength` guards, no panic/OOM.

## Verification

- `TestQPack32BitCompresses` (monotonic/low-card/full-range edges/empty/single)
  and `TestQPack32BitNeverWorse` (random full-range + small-N adversarial).
- `go test -race` + golden clean under default and `qdf_simd`; `go vet` clean;
  `gofmt` clean. No golden fixture changed (the existing golden set has no
  `[]uint32`/`[]int32` cases; 64-bit golden unaffected by the refactor).

## Docs

README / GUIDE / USAGE / CHOOSING and godoc updated to state that 32- and 64-bit
integer slices both run the codec picker.
