### PR TITLE
fix(decode): hostile-input OOM/panic guards + noCopy use-after-free

### DIFF
--- a/bench/bench_qdf.go
+++ b/bench/bench_qdf.go
@@ -94,6 +94,9 @@ func (v *LogBatch) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
 					if err != nil {
 						return 0, err
 					}
+					if err := d.CheckLength(n4, 1); err != nil {
+						return 0, err
+					}
 					v.Entries = make([]LogEntry, n4)
 					for i5 := 0; i5 < n4; i5++ {
 						{

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -926,6 +926,10 @@ func (g *gen) emitDecodeSlice(w io.Writer, lhs string, s *types.Slice, indent st
 	nVar := g.fresh("n")
 	fmt.Fprintf(w, "%s\t\t%s, err := d.ReadArrayHeader()\n", indent, nVar)
 	fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn 0, err\n%s\t\t}\n", indent, indent, indent)
+	// Bound the allocation by remaining input so a hostile length header
+	// can't trigger a multi-GB make before any element is read (matches the
+	// reflect decoder's CheckLength gate).
+	fmt.Fprintf(w, "%s\t\tif err := d.CheckLength(%s, 1); err != nil {\n%s\t\t\treturn 0, err\n%s\t\t}\n", indent, nVar, indent, indent)
 	fmt.Fprintf(w, "%s\t\t%s = make([]%s, %s)\n", indent, lhs, g.typeExprFromType(elem), nVar)
 	loopVar := g.fresh("i")
 	fmt.Fprintf(w, "%s\t\tfor %s := 0; %s < %s; %s++ {\n", indent, loopVar, loopVar, nVar, loopVar)
@@ -965,6 +969,9 @@ func (g *gen) emitDecodeMap(w io.Writer, lhs string, m *types.Map, indent string
 	fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn 0, err\n%s\t\t}\n", indent, indent, indent)
 	keyExpr := g.typeExprFromType(m.Key())
 	valExpr := g.typeExprFromType(m.Elem())
+	// Each map entry is at least two wire bytes (key + value); CheckLength(n,1)
+	// conservatively bounds the alloc by remaining input against a hostile count.
+	fmt.Fprintf(w, "%s\t\tif err := d.CheckLength(%s, 1); err != nil {\n%s\t\t\treturn 0, err\n%s\t\t}\n", indent, nVar, indent, indent)
 	fmt.Fprintf(w, "%s\t\t%s = make(map[%s]%s, %s)\n", indent, lhs, keyExpr, valExpr, nVar)
 	loopVar := g.fresh("i")
 	fmt.Fprintf(w, "%s\t\tfor %s := 0; %s < %s; %s++ {\n", indent, loopVar, loopVar, nVar, loopVar)

--- a/columnar.go
+++ b/columnar.go
@@ -1053,7 +1053,13 @@ func decodeColumnarQuery(d *Decoder, t reflect.Type, plan *columnarPlan, p unsaf
 			continue
 		}
 		col := want[c]
-		if sh.kinds[c].base() != col.kind.base() {
+		// Full-kind compare (incl. the nullable flag), matching the full-decode
+		// path. The scatter below branches on cv.present (the WIRE nullability),
+		// so a wire/plan nullability mismatch must be rejected here: otherwise a
+		// nullable wire column scattered into a non-nullable plan column hits
+		// reflect.SliceOf(nil) (col.elemType==nil) → panic, and the reverse
+		// scatters a raw value into a *T field slot → corruption.
+		if sh.kinds[c] != col.kind {
 			return ErrTypeMismatch
 		}
 		if cv.present != nil {

--- a/decoder_read.go
+++ b/decoder_read.go
@@ -314,6 +314,12 @@ func (d *Decoder) readStringBytes() ([]byte, error) {
 		if d.state == nil {
 			return nil, ErrUnknownStateID
 		}
+		// Reject before the uint32 narrowing: a hostile 10-byte varint above
+		// 2^32 would truncate to a small, possibly-valid id and silently
+		// resolve the WRONG interned string (and desync the LRU/pair chains).
+		if id64 > math.MaxUint32 {
+			return nil, ErrUnknownStateID
+		}
 		out, ok := d.state.get(uint32(id64))
 		if !ok {
 			return nil, ErrUnknownStateID
@@ -333,6 +339,11 @@ func (d *Decoder) readStringBytes() ([]byte, error) {
 		}
 		d.i += n
 		if d.state == nil {
+			return nil, ErrUnknownStateID
+		}
+		// Reject before narrowing: a >2^32 varint would truncate to a small
+		// rank and resolve a wrong entry instead of failing.
+		if rank64 > math.MaxUint32 {
 			return nil, ErrUnknownStateID
 		}
 		// Side-cache lookup: the encoder emits tagStateMTF only when

--- a/internal/codegen_test/oom_codegen_test.go
+++ b/internal/codegen_test/oom_codegen_test.go
@@ -1,0 +1,51 @@
+package cgsample
+
+import (
+	"os"
+	"testing"
+)
+
+// TestOOM_Codegen_HugeArrayHeader pins that generated decoders bound a
+// slice/map allocation by the remaining input (the emitted CheckLength gate),
+// so a hostile length header cannot trigger a multi-GB make before any element
+// is read. Without the gate this OOMs / DoS-es on a dozen bytes.
+func TestOOM_Codegen_HugeArrayHeader(t *testing.T) {
+	if _, err := os.Stat(generatedFile); err != nil {
+		t.Skipf("no generated file %s — run TestGenerate first", generatedFile)
+	}
+	// A body (no 5-byte stream header → UnmarshalQDF treats src as body):
+	//   map8{1}: "tags" -> arr32(0xFFFFFFFF), no elements.
+	// Wire tags: tagMap8=0xD5, fixstr|len=0x84, tagArr32=0xD4.
+	body := []byte{
+		0xD5, 0x01, // map, 1 entry
+		0x84, 't', 'a', 'g', 's', // key "tags"
+		0xD4, 0xFF, 0xFF, 0xFF, 0xFF, // value: arr32 claiming ~4G elements
+	}
+	var s Sample
+	if _, err := s.UnmarshalQDF(body); err == nil {
+		t.Fatal("generated decoder accepted hostile arr32 length without bounds check")
+	}
+	if len(s.Tags) > 1<<20 {
+		t.Fatalf("generated decoder allocated huge slice: %d", len(s.Tags))
+	}
+}
+
+// TestOOM_Codegen_HugeMapHeader is the map-field counterpart.
+func TestOOM_Codegen_HugeMapHeader(t *testing.T) {
+	if _, err := os.Stat(generatedFile); err != nil {
+		t.Skipf("no generated file %s — run TestGenerate first", generatedFile)
+	}
+	// map8{1}: "meta" -> map32(0xFFFFFFFF), no entries. tagMap32=0xD7.
+	body := []byte{
+		0xD5, 0x01,
+		0x84, 'm', 'e', 't', 'a',
+		0xD7, 0xFF, 0xFF, 0xFF, 0xFF,
+	}
+	var s Sample
+	if _, err := s.UnmarshalQDF(body); err == nil {
+		t.Fatal("generated decoder accepted hostile map32 length without bounds check")
+	}
+	if len(s.Meta) > 1<<20 {
+		t.Fatalf("generated decoder allocated huge map: %d", len(s.Meta))
+	}
+}

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -245,6 +245,9 @@ func (v *Sample) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
 					if err != nil {
 						return 0, err
 					}
+					if err := d.CheckLength(n25, 1); err != nil {
+						return 0, err
+					}
 					v.Tags = make([]string, n25)
 					for i26 := 0; i26 < n25; i26++ {
 						{
@@ -268,6 +271,9 @@ func (v *Sample) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
 				} else {
 					n28, err := d.ReadMapHeader()
 					if err != nil {
+						return 0, err
+					}
+					if err := d.CheckLength(n28, 1); err != nil {
 						return 0, err
 					}
 					v.Meta = make(map[string]string, n28)

--- a/nocopy_pool_test.go
+++ b/nocopy_pool_test.go
@@ -1,0 +1,45 @@
+package qdf
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// TestNoCopy_DoesNotLeakIntoUnmarshalT pins that a WithNoCopy() decode never
+// leaves the pooled decoder in aliasing mode for a later acquirer. Before the
+// fix, unmarshal() set dec.noCopy=true and never reset it, so a subsequent
+// UnmarshalT (which did not set noCopy) could inherit it and silently return
+// strings aliasing the caller's input buffer — a use-after-free the race
+// detector cannot catch.
+func TestNoCopy_DoesNotLeakIntoUnmarshalT(t *testing.T) {
+	type S struct {
+		Name string `qdf:"name"`
+	}
+	data, err := Marshal(&S{Name: "a-service-name-long-enough-to-not-be-tiny"}, OptSpeed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	within := func(s string) bool {
+		if len(s) == 0 || len(data) == 0 {
+			return false
+		}
+		p := uintptr(unsafe.Pointer(unsafe.StringData(s)))
+		base := uintptr(unsafe.Pointer(&data[0]))
+		return p >= base && p < base+uintptr(len(data))
+	}
+	for i := range 200 {
+		// Prime the pool: a WithNoCopy decode sets the pooled decoder noCopy=true.
+		var prime S
+		if err := Unmarshal(data, &prime, WithNoCopy()); err != nil {
+			t.Fatal(err)
+		}
+		// UnmarshalT must NOT inherit noCopy — it must return an owned copy.
+		var out S
+		if err := UnmarshalT(data, &out); err != nil {
+			t.Fatal(err)
+		}
+		if within(out.Name) {
+			t.Fatalf("iter %d: UnmarshalT returned a string aliasing the input — noCopy leaked from the pool", i)
+		}
+	}
+}

--- a/oom_protection_test.go
+++ b/oom_protection_test.go
@@ -133,6 +133,27 @@ func TestOOM_NegativeArrayHeaderRejected(t *testing.T) {
 	// is acceptable; the failure mode is "panic" or "OOM-attempting make".
 }
 
+// TestOOM_RLEColumnarBound pins the fix for the one integer codec that could
+// bypass the columnar length bound. RLE can legitimately claim far more
+// elements than remaining bytes (a long run is 2 bytes), so its header read
+// must gate the count through colLenOK; inside a columnar column (colMaxLen
+// set) a tiny body must not be able to claim a multi-GB element count.
+func TestOOM_RLEColumnarBound(t *testing.T) {
+	// kind byte + varuint n = 1<<20 (well under the 1<<30 standalone ceiling,
+	// so only colLenOK can reject it).
+	buf := []byte{qpackKindInt64}
+	buf = appendUvarint(buf, 1<<20)
+	d := &Decoder{buf: buf, colMaxLen: 8} // columnar column of 8 rows
+	if _, err := d.readPackedRLEHeader(qpackKindInt64); err == nil {
+		t.Fatal("RLE header claiming 1<<20 elems accepted under colMaxLen=8")
+	}
+	// Standalone (colMaxLen == 0) still accepts a plausible count.
+	d2 := &Decoder{buf: buf}
+	if _, err := d2.readPackedRLEHeader(qpackKindInt64); err != nil {
+		t.Fatalf("standalone RLE header wrongly rejected: %v", err)
+	}
+}
+
 // CheckLength contract: callers must invoke it before allocating. Verify
 // it rejects clearly-impossible claims.
 func TestOOM_CheckLengthRejectsImpossible(t *testing.T) {

--- a/qdf.go
+++ b/qdf.go
@@ -468,6 +468,11 @@ func unmarshal(data []byte, out any, fields []string, noCopy bool) error {
 	err := decodeReflect(dec, out)
 	dec.buf = nil
 	dec.selectFields = nil
+	// Reset noCopy so a WithNoCopy() decode never leaves the pooled decoder in
+	// aliasing mode for the next acquirer (e.g. UnmarshalT) — that would return
+	// buffer-aliased strings the caller never opted into (a silent
+	// use-after-free, undetectable by the race detector).
+	dec.noCopy = false
 	if cap(dec.deltaScratch) > maxRetainedDeltaScratch {
 		dec.deltaScratch = nil
 	}

--- a/qdf_generic.go
+++ b/qdf_generic.go
@@ -63,6 +63,14 @@ func UnmarshalT[T any](data []byte, out *T) error {
 	dec.i = 0
 	dec.headerRead = false
 	dec.mode = Fast
+	// Start from a clean pooled decoder: it is shared with Unmarshal /
+	// UnmarshalColumns / query paths, any of which may have left noCopy,
+	// selectFields, query, or colIndex set. Inheriting noCopy would silently
+	// alias the input buffer; inheriting selectFields/query would mis-project.
+	dec.noCopy = false
+	dec.colIndex = false
+	dec.selectFields = nil
+	dec.query = nil
 	if dec.state != nil {
 		dec.state.reset()
 	}
@@ -75,6 +83,10 @@ func UnmarshalT[T any](data []byte, out *T) error {
 	}
 	err = td.decode(dec, unsafe.Pointer(out))
 	dec.buf = nil
+	// Don't pin a spike-sized scratch buffer in the pool (mirrors unmarshal).
+	if cap(dec.deltaScratch) > maxRetainedDeltaScratch {
+		dec.deltaScratch = nil
+	}
 	decPool.Put(dec)
 	return err
 }

--- a/qpack_rle.go
+++ b/qpack_rle.go
@@ -89,11 +89,17 @@ func (d *Decoder) readPackedRLEHeader(expectKind byte) (n int, err error) {
 		return 0, ErrInvalidLength
 	}
 	d.i += nr
+	// In a columnar column every codec must yield exactly the struct count
+	// (colMaxLen); RLE can legitimately claim far more elements than remaining
+	// bytes (a long run is 2 bytes), so unlike the body-bounded codecs it MUST
+	// be gated by colLenOK or a tiny body could claim a multi-GB element count.
+	if !d.colLenOK(n64) {
+		return 0, ErrInvalidLength
+	}
 	if n64 > uint64(len(d.buf)-d.i) {
-		// Each run takes at least 2 bytes (1 byte value + 1 byte
-		// runLen). A claim of more elements than remaining bytes
-		// would mean over-long runs — let the body loop catch it,
-		// just guard the obvious lie here to avoid huge allocs.
+		// Standalone decode (colMaxLen == 0): no per-element body bound exists
+		// for RLE, so cap the obvious lie. Each run is ≥ 2 bytes; the body loop
+		// catches subtler over-claims.
 		if n64 > 1<<30 {
 			return 0, ErrInvalidLength
 		}

--- a/query_decode_test.go
+++ b/query_decode_test.go
@@ -2,6 +2,7 @@ package qdf
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -19,6 +20,61 @@ func mkQRows(n int) []qrow {
 		out[i] = qrow{TS: int64(1000 + i), Level: lv[i%3], Code: int32(200 + i%4*100)}
 	}
 	return out
+}
+
+// qrowNullCode mirrors qrow but with a nullable Code, to exercise a
+// wire/plan nullability mismatch through the columnar query (scatter) path.
+type qrowNullCode struct {
+	TS    int64  `qdf:"ts"`
+	Level string `qdf:"level"`
+	Code  *int32 `qdf:"code"`
+}
+
+func mkQRowsNull(n int) []qrowNullCode {
+	out := make([]qrowNullCode, n)
+	lv := []string{"INFO", "WARN", "ERROR"}
+	for i := range out {
+		c := int32(200 + i%4*100)
+		out[i] = qrowNullCode{TS: int64(1000 + i), Level: lv[i%3], Code: &c}
+	}
+	return out
+}
+
+// safeUnmarshalErr runs Unmarshal and converts a panic into an error so a test
+// can assert "rejected cleanly, did not panic".
+func safeUnmarshalErr(data []byte, out any, opts ...QueryOption) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New("panic: " + fmt.Sprint(r))
+		}
+	}()
+	return Unmarshal(data, out, opts...)
+}
+
+// TestQuery_NullabilityMismatchRejected pins that the columnar query (scatter)
+// path rejects a wire/plan nullability mismatch with ErrTypeMismatch instead of
+// panicking (reflect.SliceOf(nil)) or corrupting a *T field slot. The full-decode
+// path already did this; the query path used a base()-only kind compare.
+func TestQuery_NullabilityMismatchRejected(t *testing.T) {
+	// wire non-nullable Code → plan nullable *int32.
+	enc, err := Marshal(mkQRows(32), OptBalanced|OptColumnIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []qrowNullCode
+	if err := safeUnmarshalErr(enc, &out, Where("level", func(s string) bool { return s == "ERROR" })); !errors.Is(err, ErrTypeMismatch) {
+		t.Fatalf("non-nullable→nullable: err=%v, want ErrTypeMismatch (no panic/corruption)", err)
+	}
+
+	// wire nullable *int32 → plan non-nullable int32 (the panic direction).
+	enc2, err := Marshal(mkQRowsNull(32), OptBalanced|OptColumnIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out2 []qrow
+	if err := safeUnmarshalErr(enc2, &out2, Where("level", func(s string) bool { return s == "ERROR" })); !errors.Is(err, ErrTypeMismatch) {
+		t.Fatalf("nullable→non-nullable: err=%v, want ErrTypeMismatch (no panic)", err)
+	}
 }
 
 func TestQuery_ZeroOptionsEqualsPlainUnmarshal(t *testing.T) {


### PR DESCRIPTION
# Decode hardening: hostile-input OOM/panic guards + a noCopy use-after-free

Five decode-path correctness fixes. Decode-only — no wire-format or golden
change, no public API change. Each ships with a regression test.

## noCopy leaks into the pooled decoder (use-after-free)

`Unmarshal(data, out, WithNoCopy())` set `dec.noCopy = true` but never reset it
before the decoder went back to `decPool`. The next caller that doesn't set the
flag — `UnmarshalT` — reused that decoder and returned strings/`[]byte` aliasing
the caller's input buffer without anyone asking for it. Once the input is
reused or freed those values are garbage, and the race detector can't see it.

Reset `noCopy` in `unmarshal`'s cleanup, and make `UnmarshalT` start from a
clean decoder (it also wasn't trimming `deltaScratch`, so a big decode through
it pinned a large scratch buffer in the pool).

## RLE column count wasn't bounded by the struct count

Every integer codec gates its decoded element count through `colLenOK` (which
caps a columnar column at the row count) — except RLE. Because an RLE run is
2 bytes regardless of length, a tiny columnar payload could claim ~1e9 elements
and trigger an ~8 GB `make` before anything validated it. Added the same
`colLenOK` gate; standalone (non-columnar) decode keeps its existing ceiling.

## Generated decoders allocated from an unchecked length

`cmd/qdfgen` emitted `make([]T, n)` / `make(map, n)` straight from the decoded
array/map header, with none of the `CheckLength` bounds the reflect decoder
uses. A crafted `arr32`/`map32` header (~4e9) made a generated `UnmarshalQDF`
attempt a multi-GB allocation up front. Emit `CheckLength` before the `make`;
regenerated the sample and bench output.

## Columnar query scatter ignored the nullable flag

The predicate/projection path compared column kinds with `.base()` (dropping the
nullable bit) but branched the scatter on the wire's nullability. A column whose
nullability differed from the target field slipped through: nullable-wire into a
non-nullable field hit `reflect.SliceOf(nil)` and panicked; the reverse wrote a
raw value into a `*T` slot and corrupted memory. The full-decode path already
compared the full kind — made the query path do the same.

## State-ref id / MTF rank truncated before the range check

`tagStateRef`/`tagStateMTF` narrowed the decoded varint to `uint32` before
validating, so a >2³² value truncated to a small valid id/rank and resolved the
wrong interned string instead of failing. Reject out-of-range values first.

## Tests

`go test ./...` (scalar, `-tags qdf_simd`, `-race`), the codegen/bench/qdfgen
modules, `golangci-lint`, and the fuzz corpus replay all pass. New regressions:
`TestNoCopy_DoesNotLeakIntoUnmarshalT`, `TestOOM_RLEColumnarBound`,
`TestOOM_Codegen_HugeArray/MapHeader`, `TestQuery_NullabilityMismatchRejected`.
