### PR TITLE
perf: lazily allocate the encoder intern state (OptSpeed reset-skip)

### DIFF
--- a/docs/CHOOSING.md
+++ b/docs/CHOOSING.md
@@ -98,7 +98,7 @@ but the intern table is per-call when using `Marshal`).
 b, err := qdf.Marshal(event, qdf.OptSpeed)
 ```
 
-Result: encode 349 ns vs json 678 ns vs msgpack 444 ns. Decode 282 ns
+Result: encode 290 ns vs json 678 ns vs msgpack 444 ns. Decode 282 ns
 vs json 1557 ns vs msgpack 618 ns. Wire 72 B vs json 97 B (msgpack
 wins on size here at 63 B — its fixmap header is one byte cheaper).
 

--- a/encoder.go
+++ b/encoder.go
@@ -132,6 +132,13 @@ func (e *Encoder) applyOpts(opts Options) {
 	e.opts = opts
 	if opts.Has(OptDense) {
 		e.mode = Dense
+		// Lazily allocate the Dense intern state. A pooled encoder starts with
+		// state == nil (set in the pool's New) and never allocates it while it
+		// only serves OptSpeed; the first Dense encode brings it up. A reused
+		// encoder keeps its state — Reset() clears it before this runs.
+		if e.state == nil {
+			e.state = newEncState()
+		}
 	} else {
 		e.mode = Fast
 	}
@@ -187,10 +194,7 @@ func NewEncoderWith(opts Options) *Encoder {
 		maxStateEntries: 1 << 14,
 		maxDepth:        DefaultMaxDepth,
 	}
-	e.applyOpts(opts)
-	if opts.Has(OptDense) {
-		e.state = newEncState()
-	}
+	e.applyOpts(opts) // allocates Dense state when OptDense is set
 	return e
 }
 

--- a/qdf.go
+++ b/qdf.go
@@ -304,9 +304,12 @@ var (
 	// reused across calls when the cap fits maxPooledBuf.
 	encPool = sync.Pool{
 		New: func() any {
+			// state is left nil: Fast/OptSpeed encodes never touch the intern
+			// table, so a pooled encoder serving only OptSpeed pays no state
+			// allocation and no per-call state.reset(). applyOpts lazily
+			// allocates it the first time the encoder runs in Dense mode.
 			return &Encoder{
 				buf:             make([]byte, 0, initialEncBuf),
-				state:           newEncState(),
 				minIntern:       4,
 				maxStateEntries: 1 << 14,
 				maxDepth:        DefaultMaxDepth,


### PR DESCRIPTION
The encoder `sync.Pool`'s `New` always allocated `state: newEncState()`, so every
pooled encoder carried a Dense intern table — and `Reset()` (run on every
`Marshal`/`AppendMarshal`) called `state.reset()`, which `memclr`s the intern
table and refills the 128-entry `mruRing` sentinel. OptSpeed/Fast encodes never
touch the intern table, so that reset was pure waste on the hot path. A CPU
profile of single-message OptSpeed encode put `state.reset()` at ~a third of the
work.

## Fix
Leave the pooled encoder's `state` **nil**; `applyOpts` allocates it the first
time the encoder runs in Dense mode:
- `encPool.New` — drop `state: newEncState()`.
- `applyOpts` — in the Dense branch, `if e.state == nil { e.state = newEncState() }`.
- `NewEncoderWith` — drop the now-redundant Dense `state` alloc (`applyOpts` does it).
- `Reset()` — **unchanged**: still resets a non-nil state, so a direct
  `NewEncoder(Dense)` + `Reset()` + re-encode stays correct.

A pool that only ever serves OptSpeed never allocates the state and never pays
the reset. Behaviour-preserving: the Fast path already ran with a nil state
(`NewEncoderWith(OptSpeed)` leaves it nil) and `WriteString` gates the intern
path on `dense && st != nil`.

## Result
`BenchmarkProfile_HotPath` encode (OptSpeed, single 5-field event, i7-9750H,
interleaved `benchstat` n=12):

| | sec/op | vs base |
| --- | ---: | ---: |
| OptSpeed encode | 290.5 ns | **−26.8%** (p=0.000) |

Throughput +36.6%. The Dense control (`TelemetryBatch` encode) and all decode
paths are flat (no regression); `allocs/op` is unchanged everywhere (the win is
CPU — a skipped `memclr` + ring fill — not allocation count). Hot-path encode
figure in `docs/CHOOSING.md` refreshed 349 → 290 ns.

## Scope note
The win lands on pools that serve OptSpeed. A pool mixing OptSpeed and Dense
calls still pays `Reset()` on an OptSpeed call that reuses a
previously-Dense encoder (its state is non-nil); a two-pool split would remove
that too, at the cost of more machinery — deferred, the lazy form covers the
common pure-OptSpeed hot path.

## Verification
`go test` / `-race` / golden clean under default and `qdf_simd`; `go vet` clean;
`gofmt` clean. No wire/behaviour change, no golden change.