### PR TITLE
perf: reuse a Delta+FOR unpack scratch on decode

### DIFF
--- a/bench/vardelta_decode_test.go
+++ b/bench/vardelta_decode_test.go
@@ -1,0 +1,34 @@
+package bench
+
+import (
+	"github.com/alex60217101990/qdf"
+	"math/rand"
+	"testing"
+)
+
+// variable-delta int64 column -> DeltaFor bitsPer>0 -> exercises the tmp scratch
+func BenchmarkVarDeltaDecode(b *testing.B) {
+	r := rand.New(rand.NewSource(7))
+	type Row struct {
+		TS int64 `qdf:"ts"`
+		A  int64 `qdf:"a"`
+		B  int64 `qdf:"b"`
+	}
+	rows := make([]Row, 2000)
+	var ts, a, bb int64 = 1e9, 0, 0
+	for i := range rows {
+		ts += int64(r.Intn(500) + 1) // jittery monotonic -> variable deltas
+		a += int64(r.Intn(1000))
+		bb += int64(r.Intn(50) + 1)
+		rows[i] = Row{ts, a, bb}
+	}
+	enc, _ := qdf.Marshal(rows, qdf.OptBalanced)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var out []Row
+		if err := qdf.Unmarshal(enc, &out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/decoder.go
+++ b/decoder.go
@@ -49,6 +49,12 @@ type Decoder struct {
 	// predicates (AND) and project the plan's columns. Set by Unmarshal when
 	// QueryOptions are passed; cleared on reset / SetInput so it never leaks.
 	query *queryPlan
+
+	// deltaScratch is a reused unpack buffer for the Delta+FOR readers: the
+	// bit-unpacked deltas are a transient intermediate (the prefix sum writes
+	// the retained out slice), so a per-call make is pure garbage. Grows to the
+	// largest column seen; bounded on return to pool.
+	deltaScratch []uint64
 }
 
 // colLenOK reports whether a slice length is acceptable in the current

--- a/qdf.go
+++ b/qdf.go
@@ -190,6 +190,11 @@ const (
 	// the high-water buffer once it warms up, while still releasing
 	// truly outlier payloads instead of pinning them to the pool.
 	maxPooledBuf = 16 * 1024 * 1024
+	// maxRetainedDeltaScratch bounds the Delta+FOR decode scratch a pooled
+	// decoder keeps between calls. Retains it for columns up to ~16 k rows
+	// (the maxStateEntries scale) and drops it after a one-off larger decode so
+	// the pool never pins an outlier buffer.
+	maxRetainedDeltaScratch = 1 << 14
 )
 
 // Options is a bit-mask of per-call encoder feature toggles. A zero
@@ -427,6 +432,9 @@ func unmarshalQuery(data []byte, out any, qp *queryPlan) error {
 	dec.buf = nil
 	dec.selectFields = nil
 	dec.query = nil
+	if cap(dec.deltaScratch) > maxRetainedDeltaScratch {
+		dec.deltaScratch = nil
+	}
 	decPool.Put(dec)
 	return err
 }
@@ -448,6 +456,9 @@ func unmarshal(data []byte, out any, fields []string) error {
 	err := decodeReflect(dec, out)
 	dec.buf = nil
 	dec.selectFields = nil
+	if cap(dec.deltaScratch) > maxRetainedDeltaScratch {
+		dec.deltaScratch = nil
+	}
 	decPool.Put(dec)
 	return err
 }

--- a/qpack_delta.go
+++ b/qpack_delta.go
@@ -247,12 +247,15 @@ func (d *Decoder) readPackedDeltaForUint64Slice() ([]uint64, error) {
 		}
 		return out, nil
 	}
-	tmp := make([]uint64, n-1)
+	if cap(d.deltaScratch) < n-1 {
+		d.deltaScratch = make([]uint64, n-1)
+	}
+	tmp := d.deltaScratch[:n-1]
 	bitpack.Unpack(tmp, body, bitsPer)
 	minU := uint64(minDelta)
 	v := first
-	for i, d := range tmp {
-		v += d + minU
+	for i, dv := range tmp {
+		v += dv + minU
 		out[i+1] = v
 	}
 	return out, nil
@@ -279,12 +282,15 @@ func (d *Decoder) readPackedDeltaForInt64Slice() ([]int64, error) {
 		}
 		return out, nil
 	}
-	tmp := make([]uint64, n-1)
+	if cap(d.deltaScratch) < n-1 {
+		d.deltaScratch = make([]uint64, n-1)
+	}
+	tmp := d.deltaScratch[:n-1]
 	bitpack.Unpack(tmp, body, bitsPer)
 	minU := uint64(minDelta)
 	v := uint64(first)
-	for i, d := range tmp {
-		v += d + minU
+	for i, dv := range tmp {
+		v += dv + minU
 		out[i+1] = int64(v)
 	}
 	return out, nil


### PR DESCRIPTION
The Delta+FOR decoders (`readPackedDeltaForInt64Slice` / `…Uint64Slice`)
allocated a fresh `[]uint64` `tmp` buffer per column to bit-unpack the deltas
into before the prefix sum writes the retained `out` slice. That `tmp` is pure
transient garbage — bit-unpack, sum, discard. Reuse a pooled per-`Decoder`
scratch (`deltaScratch`), grown to the largest column seen and bounded to ~16k
elements on return to the pool so a one-off large decode never pins an outlier
buffer.

## Scope (honest)

This only fires on **variable-delta** columns (`bitsPer > 0`). A constant-step
column (perfectly monotonic counter / timestamp) takes the `bitsPer == 0` fast
path that never allocated `tmp` in the first place — so the canonical monotonic
telemetry/metric benches are **unaffected** (verified flat, p ≈ 1.0, allocs
byte-identical). The win lands on realistic jittery data: real timestamps with
sub-step jitter, monotonic-with-gaps counters, etc.

## Result

`BenchmarkVarDeltaDecode` (2000-row batch, 3 jittery-monotonic int64 columns →
variable deltas, i7-9750H, interleaved `benchstat` n=12):

| metric | base | head | Δ |
| --- | ---: | ---: | ---: |
| sec/op | 50.56 µs | 45.60 µs | **−9.8 %** (p=0.000) |
| B/op | 144.2 KiB | 96.2 KiB | **−33 %** (p=0.000) |
| allocs/op | 12 | 9 | **−25 %** (p=0.000) |

(3 Delta+FOR columns → 3 transient `tmp` allocs eliminated.) The constant-delta
Profile matrix shows no movement (geomean +0.5 %, all p > 0.1 = noise).

## Why measure-first mattered here

The decode alloc profile flagged `readPackedDeltaForInt64Slice` as 26 % of
alloc-space, which looked like a big lever — but most of that is the **retained**
`out` slice (unavoidable), and the `tmp` it pointed at only allocates on
variable-delta data, which the standard benches don't exercise (their timestamps
are constant-step). A naive "the profile says 26 %" change benched flat; gating
on a variable-delta workload is what surfaced the real (and real-world) win.

## Verification

- `go test -race` + golden clean under default and `qdf_simd`; `go vet` clean;
  `gofmt` clean. Round-trip unchanged (existing Delta+FOR + golden tests cover
  correctness; the scratch is a drop-in for the per-call `make`).
- Allocation stays bounded by the existing Delta+FOR header validation; the
  pooled scratch is dropped above `maxRetainedDeltaScratch` (1<<14 elems).