### PR TITLE
feat: frame Marshaler types as Fast (honest header, no needless fallback)

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -10,6 +10,15 @@ type Marshaler interface {
 // Unmarshaler is implemented by types that know how to deserialize themselves
 // from a QDF wire-format slice. Implementations should consume exactly one
 // value from src and return the number of bytes consumed.
+//
+// A custom UnmarshalQDF reads the Fast wire format. Marshal honours this: a
+// type implementing Marshaler always emits its Fast-format body and is framed
+// as Fast regardless of the Options passed, so Marshaler+Unmarshaler types
+// round-trip under any Options. A type that implements Unmarshaler WITHOUT
+// also implementing Marshaler is encoded structurally; under a Dense/QPack
+// tier that produces a Dense body its Fast-only UnmarshalQDF cannot read.
+// Implement both interfaces (or neither) to avoid this — generated code from
+// cmd/qdfgen always implements both.
 type Unmarshaler interface {
 	UnmarshalQDF(src []byte) (n int, err error)
 }

--- a/marshaler_framing_test.go
+++ b/marshaler_framing_test.go
@@ -1,0 +1,37 @@
+package qdf
+
+import "testing"
+
+// TestMarshaler_AlwaysFastFraming pins a best-UX contract: a type implementing
+// Marshaler emits its own (Fast-format) body regardless of the requested
+// Options, so its wire MUST be framed as Fast (header flag byte 0). Otherwise
+// the header lies — claiming FlagDense/FlagQPack over a Fast body — which makes
+// UnmarshalDirect take an unnecessary reflect fallback and a decoder allocate
+// dense state it never uses. The body is identical across opts (the custom
+// MarshalQDF ignores them); only the framing must stay honest.
+func TestMarshaler_AlwaysFastFraming(t *testing.T) {
+	in := directSample{ID: 7, Name: "x"}
+	var fastBody []byte
+	for _, opts := range []Options{OptSpeed, OptQPack, OptBalanced, OptCompression} {
+		b, err := Marshal(&in, opts)
+		if err != nil {
+			t.Fatalf("opts=%d marshal: %v", opts, err)
+		}
+		if b[4] != 0 {
+			t.Fatalf("opts=%d: Marshaler wire flag=%08b, want 0 (Fast) — body is the custom Fast format", opts, b[4])
+		}
+		if fastBody == nil {
+			fastBody = b
+		} else if string(b) != string(fastBody) {
+			t.Fatalf("opts=%d: Marshaler wire differs across opts (body must be opts-invariant)", opts)
+		}
+		// UnmarshalDirect decodes directly — no dense fallback needed.
+		var out directSample
+		if err := UnmarshalDirect(b, &out); err != nil {
+			t.Fatalf("opts=%d UnmarshalDirect: %v", opts, err)
+		}
+		if out != in {
+			t.Fatalf("opts=%d roundtrip mismatch: got %+v want %+v", opts, out, in)
+		}
+	}
+}

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -887,8 +887,21 @@ func decodeTime(d *Decoder, p unsafe.Pointer) error {
 
 func encodeMarshaler(t reflect.Type) func(*Encoder, unsafe.Pointer) error {
 	return func(e *Encoder, p unsafe.Pointer) error {
+		// A Marshaler emits its own Fast-format body and ignores the
+		// encoder's Options. When it is the top-level value, frame the
+		// stream honestly as Fast (flag 0) instead of stamping the
+		// encoder's Dense/QPack mode onto a Fast body — otherwise the
+		// header lies, UnmarshalDirect takes a needless reflect fallback,
+		// and the decoder allocates dense state it never uses. Nested
+		// Marshaler fields (header already emitted) are unaffected: their
+		// custom body is written inline as before.
+		if !e.headerOut {
+			savedMode, savedQPack := e.mode, e.qpack
+			e.mode, e.qpack = Fast, false
+			e.writeHeader()
+			e.mode, e.qpack = savedMode, savedQPack
+		}
 		m := reflect.NewAt(t, p).Interface().(Marshaler)
-		e.writeHeader()
 		out, err := m.MarshalQDF(e.buf)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Problem
A type implementing `Marshaler` emits its own **Fast-format** body and ignores
the encoder `Options` — but `encodeMarshaler` stamped the encoder's Dense/QPack
mode onto the 5-byte header. So `Marshal(v, OptBalanced)` of a `Marshaler`
produced a `FlagDense|FlagQPack` header over a Fast body: a header that lies
about its payload. Consequences:
- `UnmarshalDirect` saw the dense flag and took an unnecessary reflect fallback.
- The decoder allocated dense intern state it never used.

## Investigation finding
The probe showed a `Marshaler`'s wire body is **byte-identical across all
Options** (`OptSpeed`/`OptQPack`/`OptBalanced`/`OptCompression`) — the custom
`MarshalQDF` ignores them. So the feared "dense body fed to a Fast-only
receiver" case never arises for `Marshaler`+`Unmarshaler` types; they round-trip
under any Options today. The only genuine gap is a type implementing
`Unmarshaler` **without** `Marshaler` (encoded structurally), which under a
Dense tier yields a Dense body its Fast-only `UnmarshalQDF` cannot read — now
documented as unsupported (implement both interfaces, or neither; `cmd/qdfgen`
always emits both).

## Fix
Frame top-level `Marshaler` output honestly as **Fast (flag 0)**, since the body
is always the Fast custom format. Nested `Marshaler` fields are unchanged (the
outer header is already emitted; their custom body stays inline). Adds a
godoc note on the `Unmarshaler` interface describing the contract.

## Result
- `Marshal(Marshaler, anyOpts)` → flag 0, opts-invariant wire; `UnmarshalDirect`
  decodes directly with no fallback and no dense-state allocation.
- New `TestMarshaler_AlwaysFastFraming` pins it across all four tiers.

## Verification
`go test` / `-race` / golden clean (no golden fixture uses a `Marshaler`
top-level type, so wire is unchanged); `internal/codegen_test` module green
(generated types implement both interfaces); `go vet` + `golangci-lint` clean.
