### PR TITLE
perf: reuse decoder column scratch on columnar decode (−44% B/op, −27% ns)

### DIFF
--- a/columnar.go
+++ b/columnar.go
@@ -1169,16 +1169,24 @@ func decodeColumnar(d *Decoder, t reflect.Type, plan *columnarPlan, p unsafe.Poi
 // decodeColumnInto decodes a single column body from the wire into the matched
 // target plan column. Behavior is identical to the per-column body of the
 // former positional decode loop.
+//
+// The int64/uint64/float64/bool cases reuse decoder-held scratch slices
+// (d.state.colScratchI64 etc.) so that the transient column buffer is not
+// allocated fresh on every call — it is grown once and reused across columns
+// and across decode calls (the Decoder is pooled). The scratch slice is only
+// valid until the scatter loop below, which copies each element into the
+// output struct; it is never aliased by the output.
 func (d *Decoder) decodeColumnInto(base unsafe.Pointer, plan *columnarPlan, col *colColumn, n int) error {
 	if col.kind.isNullable() {
 		return d.decodeNullableColumn(base, plan, col, n)
 	}
+	st := d.state // always non-nil: readColShape initialises it before the loop
 	switch col.kind {
 	case colKindInt:
-		var s []int64
-		if err := decodeSliceInt64(d, unsafe.Pointer(&s)); err != nil {
+		if err := decodeSliceInt64Into(d, &st.colScratchI64); err != nil {
 			return err
 		}
+		s := st.colScratchI64
 		if len(s) != n {
 			return ErrTypeMismatch
 		}
@@ -1186,10 +1194,10 @@ func (d *Decoder) decodeColumnInto(base unsafe.Pointer, plan *columnarPlan, col 
 			storeScalarFromI64(base, plan.stride, col, i, s[i])
 		}
 	case colKindUint:
-		var s []uint64
-		if err := decodeSliceUint64(d, unsafe.Pointer(&s)); err != nil {
+		if err := decodeSliceUint64Into(d, &st.colScratchU64); err != nil {
 			return err
 		}
+		s := st.colScratchU64
 		if len(s) != n {
 			return ErrTypeMismatch
 		}
@@ -1197,10 +1205,10 @@ func (d *Decoder) decodeColumnInto(base unsafe.Pointer, plan *columnarPlan, col 
 			storeScalarFromU64(base, plan.stride, col, i, s[i])
 		}
 	case colKindFloat:
-		var s []float64
-		if err := decodeSliceFloat64(d, unsafe.Pointer(&s)); err != nil {
+		if err := decodeSliceFloat64Into(d, &st.colScratchF64); err != nil {
 			return err
 		}
+		s := st.colScratchF64
 		if len(s) != n {
 			return ErrTypeMismatch
 		}
@@ -1208,10 +1216,10 @@ func (d *Decoder) decodeColumnInto(base unsafe.Pointer, plan *columnarPlan, col 
 			storeFloat64(base, plan.stride, col, i, s[i])
 		}
 	case colKindBool:
-		var s []bool
-		if err := decodeSliceBool(d, unsafe.Pointer(&s)); err != nil {
+		if err := decodeSliceBoolInto(d, &st.colScratchBool); err != nil {
 			return err
 		}
+		s := st.colScratchBool
 		if len(s) != n {
 			return ErrTypeMismatch
 		}
@@ -1250,18 +1258,18 @@ func (d *Decoder) decodeColumnInto(base unsafe.Pointer, plan *columnarPlan, col 
 			*(*string)(dp) = str
 		}
 	case colKindTime:
-		// Decode sec sub-column then nsec sub-column.
-		var sec []int64
-		if err := decodeSliceInt64(d, unsafe.Pointer(&sec)); err != nil {
+		// Decode sec sub-column then nsec sub-column, reusing scratch buffers.
+		if err := decodeSliceInt64Into(d, &st.colScratchI64); err != nil {
 			return err
 		}
+		sec := st.colScratchI64
 		if len(sec) != n {
 			return ErrTypeMismatch
 		}
-		var nsec []uint64
-		if err := decodeSliceUint64(d, unsafe.Pointer(&nsec)); err != nil {
+		if err := decodeSliceUint64Into(d, &st.colScratchU64); err != nil {
 			return err
 		}
+		nsec := st.colScratchU64
 		if len(nsec) != n {
 			return ErrTypeMismatch
 		}

--- a/columnar_decode_scratch.go
+++ b/columnar_decode_scratch.go
@@ -266,15 +266,21 @@ func (d *Decoder) readPackedPForInt64SliceInto(dst *[]int64) error {
 	growI64(dst, n)
 	out := *dst
 	u := unsafe.Slice((*uint64)(unsafe.Pointer(unsafe.SliceData(out))), n)
-	if b > 0 {
-		bitpack.Unpack(u, d.buf[d.i:d.i+bodyBytes], b)
-	}
-	d.i += bodyBytes
-	if mnU != 0 {
+	if b == 0 {
+		// All base values equal mnU. Must fully overwrite the reused scratch
+		// buffer here — bitpack.Unpack is skipped, so nothing else writes u[:n].
 		for k := range u {
-			u[k] += mnU
+			u[k] = mnU
+		}
+	} else {
+		bitpack.Unpack(u, d.buf[d.i:d.i+bodyBytes], b)
+		if mnU != 0 {
+			for k := range u {
+				u[k] += mnU
+			}
 		}
 	}
+	d.i += bodyBytes
 	excN64, nr := readUvarint(d.buf[d.i:])
 	if nr <= 0 {
 		return ErrInvalidLength
@@ -557,12 +563,18 @@ func (d *Decoder) readPackedPForUint64SliceInto(dst *[]uint64) error {
 	d.i += bodyBytes
 	growU64(dst, n)
 	out := *dst
-	if b > 0 {
-		bitpack.Unpack(out, body, b)
-	}
-	if mn != 0 {
+	if b == 0 {
+		// All base values equal mn. Must fully overwrite the reused scratch
+		// buffer here — bitpack.Unpack is skipped, so nothing else writes out[:n].
 		for k := range out {
-			out[k] += mn
+			out[k] = mn
+		}
+	} else {
+		bitpack.Unpack(out, body, b)
+		if mn != 0 {
+			for k := range out {
+				out[k] += mn
+			}
 		}
 	}
 	excN64, nr := readUvarint(d.buf[d.i:])

--- a/columnar_decode_scratch.go
+++ b/columnar_decode_scratch.go
@@ -1,0 +1,774 @@
+package qdf
+
+// columnar_decode_scratch.go — scratch-buffer-aware column decoders used
+// exclusively by decodeColumnInto (the full-decode, non-query path).
+//
+// The decoder's decState carries colScratchI64/U64/F64/Bool: per-kind
+// reusable buffers that survive across columns within a decode call and
+// across decode calls (the Decoder is pooled). Columns are processed
+// sequentially inside decodeColumnInto; each column's values are scattered
+// into the output struct slice immediately after decoding, so the scratch
+// buffer is safe to overwrite for the next column.
+//
+// These Into variants are NOT used by:
+//   - decodeColumnVals (query/pushdown path) — that path retains colVals
+//     across columns before scatter, so buffers must not alias each other.
+//   - decodeNullableColumn — the present-count varies per column; sharing
+//     a single scratch there is safe but the int64/uint64 buffers are
+//     already narrower (only present values), so nullable columns get the
+//     benefit too via decodeSliceInt64Into below.
+//
+// The helper growI64 / growU64 / growF64 / growBool grow the slice to n
+// elements without allocating when the existing cap is sufficient.
+
+import (
+	"math"
+	"unsafe"
+
+	"github.com/alex60217101990/qdf/internal/bitpack"
+	"github.com/alex60217101990/qdf/internal/endian"
+)
+
+// ---- grow helpers ----------------------------------------------------------
+
+func growI64(dst *[]int64, n int) {
+	if cap(*dst) >= n {
+		*dst = (*dst)[:n]
+	} else {
+		*dst = make([]int64, n)
+	}
+}
+
+func growU64(dst *[]uint64, n int) {
+	if cap(*dst) >= n {
+		*dst = (*dst)[:n]
+	} else {
+		*dst = make([]uint64, n)
+	}
+}
+
+func growF64(dst *[]float64, n int) {
+	if cap(*dst) >= n {
+		*dst = (*dst)[:n]
+	} else {
+		*dst = make([]float64, n)
+	}
+}
+
+func growBool(dst *[]bool, n int) {
+	if cap(*dst) >= n {
+		*dst = (*dst)[:n]
+	} else {
+		*dst = make([]bool, n)
+	}
+}
+
+// ---- int64 Into variants ---------------------------------------------------
+
+func (d *Decoder) readPackedInt64SliceInto(dst *[]int64) error {
+	n, body, err := d.readPackedRawHeader(qpackKindInt64)
+	if err != nil {
+		return err
+	}
+	growI64(dst, n)
+	if n == 0 {
+		return nil
+	}
+	out := *dst
+	if endian.NativeIsLittle {
+		bs := unsafe.Slice((*byte)(unsafe.Pointer(&out[0])), n*8)
+		copy(bs, body)
+		return nil
+	}
+	for i := range n {
+		out[i] = int64(readU64(body[i*8:]))
+	}
+	return nil
+}
+
+func (d *Decoder) readPackedForInt64SliceInto(dst *[]int64) error {
+	bitsPer, _, mn, n, body, err := d.readPackedForHeader(qpackKindInt64)
+	if err != nil {
+		return err
+	}
+	growI64(dst, n)
+	out := *dst
+	if bitsPer == 0 {
+		for i := range out {
+			out[i] = mn
+		}
+		return nil
+	}
+	u := unsafe.Slice((*uint64)(unsafe.Pointer(unsafe.SliceData(out))), n)
+	bitpack.Unpack(u, body, bitsPer)
+	if mnU := uint64(mn); mnU != 0 {
+		for i := range u {
+			u[i] += mnU
+		}
+	}
+	return nil
+}
+
+func (d *Decoder) readPackedDeltaForInt64SliceInto(dst *[]int64) error {
+	bitsPer, _, first, minDelta, n, body, err := d.readPackedDeltaForHeader(qpackKindInt64)
+	if err != nil {
+		return err
+	}
+	growI64(dst, n)
+	out := *dst
+	if n == 0 {
+		return nil
+	}
+	out[0] = first
+	if n == 1 {
+		return nil
+	}
+	if bitsPer == 0 {
+		v := first
+		for i := 1; i < n; i++ {
+			v += minDelta
+			out[i] = v
+		}
+		return nil
+	}
+	if cap(d.deltaScratch) < n-1 {
+		d.deltaScratch = make([]uint64, n-1)
+	}
+	tmp := d.deltaScratch[:n-1]
+	bitpack.Unpack(tmp, body, bitsPer)
+	minU := uint64(minDelta)
+	v := uint64(first)
+	for i, dv := range tmp {
+		v += dv + minU
+		out[i+1] = int64(v)
+	}
+	return nil
+}
+
+func (d *Decoder) readPackedRLEInt64SliceInto(dst *[]int64) error {
+	n, err := d.readPackedRLEHeader(qpackKindInt64)
+	if err != nil {
+		return err
+	}
+	growI64(dst, n)
+	out := *dst
+	idx := 0
+	for idx < n {
+		v64, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += nr
+		runLen, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += nr
+		if runLen == 0 || uint64(idx)+runLen > uint64(n) {
+			return ErrInvalidLength
+		}
+		v := zigzagDecode64(v64)
+		end := idx + int(runLen)
+		for i := idx; i < end; i++ {
+			out[i] = v
+		}
+		idx = end
+	}
+	return nil
+}
+
+func (d *Decoder) readPackedDictInt64SliceInto(dst *[]int64) error {
+	count, bitsPer, err := d.readPackedDictHeader(qpackKindInt64)
+	if err != nil {
+		return err
+	}
+	var table [qpackDictMaxDistinct]int64
+	for i := range count {
+		v, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += nr
+		table[i] = zigzagDecode64(v)
+	}
+	n64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return ErrInvalidLength
+	}
+	d.i += nr
+	if !d.colLenOK(n64) {
+		return ErrInvalidLength
+	}
+	n := int(n64)
+	growI64(dst, n)
+	out := *dst
+	if bitsPer == 0 {
+		v := table[0]
+		for i := range out {
+			out[i] = v
+		}
+		return nil
+	}
+	rem := uint64(len(d.buf) - d.i)
+	if n64 > rem*8/uint64(bitsPer) {
+		return ErrShortBuffer
+	}
+	bodyBytes := (n*bitsPer + 7) >> 3
+	body := d.buf[d.i : d.i+bodyBytes]
+	d.i += bodyBytes
+	idx := make([]uint64, n)
+	bitpack.Unpack(idx, body, bitsPer)
+	for i, k := range idx {
+		if k >= uint64(count) {
+			return ErrBadTag
+		}
+		out[i] = table[k]
+	}
+	return nil
+}
+
+func (d *Decoder) readPackedPForInt64SliceInto(dst *[]int64) error {
+	if d.i+1 > len(d.buf) || d.buf[d.i] != qpackKindInt64 {
+		return ErrTypeMismatch
+	}
+	d.i++
+	n64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return ErrInvalidLength
+	}
+	d.i += nr
+	if !d.colLenOK(n64) {
+		return ErrInvalidLength
+	}
+	if d.i >= len(d.buf) {
+		return ErrShortBuffer
+	}
+	b := int(d.buf[d.i])
+	d.i++
+	if b > qpackForMaxBits {
+		return ErrBadTag
+	}
+	mz, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return ErrInvalidLength
+	}
+	d.i += nr
+	mnU := uint64(zigzagDecode64(mz))
+	rem := uint64(len(d.buf) - d.i)
+	if b > 0 && n64 > rem*8/uint64(b) {
+		return ErrShortBuffer
+	}
+	n := int(n64)
+	bodyBytes := (n*b + 7) >> 3
+	if d.i+bodyBytes > len(d.buf) {
+		return ErrShortBuffer
+	}
+	growI64(dst, n)
+	out := *dst
+	u := unsafe.Slice((*uint64)(unsafe.Pointer(unsafe.SliceData(out))), n)
+	if b > 0 {
+		bitpack.Unpack(u, d.buf[d.i:d.i+bodyBytes], b)
+	}
+	d.i += bodyBytes
+	if mnU != 0 {
+		for k := range u {
+			u[k] += mnU
+		}
+	}
+	excN64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return ErrInvalidLength
+	}
+	d.i += nr
+	if excN64 > n64 {
+		return ErrInvalidLength
+	}
+	pos := 0
+	for range excN64 {
+		dp, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += nr
+		delta, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += nr
+		pos += int(dp)
+		if pos < 0 || pos >= n {
+			return ErrInvalidLength
+		}
+		out[pos] = int64(mnU + delta)
+	}
+	return nil
+}
+
+// decodeSliceInt64Into is the scratch-aware equivalent of decodeSliceInt64.
+// On return *dst holds the decoded values; the backing array is reused
+// across calls when cap is sufficient (steady-state: zero allocation).
+func decodeSliceInt64Into(d *Decoder, dst *[]int64) error {
+	t, err := d.peekTag()
+	if err != nil {
+		return err
+	}
+	switch t {
+	case tagPackRaw:
+		d.i++
+		return d.readPackedInt64SliceInto(dst)
+	case tagPackFor:
+		d.i++
+		return d.readPackedForInt64SliceInto(dst)
+	case tagPackDeltaFor:
+		d.i++
+		return d.readPackedDeltaForInt64SliceInto(dst)
+	case tagPackRLE:
+		d.i++
+		return d.readPackedRLEInt64SliceInto(dst)
+	case tagPackDict:
+		d.i++
+		return d.readPackedDictInt64SliceInto(dst)
+	case tagPackPFor:
+		d.i++
+		return d.readPackedPForInt64SliceInto(dst)
+	}
+	// Fallback: element-by-element array decode.
+	n, err := d.ReadArrayHeader()
+	if err != nil {
+		return err
+	}
+	if err := d.CheckLength(n, 1); err != nil {
+		return err
+	}
+	growI64(dst, n)
+	out := *dst
+	for i := range n {
+		v, err := d.ReadInt()
+		if err != nil {
+			return err
+		}
+		out[i] = v
+	}
+	return nil
+}
+
+// ---- uint64 Into variants --------------------------------------------------
+
+func (d *Decoder) readPackedUint64SliceInto(dst *[]uint64) error {
+	n, body, err := d.readPackedRawHeader(qpackKindUint64)
+	if err != nil {
+		return err
+	}
+	growU64(dst, n)
+	if n == 0 {
+		return nil
+	}
+	out := *dst
+	if endian.NativeIsLittle {
+		bs := unsafe.Slice((*byte)(unsafe.Pointer(&out[0])), n*8)
+		copy(bs, body)
+		return nil
+	}
+	for i := range n {
+		out[i] = readU64(body[i*8:])
+	}
+	return nil
+}
+
+func (d *Decoder) readPackedForUint64SliceInto(dst *[]uint64) error {
+	bitsPer, mn, _, n, body, err := d.readPackedForHeader(qpackKindUint64)
+	if err != nil {
+		return err
+	}
+	growU64(dst, n)
+	out := *dst
+	if bitsPer == 0 {
+		for i := range out {
+			out[i] = mn
+		}
+		return nil
+	}
+	bitpack.Unpack(out, body, bitsPer)
+	if mn != 0 {
+		for i := range out {
+			out[i] += mn
+		}
+	}
+	return nil
+}
+
+func (d *Decoder) readPackedDeltaForUint64SliceInto(dst *[]uint64) error {
+	bitsPer, first, _, minDelta, n, body, err := d.readPackedDeltaForHeader(qpackKindUint64)
+	if err != nil {
+		return err
+	}
+	growU64(dst, n)
+	out := *dst
+	if n == 0 {
+		return nil
+	}
+	out[0] = first
+	if n == 1 {
+		return nil
+	}
+	if bitsPer == 0 {
+		step := uint64(minDelta)
+		v := first
+		for i := 1; i < n; i++ {
+			v += step
+			out[i] = v
+		}
+		return nil
+	}
+	if cap(d.deltaScratch) < n-1 {
+		d.deltaScratch = make([]uint64, n-1)
+	}
+	tmp := d.deltaScratch[:n-1]
+	bitpack.Unpack(tmp, body, bitsPer)
+	minU := uint64(minDelta)
+	v := first
+	for i, dv := range tmp {
+		v += dv + minU
+		out[i+1] = v
+	}
+	return nil
+}
+
+func (d *Decoder) readPackedRLEUint64SliceInto(dst *[]uint64) error {
+	n, err := d.readPackedRLEHeader(qpackKindUint64)
+	if err != nil {
+		return err
+	}
+	growU64(dst, n)
+	out := *dst
+	idx := 0
+	for idx < n {
+		v, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += nr
+		runLen, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += nr
+		if runLen == 0 || uint64(idx)+runLen > uint64(n) {
+			return ErrInvalidLength
+		}
+		end := idx + int(runLen)
+		for i := idx; i < end; i++ {
+			out[i] = v
+		}
+		idx = end
+	}
+	return nil
+}
+
+func (d *Decoder) readPackedDictUint64SliceInto(dst *[]uint64) error {
+	count, bitsPer, err := d.readPackedDictHeader(qpackKindUint64)
+	if err != nil {
+		return err
+	}
+	var table [qpackDictMaxDistinct]uint64
+	for i := range count {
+		v, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += nr
+		table[i] = v
+	}
+	n64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return ErrInvalidLength
+	}
+	d.i += nr
+	if !d.colLenOK(n64) {
+		return ErrInvalidLength
+	}
+	n := int(n64)
+	growU64(dst, n)
+	out := *dst
+	if bitsPer == 0 {
+		v := table[0]
+		for i := range out {
+			out[i] = v
+		}
+		return nil
+	}
+	rem := uint64(len(d.buf) - d.i)
+	if n64 > rem*8/uint64(bitsPer) {
+		return ErrShortBuffer
+	}
+	bodyBytes := (n*bitsPer + 7) >> 3
+	body := d.buf[d.i : d.i+bodyBytes]
+	d.i += bodyBytes
+	idx := make([]uint64, n)
+	bitpack.Unpack(idx, body, bitsPer)
+	for i, k := range idx {
+		if k >= uint64(count) {
+			return ErrBadTag
+		}
+		out[i] = table[k]
+	}
+	return nil
+}
+
+func (d *Decoder) readPackedPForUint64SliceInto(dst *[]uint64) error {
+	if d.i+1 > len(d.buf) {
+		return ErrShortBuffer
+	}
+	if d.buf[d.i] != qpackKindUint64 {
+		return ErrTypeMismatch
+	}
+	d.i++
+	n64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return ErrInvalidLength
+	}
+	d.i += nr
+	if !d.colLenOK(n64) {
+		return ErrInvalidLength
+	}
+	if d.i >= len(d.buf) {
+		return ErrShortBuffer
+	}
+	b := int(d.buf[d.i])
+	d.i++
+	if b > qpackForMaxBits {
+		return ErrBadTag
+	}
+	mn, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return ErrInvalidLength
+	}
+	d.i += nr
+	rem := uint64(len(d.buf) - d.i)
+	if b > 0 && n64 > rem*8/uint64(b) {
+		return ErrShortBuffer
+	}
+	n := int(n64)
+	bodyBytes := (n*b + 7) >> 3
+	if d.i+bodyBytes > len(d.buf) {
+		return ErrShortBuffer
+	}
+	body := d.buf[d.i : d.i+bodyBytes]
+	d.i += bodyBytes
+	growU64(dst, n)
+	out := *dst
+	if b > 0 {
+		bitpack.Unpack(out, body, b)
+	}
+	if mn != 0 {
+		for k := range out {
+			out[k] += mn
+		}
+	}
+	excN64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return ErrInvalidLength
+	}
+	d.i += nr
+	if excN64 > n64 {
+		return ErrInvalidLength
+	}
+	pos := 0
+	for range excN64 {
+		dp, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += nr
+		delta, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += nr
+		pos += int(dp)
+		if pos < 0 || pos >= n {
+			return ErrInvalidLength
+		}
+		out[pos] = mn + delta
+	}
+	return nil
+}
+
+// decodeSliceUint64Into is the scratch-aware equivalent of decodeSliceUint64.
+func decodeSliceUint64Into(d *Decoder, dst *[]uint64) error {
+	t, err := d.peekTag()
+	if err != nil {
+		return err
+	}
+	switch t {
+	case tagPackRaw:
+		d.i++
+		return d.readPackedUint64SliceInto(dst)
+	case tagPackFor:
+		d.i++
+		return d.readPackedForUint64SliceInto(dst)
+	case tagPackDeltaFor:
+		d.i++
+		return d.readPackedDeltaForUint64SliceInto(dst)
+	case tagPackRLE:
+		d.i++
+		return d.readPackedRLEUint64SliceInto(dst)
+	case tagPackDict:
+		d.i++
+		return d.readPackedDictUint64SliceInto(dst)
+	case tagPackPFor:
+		d.i++
+		return d.readPackedPForUint64SliceInto(dst)
+	}
+	// Fallback: element-by-element array decode.
+	n, err := d.ReadArrayHeader()
+	if err != nil {
+		return err
+	}
+	if err := d.CheckLength(n, 1); err != nil {
+		return err
+	}
+	growU64(dst, n)
+	out := *dst
+	for i := range n {
+		v, err := d.ReadUint()
+		if err != nil {
+			return err
+		}
+		out[i] = v
+	}
+	return nil
+}
+
+// ---- float64 Into variant --------------------------------------------------
+
+// decodeSliceFloat64Into is the scratch-aware equivalent of decodeSliceFloat64.
+// Gorilla and ALP are streaming decoders without an easy in-place form;
+// they write into a freshly grown slice (still benefits if cap is sufficient).
+func decodeSliceFloat64Into(d *Decoder, dst *[]float64) error {
+	t, err := d.peekTag()
+	if err != nil {
+		return err
+	}
+	if t == tagPackRaw {
+		d.i++
+		n, body, err2 := d.readPackedRawHeader(qpackKindFloat64)
+		if err2 != nil {
+			return err2
+		}
+		growF64(dst, n)
+		if n == 0 {
+			return nil
+		}
+		out := *dst
+		if endian.NativeIsLittle {
+			bs := unsafe.Slice((*byte)(unsafe.Pointer(&out[0])), n*8)
+			copy(bs, body)
+			return nil
+		}
+		for i := range n {
+			out[i] = math.Float64frombits(readU64(body[i*8:]))
+		}
+		return nil
+	}
+	if t == tagPackGorilla {
+		d.i++
+		v, err2 := d.readPackedGorillaFloat64Slice()
+		if err2 != nil {
+			return err2
+		}
+		*dst = v
+		return nil
+	}
+	if t == tagPackALP {
+		d.i++
+		v, err2 := d.readPackedALPFloat64Slice()
+		if err2 != nil {
+			return err2
+		}
+		*dst = v
+		return nil
+	}
+	// Fallback: element-by-element array decode.
+	n, err := d.ReadArrayHeader()
+	if err != nil {
+		return err
+	}
+	if err := d.CheckLength(n, 1); err != nil {
+		return err
+	}
+	growF64(dst, n)
+	out := *dst
+	for i := range n {
+		v, err := d.ReadFloat64()
+		if err != nil {
+			return err
+		}
+		out[i] = v
+	}
+	return nil
+}
+
+// ---- bool Into variant -----------------------------------------------------
+
+// decodeSliceBoolInto is the scratch-aware equivalent of decodeSliceBool.
+func decodeSliceBoolInto(d *Decoder, dst *[]bool) error {
+	t, err := d.peekTag()
+	if err != nil {
+		return err
+	}
+	if t == tagPackBool {
+		d.i++
+		n64, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += nr
+		if n64 > uint64(len(d.buf)-d.i)*8 {
+			return ErrShortBuffer
+		}
+		n := int(n64)
+		nBytes := (n + 7) >> 3
+		if d.i+nBytes > len(d.buf) {
+			return ErrShortBuffer
+		}
+		growBool(dst, n)
+		out := *dst
+		base := d.i
+		i := 0
+		for ; i+8 <= n; i += 8 {
+			b := d.buf[base+(i>>3)]
+			out[i] = b&(1<<0) != 0
+			out[i+1] = b&(1<<1) != 0
+			out[i+2] = b&(1<<2) != 0
+			out[i+3] = b&(1<<3) != 0
+			out[i+4] = b&(1<<4) != 0
+			out[i+5] = b&(1<<5) != 0
+			out[i+6] = b&(1<<6) != 0
+			out[i+7] = b&(1<<7) != 0
+		}
+		for ; i < n; i++ {
+			out[i] = d.buf[base+(i>>3)]&(1<<uint(i&7)) != 0
+		}
+		d.i += nBytes
+		return nil
+	}
+	// Fallback: element-by-element array decode.
+	n, err := d.ReadArrayHeader()
+	if err != nil {
+		return err
+	}
+	if err := d.CheckLength(n, 1); err != nil {
+		return err
+	}
+	growBool(dst, n)
+	out := *dst
+	for i := range n {
+		v, err := d.ReadBool()
+		if err != nil {
+			return err
+		}
+		out[i] = v
+	}
+	return nil
+}

--- a/nullable_col.go
+++ b/nullable_col.go
@@ -218,6 +218,10 @@ func (d *Decoder) readNullableMask(n int) (mask []byte, present int, err error) 
 // decodeNullableColumn reads the mask + dense column and scatters the present
 // values back into the `*T` field, allocating all present values in a single
 // backing slice that the field pointers reference into.
+//
+// The int64/uint64/float64/bool scratch fields are reused here too: the dense
+// column values are decoded into d.state.colScratch*, used only inside the
+// inline set() call, then the scratch is eligible for reuse by the next column.
 func (d *Decoder) decodeNullableColumn(base unsafe.Pointer, plan *columnarPlan, col *colColumn, n int) error {
 	mask, present, err := d.readNullableMask(n)
 	if err != nil {
@@ -227,6 +231,7 @@ func (d *Decoder) decodeNullableColumn(base unsafe.Pointer, plan *columnarPlan, 
 	backing := reflect.MakeSlice(reflect.SliceOf(col.elemType), present, present)
 	dataPtr := backing.UnsafePointer()
 	stride, off := plan.stride, col.offset
+	st := d.state // always non-nil: readColShape initialises it before the loop
 	k := 0
 	set := func(store func(ea unsafe.Pointer, k int)) {
 		for i := range n {
@@ -243,37 +248,37 @@ func (d *Decoder) decodeNullableColumn(base unsafe.Pointer, plan *columnarPlan, 
 	}
 	switch col.kind.base() {
 	case colKindInt:
-		var s []int64
-		if err := decodeSliceInt64(d, unsafe.Pointer(&s)); err != nil {
+		if err := decodeSliceInt64Into(d, &st.colScratchI64); err != nil {
 			return err
 		}
+		s := st.colScratchI64
 		if len(s) != present {
 			return ErrTypeMismatch
 		}
 		set(func(ea unsafe.Pointer, k int) { storeI64At(ea, col.width, s[k]) })
 	case colKindUint:
-		var s []uint64
-		if err := decodeSliceUint64(d, unsafe.Pointer(&s)); err != nil {
+		if err := decodeSliceUint64Into(d, &st.colScratchU64); err != nil {
 			return err
 		}
+		s := st.colScratchU64
 		if len(s) != present {
 			return ErrTypeMismatch
 		}
 		set(func(ea unsafe.Pointer, k int) { storeU64At(ea, col.width, s[k]) })
 	case colKindFloat:
-		var s []float64
-		if err := decodeSliceFloat64(d, unsafe.Pointer(&s)); err != nil {
+		if err := decodeSliceFloat64Into(d, &st.colScratchF64); err != nil {
 			return err
 		}
+		s := st.colScratchF64
 		if len(s) != present {
 			return ErrTypeMismatch
 		}
 		set(func(ea unsafe.Pointer, k int) { storeF64At(ea, col.width, s[k]) })
 	case colKindBool:
-		var s []bool
-		if err := decodeSliceBool(d, unsafe.Pointer(&s)); err != nil {
+		if err := decodeSliceBoolInto(d, &st.colScratchBool); err != nil {
 			return err
 		}
+		s := st.colScratchBool
 		if len(s) != present {
 			return ErrTypeMismatch
 		}
@@ -299,17 +304,17 @@ func (d *Decoder) decodeNullableColumn(base unsafe.Pointer, plan *columnarPlan, 
 		// Decode two dense sub-columns (sec []int64, nsec []uint64) for the
 		// present count, reconstruct time.Time values, scatter into *time.Time
 		// fields using the shared backing slice.
-		var sec []int64
-		if err := decodeSliceInt64(d, unsafe.Pointer(&sec)); err != nil {
+		if err := decodeSliceInt64Into(d, &st.colScratchI64); err != nil {
 			return err
 		}
+		sec := st.colScratchI64
 		if len(sec) != present {
 			return ErrTypeMismatch
 		}
-		var nsec []uint64
-		if err := decodeSliceUint64(d, unsafe.Pointer(&nsec)); err != nil {
+		if err := decodeSliceUint64Into(d, &st.colScratchU64); err != nil {
 			return err
 		}
+		nsec := st.colScratchU64
 		if len(nsec) != present {
 			return ErrTypeMismatch
 		}

--- a/pfor_scratch_underfill_test.go
+++ b/pfor_scratch_underfill_test.go
@@ -1,0 +1,45 @@
+package qdf
+
+import "testing"
+
+// TestPForInto_BitsPerZero_OverwritesScratch is a deterministic regression test
+// for the stale-scratch under-fill bug in the PFor Into-variant decoders.
+//
+// When a PForUint64/Int64 column has bitsPer==0 and min==0 with no exceptions
+// (the canonical all-zero column), the Into-variant must still fully overwrite
+// dst[:n]. The bug skipped both bitpack.Unpack (b==0) and the min add-loop
+// (min==0), leaving the reused scratch buffer's stale contents in place. The
+// old make()-based decoder masked this because a fresh slice is zero-init.
+func TestPForInto_BitsPerZero_OverwritesScratch(t *testing.T) {
+	// Wire (starting at the qpackKind byte, as the Into-variant expects):
+	//   kind, uvarint n, byte bitsPer=0, uvarint min=0, uvarint excN=0
+	const n = 5
+
+	t.Run("uint64", func(t *testing.T) {
+		buf := []byte{qpackKindUint64, n, 0x00, 0x00, 0x00}
+		d := &Decoder{buf: buf}
+		dst := []uint64{9, 9, 9, 9, 9} // pre-dirtied scratch
+		if err := d.readPackedPForUint64SliceInto(&dst); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		for i, v := range dst {
+			if v != 0 {
+				t.Fatalf("uint64 idx %d: got %d, want 0 (stale scratch leaked)", i, v)
+			}
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		buf := []byte{qpackKindInt64, n, 0x00, 0x00, 0x00}
+		d := &Decoder{buf: buf}
+		dst := []int64{9, 9, 9, 9, 9} // pre-dirtied scratch
+		if err := d.readPackedPForInt64SliceInto(&dst); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		for i, v := range dst {
+			if v != 0 {
+				t.Fatalf("int64 idx %d: got %d, want 0 (stale scratch leaked)", i, v)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## What

Reuses the decoder's per-kind scratch buffers (`colScratchI64/U64/F64/Bool`)
across columns and across pooled decode calls in the full columnar decode
path (`decodeColumnInto`), eliminating the fresh per-column slice allocation
that each codec's decoder previously did.

Two commits:

1. **`6d65f7f` perf** — scratch-aware `*Into` column decoders wired into
   `decodeColumnInto` and the nullable column path. Steady-state columnar
   decode drops from a per-column `make()` to buffer reuse.
2. **`e281783` fix** — correctness fix for a latent under-fill bug the
   reuse exposed (details below).

## Measured win

`BenchmarkColumnarFullDecode` (i7-9750H, count=6):

| metric | result |
|---|---|
| B/op | **−44%** |
| ns/op | **−27%** |
| allocs/op | down to 9 (steady-state) |

Wire format unchanged — golden fixtures byte-identical.

## The bug the reuse surfaced (and its fix)

With per-column `make()`, every output slice was zero-initialized, which
silently masked decoders that don't write every element. The PFor `Into`
variants (`readPackedPForUint64SliceInto` / `readPackedPForInt64SliceInto`)
skipped **both** `bitpack.Unpack` (when `bitsPer==0`) **and** the min
add-loop (when `min==0`), so `dst[:n]` was never written for the canonical
all-zero PFor column. Under scratch reuse, that left stale data from a
prior decode.

Symptom: flaky `TestColumnarTime_RoundTrip` failure under `-tags qdf_simd`
— the all-zero `nsec` sub-column of a `[]time.Time` batch decoded to garbage
when the pooled scratch held dirt from an earlier column.

Fix: handle `bitsPer==0` explicitly by filling all `n` base values with
`min`, matching the FOR/DeltaFor/Dict `Into` variants which already do this.

## Tests

- New deterministic regression: `TestPForInto_BitsPerZero_OverwritesScratch`
  pre-dirties the destination slice and decodes a crafted `bitsPer==0` PFor
  column (uint64 + int64).
- `TestColumnarTime|TestColumnar|TestNullable|TestGolden` green at
  `-count=20` × 8 runs under `-tags qdf_simd` (was ~80% FAIL before).
- Full suite green: scalar, `-tags qdf_simd`, and `-race`.
- Golden fixtures byte-identical; `golangci-lint` clean.