### PR TITLE
perf: O(1) dict index resolution + raise QPack dict cap 16→64

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -553,7 +553,7 @@ slice; the decoder reads the picked tag.
 0xE6  tagPackDeltaFor  []intN       Delta + zigzag + FOR
 0xE7  tagPackGorilla   []float64    Gorilla XOR coding
 0xEB  tagPackRLE       []intN       Run-length encoded (value, runLen) pairs
-0xED  tagPackDict      []intN       Dictionary-coded; ≤16 distinct values
+0xED  tagPackDict      []intN       Dictionary-coded; ≤64 distinct values
 0xEE  tagPackPFor      []intN       Patched FOR: narrow body + outlier exceptions
 0xF5  tagColStrDict    []string col Dictionary-coded string column (distinct table + bit-packed index/row)
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -147,7 +147,7 @@ time. You do not need to hint it — just set the bit.
 | `[]intN`/`[]uintN`, clustered range | Frame-of-Reference (FOR) | `OptQPack` |
 | `[]int`/`[]int32`/`[]int64`/`[]uint`/`[]uint32`/`[]uint64`, monotonic or time-series | Delta+FOR | `OptQPack` |
 | `[]intN`, run-heavy (status codes, enum-like, sparse counters) | RLE (value, runLen pairs) | `OptQPack` |
-| `[]intN`, small distinct cardinality (≤16), wide value range | Dictionary codec | `OptQPack` |
+| `[]intN`, small distinct cardinality (≤64), wide value range | Dictionary codec | `OptQPack` |
 | `[]intN`/`[]uintN`, mostly small with rare large outliers (latency spikes, counter resets) | Patched FOR (narrow body + exception list) | `OptQPack` |
 | `[]float64`/`[]float32`, smooth time-series | Gorilla XOR | `OptCompression` (or `OptGorillaFloat`) |
 | `[]float64`, quantized/decimal grid (prices, percentages, latencies) | ALP decimal (integer-mantissa FOR + exception list) | `OptCompression` |

--- a/qpack.go
+++ b/qpack.go
@@ -262,8 +262,12 @@ const (
 
 // qpackDictMaxDistinct caps the dictionary codec: a slice with more
 // than this many unique values is rarely a dictionary-shape column
-// and the probe cost grows linearly with the cap.
-const qpackDictMaxDistinct = 16
+// and the probe cost grows linearly with the cap. 64 distinct still
+// pack at 6 index bits, covering wide-but-low-cardinality enums (HTTP
+// status, state machines) that FOR would force wide; the probe bails
+// the moment a (cap+1)th distinct appears, so high-cardinality slices
+// stay cheap regardless of the cap.
+const qpackDictMaxDistinct = 64
 
 // bitsForDistinct returns the per-index bit width of a dictionary
 // codec with the given distinct count. distinct == 1 gives 0 (the
@@ -277,47 +281,74 @@ func bitsForDistinct(distinct int) int {
 	return bits.Len(uint(distinct - 1))
 }
 
+// qpackProbeSlots is the open-addressed membership set used by the
+// distinct probes: the smallest power of two that keeps the load factor
+// at or below 1/2 when the table is full (qpackDictMaxDistinct keys). A
+// linear membership scan would cost O(n·cap); the set keeps the probe
+// O(n) so raising the cap never slows the picker on high- or
+// mid-cardinality slices.
+const qpackProbeSlots = 128
+
 // probeDistinctU64 walks s up to len(s) elements and returns the
 // distinct value table along with the count. The second return is
 // false when the cardinality exceeds qpackDictMaxDistinct — in that
 // case the table is unspecified and the caller skips the dictionary
 // codec entirely. The table buffer is caller-supplied so the picker
-// can keep the probe stack-allocated.
-//
-//go:nosplit
+// can keep the probe stack-allocated. Not //go:nosplit: the membership
+// set's backing arrays exceed the nosplit stack budget, and the probe
+// runs once per slice column so the growth-check prologue is noise.
 func probeDistinctU64(s []uint64, table *[qpackDictMaxDistinct + 1]uint64) (int, bool) {
+	var slots [qpackProbeSlots]uint64
+	var used [qpackProbeSlots]bool
 	count := 0
-outer:
 	for _, v := range s {
-		for j := 0; j < count; j++ {
-			if table[j] == v {
-				continue outer
+		h := (v * 0x9E3779B97F4A7C15) >> (64 - 7) & (qpackProbeSlots - 1) // top 7 bits → 128 slots
+		seen := false
+		for used[h] {
+			if slots[h] == v {
+				seen = true
+				break
 			}
+			h = (h + 1) & (qpackProbeSlots - 1)
+		}
+		if seen {
+			continue
 		}
 		if count >= qpackDictMaxDistinct {
 			return 0, false
 		}
+		used[h] = true
+		slots[h] = v
 		table[count] = v
 		count++
 	}
 	return count, true
 }
 
-// probeDistinctI64 mirrors probeDistinctU64 for signed slices.
-//
-//go:nosplit
+// probeDistinctI64 mirrors probeDistinctU64 for signed slices, hashing
+// the two's-complement bit pattern.
 func probeDistinctI64(s []int64, table *[qpackDictMaxDistinct + 1]int64) (int, bool) {
+	var slots [qpackProbeSlots]int64
+	var used [qpackProbeSlots]bool
 	count := 0
-outer:
 	for _, v := range s {
-		for j := 0; j < count; j++ {
-			if table[j] == v {
-				continue outer
+		h := (uint64(v) * 0x9E3779B97F4A7C15) >> (64 - 7) & (qpackProbeSlots - 1)
+		seen := false
+		for used[h] {
+			if slots[h] == v {
+				seen = true
+				break
 			}
+			h = (h + 1) & (qpackProbeSlots - 1)
+		}
+		if seen {
+			continue
 		}
 		if count >= qpackDictMaxDistinct {
 			return 0, false
 		}
+		used[h] = true
+		slots[h] = v
 		table[count] = v
 		count++
 	}

--- a/qpack_dict.go
+++ b/qpack_dict.go
@@ -13,8 +13,9 @@ import (
 // reach competitive density.
 //
 // The encoder re-runs the distinct probe because the picker discards
-// the table after the size estimate; the probe is O(n * distinct)
-// and stays well under the bitpack-body work it replaces.
+// the table after the size estimate; both the probe and the per-element
+// index resolution use an open-addressed hash set, so each is O(n)
+// regardless of the distinct count.
 
 // writePackedDictUint64Slice emits s as a tagPackDict payload. The
 // caller has already decided via pickU64Codec that dict wins.
@@ -49,25 +50,44 @@ func (e *Encoder) writePackedDictUint64Slice(s []uint64) {
 	out = out[:start+bodyBytes]
 	body := out[start : start+bodyBytes]
 	clear(body)
+	// Build an open-addressed value→index map once so each element's
+	// index resolves in O(1); a linear scan over the table would be
+	// O(n·count) and grow with the cap.
+	hslot, hidx := buildDictIndexU64(&table, count)
 	// Stage indices in a chunk buffer so bitpack.PackChunk can
 	// reuse its existing LSB-first packing routine.
 	var chunk [64]uint64
 	for i := 0; i < n; i += len(chunk) {
 		end := min(i+len(chunk), n)
 		for j, v := range s[i:end] {
-			// Resolve dict index via linear scan over the small
-			// table — count is bounded by qpackDictMaxDistinct so
-			// this stays well inside the cache.
-			for k := range count {
-				if table[k] == v {
-					chunk[j] = uint64(k)
-					break
-				}
+			h := (v * 0x9E3779B97F4A7C15) >> (64 - 7) & (qpackProbeSlots - 1)
+			for hslot[h] != v { // present by construction
+				h = (h + 1) & (qpackProbeSlots - 1)
 			}
+			chunk[j] = uint64(hidx[h])
 		}
 		bitpack.PackChunk(body, chunk[:end-i], bp, i)
 	}
 	e.buf = out
+}
+
+// buildDictIndexU64 returns an open-addressed map from each of the
+// count distinct values in table to its index, used by the dict
+// encoder to resolve element indices in O(1). The hslot array holds
+// the keys; hidx[slot] is the value's position in the dictionary.
+func buildDictIndexU64(table *[qpackDictMaxDistinct + 1]uint64, count int) (hslot [qpackProbeSlots]uint64, hidx [qpackProbeSlots]int16) {
+	var used [qpackProbeSlots]bool
+	for k := range count {
+		v := table[k]
+		h := (v * 0x9E3779B97F4A7C15) >> (64 - 7)
+		for used[h] {
+			h = (h + 1) & (qpackProbeSlots - 1)
+		}
+		used[h] = true
+		hslot[h] = v
+		hidx[h] = int16(k)
+	}
+	return hslot, hidx
 }
 
 // writePackedDictInt64Slice mirrors the unsigned variant. Dictionary
@@ -98,20 +118,37 @@ func (e *Encoder) writePackedDictInt64Slice(s []int64) {
 	out = out[:start+bodyBytes]
 	body := out[start : start+bodyBytes]
 	clear(body)
+	hslot, hidx := buildDictIndexI64(&table, count)
 	var chunk [64]uint64
 	for i := 0; i < n; i += len(chunk) {
 		end := min(i+len(chunk), n)
 		for j, v := range s[i:end] {
-			for k := range count {
-				if table[k] == v {
-					chunk[j] = uint64(k)
-					break
-				}
+			h := (uint64(v) * 0x9E3779B97F4A7C15) >> (64 - 7) & (qpackProbeSlots - 1)
+			for hslot[h] != v { // present by construction
+				h = (h + 1) & (qpackProbeSlots - 1)
 			}
+			chunk[j] = uint64(hidx[h])
 		}
 		bitpack.PackChunk(body, chunk[:end-i], bp, i)
 	}
 	e.buf = out
+}
+
+// buildDictIndexI64 mirrors buildDictIndexU64 for signed dictionaries,
+// hashing the two's-complement bit pattern.
+func buildDictIndexI64(table *[qpackDictMaxDistinct + 1]int64, count int) (hslot [qpackProbeSlots]int64, hidx [qpackProbeSlots]int16) {
+	var used [qpackProbeSlots]bool
+	for k := range count {
+		v := table[k]
+		h := (uint64(v) * 0x9E3779B97F4A7C15) >> (64 - 7)
+		for used[h] {
+			h = (h + 1) & (qpackProbeSlots - 1)
+		}
+		used[h] = true
+		hslot[h] = v
+		hidx[h] = int16(k)
+	}
+	return hslot, hidx
 }
 
 // readPackedDictHeader parses the kind byte and distinct count after

--- a/qpack_dict_test.go
+++ b/qpack_dict_test.go
@@ -92,13 +92,32 @@ func TestDict_PickerHitsSpreadValues(t *testing.T) {
 // TestDict_PickerSkipsHighCardinality makes sure the probe early-
 // exits and the picker never selects dict when distinct > cap.
 func TestDict_PickerSkipsHighCardinality(t *testing.T) {
-	s := make([]uint64, 64)
+	s := make([]uint64, 256)
 	for i := range s {
-		s[i] = uint64(i * 113) // 64 unique values, well above cap
+		s[i] = uint64(i * 113) // 256 unique values, well above the cap
 	}
 	codec, _, _, _, _, _, _, _ := pickU64Codec(s)
 	if codec == qpackDict {
 		t.Fatalf("u64 picker: returned qpackDict on >cap distinct (=%d), want fallback", len(s))
+	}
+}
+
+// TestDict_PickerHitsMidCardinality covers the 17..64-distinct band the
+// cap=64 bump unlocked: wide values (FOR would need 30 bits) but only a
+// few dozen distinct (6 index bits) — dict must win on size.
+func TestDict_PickerHitsMidCardinality(t *testing.T) {
+	const distinct = 40
+	dictVals := make([]uint64, distinct)
+	for i := range dictVals {
+		dictVals[i] = uint64(i) * 25_000_000 // spread across ~30 bits
+	}
+	s := make([]uint64, 1024)
+	for i := range s {
+		s[i] = dictVals[i%distinct]
+	}
+	codec, _, _, _, _, _, _, _ := pickU64Codec(s)
+	if codec != qpackDict {
+		t.Fatalf("u64 picker: got codec %d, want qpackDict (%d) on %d-distinct/wide-range input", codec, qpackDict, distinct)
 	}
 }
 
@@ -114,7 +133,7 @@ func TestDict_ErrorCases(t *testing.T) {
 		}
 	})
 	t.Run("over_cap_distinct", func(t *testing.T) {
-		// distinct = qpackDictMaxDistinct + 1 = 17
+		// distinct = qpackDictMaxDistinct + 1 (just over the cap)
 		buf := []byte{tagPackDict, qpackKindUint64, byte(qpackDictMaxDistinct + 1)}
 		dec := NewDecoderOnBuf(buf)
 		dec.i++
@@ -172,5 +191,108 @@ func TestDict_EndToEnd(t *testing.T) {
 	}
 	if !reflect.DeepEqual(in.Codes, out.Codes) {
 		t.Fatalf("round-trip mismatch")
+	}
+}
+
+// BenchmarkPickU64Codec_Probe measures the picker's probe cost across
+// cardinality bands. The high-card case is the cap-bump regression
+// guard: the distinct probe must bail at the (cap+1)th value, so encode
+// time stays flat regardless of qpackDictMaxDistinct. The mid-card case
+// exercises the 17..64-distinct band the cap=64 bump newly admits.
+func BenchmarkPickU64Codec_Probe(b *testing.B) {
+	mk := func(distinct int, wide bool) []uint64 {
+		s := make([]uint64, 1024)
+		for i := range s {
+			v := uint64(i % distinct)
+			if wide {
+				v *= 25_000_000
+			}
+			s[i] = v
+		}
+		return s
+	}
+	cases := []struct {
+		name string
+		s    []uint64
+	}{
+		{"highcard_random", func() []uint64 {
+			s := make([]uint64, 1024)
+			x := uint64(1)
+			for i := range s {
+				x = x*6364136223846793005 + 1442695040888963407 // LCG, ~all distinct
+				s[i] = x
+			}
+			return s
+		}()},
+		{"midcard40_wide", mk(40, true)},
+		{"lowcard8_wide", mk(8, true)},
+	}
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _, _, _, _, _, _, _ = pickU64Codec(c.s)
+			}
+		})
+	}
+}
+
+// TestDict_MidCardZeroRoundTrip exercises the 17..64-distinct band with
+// a 0 in the dictionary, pinning the open-addressed index map (an empty
+// slot is also zero, so the 0 key must still resolve to its own index).
+// Round-trips through the real Marshal / Unmarshal path.
+func TestDict_MidCardZeroRoundTrip(t *testing.T) {
+	type urow struct {
+		Codes []uint64 `qdf:"codes"`
+	}
+	for _, distinct := range []int{17, 33, 64} {
+		vals := make([]uint64, distinct)
+		for i := range vals {
+			vals[i] = uint64(i) * 1_000_003 // includes 0 at i==0, wide spread
+		}
+		s := make([]uint64, 500)
+		for i := range s {
+			s[i] = vals[i%distinct]
+		}
+		if codec, _, _, _, _, _, _, _ := pickU64Codec(s); codec != qpackDict {
+			t.Fatalf("distinct=%d: picker chose %d, want dict", distinct, codec)
+		}
+		b, err := Marshal(urow{Codes: s}, OptQPack)
+		if err != nil {
+			t.Fatalf("distinct=%d: marshal: %v", distinct, err)
+		}
+		var out urow
+		if err := Unmarshal(b, &out); err != nil {
+			t.Fatalf("distinct=%d: unmarshal: %v", distinct, err)
+		}
+		if !reflect.DeepEqual(s, out.Codes) {
+			t.Fatalf("distinct=%d: roundtrip mismatch", distinct)
+		}
+	}
+
+	// Signed mirror: 40 distinct spanning negatives and including 0.
+	type irow struct {
+		Codes []int64 `qdf:"codes"`
+	}
+	dictI := make([]int64, 40)
+	for i := range dictI {
+		dictI[i] = int64(i-20) * 777_777 // spans negatives, includes 0
+	}
+	si := make([]int64, 600)
+	for i := range si {
+		si[i] = dictI[i%len(dictI)]
+	}
+	if codec, _, _, _, _, _, _, _ := pickI64Codec(si); codec != qpackDict {
+		t.Fatalf("i64 mid-card: picker chose %d, want dict", codec)
+	}
+	b, err := Marshal(irow{Codes: si}, OptQPack)
+	if err != nil {
+		t.Fatalf("i64 marshal: %v", err)
+	}
+	var out irow
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatalf("i64 unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(si, out.Codes) {
+		t.Fatalf("i64 roundtrip mismatch")
 	}
 }


### PR DESCRIPTION
## Problem
The integer dictionary codec (`tagPackDict`, selected under `OptQPack`)
resolved every element's dictionary index with a **linear scan** over the
distinct table — `O(n·count)` on both the picker probe (`probeDistinctU64/I64`)
and the encode body (`writePackedDict*`). Two consequences:

1. The cap `qpackDictMaxDistinct = 16` kept the codec's reach to ≤16-distinct
   columns. Wide-valued enums with 17–64 distinct (error codes, state IDs,
   sparse counters) fell back to FOR and encoded far larger than necessary.
2. Naively raising the cap regresses the default path: a 30-wide-distinct
   `[]int64` column then runs the full `O(n·count)` probe **and** encode
   resolution (measured **+280%** encode on a 1024-row column), and
   mid-cardinality integer columns are common.

## Fix
Replace the linear membership/index scans with a stack-allocated
open-addressed hash set (128 slots, load ≤ ½, multiplicative hash):

- `probeDistinctU64/I64` — membership is now `O(1)` per element, so the probe
  is `O(n)` regardless of the cap. High-cardinality slices still bail at the
  `(cap+1)`th distinct; the bail is now cheap.
- `buildDictIndexU64/I64` (new) + dict encode — value→index resolves in `O(1)`
  via the same map, removing the `O(n·count)` inner scan.

Then raise `qpackDictMaxDistinct` 16 → 64. 64 distinct still pack at 6 index
bits, and the hash-based probe/encode make the wider cap free.

## Result (i7-9750H, interleaved benchstat vs main)
- **Dictionary encode is 55–67% faster at any cardinality.** The `SpreadEnum`
  corpus encode drops **32.2µs → 10.5µs (−67%)**, byte-identical output;
  `StatusBatch` / `Counters` encode also improve. All other profiles flat,
  sizes byte-for-byte unchanged.
- A 1024-row column with 30 wide-valued distinct ints now selects dict
  (**−62% wire: 2049 → 768 B**) at ~10.7µs, where main fell back to FOR.
- Picker probe: high-card flat, low-card **−47%**.

Pure encode-side; decode logic is unchanged (its fixed arrays auto-size to the
new cap). No wire/behaviour change for existing payloads.

## Verification
`go test` / `-race` / golden clean under default and `qdf_simd`; `go vet` and
`golangci-lint` (root) clean; `gofmt` clean. `FuzzRoundTrip_{Int64,Uint64}Slice`
green over ~1.1M execs. New tests pin the 17–64-distinct band
(`TestDict_PickerHitsMidCardinality`), the high-card skip
(`TestDict_PickerSkipsHighCardinality`), and the zero-in-dictionary
open-addressing edge case (`TestDict_MidCardZeroRoundTrip`). Docs (`USAGE.md`,
`GUIDE.md`) updated 16 → 64.
