### PR TITLE
fix: harden decode against hostile input (stack-overflow DoS, codec OOM, never-larger)

### DIFF
--- a/columnar.go
+++ b/columnar.go
@@ -641,6 +641,9 @@ func (d *Decoder) readColShape(maxN int) (colShapeRead, error) {
 	if k2 <= 0 {
 		return out, ErrInvalidLength
 	}
+	if idv > uint64(^uint32(0)) {
+		return out, ErrUnknownStateID // would truncate on the uint32 cast below
+	}
 	d.i += k2
 	if idv == 0 {
 		cnt64, k3 := readUvarint(d.buf[d.i:])

--- a/decode_depth_test.go
+++ b/decode_depth_test.go
@@ -1,0 +1,61 @@
+package qdf
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestDecode_DepthGuard_NoStackOverflow builds a hostile deeply-nested payload
+// (arrays nested past DefaultMaxDepth) by driving the low-level Encoder, which
+// bypasses the encoder's own recursion guard. Before the decode depth guard
+// this crashed the process with an unrecoverable `fatal error: stack overflow`.
+// It must now return an error, not crash.
+func TestDecode_DepthGuard_NoStackOverflow(t *testing.T) {
+	enc := NewEncoder(Fast)
+	enc.EnsureHeader()
+	depth := DefaultMaxDepth + 100
+	for range depth {
+		enc.WriteArrayHeader(1)
+	}
+	enc.WriteNil()
+	buf := append([]byte(nil), enc.Bytes()...)
+
+	var v any
+	err := Unmarshal(buf, &v)
+	if err == nil {
+		t.Fatal("expected an error decoding an over-deep payload, got nil")
+	}
+	if !errors.Is(err, ErrCycleDetected) {
+		t.Logf("got error %v (acceptable as long as it is not a crash)", err)
+	}
+}
+
+// TestDecode_DepthGuard_NormalDepthOK confirms the guard does not reject
+// legitimately nested payloads well within DefaultMaxDepth.
+func TestDecode_DepthGuard_NormalDepthOK(t *testing.T) {
+	type node struct {
+		V    int     `qdf:"v"`
+		Next *node   `qdf:"next"`
+		Kids []*node `qdf:"kids"`
+	}
+	// Build a chain ~50 deep — far below the limit, must round-trip.
+	var head *node
+	for i := range 50 {
+		head = &node{V: i, Next: head}
+	}
+	b, err := Marshal(head, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out *node
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatalf("normal-depth decode failed: %v", err)
+	}
+	n := 0
+	for p := out; p != nil; p = p.Next {
+		n++
+	}
+	if n != 50 {
+		t.Fatalf("chain length %d, want 50", n)
+	}
+}

--- a/decoder.go
+++ b/decoder.go
@@ -19,6 +19,15 @@ type Decoder struct {
 	// lifetime.
 	noCopy bool
 
+	// depth / maxDepth bound recursive decode nesting. The wire dictates
+	// nesting for `any`, recursive pointer/slice/map types, so without a
+	// guard a crafted deeply-nested payload overflows the goroutine stack —
+	// an UNRECOVERABLE fatal error, i.e. a remote DoS. descend/ascend
+	// (defer-balanced) cap it at maxDepth (lazily DefaultMaxDepth), returning
+	// ErrCycleDetected, symmetric to the encoder's pointer-cycle guard.
+	depth    int
+	maxDepth int
+
 	// keyCache dedupes map keys and other short repeated strings across
 	// Unmarshal calls on the same pooled decoder.
 	keyCache intern.Cache
@@ -117,10 +126,28 @@ func (d *Decoder) Advance(n int) { d.i += n }
 // next read will skip the header check.
 func (d *Decoder) MarkHeaderRead() { d.headerRead = true }
 
+// descend enters one level of recursive decode, bounding nesting depth so a
+// hostile deeply-nested payload cannot overflow the goroutine stack (an
+// unrecoverable fatal error). Pair with a deferred ascend. maxDepth is lazily
+// initialised so every Decoder construction path is covered.
+func (d *Decoder) descend() error {
+	if d.maxDepth == 0 {
+		d.maxDepth = DefaultMaxDepth
+	}
+	d.depth++
+	if d.depth > d.maxDepth {
+		return ErrCycleDetected
+	}
+	return nil
+}
+
+func (d *Decoder) ascend() { d.depth-- }
+
 // SetInput rebinds the decoder to buf, dropping any prior state table.
 func (d *Decoder) SetInput(buf []byte) {
 	d.buf = buf
 	d.i = 0
+	d.depth = 0
 	d.headerRead = false
 	d.mode = Fast
 	d.colIndex = false

--- a/decoder_skip.go
+++ b/decoder_skip.go
@@ -199,6 +199,9 @@ func (d *Decoder) Skip() error {
 		if n <= 0 {
 			return ErrInvalidLength
 		}
+		if shapeID > uint64(^uint32(0)) {
+			return ErrUnknownStateID // would truncate on the uint32 cast below
+		}
 		d.i += n
 		if d.state == nil {
 			d.state = newDecState()

--- a/qpack_gorilla.go
+++ b/qpack_gorilla.go
@@ -237,6 +237,18 @@ func (d *Decoder) readPackedGorillaHeader(expectKind byte) (n int, firstU64 uint
 		return 0, 0, nil, ErrInvalidLength
 	}
 	d.i += nr
+	// Bound the element count before make([]float, n). In a columnar column
+	// it must equal the row count (colLenOK); standalone, every element past
+	// the first costs >=1 control bit in the body, so a valid n cannot exceed
+	// the remaining bits — this stops a tiny payload from claiming billions of
+	// elements and triggering an OOM (the body-bytes check below does not
+	// bound n, which is read independently).
+	if !d.colLenOK(n64) {
+		return 0, 0, nil, ErrInvalidLength
+	}
+	if rem := uint64(len(d.buf) - d.i); n64 > rem*8+1 {
+		return 0, 0, nil, ErrShortBuffer
+	}
 	n = int(n64)
 	if n == 0 {
 		return n, 0, nil, nil

--- a/qpack_pfor.go
+++ b/qpack_pfor.go
@@ -33,13 +33,18 @@ func pforPlanUnsigned(s []uint64, mn uint64, forBits int) (b int, cost int, ok b
 		}
 	}
 	valLen := uvarintLen(maxDelta) // conservative upper bound per exception value
+	// Each exception is written as uvarint(i-prev) + value; the index gap is at
+	// most n, so uvarintLen(n) is a safe per-exception upper bound. Charging 1
+	// byte (as before) under-counted far-apart outliers, letting PFOR be picked
+	// while its real output exceeded the runner-up — a never-larger violation.
+	gapLen := uvarintLen(uint64(n))
 	hdr := 3 + uvarintLen(uint64(n)) + uvarintLen(mn)
 	bestB, bestCost := -1, int(^uint(0)>>1)
 	suffix := 0 // number of values with width > cand, accumulated as cand descends
 	for cand := forBits - 1; cand >= 0; cand-- {
 		suffix += hist[cand+1]
 		body := (n*cand + 7) >> 3
-		c := hdr + body + uvarintLen(uint64(suffix)) + suffix*(1+valLen)
+		c := hdr + body + uvarintLen(uint64(suffix)) + suffix*(gapLen+valLen)
 		if c < bestCost {
 			bestCost, bestB = c, cand
 		}
@@ -119,13 +124,14 @@ func pforPlanSigned(s []int64, mn int64, forBits int) (b int, cost int, ok bool)
 		}
 	}
 	valLen := uvarintLen(maxDelta)
+	gapLen := uvarintLen(uint64(n)) // uvarint(i-prev) <= uvarint(n); see pforPlanUnsigned
 	hdr := 3 + uvarintLen(uint64(n)) + uvarintLen(zigzagEncode64(mn))
 	bestB, bestCost := -1, int(^uint(0)>>1)
 	suffix := 0
 	for cand := forBits - 1; cand >= 0; cand-- {
 		suffix += hist[cand+1]
 		body := (n*cand + 7) >> 3
-		c := hdr + body + uvarintLen(uint64(suffix)) + suffix*(1+valLen)
+		c := hdr + body + uvarintLen(uint64(suffix)) + suffix*(gapLen+valLen)
 		if c < bestCost {
 			bestCost, bestB = c, cand
 		}

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -628,6 +628,9 @@ func decodeStruct(td *typeDesc) func(*Decoder, unsafe.Pointer) error {
 			if n <= 0 {
 				return ErrInvalidLength
 			}
+			if shapeID > uint64(^uint32(0)) {
+				return ErrUnknownStateID // would truncate on the uint32 cast below
+			}
 			d.i += n
 			if d.state == nil {
 				d.state = newDecState()
@@ -853,6 +856,9 @@ func decodeAny(d *Decoder) (any, error) {
 		shapeID, n := readUvarint(d.buf[d.i:])
 		if n <= 0 {
 			return nil, ErrInvalidLength
+		}
+		if shapeID > uint64(^uint32(0)) {
+			return nil, ErrUnknownStateID // would truncate on the uint32 cast below
 		}
 		d.i += n
 		if d.state == nil {

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -238,6 +238,10 @@ func decodeSlice(t reflect.Type, elem *typeDesc, stride uintptr, colPlan *column
 	elemType := t.Elem()
 	elemDynamic := elemType == reflect.TypeFor[map[string]any]() || elemType.Kind() == reflect.Interface
 	return func(d *Decoder, p unsafe.Pointer) error {
+		if err := d.descend(); err != nil {
+			return err
+		}
+		defer d.ascend()
 		if colPlan != nil {
 			if tag, err := d.peekTag(); err == nil && tag == tagColStruct {
 				if d.query != nil {
@@ -306,6 +310,10 @@ func encodeArray(elem *typeDesc, stride uintptr, n int) func(*Encoder, unsafe.Po
 }
 func decodeArray(elem *typeDesc, stride uintptr, n int) func(*Decoder, unsafe.Pointer) error {
 	return func(d *Decoder, p unsafe.Pointer) error {
+		if err := d.descend(); err != nil {
+			return err
+		}
+		defer d.ascend()
 		m, err := d.ReadArrayHeader()
 		if err != nil {
 			return err
@@ -369,6 +377,10 @@ func decodeMap(t reflect.Type, k, v *typeDesc) func(*Decoder, unsafe.Pointer) er
 	keyType := t.Key()
 	valType := t.Elem()
 	return func(d *Decoder, p unsafe.Pointer) error {
+		if err := d.descend(); err != nil {
+			return err
+		}
+		defer d.ascend()
 		tag, err := d.peekTag()
 		if err != nil {
 			return err
@@ -427,6 +439,10 @@ func encodePtr(elem *typeDesc) func(*Encoder, unsafe.Pointer) error {
 }
 func decodePtr(t reflect.Type, elem *typeDesc) func(*Decoder, unsafe.Pointer) error {
 	return func(d *Decoder, p unsafe.Pointer) error {
+		if err := d.descend(); err != nil {
+			return err
+		}
+		defer d.ascend()
 		tag, err := d.peekTag()
 		if err != nil {
 			return err
@@ -741,6 +757,10 @@ func decodeIface(d *Decoder, p unsafe.Pointer) error {
 
 // decodeAny reads the next value as a generic any, mirroring encoding/json.
 func decodeAny(d *Decoder) (any, error) {
+	if err := d.descend(); err != nil {
+		return nil, err
+	}
+	defer d.ascend()
 	tag, err := d.peekTag()
 	if err != nil {
 		return nil, err

--- a/security_fixes_test.go
+++ b/security_fixes_test.go
@@ -3,6 +3,7 @@ package qdf
 import (
 	"bytes"
 	"errors"
+	"math"
 	"testing"
 )
 
@@ -73,6 +74,44 @@ func TestGorilla_RoundTrip_Smooth(t *testing.T) {
 	for i := range in {
 		if out.F[i] != in[i] {
 			t.Fatalf("idx %d: %v != %v", i, out.F[i], in[i])
+		}
+	}
+}
+
+// TestGorilla_NeverLarger: an adversarial float slice (smooth prefix, high-
+// entropy tail) must never make OptGorillaFloat output exceed the raw-float
+// encoding — the picker projected from a sample and could bloat the wire.
+func TestGorilla_NeverLarger(t *testing.T) {
+	type wrap struct {
+		F []float64 `qdf:"f"`
+	}
+	f := make([]float64, 4000)
+	for i := range f {
+		if i < 33 {
+			f[i] = 1.0
+		} else {
+			f[i] = math.Float64frombits(uint64(i) * 0x9E3779B97F4A7C15)
+		}
+	}
+	raw, err := Marshal(wrap{F: f}, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gor, err := Marshal(wrap{F: f}, OptBalanced|OptGorillaFloat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gor) > len(raw) {
+		t.Fatalf("never-larger violated: gorilla=%d > raw=%d", len(gor), len(raw))
+	}
+	// Round-trip must still be exact.
+	var out wrap
+	if err := Unmarshal(gor, &out); err != nil {
+		t.Fatal(err)
+	}
+	for i := range f {
+		if math.Float64bits(out.F[i]) != math.Float64bits(f[i]) {
+			t.Fatalf("idx %d round-trip mismatch", i)
 		}
 	}
 }

--- a/security_fixes_test.go
+++ b/security_fixes_test.go
@@ -1,6 +1,35 @@
 package qdf
 
-import "testing"
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+type streamCycleNode struct {
+	Name string           `qdf:"name"`
+	Self *streamCycleNode `qdf:"self"`
+}
+
+// TestStream_BrokenAfterMidMessageError: a mid-message encode failure advances
+// cross-message encoder state (interned strings / shapes) that the decoder
+// never saw; emitting further frames would silently desync. The stream must
+// refuse further Encode with ErrStreamBroken instead.
+func TestStream_BrokenAfterMidMessageError(t *testing.T) {
+	var buf bytes.Buffer
+	s := NewStreamEncoder(&buf, Dense)
+	if err := s.Encode(map[string]string{"a": "1"}); err != nil {
+		t.Fatalf("first encode: %v", err)
+	}
+	cyc := &streamCycleNode{Name: "loop"}
+	cyc.Self = cyc // self-cycle → encode error after some state mutates
+	if err := s.Encode(cyc); err == nil {
+		t.Fatal("expected an error encoding a cyclic value")
+	}
+	if err := s.Encode(map[string]string{"b": "2"}); !errors.Is(err, ErrStreamBroken) {
+		t.Fatalf("after mid-message error, Encode = %v, want ErrStreamBroken", err)
+	}
+}
 
 // TestGorilla_HugeN_NoOOM: a tiny Gorilla payload claiming a huge element
 // count must error before allocating, not attempt a multi-GB make([]float64).

--- a/security_fixes_test.go
+++ b/security_fixes_test.go
@@ -1,0 +1,49 @@
+package qdf
+
+import "testing"
+
+// TestGorilla_HugeN_NoOOM: a tiny Gorilla payload claiming a huge element
+// count must error before allocating, not attempt a multi-GB make([]float64).
+func TestGorilla_HugeN_NoOOM(t *testing.T) {
+	for _, kind := range []byte{qpackKindFloat64, qpackKindFloat32} {
+		buf := []byte{kind}
+		buf = appendUvarint(buf, 1<<34) // ~17 billion elements
+		d := &Decoder{buf: buf}
+		var err error
+		if kind == qpackKindFloat64 {
+			_, err = d.readPackedGorillaFloat64Slice()
+		} else {
+			_, err = d.readPackedGorillaFloat32Slice()
+		}
+		if err == nil {
+			t.Fatalf("kind %#x: expected error on huge-n Gorilla payload, got nil", kind)
+		}
+	}
+}
+
+// TestGorilla_RoundTrip_Smooth confirms the bound does not break valid decode.
+func TestGorilla_RoundTrip_Smooth(t *testing.T) {
+	in := make([]float64, 200)
+	for i := range in {
+		in[i] = 100.0 + float64(i)*0.5
+	}
+	type wrap struct {
+		F []float64 `qdf:"f"`
+	}
+	b, err := Marshal(wrap{F: in}, OptCompression)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out wrap
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.F) != len(in) {
+		t.Fatalf("len %d != %d", len(out.F), len(in))
+	}
+	for i := range in {
+		if out.F[i] != in[i] {
+			t.Fatalf("idx %d: %v != %v", i, out.F[i], in[i])
+		}
+	}
+}

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -640,17 +640,25 @@ func encodeSliceFloat64(e *Encoder, p unsafe.Pointer) error {
 		// and nothing grows the wire.
 		if e.gorillaFloat {
 			rawEst := 12 + len(s)*8
-			best := rawEst
-			gorCodec, gorEst := pickF64Codec(s)
-			if gorCodec == qpackGorilla && gorEst < best {
-				best = gorEst
-			}
-			if plan, alpEst, ok := alpPlanFloat64(s); ok && alpEst < best {
-				e.writePackedALPFloat64Slice(s, plan)
-				return nil
-			}
-			if gorCodec == qpackGorilla && gorEst < rawEst {
+			plan, alpEst, alpOK := alpPlanFloat64(s) // ALP estimate is a safe upper bound
+			alpWins := alpOK && alpEst < rawEst
+			// pickF64Codec only projects Gorilla from a sample prefix, which can
+			// be wildly optimistic on a smooth-prefix/high-entropy-tail slice.
+			// Emit Gorilla for real and measure it; keep it only when it is
+			// actually smaller than raw (and than ALP) — a true never-larger
+			// gate. The rollback re-emits raw/ALP only on the rare lose case, so
+			// the common smooth-data path still encodes Gorilla once.
+			if gorCodec, _ := pickF64Codec(s); gorCodec == qpackGorilla {
+				start := len(e.buf)
 				e.writePackedGorillaFloat64Slice(s)
+				gorActual := len(e.buf) - start
+				if gorActual < rawEst && !(alpWins && alpEst < gorActual) {
+					return nil
+				}
+				e.buf = e.buf[:start] // Gorilla did not win — roll back
+			}
+			if alpWins {
+				e.writePackedALPFloat64Slice(s, plan)
 				return nil
 			}
 		}

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -652,7 +652,7 @@ func encodeSliceFloat64(e *Encoder, p unsafe.Pointer) error {
 				start := len(e.buf)
 				e.writePackedGorillaFloat64Slice(s)
 				gorActual := len(e.buf) - start
-				if gorActual < rawEst && !(alpWins && alpEst < gorActual) {
+				if gorActual < rawEst && (!alpWins || alpEst >= gorActual) {
 					return nil
 				}
 				e.buf = e.buf[:start] // Gorilla did not win — roll back

--- a/stream.go
+++ b/stream.go
@@ -14,7 +14,19 @@ type StreamEncoder struct {
 	w   io.Writer
 	enc *Encoder
 	buf *[]byte
+	// broken is set when a mid-message encode fails. The body bytes are rolled
+	// back, but the encoder's cross-message state (intern table, declared
+	// struct/map shapes, LRU, predictors) may have advanced past what the
+	// decoder saw — so every later frame's back-refs would desync. Once broken,
+	// further Encode is refused; the already-buffered valid prefix can still be
+	// Flushed.
+	broken bool
 }
+
+// ErrStreamBroken is returned by StreamEncoder.Encode after a previous Encode
+// failed mid-message: the cross-message encoder state can no longer be trusted,
+// so the stream must be abandoned (the valid prefix may still be flushed).
+var ErrStreamBroken = errors.New("qdf: stream encoder broken by a prior mid-message error")
 
 // NewStreamEncoder returns a stream encoder backed by w. Dense mode
 // activates the full balanced codec set (OptBalanced); Fast mode
@@ -55,6 +67,9 @@ func (s *StreamEncoder) Encode(v any) error {
 	if s.enc == nil {
 		return io.ErrClosedPipe
 	}
+	if s.broken {
+		return ErrStreamBroken
+	}
 	// One-per-stream header preamble, outside the frames.
 	if !s.enc.headerOut {
 		s.enc.writeHeader()
@@ -67,6 +82,10 @@ func (s *StreamEncoder) Encode(v any) error {
 	bodyStart := len(s.enc.buf)
 	if err := encodeReflect(s.enc, v); err != nil {
 		s.enc.buf = s.enc.buf[:start] // drop the reservation + any partial body
+		// The buffer is rolled back, but encoder state (intern IDs, shape
+		// declarations, predictors) may have advanced — desyncing every later
+		// frame. Poison the stream so no further frame is emitted against it.
+		s.broken = true
 		return err
 	}
 	n := len(s.enc.buf) - bodyStart


### PR DESCRIPTION
Whole-project adversarial review (multi-agent) of the encode/decode paths,
codecs, columnar/predicate engine, FSST/rANS, streaming, and reflection.
Every finding was reproduced against `main` before fixing; one agent-reported
issue did not reproduce and was downgraded (see below).

No wire-format change. All codecs stay self-describing and backward/forward
compatible. Full suite + `-race` + 20s decode fuzz + `vet` green.

**Fixes**

- **CRITICAL — decode recursion is now depth-bounded (stack-overflow DoS).**
  The decoder had no depth guard (the encoder does). A crafted deeply-nested
  payload (`any`, recursive pointer/slice/map types) overflowed the goroutine
  stack — an *unrecoverable* `fatal error: stack overflow` that `recover()`
  cannot catch, i.e. a remote DoS from a small input (reproduced with ~2 MB of
  nested arrays decoded into `any`). Added `descend()/ascend()` (defer-balanced,
  capped at `DefaultMaxDepth`, returns `ErrCycleDetected`) to
  `decodeSlice`/`decodeArray`/`decodeMap`/`decodePtr`/`decodeAny`, mirroring the
  encoder's pointer-cycle guard.

- **HIGH — Gorilla float decode bounds the element count before allocating
  (OOM DoS).** `readPackedGorillaHeader` read `n` and then `make([]float64, n)`
  with only the compressed *body bytes* bounded, never `n` itself. A ~12-byte
  payload could claim `n = 2^34` and force a ~128 GB allocation. `n` is now
  bounded by `colLenOK` (the columnar row count) and, standalone, by the
  remaining bits + 1 (every element past the first costs ≥1 control bit).
  Covers `float64` and `float32`.

- **MED — reject wire shape/column IDs ≥ 2³² before the `uint32` narrowing.**
  `decodeStruct`, `decodeAny`, the skip path, and the columnar shape lookup
  narrowed a `uint64` wire ID to `uint32` with no range check, so a crafted
  `id ≥ 2³²` aliased a real `(id mod 2³²)` shape instead of being rejected —
  wrong-but-valid decode on hostile input. Rejected up front.

- **MED — Gorilla codec is now a true never-larger gate.** `pickF64Codec`
  projected Gorilla's size from a 32-element prefix; a smooth-prefix /
  high-entropy-tail slice was encoded with Gorilla even though the result was
  larger than raw (measured +746 B). The encoder now emits Gorilla for real,
  measures the actual byte count, and keeps it only when it is smaller than raw
  (and than the ALP upper-bound estimate); otherwise it rolls back. Smooth data
  still encodes Gorilla exactly once.

- **MED — PFOR cost model is a strict upper bound.** The plan charged 1 byte per
  exception index gap, but the encoder writes `uvarint(i-prev)` (2–5 bytes for
  far-apart outliers), so PFOR could be picked while its real output exceeded
  the runner-up. The cost now charges `uvarintLen(n)` per exception (the gap is
  ≤ n), making the never-larger gate exact for both signed and unsigned slices.

- **LOW (defensive) — `StreamEncoder` is poisoned after a mid-message error.**
  On an `encodeReflect` failure the body bytes are rolled back, but the
  cross-message encoder state (intern IDs, shape declarations, predictors) may
  have advanced past what the decoder saw. (The agent flagged this as silent
  corruption; in practice the relative MTF/repeat back-refs mask it and a repro
  decoded correctly — hence "defensive".) A subsequent `Encode` now returns
  `ErrStreamBroken`; the already-buffered valid prefix can still be `Flush`ed.

**Reviewed clean** (no change needed): decode hostile-input allocation bounds,
columnar 3-valued-logic / nil-F-complement / selective-seek bounds / nullable
popcount guards, FSST/rANS (table validity, no infinite loop, real never-larger,
`FSSTDict` read-only concurrency), the time codec, `typeDesc` `sync.Map`
concurrency, `unsafe.Add` strides, and reused-scratch fill.