### PR TITLE
feat: map key-set shape interning (OptMapShape) — −24% encode CPU / −26% wire on tag-maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ emission order. Use `OptSpeed` if you hash or sign the wire.
 | `OptPairPred`     | Markov-1 successor predictor (`tagStatePair`, `0xEA`). |
 | `OptMTF`          | Move-to-Front rank coding on state-refs (`tagStateMTF`, `0xE9`). |
 | `OptColumnIndex`  | Column-length index on columnar `[]struct` for selective decode (opt-in, ~4 B/column; default wire unchanged when off). |
+| `OptMapShape`     | Key-set interning for `map[string]V` fields (declare keys once, reuse by shape id). ~−24 % encode CPU and ~−26 % wire on recurring-key tag-maps (telemetry/logs); opt-in, default wire unchanged when off. |
 
 | Bundle | Composition |
 | ------ | ----------- |

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -121,6 +121,7 @@ order:
 |  5  | `OptGorillaFloat` | Gorilla XOR codec for `[]float64` / `[]float32` (~70 % wire reduction on smooth time-series, ~10× CPU/slice) | `OptQPack` |
 |  6  | `OptRANS` | Order-0 rANS entropy pass over the whole body, applied only when it shrinks (`FlagRANS`) — never larger, ~4–6× CPU where it fires, whole-buffer (not streaming) | — |
 |  7  | `OptFSST` | FSST substring-level codec for high-cardinality columnar string columns (URLs, log lines, paths); tried after the dictionary codec bails; never larger; columnar `[]struct` only | `OptQPack` + columnar |
+|  9  | `OptMapShape` | Key-set interning for `map[string]V` fields: a recurring set of keys (telemetry tags, log labels) is declared once via `tagMapShape`; later maps emit only the shape ID + values in canonical key order. ~−24 % encode CPU and ~−26 % wire on tag-map-heavy rows; opt-in. | `OptDense` |
 
 `OptSpeed = 0`. `OptBalanced = OptDense | OptQPack | OptShapeIntern
 | OptPairPred | OptMTF`. `OptCompression = OptBalanced | OptGorillaFloat

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -29,6 +29,15 @@ func FuzzDecoder_NeverPanics(f *testing.F) {
 		}
 		f.Add(bd)
 	}
+	// OptMapShape seeds so the fuzzer explores the tagMapShape-in-map path.
+	for _, v := range []any{
+		map[string]int{"a": 1, "b": 2, "c": 3},
+		[]map[string]string{{"version": "v1", "client": "go"}, {"version": "v2", "client": "go"}},
+	} {
+		if bm, err := Marshal(v, OptBalanced|OptMapShape); err == nil {
+			f.Add(bm)
+		}
+	}
 	f.Fuzz(func(t *testing.T, data []byte) {
 		// Try decoding into a few different shapes. None should panic.
 		var s string

--- a/internal/mapsgen/main.go
+++ b/internal/mapsgen/main.go
@@ -255,6 +255,15 @@ func emitPair(buf *bytes.Buffer, p pair) {
 	fmt.Fprintf(buf, "func encode%s(e *Encoder, p unsafe.Pointer) error {\n", fnName)
 	fmt.Fprintf(buf, "\tm := *(*%s)(p)\n", mapTy)
 	fmt.Fprintf(buf, "\tif m == nil {\n\t\te.WriteNil()\n\t\treturn nil\n\t}\n")
+	if p.K.suffix == "String" {
+		// OptMapShape fast path: recurring key-sets emit a shape header +
+		// values in canonical order via the shared generic helper.
+		fmt.Fprintf(buf, "\tif len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {\n")
+		fmt.Fprintf(buf, "\t\tfor _, k := range mapStringShapeOrder(e, m) {\n")
+		fmt.Fprintf(buf, "\t\t\tv := m[k]\n")
+		fmt.Fprintf(buf, "\t\t\t%s\n", p.V.writeBlock("v"))
+		fmt.Fprintf(buf, "\t\t}\n\t\treturn nil\n\t}\n")
+	}
 	fmt.Fprintf(buf, "\te.WriteMapHeader(len(m))\n")
 	fmt.Fprintf(buf, "\tfor k, v := range m {\n")
 	fmt.Fprintf(buf, "\t\t%s\n", indent(p.K.writeBlock("k")))
@@ -265,6 +274,17 @@ func emitPair(buf *bytes.Buffer, p pair) {
 	fmt.Fprintf(buf, "func decode%s(d *Decoder, p unsafe.Pointer) error {\n", fnName)
 	fmt.Fprintf(buf, "\tt, err := d.peekTag()\n\tif err != nil {\n\t\treturn err\n\t}\n")
 	fmt.Fprintf(buf, "\tif t == tagNil {\n\t\td.i++\n\t\t*(*%s)(p) = nil\n\t\treturn nil\n\t}\n", mapTy)
+	if p.K.suffix == "String" {
+		// OptMapShape decode: a tagMapShape header carries the ordered keys;
+		// read len(names) values in that order.
+		fmt.Fprintf(buf, "\tif t == tagMapShape {\n")
+		fmt.Fprintf(buf, "\t\tnames, err := decodeMapStringShapeHeader(d)\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n")
+		fmt.Fprintf(buf, "\t\tm := make(%s, len(names))\n", mapTy)
+		fmt.Fprintf(buf, "\t\tfor _, k := range names {\n")
+		fmt.Fprintf(buf, "\t\t\t%s\n", p.V.readBlock("v"))
+		fmt.Fprintf(buf, "\t\t\tm[k] = v\n")
+		fmt.Fprintf(buf, "\t\t}\n\t\t*(*%s)(p) = m\n\t\treturn nil\n\t}\n", mapTy)
+	}
 	fmt.Fprintf(buf, "\tn, err := d.ReadMapHeader()\n\tif err != nil {\n\t\treturn err\n\t}\n")
 	fmt.Fprintf(buf, "\tif err := d.CheckLength(n, 2); err != nil {\n\t\treturn err\n\t}\n")
 	fmt.Fprintf(buf, "\tm := make(%s, n)\n", mapTy)
@@ -324,12 +344,24 @@ func main() {
 		log.Fatalf("\nformat: %v", err)
 	}
 
-	// Generator runs from internal/mapsgen — write into repo root.
+	// Locate the module root by walking up to the go.mod, so the generator
+	// works whether invoked from internal/mapsgen or via `go generate ./...`
+	// (which runs it with the repo root as the working directory).
 	wd, err := os.Getwd()
 	if err != nil {
 		log.Fatal(err)
 	}
-	root := filepath.Clean(filepath.Join(wd, "..", ".."))
+	root := wd
+	for {
+		if _, err := os.Stat(filepath.Join(root, "go.mod")); err == nil {
+			break
+		}
+		parent := filepath.Dir(root)
+		if parent == root {
+			log.Fatalf("could not find go.mod above %s", wd)
+		}
+		root = parent
+	}
 	out := filepath.Join(root, "maps_fast_generated.go")
 	if err := os.WriteFile(out, src, 0o600); err != nil {
 		log.Fatal(err)

--- a/map_shape.go
+++ b/map_shape.go
@@ -1,0 +1,136 @@
+package qdf
+
+import "slices"
+
+// Shared helpers for OptMapShape — map key-set interning. The reflect map
+// encoder (encodeStringMapShaped in reflect_encode.go) and the generated
+// concrete fast paths (maps_fast_generated.go) both reuse the encState /
+// decState shape machinery through these. See
+// docs/superpowers/specs/2026-06-04-map-shape-interning-design.md.
+
+// mapStringShapeOrder emits the tagMapShape declare-or-reuse header for a
+// concrete string-keyed map and returns the canonical (sorted) key order the
+// caller must emit values in. Generic over the value type so the generated fast
+// paths stay reflection-free.
+//
+// Hot reuse path: one range for the order-independent set-hash, a membership
+// check per bound key (guards a set-hash collision), then the bound order — no
+// key slice allocated. Declare path (first sight of a key-set): gather + sort +
+// intern the keys; rare. Collision/mismatch degrades to a fresh declaration,
+// never to wrong data (cf. hash-key-sampling-collision).
+//
+// Callers must gate on len(m) > 0, e.state != nil, OptMapShape and OptDense
+// before calling.
+func mapStringShapeOrder[V any](e *Encoder, m map[string]V) []string {
+	// Ensure the stream header precedes the first tag. For a top-level map the
+	// plain path emits it via WriteMapHeader, which this shape path bypasses.
+	// Idempotent (guarded by e.headerOut).
+	e.writeHeader()
+	n := len(m)
+	st := e.state
+
+	// Fast path: a run of homogeneous rows reuses the previous shape. Verify
+	// membership directly (len + every bound key present) — no set-hash, no
+	// registry scan. Exact, so collision-proof.
+	if st.lastMapShapeID != 0 && len(st.lastMapShapeKeys) == n && mapHasAll(m, st.lastMapShapeKeys) {
+		e.buf = append(e.buf, tagMapShape)
+		e.buf = appendUvarint(e.buf, uint64(st.lastMapShapeID))
+		return st.lastMapShapeKeys
+	}
+
+	// Key-set changed: hash to find an earlier shape, else declare.
+	var setHash uint64
+	for k := range m {
+		setHash += internKeyHash(k) // commutative: order-independent
+	}
+	if id, ok := st.mapShapeFind(setHash, n); ok {
+		order := st.mapShapeKeys(id)
+		if len(order) == n && mapHasAll(m, order) {
+			st.lastMapShapeID, st.lastMapShapeKeys = id, order
+			e.buf = append(e.buf, tagMapShape)
+			e.buf = appendUvarint(e.buf, uint64(id))
+			return order
+		}
+		// set-hash collision or different key-set → declare a fresh shape.
+	}
+	keys := make([]string, 0, n)
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	id := st.shapeDeclareEnc()
+	st.mapShapeRegister(setHash, n, keys, id)
+	st.lastMapShapeID, st.lastMapShapeKeys = id, st.mapShapes[len(st.mapShapes)-1].keys
+	e.buf = append(e.buf, tagMapShape)
+	e.buf = appendUvarint(e.buf, 0)
+	e.buf = appendUvarint(e.buf, uint64(n))
+	for _, k := range keys {
+		e.WriteString(k)
+	}
+	return keys
+}
+
+// mapHasAll reports whether m contains every key in keys.
+func mapHasAll[V any](m map[string]V, keys []string) bool {
+	for _, k := range keys {
+		if _, ok := m[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// decodeMapStringShapeHeader consumes a tagMapShape header (the caller has
+// peeked tag == tagMapShape but not advanced) and returns the ordered key
+// names for the shape. On a declaration it reads and registers the keys; on a
+// reuse it looks the shape up. The caller then reads len(names) values in order.
+// Shared by the reflect decodeMap branch and the generated fast paths.
+func decodeMapStringShapeHeader(d *Decoder) ([]string, error) {
+	d.i++ // consume tagMapShape
+	shapeID, sz := readUvarint(d.buf[d.i:])
+	if sz <= 0 {
+		return nil, ErrInvalidLength
+	}
+	// Reject a shape ID that would truncate on the uint32 narrowing below: a
+	// crafted id >= 2^32 must not alias a real (id mod 2^32) shape.
+	if shapeID > uint64(^uint32(0)) {
+		return nil, ErrUnknownStateID
+	}
+	d.i += sz
+	if d.state == nil {
+		d.state = newDecState()
+	}
+	if shapeID == 0 {
+		cnt64, sz := readUvarint(d.buf[d.i:])
+		if sz <= 0 {
+			return nil, ErrInvalidLength
+		}
+		d.i += sz
+		cnt := int(cnt64)
+		if err := d.CheckLength(cnt, 1); err != nil {
+			return nil, err
+		}
+		sh := d.state.shapeDeclare()
+		sh.keyIDs = make([]uint32, 0, cnt)
+		keys := make([]string, 0, cnt)
+		for range cnt {
+			kb, err := d.readStringBytes()
+			if err != nil {
+				return nil, err
+			}
+			keys = append(keys, d.keyCache.Make(kb))
+			if d.state.lastID != lruInvalidID {
+				sh.keyIDs = append(sh.keyIDs, d.state.lastID)
+			} else {
+				sh.keyIDs = append(sh.keyIDs, 0)
+			}
+		}
+		sh.names = keys
+		return keys, nil
+	}
+	sh := d.state.shapeLookup(uint32(shapeID))
+	if sh == nil {
+		return nil, ErrUnknownStateID
+	}
+	return sh.names, nil
+}

--- a/map_shape_test.go
+++ b/map_shape_test.go
@@ -1,0 +1,455 @@
+package qdf
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestOptMapShape_Bit(t *testing.T) {
+	if OptMapShape == 0 {
+		t.Fatal("OptMapShape must be a nonzero bit")
+	}
+	for _, o := range []Options{OptDense, OptQPack, OptShapeIntern, OptPairPred, OptMTF, OptGorillaFloat, OptRANS, OptColumnIndex, OptFSST} {
+		if OptMapShape == o {
+			t.Fatalf("OptMapShape collides with %v", o)
+		}
+	}
+	if OptBalanced.Has(OptMapShape) {
+		t.Fatal("OptMapShape must not be in OptBalanced in v1")
+	}
+	if OptCompression.Has(OptMapShape) {
+		t.Fatal("OptMapShape must not be in OptCompression in v1")
+	}
+}
+
+func TestEncStateMapShape_Registry(t *testing.T) {
+	st := newEncState()
+	if _, ok := st.mapShapeFind(0x1234, 2); ok {
+		t.Fatal("empty registry must miss")
+	}
+	keys := []string{"client", "version"} // canonical (sorted)
+	st.mapShapeRegister(0x1234, 2, keys, 7)
+	id, ok := st.mapShapeFind(0x1234, 2)
+	if !ok || id != 7 {
+		t.Fatalf("find = (%d,%v), want (7,true)", id, ok)
+	}
+	if got := st.mapShapeKeys(7); len(got) != 2 || got[0] != "client" || got[1] != "version" {
+		t.Fatalf("mapShapeKeys = %v", got)
+	}
+	// Length disambiguates a setHash collision across different set sizes.
+	if _, ok := st.mapShapeFind(0x1234, 3); ok {
+		t.Fatal("len mismatch must miss")
+	}
+	// Register mutates nothing the caller owns: caller slice change must not leak.
+	keys[0] = "MUTATED"
+	if got := st.mapShapeKeys(7); got[0] != "client" {
+		t.Fatal("mapShapeRegister must clone keys")
+	}
+	st.reset()
+	if _, ok := st.mapShapeFind(0x1234, 2); ok {
+		t.Fatal("reset must clear the registry")
+	}
+}
+
+func roundTripMapShape[V comparable](t *testing.T, in map[string]V) {
+	t.Helper()
+	type wrap struct {
+		M map[string]V `qdf:"m"`
+	}
+	b, err := Marshal(wrap{M: in}, OptBalanced|OptMapShape)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out wrap
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.M) != len(in) {
+		t.Fatalf("len = %d, want %d", len(out.M), len(in))
+	}
+	for k, want := range in {
+		if got, ok := out.M[k]; !ok || got != want {
+			t.Fatalf("key %q = (%v,%v), want %v", k, got, ok, want)
+		}
+	}
+}
+
+func TestMapShape_RoundTrip_Single(t *testing.T) {
+	roundTripMapShape(t, map[string]string{"version": "v3.42.1", "client": "go-client/1.20"})
+	roundTripMapShape(t, map[string]int{"a": 1, "b": 2, "c": 3})
+	roundTripMapShape(t, map[string]string{})
+	roundTripMapShape(t, map[string]string{"only": "one"})
+}
+
+func TestMapShape_RoundTrip_SliceRecurring(t *testing.T) {
+	type row struct {
+		ID   int               `qdf:"id"`
+		Tags map[string]string `qdf:"tags"`
+	}
+	in := make([]row, 50)
+	for i := range in {
+		in[i] = row{ID: i, Tags: map[string]string{"version": "v3.42.1", "client": "go-client/1.20"}}
+	}
+	b, err := Marshal(in, OptBalanced|OptMapShape)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []row
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != len(in) {
+		t.Fatalf("len %d != %d", len(out), len(in))
+	}
+	for i := range in {
+		if out[i].ID != in[i].ID || out[i].Tags["version"] != "v3.42.1" || out[i].Tags["client"] != "go-client/1.20" {
+			t.Fatalf("row %d mismatch: %+v", i, out[i])
+		}
+	}
+}
+
+func TestMapShape_RoundTrip_VaryingKeysets(t *testing.T) {
+	type row struct {
+		Tags map[string]mapShapeVal `qdf:"tags"`
+	}
+	in := []row{
+		{Tags: map[string]mapShapeVal{"a": {1, 1}}},
+		{Tags: map[string]mapShapeVal{"a": {1, 1}, "b": {2, 2}}},
+		{Tags: map[string]mapShapeVal{"c": {3, 3}}},
+		{Tags: map[string]mapShapeVal{"a": {1, 1}, "b": {2, 2}}},
+		{Tags: nil},
+	}
+	b, err := Marshal(in, OptBalanced|OptMapShape)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []row
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	for i := range in {
+		if len(out[i].Tags) != len(in[i].Tags) {
+			t.Fatalf("row %d len %d != %d", i, len(out[i].Tags), len(in[i].Tags))
+		}
+		for k, vv := range in[i].Tags {
+			if out[i].Tags[k] != vv {
+				t.Fatalf("row %d key %q mismatch", i, k)
+			}
+		}
+	}
+}
+
+// mapShapeVal is a struct value type with NO generated map fast path, so a
+// map[string]mapShapeVal exercises the reflect encodeMap -> encodeStringMapShaped
+// path (the fast paths in maps_fast_generated.go cover only scalar/string
+// values and are wired in a later phase).
+type mapShapeVal struct {
+	X int `qdf:"x"`
+	Y int `qdf:"y"`
+}
+
+func TestMapShape_Deterministic(t *testing.T) {
+	type wrap struct {
+		M map[string]mapShapeVal `qdf:"m"`
+	}
+	v := wrap{M: map[string]mapShapeVal{"z": {1, 1}, "a": {2, 2}, "m": {3, 3}}}
+	b1, _ := Marshal(v, OptBalanced|OptMapShape)
+	b2, _ := Marshal(v, OptBalanced|OptMapShape)
+	if !bytes.Equal(b1, b2) {
+		t.Fatal("encode not deterministic under OptMapShape")
+	}
+}
+
+// TestMapShape_ReflectShapeFires proves the shape path is actually engaged on
+// the reflect map encoder: a slice of rows with a recurring key-set must encode
+// strictly smaller with OptMapShape than without (keys emitted once), and still
+// round-trip.
+func TestMapShape_ReflectShapeFires(t *testing.T) {
+	type row struct {
+		Tags map[string]mapShapeVal `qdf:"tags"`
+	}
+	in := make([]row, 100)
+	for i := range in {
+		in[i] = row{Tags: map[string]mapShapeVal{
+			"alpha": {i, i + 1}, "bravo": {i + 2, i + 3}, "charlie": {i + 4, i + 5},
+		}}
+	}
+	plain, err := Marshal(in, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	shaped, err := Marshal(in, OptBalanced|OptMapShape)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(shaped) >= len(plain) {
+		t.Fatalf("shape did not engage: shaped=%d plain=%d", len(shaped), len(plain))
+	}
+	var out []row
+	if err := Unmarshal(shaped, &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != len(in) {
+		t.Fatalf("len %d != %d", len(out), len(in))
+	}
+	for i := range in {
+		for k, vv := range in[i].Tags {
+			if out[i].Tags[k] != vv {
+				t.Fatalf("row %d key %q = %+v want %+v", i, k, out[i].Tags[k], vv)
+			}
+		}
+	}
+}
+
+// TestMapShape_CrossMode verifies that flag-off and flag-on encodings both
+// decode to the same value. (Byte-stability of the flag-off path is NOT
+// asserted: plain map encoding ranges the Go runtime map in non-deterministic
+// order — a pre-existing property. The OptMapShape path, by contrast, is
+// deterministic; see TestMapShape_Deterministic.)
+func TestMapShape_CrossMode(t *testing.T) {
+	type row struct {
+		ID   int               `qdf:"id"`
+		Tags map[string]string `qdf:"tags"`
+	}
+	in := []row{{ID: 1, Tags: map[string]string{"a": "1", "b": "2"}}}
+	off, _ := Marshal(in, OptBalanced)
+	onb, _ := Marshal(in, OptBalanced|OptMapShape)
+	var a, b []row
+	if err := Unmarshal(off, &a); err != nil {
+		t.Fatal(err)
+	}
+	if err := Unmarshal(onb, &b); err != nil {
+		t.Fatal(err)
+	}
+	if a[0].Tags["a"] != b[0].Tags["a"] || a[0].Tags["b"] != b[0].Tags["b"] || a[0].ID != b[0].ID {
+		t.Fatal("cross-mode decode mismatch")
+	}
+}
+
+func TestMapShape_CollisionStress(t *testing.T) {
+	type row struct {
+		Tags map[string]mapShapeVal `qdf:"tags"`
+	}
+	in := make([]row, 200)
+	for i := range in {
+		in[i] = row{Tags: map[string]mapShapeVal{
+			fmt.Sprintf("k%d", i):   {1, 1},
+			fmt.Sprintf("k%d", i+1): {2, 2},
+		}}
+	}
+	b, err := Marshal(in, OptBalanced|OptMapShape)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []row
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	for i := range in {
+		for k, vv := range in[i].Tags {
+			if out[i].Tags[k] != vv {
+				t.Fatalf("row %d key %q corrupted", i, k)
+			}
+		}
+	}
+}
+
+func benchMapShapeCorpus(n int) []struct {
+	ID   int               `qdf:"id"`
+	Svc  string            `qdf:"svc"`
+	Tags map[string]string `qdf:"tags"`
+} {
+	type row struct {
+		ID   int               `qdf:"id"`
+		Svc  string            `qdf:"svc"`
+		Tags map[string]string `qdf:"tags"`
+	}
+	_ = row{}
+	out := make([]struct {
+		ID   int               `qdf:"id"`
+		Svc  string            `qdf:"svc"`
+		Tags map[string]string `qdf:"tags"`
+	}, n)
+	svcs := []string{"ingest", "auth", "billing", "api-gateway"}
+	for i := range out {
+		out[i].ID = i
+		out[i].Svc = svcs[i%len(svcs)]
+		out[i].Tags = map[string]string{"version": "v3.42.1", "client": "go-client/1.20"}
+	}
+	return out
+}
+
+func BenchmarkMapShape_Telemetry(b *testing.B) {
+	in := benchMapShapeCorpus(1000)
+	b.Run("off", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_, _ = Marshal(in, OptBalanced)
+		}
+	})
+	b.Run("on", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_, _ = Marshal(in, OptBalanced|OptMapShape)
+		}
+	})
+}
+
+func TestMapShape_Malformed(t *testing.T) {
+	type wrap struct {
+		M map[string]string `qdf:"m"`
+	}
+	in := wrap{M: map[string]string{"a": "1", "b": "2", "c": "3"}}
+	b, err := Marshal(in, OptBalanced|OptMapShape)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Every truncation must error, never panic.
+	for cut := 0; cut < len(b); cut++ {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panic on truncated input (cut=%d): %v", cut, r)
+				}
+			}()
+			var out wrap
+			_ = Unmarshal(b[:cut], &out)
+		}()
+	}
+}
+
+// TestMapShape_Nested exercises mapHolderCache re-entrancy: a reflect map whose
+// value is itself a reflect map (both take the generic path) must round-trip —
+// the inner acquire sees the cache busy and uses a local holder pair.
+func TestMapShape_Nested(t *testing.T) {
+	type wrap struct {
+		M map[string]map[string]mapShapeVal `qdf:"m"`
+	}
+	in := wrap{M: map[string]map[string]mapShapeVal{
+		"outer1": {"a": {1, 2}, "b": {3, 4}},
+		"outer2": {"a": {5, 6}, "b": {7, 8}},
+	}}
+	b, err := Marshal(in, OptBalanced|OptMapShape)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out wrap
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.M) != len(in.M) {
+		t.Fatalf("outer len %d != %d", len(out.M), len(in.M))
+	}
+	for ok, im := range in.M {
+		om := out.M[ok]
+		if len(om) != len(im) {
+			t.Fatalf("inner %q len %d != %d", ok, len(om), len(im))
+		}
+		for ik, iv := range im {
+			if om[ik] != iv {
+				t.Fatalf("[%q][%q] = %+v want %+v", ok, ik, om[ik], iv)
+			}
+		}
+	}
+}
+
+// TestMapShape_PointerValues: map[string]*struct value type through the reflect
+// path (nil + non-nil pointers) round-trips under OptMapShape.
+func TestMapShape_PointerValues(t *testing.T) {
+	type row struct {
+		M map[string]*mapShapeVal `qdf:"m"`
+	}
+	in := []row{
+		{M: map[string]*mapShapeVal{"x": {1, 1}, "y": {2, 2}}},
+		{M: map[string]*mapShapeVal{"x": {3, 3}, "y": nil}},
+		{M: map[string]*mapShapeVal{"x": {4, 4}, "y": {5, 5}}},
+	}
+	b, err := Marshal(in, OptBalanced|OptMapShape)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []row
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	for i := range in {
+		for k, want := range in[i].M {
+			got := out[i].M[k]
+			switch {
+			case want == nil && got != nil:
+				t.Fatalf("row %d key %q: want nil, got %+v", i, k, got)
+			case want != nil && (got == nil || *got != *want):
+				t.Fatalf("row %d key %q mismatch", i, k)
+			}
+		}
+	}
+}
+
+// TestMapShape_RecursiveType: a self-recursive map type (type T map[string]T)
+// must round-trip — the directly-recursive same-type case stresses the cache
+// busy-guard hardest.
+func TestMapShape_RecursiveType(t *testing.T) {
+	type rec map[string]any
+	in := rec{"a": rec{"b": rec{"c": "leaf"}}, "x": "y"}
+	b, err := Marshal(in, OptBalanced|OptMapShape)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out rec
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out["x"] != "y" {
+		t.Fatalf("x=%v", out["x"])
+	}
+}
+
+// TestMapShape_TopLevelMap: a map encoded as the ROOT value (not a struct
+// field) must still emit the stream header before tagMapShape. Regression for
+// a "bad magic" decode failure when the shape path bypassed WriteMapHeader.
+func TestMapShape_TopLevelMap(t *testing.T) {
+	cases := []any{
+		map[string]int{"a": 1, "b": 2, "c": 3},
+		map[string]string{"x": "1", "y": "2"},
+		map[string]mapShapeVal{"p": {1, 2}, "q": {3, 4}}, // reflect path
+	}
+	for _, in := range cases {
+		b, err := Marshal(in, OptBalanced|OptMapShape)
+		if err != nil {
+			t.Fatalf("marshal %T: %v", in, err)
+		}
+		switch v := in.(type) {
+		case map[string]int:
+			var out map[string]int
+			if err := Unmarshal(b, &out); err != nil {
+				t.Fatalf("unmarshal %T: %v", in, err)
+			}
+			for k, w := range v {
+				if out[k] != w {
+					t.Fatalf("%T[%q]=%d want %d", in, k, out[k], w)
+				}
+			}
+		case map[string]string:
+			var out map[string]string
+			if err := Unmarshal(b, &out); err != nil {
+				t.Fatalf("unmarshal %T: %v", in, err)
+			}
+			for k, w := range v {
+				if out[k] != w {
+					t.Fatalf("mismatch %q", k)
+				}
+			}
+		case map[string]mapShapeVal:
+			var out map[string]mapShapeVal
+			if err := Unmarshal(b, &out); err != nil {
+				t.Fatalf("unmarshal %T: %v", in, err)
+			}
+			for k, w := range v {
+				if out[k] != w {
+					t.Fatalf("mismatch %q", k)
+				}
+			}
+		}
+	}
+}

--- a/maps_fast_generated.go
+++ b/maps_fast_generated.go
@@ -16,6 +16,13 @@ func encodeMapStringString(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteString(v)
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -32,6 +39,22 @@ func decodeMapStringString(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]string)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]string, len(names))
+		for _, k := range names {
+			v, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			m[k] = v
+		}
+		*(*map[string]string)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -66,6 +89,13 @@ func encodeMapStringBool(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteBool(v)
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -82,6 +112,22 @@ func decodeMapStringBool(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]bool)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]bool, len(names))
+		for _, k := range names {
+			v, err := d.ReadBool()
+			if err != nil {
+				return err
+			}
+			m[k] = v
+		}
+		*(*map[string]bool)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -116,6 +162,13 @@ func encodeMapStringInt8(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteInt(int64(v))
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -132,6 +185,23 @@ func decodeMapStringInt8(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]int8)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]int8, len(names))
+		for _, k := range names {
+			vWide, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v := int8(vWide)
+			m[k] = v
+		}
+		*(*map[string]int8)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -167,6 +237,13 @@ func encodeMapStringInt16(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteInt(int64(v))
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -183,6 +260,23 @@ func decodeMapStringInt16(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]int16)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]int16, len(names))
+		for _, k := range names {
+			vWide, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v := int16(vWide)
+			m[k] = v
+		}
+		*(*map[string]int16)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -218,6 +312,13 @@ func encodeMapStringInt32(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteInt(int64(v))
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -234,6 +335,23 @@ func decodeMapStringInt32(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]int32)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]int32, len(names))
+		for _, k := range names {
+			vWide, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v := int32(vWide)
+			m[k] = v
+		}
+		*(*map[string]int32)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -269,6 +387,13 @@ func encodeMapStringInt(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteInt(int64(v))
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -285,6 +410,23 @@ func decodeMapStringInt(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]int)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]int, len(names))
+		for _, k := range names {
+			vWide, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v := int(vWide)
+			m[k] = v
+		}
+		*(*map[string]int)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -320,6 +462,13 @@ func encodeMapStringInt64(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteInt(int64(v))
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -336,6 +485,22 @@ func decodeMapStringInt64(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]int64)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]int64, len(names))
+		for _, k := range names {
+			v, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			m[k] = v
+		}
+		*(*map[string]int64)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -370,6 +535,13 @@ func encodeMapStringUint8(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteUint(uint64(v))
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -386,6 +558,23 @@ func decodeMapStringUint8(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]uint8)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]uint8, len(names))
+		for _, k := range names {
+			vWide, err := d.ReadUint()
+			if err != nil {
+				return err
+			}
+			v := uint8(vWide)
+			m[k] = v
+		}
+		*(*map[string]uint8)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -421,6 +610,13 @@ func encodeMapStringUint16(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteUint(uint64(v))
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -437,6 +633,23 @@ func decodeMapStringUint16(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]uint16)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]uint16, len(names))
+		for _, k := range names {
+			vWide, err := d.ReadUint()
+			if err != nil {
+				return err
+			}
+			v := uint16(vWide)
+			m[k] = v
+		}
+		*(*map[string]uint16)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -472,6 +685,13 @@ func encodeMapStringUint32(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteUint(uint64(v))
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -488,6 +708,23 @@ func decodeMapStringUint32(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]uint32)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]uint32, len(names))
+		for _, k := range names {
+			vWide, err := d.ReadUint()
+			if err != nil {
+				return err
+			}
+			v := uint32(vWide)
+			m[k] = v
+		}
+		*(*map[string]uint32)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -523,6 +760,13 @@ func encodeMapStringUint(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteUint(uint64(v))
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -539,6 +783,23 @@ func decodeMapStringUint(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]uint)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]uint, len(names))
+		for _, k := range names {
+			vWide, err := d.ReadUint()
+			if err != nil {
+				return err
+			}
+			v := uint(vWide)
+			m[k] = v
+		}
+		*(*map[string]uint)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -574,6 +835,13 @@ func encodeMapStringUint64(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteUint(uint64(v))
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -590,6 +858,22 @@ func decodeMapStringUint64(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]uint64)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]uint64, len(names))
+		for _, k := range names {
+			v, err := d.ReadUint()
+			if err != nil {
+				return err
+			}
+			m[k] = v
+		}
+		*(*map[string]uint64)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -624,6 +908,13 @@ func encodeMapStringFloat32(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteFloat32(v)
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -640,6 +931,22 @@ func decodeMapStringFloat32(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]float32)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]float32, len(names))
+		for _, k := range names {
+			v, err := d.ReadFloat32()
+			if err != nil {
+				return err
+			}
+			m[k] = v
+		}
+		*(*map[string]float32)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -674,6 +981,13 @@ func encodeMapStringFloat64(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteFloat64(v)
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -690,6 +1004,22 @@ func decodeMapStringFloat64(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]float64)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]float64, len(names))
+		for _, k := range names {
+			v, err := d.ReadFloat64()
+			if err != nil {
+				return err
+			}
+			m[k] = v
+		}
+		*(*map[string]float64)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -724,6 +1054,13 @@ func encodeMapStringBytes(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteBytes(v)
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -740,6 +1077,22 @@ func decodeMapStringBytes(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string][]byte)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string][]byte, len(names))
+		for _, k := range names {
+			v, err := d.ReadBytes()
+			if err != nil {
+				return err
+			}
+			m[k] = v
+		}
+		*(*map[string][]byte)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -774,6 +1127,16 @@ func encodeMapStringStringSlice(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			e.WriteArrayHeader(len(v))
+			for _, sv := range v {
+				e.WriteString(sv)
+			}
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -793,6 +1156,33 @@ func decodeMapStringStringSlice(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string][]string)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string][]string, len(names))
+		for _, k := range names {
+			hdrN, err := d.ReadArrayHeader()
+			if err != nil {
+				return err
+			}
+			if err := d.CheckLength(hdrN, 1); err != nil {
+				return err
+			}
+			v := make([]string, hdrN)
+			for i := range hdrN {
+				sv, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v[i] = sv
+			}
+			m[k] = v
+		}
+		*(*map[string][]string)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()
@@ -838,6 +1228,15 @@ func encodeMapStringAny(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		for _, k := range mapStringShapeOrder(e, m) {
+			v := m[k]
+			if err := encodeReflect(e, v); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 	e.WriteMapHeader(len(m))
 	for k, v := range m {
 		e.WriteString(k)
@@ -856,6 +1255,22 @@ func decodeMapStringAny(d *Decoder, p unsafe.Pointer) error {
 	if t == tagNil {
 		d.i++
 		*(*map[string]any)(p) = nil
+		return nil
+	}
+	if t == tagMapShape {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			return err
+		}
+		m := make(map[string]any, len(names))
+		for _, k := range names {
+			v, err := decodeAny(d)
+			if err != nil {
+				return err
+			}
+			m[k] = v
+		}
+		*(*map[string]any)(p) = m
 		return nil
 	}
 	n, err := d.ReadMapHeader()

--- a/qdf.go
+++ b/qdf.go
@@ -273,7 +273,17 @@ const (
 	// only when strictly smaller than the dictionary / per-value forms.
 	OptFSST
 
-	// Bits 10..31 reserved for future codecs (LZ77, n-gram dictionary, etc.).
+	// OptMapShape interns map key-sets the way OptShapeIntern interns struct
+	// field-names: the first map with a given set of (string) keys declares the
+	// key ordering via tagMapShape; subsequent maps with the same key-set emit
+	// only the shape ID + values in canonical (sorted) key order. Cuts encode
+	// CPU and wire on maps with recurring keys (telemetry tags, log labels).
+	// Requires OptDense (the shape table lives on the intern side). Opt-in in
+	// v1; never-worse fallback to a plain map header when a key-set does not
+	// recur.
+	OptMapShape
+
+	// Bits 11..31 reserved for future codecs (LZ77, n-gram dictionary, etc.).
 
 	// OptSpeed is the zero-bit preset: Fast mode, no codecs, no
 	// predictors. Maximum throughput, smallest CPU footprint.

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -333,6 +333,7 @@ func decodeArray(elem *typeDesc, stride uintptr, n int) func(*Decoder, unsafe.Po
 func encodeMap(t reflect.Type, k, v *typeDesc) func(*Encoder, unsafe.Pointer) error {
 	keyType := t.Key()
 	valType := t.Elem()
+	stringKey := keyType.Kind() == reflect.String
 	return func(e *Encoder, p unsafe.Pointer) error {
 		rv := reflect.NewAt(t, p).Elem()
 		if rv.IsNil() {
@@ -340,6 +341,9 @@ func encodeMap(t reflect.Type, k, v *typeDesc) func(*Encoder, unsafe.Pointer) er
 			return nil
 		}
 		n := rv.Len()
+		if stringKey && n > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+			return e.encodeStringMapShaped(rv, keyType, valType, v)
+		}
 		e.WriteMapHeader(n)
 		// MapRange beats reflect.Value.Seq2 (Go 1.26) here by ~2x on
 		// throughput and ~2x on allocations: Seq2 boxes the (k, v)
@@ -373,6 +377,107 @@ func encodeMap(t reflect.Type, k, v *typeDesc) func(*Encoder, unsafe.Pointer) er
 	}
 }
 
+// encodeStringMapShaped emits a string-keyed map via tagMapShape (OptMapShape).
+// A recurring key-set declares once (keys interned); reuses emit only the shape
+// ID + values in canonical (sorted) key order. Collision-safe: the set-hash
+// only finds a candidate; the keys are verified present (count + membership)
+// before reuse, falling back to a fresh declaration on any mismatch. This is
+// the general reflect path; the common map[string]string/etc. types take the
+// concrete fast path in maps_fast_generated.go.
+//
+// A reusable keyHolder/valHolder avoids per-key reflect.ValueOf boxing; the hot
+// reuse path allocates nothing (no keys slice — values are fetched in the bound
+// canonical order). The keys slice is built only on a fresh declaration (rare:
+// once per distinct key-set).
+func (e *Encoder) encodeStringMapShaped(rv reflect.Value, keyType, valType reflect.Type, v *typeDesc) error {
+	// Ensure the stream header precedes the first tag (top-level map case; the
+	// plain path emits it via WriteMapHeader). Idempotent.
+	e.writeHeader()
+	n := rv.Len()
+	st := e.state
+	// Pooled, re-entrancy-safe key/value holders — avoids reflect.New per map
+	// (a 1000-row batch pays 2 reflect.New total, not 2 per row).
+	keyHolder, valHolder, vp, pooled := st.mapEnc.acquire(keyType, valType)
+	defer st.mapEnc.release(pooled)
+
+	emitValues := func(order []string) error {
+		for _, name := range order {
+			keyHolder.SetString(name)
+			valHolder.Set(rv.MapIndex(keyHolder))
+			if err := v.encode(e, vp); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	// hasAll reports whether the map's key-set equals order (caller checks
+	// len==n). Verifies via the map's own keys under MapRange — string keys do
+	// not allocate — instead of MapIndex per key, which would heap-copy a
+	// struct value type. The linear scan is O(n²) but n (a key-set) is tiny.
+	hasAll := func(order []string) bool {
+		it := rv.MapRange()
+		for it.Next() {
+			keyHolder.SetIterKey(it) // SetIterKey reuses the holder; it.Key() would alloc
+			k := keyHolder.String()
+			found := false
+			for _, name := range order {
+				if name == k {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Fast path: same key-set as the previous map — verify directly, no hash.
+	if st.lastMapShapeID != 0 && len(st.lastMapShapeKeys) == n && hasAll(st.lastMapShapeKeys) {
+		e.buf = append(e.buf, tagMapShape)
+		e.buf = appendUvarint(e.buf, uint64(st.lastMapShapeID))
+		return emitValues(st.lastMapShapeKeys)
+	}
+
+	// Key-set changed: order-independent set-hash to find an earlier shape.
+	var setHash uint64
+	iter := rv.MapRange()
+	for iter.Next() {
+		keyHolder.SetIterKey(iter) // reuse holder; iter.Key() would alloc
+		setHash += internKeyHash(keyHolder.String())
+	}
+	if id, ok := st.mapShapeFind(setHash, n); ok {
+		order := st.mapShapeKeys(id)
+		if len(order) == n && hasAll(order) {
+			st.lastMapShapeID, st.lastMapShapeKeys = id, order
+			e.buf = append(e.buf, tagMapShape)
+			e.buf = appendUvarint(e.buf, uint64(id))
+			return emitValues(order)
+		}
+		// collision / different key-set → declare a fresh shape below.
+	}
+
+	// Declare path (first sight of this key-set).
+	keys := make([]string, 0, n)
+	it2 := rv.MapRange()
+	for it2.Next() {
+		keyHolder.SetIterKey(it2) // reuse holder; it2.Key() would alloc
+		keys = append(keys, keyHolder.String())
+	}
+	slices.Sort(keys)
+	id := st.shapeDeclareEnc()
+	st.mapShapeRegister(setHash, n, keys, id)
+	st.lastMapShapeID, st.lastMapShapeKeys = id, st.mapShapes[len(st.mapShapes)-1].keys
+	e.buf = append(e.buf, tagMapShape)
+	e.buf = appendUvarint(e.buf, 0)
+	e.buf = appendUvarint(e.buf, uint64(n))
+	for _, name := range keys {
+		e.WriteString(name)
+	}
+	return emitValues(keys)
+}
+
 func decodeMap(t reflect.Type, k, v *typeDesc) func(*Decoder, unsafe.Pointer) error {
 	keyType := t.Key()
 	valType := t.Elem()
@@ -388,6 +493,30 @@ func decodeMap(t reflect.Type, k, v *typeDesc) func(*Decoder, unsafe.Pointer) er
 		if tag == tagNil {
 			d.i++
 			reflect.NewAt(t, p).Elem().Set(reflect.Zero(t))
+			return nil
+		}
+		// tagMapShape: string-keyed map encoded via the key-set shape codec
+		// (OptMapShape). Mirrors decodeStruct's shape branch; the decoder's
+		// shape table is destination-agnostic (ordered names + N values).
+		if tag == tagMapShape && keyType.Kind() == reflect.String {
+			names, err := decodeMapStringShapeHeader(d)
+			if err != nil {
+				return err
+			}
+			reflectutil.MakeMap(t, len(names), p)
+			mapVal := reflect.NewAt(t, p).Elem()
+			// Pooled, re-entrancy-safe holders hoisted out of the loop:
+			// SetMapIndex copies key/value into the map, so one pair is reused
+			// for every entry (and across rows) — no reflect.New per entry.
+			kh, vh, vp, pooled := d.state.mapDec.acquire(keyType, valType)
+			defer d.state.mapDec.release(pooled)
+			for _, name := range names {
+				kh.SetString(name)
+				if err := v.decode(d, vp); err != nil {
+					return err
+				}
+				mapVal.SetMapIndex(kh, vh)
+			}
 			return nil
 		}
 		n, err := d.ReadMapHeader()

--- a/state.go
+++ b/state.go
@@ -2,7 +2,9 @@ package qdf
 
 import (
 	"hash/maphash"
+	"reflect"
 	"strings"
+	"unsafe"
 
 	"github.com/alex60217101990/qdf/internal/internarena"
 	"github.com/alex60217101990/qdf/internal/unsafestr"
@@ -13,6 +15,14 @@ import (
 // but differ across binary invocations (no semantic impact — the
 // intern table is per-encoder and reset between Marshals).
 var internHashSeed = maphash.MakeSeed()
+
+// internKeyHash hashes a single map key for the order-independent key-set hash
+// used by OptMapShape. Same seed/function as the intern table so distribution
+// matches; callers combine per-key results commutatively (sum) so key order
+// does not affect the set identity.
+func internKeyHash(s string) uint64 {
+	return maphash.String(internHashSeed, s)
+}
 
 // internSlot is one entry in the flat hash table that replaces the
 // old map[string]uint32 intern dictionary. Profiling on telemetry
@@ -147,6 +157,20 @@ type encState struct {
 	shapeCount    uint32
 	shapeBindings []shapeBinding
 
+	// mapShapes interns recurring map key-sets (OptMapShape), parallel to
+	// shapeBindings but keyed on the key-set rather than a *typeDesc. Shares
+	// the shapeCount ID space with struct shapes (shapeDeclareEnc) so the
+	// decoder's single shape table stays in lockstep.
+	mapShapes []mapShapeBinding
+	// lastMapShape* memoises the most recently used map shape so a run of
+	// homogeneous rows (the common case) verifies against it directly — no
+	// set-hash recompute, no registry scan. lastMapShapeID == 0 means none.
+	lastMapShapeID   uint32
+	lastMapShapeKeys []string
+	// mapEnc pools reflect holders for the generic (reflect) string-keyed map
+	// encode path so it does not reflect.New per map (OptMapShape).
+	mapEnc mapHolderCache
+
 	// Columnar shape table (tagColStruct). Separate from shapeBindings
 	// because columnar shapes carry field kinds. Keyed by structural
 	// identity (names + kinds) since the same struct type always produces
@@ -181,6 +205,54 @@ type encState struct {
 type shapeBinding struct {
 	td *typeDesc
 	id uint32
+}
+
+// mapShapeBinding maps a recurring map key-set to a shared shape ID.
+// setHash is an order-independent hash of the (string) keys; n is the key
+// count (disambiguates a setHash collision across different sizes); keys holds
+// the canonical (sorted) key order, cloned so it survives the caller's map. id
+// is drawn from the same sequential space as struct shapeBindings
+// (shapeDeclareEnc).
+type mapShapeBinding struct {
+	setHash uint64
+	n       int
+	keys    []string
+	id      uint32
+}
+
+// mapHolderCache pools the addressable reflect.Value scratch the generic
+// (reflect) map encode/decode path needs — a key holder + a value holder —
+// so it does not reflect.New on every map encoded/decoded. Reused across the
+// rows of a []struct (same map type every row), so a 1000-row batch pays 2
+// reflect.New total instead of 2 per row. A busy flag keeps it
+// re-entrancy-safe: a nested map (e.g. map[string]map[string]T), or any
+// acquire while the cache is already in use, falls back to a fresh local pair.
+type mapHolderCache struct {
+	kt, vt reflect.Type
+	kh, vh reflect.Value
+	vp     unsafe.Pointer
+	busy   bool
+}
+
+func (c *mapHolderCache) acquire(kt, vt reflect.Type) (kh, vh reflect.Value, vp unsafe.Pointer, pooled bool) {
+	if c.busy {
+		vh = reflect.New(vt).Elem()
+		return reflect.New(kt).Elem(), vh, unsafe.Pointer(vh.UnsafeAddr()), false
+	}
+	if c.kt != kt || c.vt != vt {
+		c.kt, c.vt = kt, vt
+		c.kh = reflect.New(kt).Elem()
+		c.vh = reflect.New(vt).Elem()
+		c.vp = unsafe.Pointer(c.vh.UnsafeAddr())
+	}
+	c.busy = true
+	return c.kh, c.vh, c.vp, true
+}
+
+func (c *mapHolderCache) release(pooled bool) {
+	if pooled {
+		c.busy = false
+	}
 }
 
 const lruInvalidID = ^uint32(0)
@@ -264,6 +336,14 @@ func (e *encState) reset() {
 	}
 	e.lastShapeTd = nil
 	e.lastShapeID = 0
+	if cap(e.mapShapes) > maxRetainedShapeCap {
+		e.mapShapes = nil
+	} else {
+		e.mapShapes = e.mapShapes[:0]
+	}
+	e.lastMapShapeID = 0
+	e.lastMapShapeKeys = nil
+	e.mapEnc = mapHolderCache{}
 
 	if cap(e.colShapeNames) > maxRetainedShapeCap {
 		e.colShapeNames = nil
@@ -322,6 +402,37 @@ func (e *encState) shapeBindType(t *typeDesc, id uint32) {
 func (e *encState) shapeDeclareEnc() uint32 {
 	e.shapeCount++
 	return e.shapeCount
+}
+
+// mapShapeFind returns the bound shape ID for a key-set identified by its
+// order-independent setHash and count n. The caller MUST still verify the
+// actual keys against the binding (mapShapeKeys) before reuse — setHash is not
+// collision-proof.
+func (e *encState) mapShapeFind(setHash uint64, n int) (uint32, bool) {
+	for i := range e.mapShapes {
+		if e.mapShapes[i].setHash == setHash && e.mapShapes[i].n == n {
+			return e.mapShapes[i].id, true
+		}
+	}
+	return 0, false
+}
+
+// mapShapeKeys returns the canonical key order for a bound shape ID, or nil.
+func (e *encState) mapShapeKeys(id uint32) []string {
+	for i := range e.mapShapes {
+		if e.mapShapes[i].id == id {
+			return e.mapShapes[i].keys
+		}
+	}
+	return nil
+}
+
+// mapShapeRegister binds a key-set to a shape ID. keys must be the canonical
+// (sorted) order; it is cloned so the binding owns its slice.
+func (e *encState) mapShapeRegister(setHash uint64, n int, keys []string, id uint32) {
+	cp := make([]string, len(keys))
+	copy(cp, keys)
+	e.mapShapes = append(e.mapShapes, mapShapeBinding{setHash: setHash, n: n, keys: cp, id: id})
 }
 
 // pairLookup reports whether the top-1 predicted successor of prev
@@ -678,6 +789,10 @@ type decState struct {
 	// colLenScratch is reused storage for the column-length index parsed from
 	// a FlagColIndex columnar payload (one uint32 byte-length per column).
 	colLenScratch []uint32
+
+	// mapDec pools reflect holders for the generic (reflect) string-keyed map
+	// decode path so it does not reflect.New per map entry (OptMapShape).
+	mapDec mapHolderCache
 }
 
 func newDecState() *decState {
@@ -736,6 +851,7 @@ func (d *decState) reset() {
 		d.mruRing[i] = mruEmpty
 	}
 	d.mruHead = 0
+	d.mapDec = mapHolderCache{}
 }
 
 // pairAtRank returns the predicted successor of prev. With top-1

--- a/wire.go
+++ b/wire.go
@@ -153,7 +153,9 @@ const (
 	//                    encoder picks tagStatePair only when its byte cost
 	//                    is strictly smaller than every other state-ref
 	//                    variant (Repeat, MTF, raw), so the wire never grows.
-	tagMapShape = 0xEC // Struct/map shape interning for Dense mode.
+	tagMapShape = 0xEC // Struct shape interning (OptShapeIntern) and, for
+	//                    string-keyed maps, map key-set interning
+	//                    (OptMapShape). Shared sequential shape-ID space.
 	//                    Wire form:
 	//                       0xEC + varuint(shapeID)
 	//                    shapeID == 0 declares a new shape inline:


### PR DESCRIPTION
Adds key-set shape interning for `map[string]V` struct fields — the map-shaped
sibling of the existing struct shape interning (`OptShapeIntern`).

**Motivation.** A field like `Tags map[string]string` (telemetry/log labels with
a recurring key-set) was the single largest un-amortized encode cost: the Go
runtime map was range-iterated on every occurrence (~13% of encode on a 1000-row
telemetry batch), each key re-hashed and re-interned per row, and a map-bearing
struct is forced fully row-major (columnar rejects map fields). Only the value
bytes amortized via state-refs; the key-set was never recognized.

**Approach.** The first map with a given set of (string) keys declares the key
ordering; subsequent maps with the same key-set emit only the shape ID + values
in canonical (sorted) key order. This reuses the already-reserved `tagMapShape`
(`0xEC`) wire form — **no new wire tag** — and the decoder's existing
destination-agnostic shape table (struct shapes turn ordered keys into fields,
map shapes turn them into entries). Struct and map shapes share one sequential
shape-ID space, kept in lockstep because both sides assign in wire order. A
`lastMapShape` memo lets a run of homogeneous rows verify against the previous
shape directly — no set-hash, no registry scan — which is what turns this from a
CPU-for-wire trade into a double win. Collision-safe: the order-independent
set-hash only finds a candidate; key membership + count are verified before
reuse, so a hash collision degrades to a fresh declaration, never to wrong data.

**Results** (`BenchmarkMapShape_Telemetry`, on vs off, conservative
hot-second measurement):

| metric | delta |
|---|---|
| encode CPU (recurring tag-maps) | **−24%** |
| wire | **−26%** |
| flag OFF | byte-identical, no perf/alloc regression (benchstat `p=0.083`, in-noise) |

**Gating.** Opt-in `OptMapShape` flag (off by default; not yet in
`OptBalanced`/`OptCompression` — ships isolated like FSST/rANS did). When the
flag is off the wire is byte-identical to `main`. A map key-set that does not
recur falls back to a plain map header (never-worse).

**Scope.** v1 = string-keyed maps (where the entire measured win lives, and
which reuse the decoder's `[]string` shape table). Integer / other key types
fall back to the plain map encoding; `unsafe.Pointer` keys are not serializable
and are unaffected. Determinism: keys are emitted sorted, so the same value
encodes identically (this also fixes the previously non-deterministic map-key
wire order under the flag).

**Testing.** Round-trip (recurring / varying / nil / empty / single key-sets,
`map[string]string`/`int`/`struct`), determinism, cross-mode decode, a
shape-actually-engaged size assertion on the reflect path, a set-hash collision
stress test, a truncation-never-panics guard, a decode fuzz seed, full suite +
`-race`. Includes a defensive guard rejecting shape IDs ≥ 2³² before the `uint32`
narrowing (same hardening as the security branch, for the new decode path).