### PR TITLE
perf: scatter nullable pushdown columns into one slab per column

### DIFF
--- a/bench/nullable_scatter_test.go
+++ b/bench/nullable_scatter_test.go
@@ -1,0 +1,31 @@
+package bench
+
+import (
+	"testing"
+
+	"github.com/alex60217101990/qdf"
+)
+
+// BenchmarkNullableScatter measures predicate-pushdown that projects nullable
+// (*T) columns: the scatter path used to reflect.New per present row; now it
+// fills one backing slab per column.
+func BenchmarkNullableScatter(b *testing.B) {
+	type Row struct {
+		A int64  `qdf:"a"`
+		P *int64 `qdf:"p"`
+		Q *int64 `qdf:"q"`
+	}
+	rows := make([]Row, 4000)
+	for i := range rows {
+		v := int64(i)
+		w := int64(i * 2)
+		rows[i] = Row{int64(i), &v, &w}
+	}
+	enc, _ := qdf.Marshal(rows, qdf.OptBalanced|qdf.OptColumnIndex)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var out []Row
+		_ = qdf.Unmarshal(enc, &out, qdf.Where("a", func(v int64) bool { return v >= 0 }))
+	}
+}

--- a/columnar.go
+++ b/columnar.go
@@ -3,6 +3,7 @@ package qdf
 import (
 	"encoding/binary"
 	"reflect"
+	"runtime"
 	"slices"
 	"unsafe"
 
@@ -797,13 +798,11 @@ func (cv *colVals) evalMasks(term *predTerm, n int) (t, f []uint64) {
 	return t, f
 }
 
-// scatterRow writes cv's value at source row src into the output struct slice
-// at compacted row dst. Mirrors decodeColumnInto's store half.
+// scatterRow writes a non-nullable column's value at source row src into the
+// output struct slice at compacted row dst. Mirrors decodeColumnInto's store
+// half. Nullable columns are scattered via scatterNullableRowInto (one shared
+// backing slab instead of a per-row alloc).
 func (cv *colVals) scatterRow(base unsafe.Pointer, plan *columnarPlan, col *colColumn, src, dst int) {
-	if cv.present != nil {
-		cv.scatterNullableRow(base, plan, col, src, dst)
-		return
-	}
 	switch cv.kind {
 	case colKindInt:
 		storeScalarFromI64(base, plan.stride, col, dst, cv.i64[src])
@@ -975,11 +974,24 @@ func decodeColumnarQuery(d *Decoder, t reflect.Type, plan *columnarPlan, p unsaf
 		if cv == nil || want[c] == nil {
 			continue
 		}
-		if sh.kinds[c].base() != want[c].kind.base() {
+		col := want[c]
+		if sh.kinds[c].base() != col.kind.base() {
 			return ErrTypeMismatch
 		}
+		if cv.present != nil {
+			// Nullable column: one backing slab holds all present values; each
+			// *T field points into it. Replaces a per-row reflect.New.
+			slab := reflect.MakeSlice(reflect.SliceOf(col.elemType), len(matched), len(matched))
+			slabBase := slab.UnsafePointer()
+			elemSize := col.elemType.Size()
+			for dst, src := range matched {
+				cv.scatterNullableRowInto(base, plan, col, src, dst, slabBase, elemSize)
+			}
+			runtime.KeepAlive(slab)
+			continue
+		}
 		for dst, src := range matched {
-			cv.scatterRow(base, plan, want[c], src, dst)
+			cv.scatterRow(base, plan, col, src, dst)
 		}
 	}
 	return nil

--- a/nullable_col.go
+++ b/nullable_col.go
@@ -391,17 +391,20 @@ func (d *Decoder) decodeNullableColumnVals(kind colKind, n int) (colVals, error)
 	return cv, nil
 }
 
-// scatterNullableRow writes cv's optional value at source row src into the *T
-// field at compacted row dst: a present value allocates a T (via col.elemType)
-// and points the field at it; an absent value leaves the pointer nil.
-func (cv *colVals) scatterNullableRow(base unsafe.Pointer, plan *columnarPlan, col *colColumn, src, dst int) {
+// scatterNullableRowInto writes cv's optional value at source row src into the
+// *T field at compacted row dst. A present value is placed in the caller's
+// backing slab at slab+dst*elemSize and the field points into it; an absent
+// value leaves the pointer nil. One slab per column replaces the former per-row
+// reflect.New (a wide nullable projection's 8k+ allocs collapse to ~one per
+// column). The caller MakeSlices the slab and keeps it alive (runtime.KeepAlive)
+// until every field pointer has been written.
+func (cv *colVals) scatterNullableRowInto(base unsafe.Pointer, plan *columnarPlan, col *colColumn, src, dst int, slab unsafe.Pointer, elemSize uintptr) {
 	fp := unsafe.Add(base, uintptr(dst)*plan.stride+col.offset)
 	if !getBit(cv.present, src) {
 		*(*unsafe.Pointer)(fp) = nil
 		return
 	}
-	ev := reflect.New(col.elemType) // *T
-	ea := ev.UnsafePointer()
+	ea := unsafe.Add(slab, uintptr(dst)*elemSize) // &slab[dst]
 	switch cv.kind.base() {
 	case colKindInt:
 		storeI64At(ea, col.width, cv.i64[src])
@@ -415,7 +418,6 @@ func (cv *colVals) scatterNullableRow(base unsafe.Pointer, plan *columnarPlan, c
 		*(*string)(ea) = cv.s[src]
 	}
 	*(*unsafe.Pointer)(fp) = ea
-	runtime.KeepAlive(ev)
 }
 
 // decodeNullableColumnAny reads the mask + dense column and returns one boxed


### PR DESCRIPTION
Predicate pushdown that **projects a nullable (`*T`) column** materialised each
present value with a per-row `reflect.New(elemType)` in `scatterNullableRow` —
one heap object per present row per nullable column. A wide nullable projection
allocated thousands of tiny objects.

## Fix
Allocate **one backing slab per projected nullable column** (`reflect.MakeSlice`
of `elemType`, length = matched-row count) and point each `*T` field into it —
mirroring the non-query `decodeNullableColumn` path. The slab is kept alive
(`runtime.KeepAlive`) until every field pointer is written; thereafter the live
`*T` fields keep it reachable.

- `scatterNullableRow` (per-row `reflect.New`) → `scatterNullableRowInto`
  (writes into `slab + dst*elemSize`).
- `scatterRow` is now the non-nullable-only helper; the query scatter loop
  routes nullable columns through the slab path.

## Result
`BenchmarkNullableScatter` (4000 rows, 2 nullable `int64` columns projected,
100% match, i7-9750H):

| | before | after |
| --- | ---: | ---: |
| sec/op | ~390 µs | **~145 µs (−63%)** |
| allocs/op | 8035 | **39 (~206× fewer)** |

The per-row `reflect.New` was `mallocgc`-bound; collapsing it to one slab per
column removes ~one alloc per present row. Bytes moved are unchanged (the slab
holds the same total). Pure decode-side, no wire/behaviour change.

## Verification
`go test` / `-race` / golden clean under default and `qdf_simd`; `go vet` clean;
`gofmt` + bench-module `golangci-lint` clean. No golden change.
