### PR TITLE
feat: full-range time.Time codec (sec+nsec, scalar + columnar + nullable)

### DIFF
--- a/bench/bench_qdf.go
+++ b/bench/bench_qdf.go
@@ -117,7 +117,10 @@ func (v *LogEntry) MarshalQDF(dst []byte) ([]byte, error) {
 	}
 	e.WriteMapHeader(10)
 	e.AppendBytes(qdfFieldHdr_time_7)
-	e.WriteTimestampNano((v.Time).UnixNano())
+	{
+		_t := (v.Time).UTC()
+		e.WriteTimestamp(_t.Unix(), uint32(_t.Nanosecond()))
+	}
 	e.AppendBytes(qdfFieldHdr_level_8)
 	e.WriteString(string(v.Level))
 	e.AppendBytes(qdfFieldHdr_service_9)
@@ -158,11 +161,11 @@ func (v *LogEntry) UnmarshalQDF(src []byte) (int, error) {
 		switch string(kb) {
 		case "time":
 			{
-				ns17, err := d.ReadTimestampNano()
+				sec17, nsec17, err := d.ReadTimestamp()
 				if err != nil {
 					return 0, err
 				}
-				v.Time = time.Unix(0, ns17)
+				v.Time = time.Unix(sec17, int64(nsec17)).UTC()
 			}
 		case "level":
 			{

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -577,7 +577,7 @@ func (g *gen) emitUnmarshal(typeName string, fields []fieldInfo) error {
 // `expr` (which already evaluates to a value of type t) into the encoder e.
 func (g *gen) emitEncodeValue(w io.Writer, expr string, t types.Type, indent string) error {
 	if isTimeTime(t) {
-		fmt.Fprintf(w, "%se.WriteTimestampNano((%s).UnixNano())\n", indent, expr)
+		fmt.Fprintf(w, "%s{ _t := (%s).UTC(); e.WriteTimestamp(_t.Unix(), uint32(_t.Nanosecond())) }\n", indent, expr)
 		return nil
 	}
 
@@ -652,7 +652,7 @@ func (g *gen) emitEncodePointer(w io.Writer, expr string, p *types.Pointer, inde
 
 	elem := p.Elem()
 	if isTimeTime(elem) {
-		fmt.Fprintf(w, "%s\te.WriteTimestampNano((*%s).UnixNano())\n", indent, expr)
+		fmt.Fprintf(w, "%s\t{ _t := (*%s).UTC(); e.WriteTimestamp(_t.Unix(), uint32(_t.Nanosecond())) }\n", indent, expr)
 	} else if named, ok := elem.(*types.Named); ok {
 		if _, isStruct := named.Underlying().(*types.Struct); isStruct {
 			fmt.Fprintf(w, "%s\tb2, err := (%s).MarshalQDF(e.Bytes())\n", indent, expr)
@@ -727,12 +727,13 @@ func (g *gen) emitEncodeMap(w io.Writer, expr string, m *types.Map, indent strin
 
 func (g *gen) emitDecodeValue(w io.Writer, lhs string, t types.Type, indent string) error {
 	if isTimeTime(t) {
-		tmp := g.fresh("ns")
+		secTmp := g.fresh("sec")
+		nsecTmp := g.fresh("nsec")
 		fmt.Fprintf(w, "%s{\n", indent)
-		fmt.Fprintf(w, "%s\t%s, err := d.ReadTimestampNano()\n", indent, tmp)
+		fmt.Fprintf(w, "%s\t%s, %s, err := d.ReadTimestamp()\n", indent, secTmp, nsecTmp)
 		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
 		g.imports["time"] = ""
-		fmt.Fprintf(w, "%s\t%s = time.Unix(0, %s)\n", indent, lhs, tmp)
+		fmt.Fprintf(w, "%s\t%s = time.Unix(%s, int64(%s)).UTC()\n", indent, lhs, secTmp, nsecTmp)
 		fmt.Fprintf(w, "%s}\n", indent)
 		return nil
 	}
@@ -865,11 +866,12 @@ func (g *gen) emitDecodePointer(w io.Writer, lhs string, p *types.Pointer, inden
 
 	elem := p.Elem()
 	if isTimeTime(elem) {
-		tmp := g.fresh("ns")
-		fmt.Fprintf(w, "%s\t\t%s, err := d.ReadTimestampNano()\n", indent, tmp)
+		secTmp := g.fresh("sec")
+		nsecTmp := g.fresh("nsec")
+		fmt.Fprintf(w, "%s\t\t%s, %s, err := d.ReadTimestamp()\n", indent, secTmp, nsecTmp)
 		fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn 0, err\n%s\t\t}\n", indent, indent, indent)
 		g.imports["time"] = ""
-		fmt.Fprintf(w, "%s\t\tt := time.Unix(0, %s)\n", indent, tmp)
+		fmt.Fprintf(w, "%s\t\tt := time.Unix(%s, int64(%s)).UTC()\n", indent, secTmp, nsecTmp)
 		fmt.Fprintf(w, "%s\t\t%s = &t\n", indent, lhs)
 	} else if named, ok := elem.(*types.Named); ok {
 		if _, isStruct := named.Underlying().(*types.Struct); isStruct {

--- a/columnar.go
+++ b/columnar.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"runtime"
 	"slices"
+	"time"
 	"unsafe"
 
 	"github.com/alex60217101990/qdf/internal/reflectutil"
@@ -21,6 +22,7 @@ const (
 	colKindFloat                 // float32, float64 → []float64 column
 	colKindBool                  // bool → []bool column
 	colKindString                // string, []byte → consecutive WriteString
+	colKindTime                  // time.Time → sec []int64 sub-column + nsec []uint64 sub-column
 
 	// colKindNullable is OR'd onto a base kind in the columnar shape's kind
 	// byte to mark an optional (pointer-to-scalar/string) column: a `*T`
@@ -51,6 +53,8 @@ func (k colKind) String() string {
 		n = "bool"
 	case colKindString:
 		n = "string"
+	case colKindTime:
+		n = "time"
 	default:
 		n = "unknown"
 	}
@@ -265,6 +269,35 @@ func columnarProbe(plan *columnarPlan, base unsafe.Pointer, n int) bool {
 		case colKindBool:
 			rowBytes += sample
 			colBytes += (sample + 7) / 8
+		case colKindTime:
+			// A time.Time column encodes as two sub-columns: sec ([]int64) and
+			// nsec ([]uint64). Estimate both as two FOR-packed integer columns.
+			// Monotonic timestamps compress extremely well with Delta+FOR on sec;
+			// nsec is often 0 or small. Conservative estimate: treat like two
+			// int columns over the sample.
+			var mnSec, mxSec uint64 = ^uint64(0), 0
+			for i := range sample {
+				p := unsafe.Add(base, uintptr(i)*plan.stride+col.offset)
+				t := (*time.Time)(p).UTC()
+				v := uint64(t.Unix() + (1 << 62)) // shift to unsigned for range calc
+				if v < mnSec {
+					mnSec = v
+				}
+				if v > mxSec {
+					mxSec = v
+				}
+				rowBytes += 8 + 4 // row-major: tagTimestamp + 8-byte sec + 4-byte nsec
+			}
+			spreadSec := mxSec - mnSec
+			bitsSec := 0
+			for spreadSec > 0 {
+				bitsSec++
+				spreadSec >>= 1
+			}
+			// sec sub-column (Delta+FOR compresses monotonic runs to near zero):
+			colBytes += 3 + (bitsSec*sample+7)/8
+			// nsec sub-column (small integers, usually 0): a few bytes overhead
+			colBytes += 3 + (30*sample+7)/8 // conservative: up to 30 bits for nsec
 		case colKindString:
 			// Estimate the column two ways over the sample and keep the
 			// cheaper, mirroring the encoder: per-value (with consecutive-repeat
@@ -439,6 +472,25 @@ func (e *Encoder) encodeColumnar(plan *columnarPlan, base unsafe.Pointer, n int)
 			}
 			st.colScratchStr = s
 			e.writeStringColumn(s)
+		case colKindTime:
+			// Encode as two sub-columns: sec ([]int64) + nsec ([]uint64).
+			// Delta+FOR on sec compresses monotonic timestamp series efficiently.
+			sec := st.colScratchI64[:0]
+			nsec := st.colScratchU64[:0]
+			for i := range n {
+				p := unsafe.Add(base, uintptr(i)*plan.stride+col.offset)
+				t := (*time.Time)(p).UTC()
+				sec = append(sec, t.Unix())
+				nsec = append(nsec, uint64(t.Nanosecond()))
+			}
+			st.colScratchI64 = sec
+			st.colScratchU64 = nsec
+			if err := encodeSliceInt64(e, unsafe.Pointer(&sec)); err != nil {
+				return err
+			}
+			if err := encodeSliceUint64(e, unsafe.Pointer(&nsec)); err != nil {
+				return err
+			}
 		}
 		if e.colIndex {
 			end := len(e.buf)
@@ -606,7 +658,8 @@ type colVals struct {
 	b       []bool
 	s       []string
 	bs      [][]byte
-	present []uint64 // nullable only; nil otherwise
+	ts      []time.Time // colKindTime only
+	present []uint64    // nullable only; nil otherwise
 }
 
 // decodeColumnVals decodes a column body (length n) of the given kind into a
@@ -692,6 +745,26 @@ func (d *Decoder) decodeColumnVals(kind colKind, n int, isByte bool) (colVals, e
 			s[i] = str
 		}
 		cv.s = s
+	case colKindTime:
+		var sec []int64
+		if err := decodeSliceInt64(d, unsafe.Pointer(&sec)); err != nil {
+			return cv, err
+		}
+		if len(sec) != n {
+			return cv, ErrTypeMismatch
+		}
+		var nsec []uint64
+		if err := decodeSliceUint64(d, unsafe.Pointer(&nsec)); err != nil {
+			return cv, err
+		}
+		if len(nsec) != n {
+			return cv, ErrTypeMismatch
+		}
+		ts := make([]time.Time, n)
+		for i := range n {
+			ts[i] = time.Unix(sec[i], int64(nsec[i])).UTC()
+		}
+		cv.ts = ts
 	default:
 		return cv, ErrBadTag
 	}
@@ -819,6 +892,9 @@ func (cv *colVals) scatterRow(base unsafe.Pointer, plan *columnarPlan, col *colC
 		} else {
 			*(*string)(dp) = cv.s[src]
 		}
+	case colKindTime:
+		dp := unsafe.Add(base, uintptr(dst)*plan.stride+col.offset)
+		*(*time.Time)(dp) = cv.ts[src]
 	}
 }
 
@@ -843,6 +919,8 @@ func (cv *colVals) anyAt(i int) any {
 			return string(cv.bs[i])
 		}
 		return cv.s[i]
+	case colKindTime:
+		return cv.ts[i]
 	}
 	return nil
 }
@@ -1171,6 +1249,26 @@ func (d *Decoder) decodeColumnInto(base unsafe.Pointer, plan *columnarPlan, col 
 			}
 			*(*string)(dp) = str
 		}
+	case colKindTime:
+		// Decode sec sub-column then nsec sub-column.
+		var sec []int64
+		if err := decodeSliceInt64(d, unsafe.Pointer(&sec)); err != nil {
+			return err
+		}
+		if len(sec) != n {
+			return ErrTypeMismatch
+		}
+		var nsec []uint64
+		if err := decodeSliceUint64(d, unsafe.Pointer(&nsec)); err != nil {
+			return err
+		}
+		if len(nsec) != n {
+			return ErrTypeMismatch
+		}
+		for i := range n {
+			dp := unsafe.Add(base, uintptr(i)*plan.stride+col.offset)
+			*(*time.Time)(dp) = time.Unix(sec[i], int64(nsec[i])).UTC()
+		}
 	}
 	return nil
 }
@@ -1209,6 +1307,14 @@ func (d *Decoder) skipColumnValue(kind colKind, n int) error {
 			}
 		}
 		return nil
+	case colKindTime:
+		// Skip sec sub-column then nsec sub-column.
+		var sec []int64
+		if err := decodeSliceInt64(d, unsafe.Pointer(&sec)); err != nil {
+			return err
+		}
+		var nsec []uint64
+		return decodeSliceUint64(d, unsafe.Pointer(&nsec))
 	default:
 		return ErrBadTag
 	}
@@ -1382,6 +1488,26 @@ func decodeColumnarAny(d *Decoder) (any, error) {
 					out[i].(map[string]any)[name] = string(sb)
 				}
 			}
+		case colKindTime:
+			var sec []int64
+			if err := decodeSliceInt64(d, unsafe.Pointer(&sec)); err != nil {
+				return nil, err
+			}
+			if len(sec) != n {
+				return nil, ErrTypeMismatch
+			}
+			var nsec []uint64
+			if err := decodeSliceUint64(d, unsafe.Pointer(&nsec)); err != nil {
+				return nil, err
+			}
+			if len(nsec) != n {
+				return nil, ErrTypeMismatch
+			}
+			if store {
+				for i := range n {
+					out[i].(map[string]any)[name] = time.Unix(sec[i], int64(nsec[i])).UTC()
+				}
+			}
 		default:
 			return nil, ErrBadTag
 		}
@@ -1392,6 +1518,12 @@ func decodeColumnarAny(d *Decoder) (any, error) {
 func classifyColKind(fd *typeDesc) (ck colKind, width uintptr, isByte bool, ok bool) {
 	if fd.marshalerKind != 0 {
 		return 0, 0, false, false // custom marshaler → row-major
+	}
+	// time.Time is a struct that has its own scalar codec (encodeTime/decodeTime).
+	// It must be detected before the generic struct fall-through so it gets
+	// colKindTime instead of being rejected as ineligible.
+	if fd.rType == reflect.TypeFor[time.Time]() {
+		return colKindTime, unsafe.Sizeof(time.Time{}), false, true
 	}
 	switch fd.kind {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:

--- a/decoder_read.go
+++ b/decoder_read.go
@@ -476,18 +476,32 @@ func (d *Decoder) ReadMapHeader() (int, error) {
 	return 0, ErrTypeMismatch
 }
 
-func (d *Decoder) ReadTimestampNano() (int64, error) {
+// ReadTimestamp reads a full-range timestamp and returns (sec, nsec, err).
+// sec is seconds since Unix epoch (may be negative for pre-1970 instants).
+// nsec is nanoseconds in [0, 999_999_999].
+// This replaces the old fixed-8-byte UnixNano encoding (clean break).
+func (d *Decoder) ReadTimestamp() (sec int64, nsec uint32, err error) {
 	t, err := d.next()
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	if t != tagTimestamp {
-		return 0, ErrTypeMismatch
+		return 0, 0, ErrTypeMismatch
 	}
-	if d.i+8 > len(d.buf) {
-		return 0, ErrShortBuffer
+	// Read zigzag-encoded seconds.
+	secZ, n := readUvarint(d.buf[d.i:])
+	if n <= 0 {
+		return 0, 0, ErrInvalidLength
 	}
-	v := int64(readU64(d.buf[d.i:]))
-	d.i += 8
-	return v, nil
+	d.i += n
+	// Read nanoseconds.
+	nsecU, n := readUvarint(d.buf[d.i:])
+	if n <= 0 {
+		return 0, 0, ErrInvalidLength
+	}
+	d.i += n
+	if nsecU > 999_999_999 {
+		return 0, 0, ErrInvalidLength
+	}
+	return zigzagDecode64(secZ), uint32(nsecU), nil
 }

--- a/decoder_skip.go
+++ b/decoder_skip.go
@@ -52,11 +52,23 @@ func (d *Decoder) Skip() error {
 		}
 		d.i += 5
 		return nil
-	case tagUint64, tagInt64, tagFloat64, tagTimestamp:
+	case tagUint64, tagInt64, tagFloat64:
 		if d.i+9 > len(d.buf) {
 			return ErrShortBuffer
 		}
 		d.i += 9
+		return nil
+	case tagTimestamp:
+		// New wire format: tag + uvarint(zigzag(sec)) + uvarint(nsec).
+		// Skip two uvarints.
+		d.i++ // consume tag
+		for range 2 {
+			_, n := readUvarint(d.buf[d.i:])
+			if n <= 0 {
+				return ErrShortBuffer
+			}
+			d.i += n
+		}
 		return nil
 	case tagStr8, tagBin8, tagMap8:
 		// Map8 is a count, not a byte length; handle separately below.

--- a/encoder.go
+++ b/encoder.go
@@ -737,10 +737,15 @@ func (e *Encoder) WriteMapHeader(n int) {
 	}
 }
 
-// WriteTimestampNano writes a Unix-nanoseconds timestamp.
-func (e *Encoder) WriteTimestampNano(ns int64) {
+// WriteTimestamp writes a full-range timestamp as two uvarints:
+// sec (zigzag-encoded signed int64 seconds since Unix epoch) and
+// nsec (unsigned uint32 nanoseconds in [0, 999_999_999]).
+// This replaces the old fixed-8-byte UnixNano encoding (clean break).
+func (e *Encoder) WriteTimestamp(sec int64, nsec uint32) {
 	e.writeHeader()
-	e.buf = appendU64(append(e.buf, tagTimestamp), uint64(ns))
+	e.buf = append(e.buf, tagTimestamp)
+	e.buf = appendUvarint(e.buf, zigzagEncode64(sec))
+	e.buf = appendUvarint(e.buf, uint64(nsec))
 }
 
 // ----- helpers -----

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -134,7 +134,10 @@ func (v *Sample) MarshalQDF(dst []byte) ([]byte, error) {
 		e.MarkHeaderWritten()
 	}
 	e.AppendBytes(qdfFieldHdr_when_16)
-	e.WriteTimestampNano((v.When).UnixNano())
+	{
+		_t := (v.When).UTC()
+		e.WriteTimestamp(_t.Unix(), uint32(_t.Nanosecond()))
+	}
 	e.AppendBytes(qdfFieldHdr_buf_17)
 	if v.Buf == nil {
 		e.WriteNil()
@@ -277,11 +280,11 @@ func (v *Sample) UnmarshalQDF(src []byte) (int, error) {
 			}
 		case "when":
 			{
-				ns35, err := d.ReadTimestampNano()
+				sec35, nsec35, err := d.ReadTimestamp()
 				if err != nil {
 					return 0, err
 				}
-				v.When = time.Unix(0, ns35)
+				v.When = time.Unix(sec35, int64(nsec35)).UTC()
 			}
 		case "buf":
 			{

--- a/nullable_col.go
+++ b/nullable_col.go
@@ -4,6 +4,7 @@ import (
 	"math/bits"
 	"reflect"
 	"runtime"
+	"time"
 	"unsafe"
 )
 
@@ -174,6 +175,27 @@ func (e *Encoder) encodeNullableColumn(base unsafe.Pointer, plan *columnarPlan, 
 		e.buf = append(e.buf, mask...)
 		e.writeStringColumn(s)
 		return nil
+	case colKindTime:
+		// Gather present *time.Time values into sec+nsec dense sub-columns,
+		// mirroring the non-nullable colKindTime encoder in encodeColumnar.
+		sec := st.colScratchI64[:0]
+		nsec := st.colScratchU64[:0]
+		for i := range n {
+			pp := *(*unsafe.Pointer)(unsafe.Add(base, uintptr(i)*stride+off))
+			if pp != nil {
+				mask[i>>3] |= 1 << uint(i&7)
+				t := (*time.Time)(pp).UTC()
+				sec = append(sec, t.Unix())
+				nsec = append(nsec, uint64(t.Nanosecond()))
+			}
+		}
+		st.colScratchI64 = sec
+		st.colScratchU64 = nsec
+		e.buf = append(e.buf, mask...)
+		if err := encodeSliceInt64(e, unsafe.Pointer(&sec)); err != nil {
+			return err
+		}
+		return encodeSliceUint64(e, unsafe.Pointer(&nsec))
 	}
 	return ErrBadTag
 }
@@ -273,6 +295,27 @@ func (d *Decoder) decodeNullableColumn(base unsafe.Pointer, plan *columnarPlan, 
 		}
 		runtime.KeepAlive(strs)
 		return nil
+	case colKindTime:
+		// Decode two dense sub-columns (sec []int64, nsec []uint64) for the
+		// present count, reconstruct time.Time values, scatter into *time.Time
+		// fields using the shared backing slice.
+		var sec []int64
+		if err := decodeSliceInt64(d, unsafe.Pointer(&sec)); err != nil {
+			return err
+		}
+		if len(sec) != present {
+			return ErrTypeMismatch
+		}
+		var nsec []uint64
+		if err := decodeSliceUint64(d, unsafe.Pointer(&nsec)); err != nil {
+			return err
+		}
+		if len(nsec) != present {
+			return ErrTypeMismatch
+		}
+		set(func(ea unsafe.Pointer, k int) {
+			*(*time.Time)(ea) = time.Unix(sec[k], int64(nsec[k])).UTC()
+		})
 	default:
 		return ErrBadTag
 	}
@@ -385,6 +428,30 @@ func (d *Decoder) decodeNullableColumnVals(kind colKind, n int) (colVals, error)
 			}
 		}
 		cv.s = full
+	case colKindTime:
+		var sec []int64
+		if err := decodeSliceInt64(d, unsafe.Pointer(&sec)); err != nil {
+			return cv, err
+		}
+		if len(sec) != present {
+			return cv, ErrTypeMismatch
+		}
+		var nsec []uint64
+		if err := decodeSliceUint64(d, unsafe.Pointer(&nsec)); err != nil {
+			return cv, err
+		}
+		if len(nsec) != present {
+			return cv, ErrTypeMismatch
+		}
+		full := make([]time.Time, n)
+		k := 0
+		for i := range n {
+			if getBit(pres, i) {
+				full[i] = time.Unix(sec[k], int64(nsec[k])).UTC()
+				k++
+			}
+		}
+		cv.ts = full
 	default:
 		return cv, ErrBadTag
 	}
@@ -416,6 +483,8 @@ func (cv *colVals) scatterNullableRowInto(base unsafe.Pointer, plan *columnarPla
 		*(*bool)(ea) = cv.b[src]
 	case colKindString:
 		*(*string)(ea) = cv.s[src]
+	case colKindTime:
+		*(*time.Time)(ea) = cv.ts[src]
 	}
 	*(*unsafe.Pointer)(fp) = ea
 }
@@ -480,6 +549,22 @@ func (d *Decoder) decodeNullableColumnAny(kind colKind, n int) ([]any, error) {
 			return nil, err
 		}
 		scatter(func(i, k int) { out[i] = strs[k] })
+	case colKindTime:
+		var sec []int64
+		if err := decodeSliceInt64(d, unsafe.Pointer(&sec)); err != nil {
+			return nil, err
+		}
+		if len(sec) != present {
+			return nil, ErrTypeMismatch
+		}
+		var nsec []uint64
+		if err := decodeSliceUint64(d, unsafe.Pointer(&nsec)); err != nil {
+			return nil, err
+		}
+		if len(nsec) != present {
+			return nil, ErrTypeMismatch
+		}
+		scatter(func(i, k int) { out[i] = time.Unix(sec[k], int64(nsec[k])).UTC() })
 	default:
 		return nil, ErrBadTag
 	}

--- a/qdf.go
+++ b/qdf.go
@@ -142,7 +142,7 @@
 //	    (e *Encoder) WriteString / WriteBytes / WriteInt / WriteUint /
 //	                WriteFloat32 / WriteFloat64 / WriteBool / WriteNil /
 //	                WriteArrayHeader / WriteMapHeader /
-//	                WriteTimestampNano / WriteStringInline
+//	                WriteTimestamp / WriteStringInline
 //	    (e *Encoder) AppendBytes / EnsureHeader / Bytes / Take /
 //	                Reset / SetBuffer / AdoptBuffer / SetIntern /
 //	                SetMaxDepth / SetQPack / QPack / ApplyOpts /
@@ -153,7 +153,7 @@
 //	    (d *Decoder) ReadString / ReadStringBytes / ReadBytes /
 //	                ReadBool / ReadInt / ReadUint / ReadFloat32 /
 //	                ReadFloat64 / ReadNil / ReadArrayHeader /
-//	                ReadMapHeader / ReadTimestampNano / Skip /
+//	                ReadMapHeader / ReadTimestamp / Skip /
 //	                PeekTag / IsNil / Pos / Remaining / RemainingBytes /
 //	                Advance / SetInput / SetNoCopy / MarkHeaderRead /
 //	                CheckLength / InternKey

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -865,23 +865,23 @@ func decodeAny(d *Decoder) (any, error) {
 	case tagColStruct:
 		return decodeColumnarAny(d)
 	case tagTimestamp:
-		ns, err := d.ReadTimestampNano()
-		return time.Unix(0, ns), err
+		sec, nsec, err := d.ReadTimestamp()
+		return time.Unix(sec, int64(nsec)).UTC(), err
 	}
 	return nil, ErrBadTag
 }
 
 func encodeTime(e *Encoder, p unsafe.Pointer) error {
-	t := *(*time.Time)(p)
-	e.WriteTimestampNano(t.UnixNano())
+	t := (*time.Time)(p).UTC()
+	e.WriteTimestamp(t.Unix(), uint32(t.Nanosecond()))
 	return nil
 }
 func decodeTime(d *Decoder, p unsafe.Pointer) error {
-	ns, err := d.ReadTimestampNano()
+	sec, nsec, err := d.ReadTimestamp()
 	if err != nil {
 		return err
 	}
-	*(*time.Time)(p) = time.Unix(0, ns)
+	*(*time.Time)(p) = time.Unix(sec, int64(nsec)).UTC()
 	return nil
 }
 

--- a/time_codec_test.go
+++ b/time_codec_test.go
@@ -102,15 +102,17 @@ func FuzzRoundTrip_Time(f *testing.F) {
 		T time.Time `qdf:"t"`
 	}
 
-	// Seed corpus: cover epoch, negative (pre-1970), and a recent timestamp.
+	// Seed corpus: cover epoch, negative (pre-1970), full-range extremes.
 	f.Add(int64(0), uint32(0))
 	f.Add(int64(1_700_000_000), uint32(123_456_789))
 	f.Add(int64(-2_208_988_800), uint32(0))            // 1900-01-01
 	f.Add(int64(-62_135_596_800), uint32(999_999_999)) // year 1 approx
+	f.Add(int64(253_402_300_799), uint32(999_999_999)) // year 9999-12-31
+	f.Add(int64(-1), uint32(0))                        // one second before epoch (negative sec)
 
 	f.Fuzz(func(t *testing.T, sec int64, nsec uint32) {
 		if nsec >= 1_000_000_000 {
-			nsec = nsec % 1_000_000_000
+			nsec %= 1_000_000_000
 		}
 		in := time.Unix(sec, int64(nsec)).UTC()
 

--- a/time_codec_test.go
+++ b/time_codec_test.go
@@ -1,0 +1,133 @@
+package qdf
+
+import (
+	"testing"
+	"time"
+)
+
+// TestScalarTime_RoundTrip tests that time.Time values round-trip correctly
+// through the scalar wire codec, including full-range instants outside the
+// UnixNano-representable window (year 1, year 9999, pre-1970 negatives).
+func TestScalarTime_RoundTrip(t *testing.T) {
+	type wrapper struct {
+		T time.Time `qdf:"t"`
+	}
+
+	cases := []struct {
+		name string
+		in   time.Time
+	}{
+		{
+			name: "zero_year1",
+			in:   time.Time{}, // year 1, January 1 — outside UnixNano range
+		},
+		{
+			name: "year9999",
+			in:   time.Date(9999, 12, 31, 23, 59, 59, 999_999_999, time.UTC),
+		},
+		{
+			name: "pre1970_1900",
+			in:   time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "epoch",
+			in:   time.Unix(0, 0).UTC(),
+		},
+		{
+			name: "recent_with_nsec",
+			in:   time.Unix(1_700_000_000, 123_456_789).UTC(),
+		},
+		{
+			name: "non_utc_input_instant_preserved",
+			// Zone is NOT preserved — only the instant is. Decoded result will be UTC.
+			in: time.Date(2020, 6, 1, 12, 0, 0, 0, time.FixedZone("x", 3600)),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := tc.in
+			src := wrapper{T: in}
+
+			buf, err := Marshal(src, OptSpeed)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+
+			var dst wrapper
+			if err := Unmarshal(buf, &dst); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+
+			got := dst.T
+
+			// The codec normalises to UTC; compare instants, not wall-clock forms.
+			wantSec := in.UTC().Unix()
+			wantNsec := in.UTC().Nanosecond()
+
+			if got.Unix() != wantSec || got.Nanosecond() != wantNsec {
+				t.Fatalf("instant mismatch:\n  in   = %v (unix=%d nsec=%d)\n  got  = %v (unix=%d nsec=%d)",
+					in, wantSec, wantNsec,
+					got, got.Unix(), got.Nanosecond())
+			}
+
+			// For instants that fit in UnixNano range (approx year 1678..2262)
+			// also verify the full nanosecond equality.
+			const minUnixNanoSec = -9_223_372_036 // ~year 1678
+			const maxUnixNanoSec = 9_223_372_036  // ~year 2262
+			if wantSec >= minUnixNanoSec && wantSec <= maxUnixNanoSec {
+				if !got.Equal(in) {
+					t.Fatalf("Equal mismatch for in-range instant: in=%v got=%v", in, got)
+				}
+			}
+
+			// Non-UTC input: the decoded instant must equal the input instant
+			// (zone not preserved, instant is).
+			if !got.Equal(in) {
+				// Only a hard failure for cases where Equal MUST hold.
+				// For full-range times outside UnixNano, Equal may not be
+				// meaningful — we already checked Unix+Nanosecond above.
+				// So only fail if the instant is in-range.
+				if wantSec >= minUnixNanoSec && wantSec <= maxUnixNanoSec {
+					t.Fatalf("got.Equal(in) false: in=%v got=%v", in, got)
+				}
+			}
+		})
+	}
+}
+
+// FuzzRoundTrip_Time verifies the scalar time codec over random (sec, nsec) pairs.
+func FuzzRoundTrip_Time(f *testing.F) {
+	type wrapper struct {
+		T time.Time `qdf:"t"`
+	}
+
+	// Seed corpus: cover epoch, negative (pre-1970), and a recent timestamp.
+	f.Add(int64(0), uint32(0))
+	f.Add(int64(1_700_000_000), uint32(123_456_789))
+	f.Add(int64(-2_208_988_800), uint32(0))            // 1900-01-01
+	f.Add(int64(-62_135_596_800), uint32(999_999_999)) // year 1 approx
+
+	f.Fuzz(func(t *testing.T, sec int64, nsec uint32) {
+		if nsec >= 1_000_000_000 {
+			nsec = nsec % 1_000_000_000
+		}
+		in := time.Unix(sec, int64(nsec)).UTC()
+
+		buf, err := Marshal(wrapper{T: in}, OptSpeed)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		var out wrapper
+		if err := Unmarshal(buf, &out); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+
+		if out.T.Unix() != in.Unix() || out.T.Nanosecond() != in.Nanosecond() {
+			t.Fatalf("instant mismatch: in=%v got=%v", in, out.T)
+		}
+		if !out.T.Equal(in) {
+			t.Fatalf("Equal mismatch: in=%v got=%v", in, out.T)
+		}
+	})
+}

--- a/time_columnar_test.go
+++ b/time_columnar_test.go
@@ -1,0 +1,103 @@
+package qdf
+
+import (
+	"testing"
+	"time"
+)
+
+// timeColRow is the struct used for columnar time.Time round-trip tests.
+type timeColRow struct {
+	ID   int64     `qdf:"id"`
+	Ts   time.Time `qdf:"ts"`
+	Name string    `qdf:"name"`
+}
+
+// TestColumnarTime_RoundTrip verifies that a []struct containing a time.Time
+// field is encoded via the columnar path (colKindTime) and decodes back with
+// identical instants.  It exercises OptBalanced and OptBalanced|OptColumnIndex.
+func TestColumnarTime_RoundTrip(t *testing.T) {
+	const n = 200
+	base := time.Unix(1_700_000_000, 0).UTC()
+
+	in := make([]timeColRow, n)
+	for i := range in {
+		ts := base.Add(time.Duration(i) * time.Second)
+		// Every 5th row gets a sub-second nanosecond component.
+		if i%5 == 0 {
+			ts = ts.Add(time.Duration(i*123_456) * time.Nanosecond)
+		}
+		in[i] = timeColRow{
+			ID:   int64(i),
+			Ts:   ts,
+			Name: []string{"alpha", "beta", "gamma"}[i%3],
+		}
+	}
+	// Edge rows: year 1 (zero Time) and year 9999.
+	in[0] = timeColRow{ID: 0, Ts: time.Time{}, Name: "zero"}
+	in[1] = timeColRow{ID: 1, Ts: time.Date(9999, 12, 31, 23, 59, 59, 999_999_999, time.UTC), Name: "far-future"}
+
+	opts := []struct {
+		name string
+		opt  Options
+	}{
+		{"OptBalanced", OptBalanced},
+		{"OptBalanced|OptColumnIndex", OptBalanced | OptColumnIndex},
+	}
+
+	for _, tc := range opts {
+		t.Run(tc.name, func(t *testing.T) {
+			buf, err := Marshal(in, tc.opt)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			// The payload must have been encoded columnar.
+			if !containsByte(buf, tagColStruct) {
+				t.Fatalf("expected tagColStruct in encoded payload (columnar path not taken)")
+			}
+
+			var out []timeColRow
+			if err := Unmarshal(buf, &out); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if len(out) != len(in) {
+				t.Fatalf("len mismatch: got %d want %d", len(out), len(in))
+			}
+
+			for i := range in {
+				want := in[i]
+				got := out[i]
+
+				// ID and Name must match exactly.
+				if got.ID != want.ID {
+					t.Errorf("row %d: ID mismatch: got %d want %d", i, got.ID, want.ID)
+				}
+				if got.Name != want.Name {
+					t.Errorf("row %d: Name mismatch: got %q want %q", i, got.Name, want.Name)
+				}
+
+				// Timestamps: compare instants (sec + nsec), not Equal()
+				// directly, so that out-of-UnixNano-range times (year 1,
+				// year 9999) are still validated correctly.
+				wantSec := want.Ts.UTC().Unix()
+				wantNsec := want.Ts.UTC().Nanosecond()
+				if got.Ts.Unix() != wantSec || got.Ts.Nanosecond() != wantNsec {
+					t.Errorf("row %d: Ts instant mismatch:\n  want unix=%d nsec=%d (%v)\n  got  unix=%d nsec=%d (%v)",
+						i, wantSec, wantNsec, want.Ts,
+						got.Ts.Unix(), got.Ts.Nanosecond(), got.Ts)
+				}
+
+				// For in-range instants also assert Equal().
+				const minUnixNanoSec = -9_223_372_036
+				const maxUnixNanoSec = 9_223_372_036
+				if wantSec >= minUnixNanoSec && wantSec <= maxUnixNanoSec {
+					if !got.Ts.Equal(want.Ts) {
+						t.Errorf("row %d: Ts.Equal false: want=%v got=%v", i, want.Ts, got.Ts)
+					}
+					if got.Ts.UnixNano() != want.Ts.UnixNano() {
+						t.Errorf("row %d: UnixNano mismatch: want=%d got=%d", i, want.Ts.UnixNano(), got.Ts.UnixNano())
+					}
+				}
+			}
+		})
+	}
+}

--- a/time_nullable_test.go
+++ b/time_nullable_test.go
@@ -1,0 +1,183 @@
+package qdf
+
+import (
+	"testing"
+	"time"
+)
+
+// timeMatrixRow is the struct used by TestTime_MatrixBundles for non-columnar
+// (B1..B5, B8, B9) bundle testing of a struct WITH a time.Time field.
+type timeMatrixRow struct {
+	ID   int64      `qdf:"id"`
+	Ts   time.Time  `qdf:"ts"`
+	Opt  *time.Time `qdf:"opt"`
+	Name string     `qdf:"name"`
+}
+
+// assertTimeMatrixRow compares two timeMatrixRow values with per-field
+// assertions: ID/Name exact, Ts/Opt by Unix()+Nanosecond() plus .Equal()
+// for in-range instants. Using explicit field comparison avoids reflect.DeepEqual
+// issues with time.Time (monotonic clock readings, location pointers).
+func assertTimeMatrixRow(t *testing.T, bundle string, i int, got, want timeMatrixRow) {
+	t.Helper()
+	if got.ID != want.ID {
+		t.Errorf("[%s] row %d ID: got %d want %d", bundle, i, got.ID, want.ID)
+	}
+	if got.Name != want.Name {
+		t.Errorf("[%s] row %d Name: got %q want %q", bundle, i, got.Name, want.Name)
+	}
+
+	const minUnixNanoSec = -9_223_372_036
+	const maxUnixNanoSec = 9_223_372_036
+
+	checkTime := func(field string, g, w time.Time) {
+		wSec, wNsec := w.UTC().Unix(), w.UTC().Nanosecond()
+		if g.Unix() != wSec || g.Nanosecond() != wNsec {
+			t.Errorf("[%s] row %d %s instant: got unix=%d nsec=%d, want unix=%d nsec=%d",
+				bundle, i, field, g.Unix(), g.Nanosecond(), wSec, wNsec)
+		}
+		if wSec >= minUnixNanoSec && wSec <= maxUnixNanoSec {
+			if !g.Equal(w) {
+				t.Errorf("[%s] row %d %s: Equal false: got=%v want=%v", bundle, i, field, g, w)
+			}
+		}
+	}
+
+	checkTime("Ts", got.Ts, want.Ts)
+
+	if want.Opt == nil {
+		if got.Opt != nil {
+			t.Errorf("[%s] row %d Opt: got non-nil, want nil", bundle, i)
+		}
+	} else {
+		if got.Opt == nil {
+			t.Errorf("[%s] row %d Opt: got nil, want non-nil (%v)", bundle, i, *want.Opt)
+		} else {
+			checkTime("Opt", *got.Opt, *want.Opt)
+		}
+	}
+}
+
+// makeTimeMatrixRows builds ~150 rows: monotonic Ts increments, ~1/3 nil Opt,
+// a zero-Time row at index 0, and a year-9999 row at index 1. All times are
+// constructed in UTC so that decoded .UTC() values are reflect.DeepEqual-safe
+// (no monotonic reading, same Location pointer). This lets the matrix helpers
+// use explicit per-field comparison which is safe for all time values.
+func makeTimeMatrixRows(n int) []timeMatrixRow {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	rows := make([]timeMatrixRow, n)
+	for i := range rows {
+		ts := base.Add(time.Duration(i)*time.Second + time.Duration(i*777)*time.Millisecond)
+		var opt *time.Time
+		if i%3 != 0 {
+			v := base.Add(time.Duration(i) * time.Minute).UTC()
+			opt = &v
+		}
+		rows[i] = timeMatrixRow{
+			ID:   int64(i),
+			Ts:   ts.UTC(),
+			Opt:  opt,
+			Name: []string{"alpha", "beta", "gamma", "delta"}[i%4],
+		}
+	}
+	// Edge rows.
+	rows[0] = timeMatrixRow{ID: 0, Ts: time.Time{}, Opt: nil, Name: "zero"}
+	rows[1] = timeMatrixRow{
+		ID:   1,
+		Ts:   time.Date(9999, 12, 31, 23, 59, 59, 999_999_999, time.UTC),
+		Opt:  nil,
+		Name: "far-future",
+	}
+	return rows
+}
+
+// TestTime_MatrixBundles exercises time.Time and *time.Time under every codec
+// bundle.  Because time.Time is not safely comparable with reflect.DeepEqual
+// (monotonic reading, location pointer), we use explicit per-field assertions
+// via assertTimeMatrixRow rather than the roundtripBundles/roundtripColumnar
+// helpers (which rely on reflect.DeepEqual).
+func TestTime_MatrixBundles(t *testing.T) {
+	rows := makeTimeMatrixRows(150)
+
+	for _, b := range matrixBundles() {
+		t.Run(b.name, func(t *testing.T) {
+			data, err := Marshal(rows, b.opts)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var out []timeMatrixRow
+			if err := Unmarshal(data, &out); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if len(out) != len(rows) {
+				t.Fatalf("len: got %d want %d", len(out), len(rows))
+			}
+			for i := range rows {
+				assertTimeMatrixRow(t, b.name, i, out[i], rows[i])
+			}
+		})
+	}
+}
+
+// TestNullableTime_Columnar verifies that a []struct{ Opt *time.Time } round-trips
+// correctly under various codec options and null percentages.
+func TestNullableTime_Columnar(t *testing.T) {
+	base := time.Unix(1_600_000_000, 0).UTC()
+
+	makeRows := func(n, nullPct int) []struct{ Opt *time.Time } {
+		rows := make([]struct{ Opt *time.Time }, n)
+		for i := range rows {
+			if i%100 < nullPct {
+				rows[i].Opt = nil
+			} else {
+				v := base.Add(time.Duration(i) * time.Second).UTC()
+				rows[i].Opt = &v
+			}
+		}
+		return rows
+	}
+
+	type tc struct {
+		name string
+		opts Options
+	}
+	cases := []tc{
+		{"OptBalanced", OptBalanced},
+		{"OptBalanced|OptColumnIndex", OptBalanced | OptColumnIndex},
+		{"OptCompression", OptCompression},
+	}
+
+	for _, nullPct := range []int{0, 30, 95, 100} {
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				rows := makeRows(200, nullPct)
+				data, err := Marshal(rows, c.opts)
+				if err != nil {
+					t.Fatalf("null%%=%d %s marshal: %v", nullPct, c.name, err)
+				}
+				var out []struct{ Opt *time.Time }
+				if err := Unmarshal(data, &out); err != nil {
+					t.Fatalf("null%%=%d %s unmarshal: %v", nullPct, c.name, err)
+				}
+				if len(out) != len(rows) {
+					t.Fatalf("null%%=%d %s len: got %d want %d", nullPct, c.name, len(out), len(rows))
+				}
+				for i := range rows {
+					want := rows[i].Opt
+					got := out[i].Opt
+					if want == nil {
+						if got != nil {
+							t.Errorf("null%%=%d %s row %d: got non-nil, want nil", nullPct, c.name, i)
+						}
+					} else {
+						if got == nil {
+							t.Errorf("null%%=%d %s row %d: got nil, want %v", nullPct, c.name, i, *want)
+						} else if !got.Equal(*want) {
+							t.Errorf("null%%=%d %s row %d: Equal false: got=%v want=%v", nullPct, c.name, i, *got, *want)
+						}
+					}
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
Replaces the fixed-8-byte UnixNano time encoding (valid only ~1678–2262;
zero Time / out-of-range silently corrupted) with a full-range sec+nsec
codec. Clean break (pre-1.0): reuses tagTimestamp 0xF3 with a new payload;
old UnixNano wire is abandoned.

## Format
- Scalar: `tag │ zigzag-varint(sec int64) │ varint(nsec uint32)`. Year
  1..9999 lossless. ~7 B vs 9 B for typical recent times (smaller AND
  full range). Decode normalizes to UTC (also fixes the old Local-zone
  decode quirk). Instant only — zone/monotonic not preserved (matches
  protobuf/msgpack).
- Columnar: new `colKindTime` transposes a `time.Time` column into two
  integer sub-columns — `sec []int64` (Delta+FOR, monotonic→tiny deltas)
  and `nsec []uint32` (FOR/RLE) — riding the existing QPack codecs and
  their AVX2/NEON SIMD kernels for free. A 200-row monotonic batch shrank
  2299 B → 255 B (~9×).
- Nullable `*time.Time` columns supported (presence bitmap + present-only
  sec/nsec).

API: `WriteTimestampNano`→`WriteTimestamp(sec,nsec)`, `ReadTimestampNano`→
`ReadTimestamp()` (breaking, justified by the format change; codegen
templates + generated samples updated).

## Verified
Scalar/columnar/nullable roundtrip incl. year-1 & year-9999 across all 9
option bundles; `FuzzRoundTrip_Time` ~2.9M execs; root + codegen modules
green under `-race` and `-tags qdf_simd`; lint clean. No golden change
(no fixture carries a time.Time).