### PR TITLE
perf: outline header parse so the per-tag decode hot path drops a call (~7%)

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -157,11 +157,22 @@ func (d *Decoder) CheckLength(n int, perElem int) error {
 	return nil
 }
 
-// readHeader parses the 5-byte header. Called once per buffer.
+// readHeader consumes the 5-byte header once per buffer. The hot path is the
+// already-read check; the actual parse is outlined into readHeaderSlow so this
+// (and its callers, peekTag/next) stay within the inliner budget.
 func (d *Decoder) readHeader() error {
 	if d.headerRead {
 		return nil
 	}
+	return d.readHeaderSlow()
+}
+
+// readHeaderSlow parses the 5-byte header (and an optional rANS body). Kept out
+// of line: it runs once per decode, so inlining its cost into the per-tag hot
+// path would only bloat callers.
+//
+//go:noinline
+func (d *Decoder) readHeaderSlow() error {
 	if len(d.buf)-d.i < 5 {
 		return ErrShortBuffer
 	}
@@ -205,10 +216,14 @@ func (d *Decoder) readHeader() error {
 	return nil
 }
 
-// peekTag returns the next tag without consuming it.
+// peekTag returns the next tag without consuming it. The header check is
+// inlined here so the common (header-already-read) path has no call; the parse
+// is taken only on the first tag of a decode.
 func (d *Decoder) peekTag() (byte, error) {
-	if err := d.readHeader(); err != nil {
-		return 0, err
+	if !d.headerRead {
+		if err := d.readHeaderSlow(); err != nil {
+			return 0, err
+		}
 	}
 	if d.i >= len(d.buf) {
 		return 0, ErrShortBuffer

--- a/docs/BENCH.md
+++ b/docs/BENCH.md
@@ -191,6 +191,18 @@ at ~3 allocs/op for fast path.
 | Wide ×1000       | 4.14M   | 1.95M   | **1.06M**   | 1.84×      | 3.89×   |
 | LogBatch ×1000   | 3.42M   | 1.32M   | **469k**    | 2.81×      | 7.30×   |
 
+## Decode hot-path: header parse outlined (inliner)
+
+`peekTag` ran on every tag and called `readHeader` just to test the
+already-read flag; `readHeader` was too complex to inline, so it stayed a real
+call. Outlining the parse into `readHeaderSlow` (`//go:noinline`) and inlining
+the flag check into `peekTag` drops that call from the common path. benchstat
+(i7-9750H, count=10, reflect decode): **Flat −6.8%, Nested −10.0%,
+LogBatch1k −7.6%, geomean −6.8% / +7.3% throughput**; allocs and wire
+unchanged. Per-tag overhead matters most on small/per-message decodes; the
+big columnar `Wide ×1000` fixture is dominated by codec work and moves within
+noise.
+
 ## Decode — realistic (different bytes per iteration)
 
 | Bench                              | json | msgpack | qdf_fast | vs msgpack | vs json |


### PR DESCRIPTION
## What

`(*Decoder).peekTag` runs on every tag read. It called `readHeader` each time
just to test the already-read flag — but `readHeader` (cost 335) was far over
the inliner budget, so it stayed a **real function call on every tag**.

Fix (the mid-stack-inliner "outline the slow path" pattern):
- Split the header parse into `readHeaderSlow` (`//go:noinline`) — it runs once
  per decode, so its cost should never bloat the hot path.
- `readHeader()` becomes a tiny `if d.headerRead { return nil }; return
  d.readHeaderSlow()` wrapper (now inlinable; kept for `decodeUnmarshaler`).
- `peekTag` inlines the `!d.headerRead` check directly, so the common path
  (header already read) makes **no call**; `readHeaderSlow` is reached only on
  the first tag of a decode.

Lazy-header semantics are unchanged: `peekTag` still triggers the parse when the
header has not been read, so every existing entry point keeps working.

## Measured (i7-9750H, count=10, reflect decode, benchstat)

| fixture | Δ ns/op |
|---|---|
| Decode_Flat | **−6.8%** (p=0.002) |
| Decode_Nested | **−10.0%** (p=0.000) |
| Decode_LogBatch1k | **−7.6%** (p=0.000) |
| Decode_Wide_x1000 | ~ (p=0.089, codec-dominated) |
| **geomean** | **−6.8% / +7.3% throughput** |

`allocs/op`, `B/op`, and the wire format are all unchanged — this is pure
call-elimination on the control plane. Per-tag overhead matters most on
small/per-message decodes; the big columnar `Wide` fixture is dominated by
bitpack/codec work, so it moves within noise.

## Origin

A measure-first probe prompted by Filippo Valsorda's
["Efficient Go APIs with the inliner"](https://words.filippo.io/efficient-go-apis-with-the-inliner/).
An earlier decode profile flagged `peekTag`+`next` as a control-plane hotspot;
`-gcflags=-m=2` confirmed `readHeader` blocked inlining. (The other articles
reviewed — rustgo, assembly-mutation, wide-reduction, kyber-math — did not apply:
qdf uses native Go asm with no cgo/ABI overhead, its SIMD correctness is already
gated by scalar-vs-SIMD parity + golden + fuzz, and it does no modular arithmetic.)

## Tests

Full suite green: scalar, `-tags qdf_simd`, `-race` on the header-critical paths
(golden / columnar / nullable / direct / stream / rANS / time / nocopy);
`golangci-lint` clean. No wire or golden change.