### PR TITLE
perf(encode): pool the QPack int32/uint32 widening scratch (+ correctness fixes found in pre-PR review)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,12 @@ breaks any of them is a vulnerability:
   - **No silent type confusion.** Tag-byte mismatches return
     `ErrTypeMismatch`; unknown tags return `ErrBadTag`. A decoder
     that does not recognise a new wire feature fails loud.
+  - **Structurally impossible codec parameters are rejected.** A
+    Gorilla XOR float window claiming more leading-zero + meaningful
+    bits than the float width (64 / 32) — an unsatisfiable layout a
+    valid encoder never emits — returns `ErrInvalidLength` instead of
+    underflowing the bit accounting into a silently wrong value.
+    Coverage: `qpack_gorilla_hostile_test.go`.
 
 ## Known Limitations
 

--- a/columnar.go
+++ b/columnar.go
@@ -580,7 +580,7 @@ func loadStringFieldBytes(base unsafe.Pointer, stride uintptr, col *colColumn, i
 // Speed/Balanced hot path.
 func estimateFSSTColumnBytes(base unsafe.Pointer, stride uintptr, col *colColumn, sample, n int, dict *fsst.SymbolTable) int {
 	var strs [columnarProbeSample][]byte
-	for i := 0; i < sample; i++ {
+	for i := range sample {
 		strs[i] = loadStringFieldBytes(base, stride, col, i)
 	}
 	tbl := dict
@@ -591,7 +591,7 @@ func estimateFSSTColumnBytes(base unsafe.Pointer, stride uintptr, col *colColumn
 	}
 	var scratch []byte
 	body := 0
-	for i := 0; i < sample; i++ {
+	for i := range sample {
 		scratch = tbl.Compress(strs[i], scratch[:0])
 		body += len(scratch) + uvarintLen(uint64(len(scratch)))
 	}

--- a/decode_reuse_test.go
+++ b/decode_reuse_test.go
@@ -20,7 +20,7 @@ func reuseRoundTrip(t *testing.T, n int) {
 		t.Fatal(err)
 	}
 	out := make([]reuseNum, 0, n) // pre-sized → reuse path
-	for k := 0; k < 3; k++ {      // multiple decodes into the SAME backing
+	for k := range 3 {            // multiple decodes into the SAME backing
 		if err := Unmarshal(buf, &out); err != nil {
 			t.Fatalf("n=%d iter=%d: %v", n, k, err)
 		}

--- a/encode_header_rollback_test.go
+++ b/encode_header_rollback_test.go
@@ -1,0 +1,75 @@
+package qdf
+
+import (
+	"math"
+	"testing"
+)
+
+// TestGorillaRollbackKeepsHeader pins the fix for the header-latch bug: when a
+// top-level float64 slice attempts Gorilla (which lazily writes the stream
+// header), loses the never-larger gate, and rolls back, the fallback codec must
+// still emit the header. Before the fix the rollback truncated the header bytes
+// but left e.headerOut latched, so writeHeader became a no-op and the output was
+// a headerless, undecodable stream ("bad magic" on Unmarshal).
+func TestGorillaRollbackKeepsHeader(t *testing.T) {
+	// 65 identical float64 values whose bits are 0x4141414141414141: Gorilla is
+	// attempted but ALP/raw wins, forcing the rollback path. (Exact repro of the
+	// FuzzRoundTrip_Float64Slice crasher.)
+	in := make([]float64, 65)
+	for i := range in {
+		in[i] = math.Float64frombits(0x4141414141414141)
+	}
+	for _, opts := range []Options{OptQPack | OptGorillaFloat, OptCompression} {
+		buf, err := Marshal(in, opts)
+		if err != nil {
+			t.Fatalf("opts=%d marshal: %v", opts, err)
+		}
+		if len(buf) < 5 || buf[0] != Magic0 || buf[1] != Magic1 || buf[2] != Magic2 {
+			t.Fatalf("opts=%d: output missing magic header, head=% x", opts, buf[:min(8, len(buf))])
+		}
+		var out []float64
+		if err := Unmarshal(buf, &out); err != nil {
+			t.Fatalf("opts=%d unmarshal: %v", opts, err)
+		}
+		if len(out) != len(in) {
+			t.Fatalf("opts=%d len=%d want %d", opts, len(out), len(in))
+		}
+		for i := range in {
+			if math.Float64bits(out[i]) != math.Float64bits(in[i]) {
+				t.Fatalf("opts=%d [%d] = %x want %x", opts, i, math.Float64bits(out[i]), math.Float64bits(in[i]))
+			}
+		}
+	}
+}
+
+// TestGorillaRollbackNestedHeaderUnaffected guards the other side: when the
+// header was ALREADY written before the float slice (a struct field, so the
+// rollback must NOT clear a header that lives before `start`), the round-trip
+// still holds.
+func TestGorillaRollbackNestedHeaderUnaffected(t *testing.T) {
+	type row struct {
+		Tag string    `qdf:"tag"`
+		V   []float64 `qdf:"v"`
+	}
+	in := row{Tag: "metrics"}
+	in.V = make([]float64, 65)
+	for i := range in.V {
+		in.V[i] = math.Float64frombits(0x4141414141414141)
+	}
+	buf, err := Marshal(in, OptCompression)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out row
+	if err := Unmarshal(buf, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Tag != in.Tag || len(out.V) != len(in.V) {
+		t.Fatalf("mismatch: %+v", out)
+	}
+	for i := range in.V {
+		if math.Float64bits(out.V[i]) != math.Float64bits(in.V[i]) {
+			t.Fatalf("V[%d] mismatch", i)
+		}
+	}
+}

--- a/encode_widen_scratch_test.go
+++ b/encode_widen_scratch_test.go
@@ -1,62 +1,83 @@
 package qdf
 
-import "testing"
+import (
+	"testing"
+	"unsafe"
+)
 
-// TestEncodeWidenScratchPooled is the RED test for pooling the int32→int64 /
-// uint32→uint64 widening scratch in the QPack slice encoders. Each []int32 /
-// []uint32 field currently allocates a fresh make([]int64,len) / make([]uint64,
-// len) before the codec picker runs; on a reused encoder that scratch must be
-// pooled so a steady-state encode of many narrow-int slices is allocation-free.
+// TestEncodeWidenScratchPooled verifies the int32→int64 / uint32→uint64 QPack
+// widening scratch is REUSED across calls rather than reallocated per field. It
+// tests the mechanism directly — the backing array must not move when a
+// later widen of equal-or-smaller length runs — instead of counting allocations
+// (which the race detector's bookkeeping makes unreliable), so it is exact and
+// runs identically under -race.
 func TestEncodeWidenScratchPooled(t *testing.T) {
-	// One- vs five-narrow-int-slice payloads. With the widening scratch pooled,
-	// both cost the SAME number of allocations per encode (only the fixed
-	// AppendMarshal overhead) — every per-field make([]int64/[]uint64,len) is
-	// gone. Comparing the two counts is robust to the constant overhead and to
-	// the race detector's extra bookkeeping allocs (an absolute bound is not).
-	type row1 struct {
-		A []int32 `qdf:"a"`
-	}
-	type row5 struct {
-		A []int32  `qdf:"a"`
-		B []int32  `qdf:"b"`
-		C []uint32 `qdf:"c"`
-		D []int32  `qdf:"d"`
-		E []uint32 `qdf:"e"`
-	}
-	seqI := func(n int) []int32 {
-		s := make([]int32, n)
-		for i := range s {
-			s[i] = int32(i)
-		}
-		return s
-	}
-	seqU := func(n int) []uint32 {
-		s := make([]uint32, n)
-		for i := range s {
-			s[i] = uint32(i)
-		}
-		return s
-	}
-	v1 := row1{A: seqI(500)}
-	v5 := row5{A: seqI(500), B: seqI(500), C: seqU(500), D: seqI(500), E: seqU(500)}
+	e := &Encoder{qpack: true}
 
-	measure := func(v any) float64 {
-		dst, err := AppendMarshal(nil, v, OptQPack) // warm scratch + grow dst
-		if err != nil {
-			t.Fatal(err)
-		}
-		return testing.AllocsPerRun(50, func() {
-			var e error
-			if dst, e = AppendMarshal(dst[:0], v, OptQPack); e != nil {
-				t.Fatal(e)
-			}
-		})
+	// First widen sizes the scratch.
+	if w := e.widenI64([]int32{10, 20, 30, 40, 50}); len(w) != 5 {
+		t.Fatalf("widenI64 len = %d, want 5", len(w))
 	}
-	a1, a5 := measure(v1), measure(v5)
-	// Four extra narrow-int slices in row5 must add ZERO allocations once the
-	// widening scratch is pooled (pre-fix this gap was 4).
-	if a5 > a1 {
-		t.Fatalf("5-slice encode = %.0f allocs/op vs 1-slice = %.0f: per-field widening not pooled (gap %.0f)", a5, a1, a5-a1)
+	backing := unsafe.SliceData(e.wideI64)
+	capacity := cap(e.wideI64)
+
+	// Every subsequent widen of length <= capacity must reuse the SAME backing
+	// array — that reuse is exactly what turns one make per narrow-int field into
+	// zero allocations on a steady-state encode.
+	for _, s := range [][]int32{{1, 2}, {3, 4, 5}, {-9, -8, -7, -6, -5}} {
+		w := e.widenI64(s)
+		if unsafe.SliceData(e.wideI64) != backing || cap(e.wideI64) != capacity {
+			t.Fatalf("widenI64 reallocated scratch for len %d (cap %d->%d): not pooled", len(s), capacity, cap(e.wideI64))
+		}
+		for i, v := range s {
+			if w[i] != int64(v) {
+				t.Fatalf("widenI64 value [%d] = %d, want %d", i, w[i], v)
+			}
+		}
+	}
+
+	// Same contract for the uint32 path.
+	if w := e.widenU64([]uint32{1, 2, 3, 4, 5}); len(w) != 5 {
+		t.Fatalf("widenU64 len = %d, want 5", len(w))
+	}
+	backingU := unsafe.SliceData(e.wideU64)
+	capacityU := cap(e.wideU64)
+	for _, s := range [][]uint32{{7, 8}, {9, 10, 11}} {
+		w := e.widenU64(s)
+		if unsafe.SliceData(e.wideU64) != backingU || cap(e.wideU64) != capacityU {
+			t.Fatalf("widenU64 reallocated scratch for len %d: not pooled", len(s))
+		}
+		for i, v := range s {
+			if w[i] != uint64(v) {
+				t.Fatalf("widenU64 value [%d] = %d, want %d", i, w[i], v)
+			}
+		}
+	}
+
+	// A widen LARGER than the current capacity must grow exactly once and then
+	// stay pooled at the new size.
+	e.widenI64(make([]int32, capacity*4))
+	grown := unsafe.SliceData(e.wideI64)
+	if e.widenI64(make([]int32, capacity*4)); unsafe.SliceData(e.wideI64) != grown {
+		t.Fatal("widenI64 reallocated on a repeat at the grown size: not pooled after growth")
+	}
+
+	// Integration: the real QPack encode path must route []int32 / []uint32
+	// through the pooled scratch (not an inline make), so the scratch is
+	// populated after an encode. Guards against the call site being un-wired.
+	type wired struct {
+		A []int32  `qdf:"a"`
+		B []uint32 `qdf:"b"`
+	}
+	enc := NewEncoderWith(OptQPack)
+	if err := enc.EncodeValue(wired{A: make([]int32, 300), B: make([]uint32, 300)}); err != nil {
+		t.Fatal(err)
+	}
+	if cap(enc.wideI64) < 300 {
+		t.Fatalf("encode did not use the pooled int32 widen scratch (cap=%d): call site not wired", cap(enc.wideI64))
+	}
+	if cap(enc.wideU64) < 300 {
+		t.Fatalf("encode did not use the pooled uint32 widen scratch (cap=%d): call site not wired", cap(enc.wideU64))
 	}
 }
 

--- a/encode_widen_scratch_test.go
+++ b/encode_widen_scratch_test.go
@@ -106,7 +106,7 @@ func TestEncodeWidenScratchRoundTrip(t *testing.T) {
 		if len(out.A) != n || len(out.B) != n {
 			t.Fatalf("n=%d len mismatch: %d %d", n, len(out.A), len(out.B))
 		}
-		for i := 0; i < n; i++ {
+		for i := range n {
 			if out.A[i] != in.A[i] || out.B[i] != in.B[i] {
 				t.Fatalf("n=%d row %d: A %d!=%d  B %d!=%d", n, i, out.A[i], in.A[i], out.B[i], in.B[i])
 			}

--- a/encode_widen_scratch_test.go
+++ b/encode_widen_scratch_test.go
@@ -1,0 +1,94 @@
+package qdf
+
+import "testing"
+
+// TestEncodeWidenScratchPooled is the RED test for pooling the int32→int64 /
+// uint32→uint64 widening scratch in the QPack slice encoders. Each []int32 /
+// []uint32 field currently allocates a fresh make([]int64,len) / make([]uint64,
+// len) before the codec picker runs; on a reused encoder that scratch must be
+// pooled so a steady-state encode of many narrow-int slices is allocation-free.
+func TestEncodeWidenScratchPooled(t *testing.T) {
+	// One- vs five-narrow-int-slice payloads. With the widening scratch pooled,
+	// both cost the SAME number of allocations per encode (only the fixed
+	// AppendMarshal overhead) — every per-field make([]int64/[]uint64,len) is
+	// gone. Comparing the two counts is robust to the constant overhead and to
+	// the race detector's extra bookkeeping allocs (an absolute bound is not).
+	type row1 struct {
+		A []int32 `qdf:"a"`
+	}
+	type row5 struct {
+		A []int32  `qdf:"a"`
+		B []int32  `qdf:"b"`
+		C []uint32 `qdf:"c"`
+		D []int32  `qdf:"d"`
+		E []uint32 `qdf:"e"`
+	}
+	seqI := func(n int) []int32 {
+		s := make([]int32, n)
+		for i := range s {
+			s[i] = int32(i)
+		}
+		return s
+	}
+	seqU := func(n int) []uint32 {
+		s := make([]uint32, n)
+		for i := range s {
+			s[i] = uint32(i)
+		}
+		return s
+	}
+	v1 := row1{A: seqI(500)}
+	v5 := row5{A: seqI(500), B: seqI(500), C: seqU(500), D: seqI(500), E: seqU(500)}
+
+	measure := func(v any) float64 {
+		dst, err := AppendMarshal(nil, v, OptQPack) // warm scratch + grow dst
+		if err != nil {
+			t.Fatal(err)
+		}
+		return testing.AllocsPerRun(50, func() {
+			var e error
+			if dst, e = AppendMarshal(dst[:0], v, OptQPack); e != nil {
+				t.Fatal(e)
+			}
+		})
+	}
+	a1, a5 := measure(v1), measure(v5)
+	// Four extra narrow-int slices in row5 must add ZERO allocations once the
+	// widening scratch is pooled (pre-fix this gap was 4).
+	if a5 > a1 {
+		t.Fatalf("5-slice encode = %.0f allocs/op vs 1-slice = %.0f: per-field widening not pooled (gap %.0f)", a5, a1, a5-a1)
+	}
+}
+
+// TestEncodeWidenScratchRoundTrip guards correctness: the pooled scratch must
+// not corrupt the encoded values across repeated encodes of different-length
+// slices on the same encoder.
+func TestEncodeWidenScratchRoundTrip(t *testing.T) {
+	type row struct {
+		A []int32  `qdf:"a"`
+		B []uint32 `qdf:"b"`
+	}
+	for _, n := range []int{1, 7, 64, 300, 50, 2} { // varying lengths reuse the scratch
+		in := row{A: make([]int32, n), B: make([]uint32, n)}
+		for i := range n {
+			in.A[i] = int32(-i * 3)
+			in.B[i] = uint32(i * 5)
+		}
+		buf, err := Marshal(in, OptQPack)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out row
+		if err := Unmarshal(buf, &out); err != nil {
+			t.Fatal(err)
+		}
+		if len(out.A) != n || len(out.B) != n {
+			t.Fatalf("n=%d len mismatch: %d %d", n, len(out.A), len(out.B))
+		}
+		for i := 0; i < n; i++ {
+			if out.A[i] != in.A[i] || out.B[i] != in.B[i] {
+				t.Fatalf("n=%d row %d: A %d!=%d  B %d!=%d", n, i, out.A[i], in.A[i], out.B[i], in.B[i])
+			}
+		}
+	}
+}

--- a/encoder.go
+++ b/encoder.go
@@ -132,6 +132,16 @@ type Encoder struct {
 	// single branch-predicted compare) when no caller has opted
 	// in, so it does not regress the default Marshal path.
 	preIntern []preInternEntry
+
+	// wideI64 / wideU64 are reused widening scratch for the QPack slice
+	// encoders: []int32 / []uint32 must be promoted to []int64 / []uint64 so
+	// the int64/uint64 codec pickers can score them. The widen → pick → emit
+	// sequence is atomic (no nested slice encode runs between fill and the last
+	// read), so a single scratch per element type is safely reused across every
+	// narrow-int slice field in a message — turning one make per field into
+	// zero. Bounded on return to the encoder pool (putEnc).
+	wideI64 []int64
+	wideU64 []uint64
 }
 
 // applyOpts mirrors the options bitmask onto the cached mode / qpack

--- a/fsst_dict_test.go
+++ b/fsst_dict_test.go
@@ -91,11 +91,9 @@ func TestFSSTDictConcurrent(t *testing.T) {
 	rows := mkRows(genURLs(512))
 	d := TrainFSSTDictStrings(genURLs(512))
 	var wg sync.WaitGroup
-	for g := 0; g < 8; g++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for i := 0; i < 50; i++ {
+	for range 8 {
+		wg.Go(func() {
+			for range 50 {
 				b, err := d.Marshal(rows, OptBalanced)
 				if err != nil {
 					t.Error(err)
@@ -111,7 +109,7 @@ func TestFSSTDictConcurrent(t *testing.T) {
 					return
 				}
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/internal/fsst/build.go
+++ b/internal/fsst/build.go
@@ -26,7 +26,7 @@ type symKey struct {
 
 func packKey(b []byte) symKey {
 	var lo uint64
-	for i := 0; i < len(b); i++ {
+	for i := range b {
 		lo |= uint64(b[i]) << (8 * i)
 	}
 	return symKey{lo, uint8(len(b))}
@@ -131,7 +131,7 @@ func (b *Builder) Build(samples [][]byte) *SymbolTable {
 func (b *Builder) BuildRounds(samples [][]byte, rounds int) *SymbolTable {
 	scan := sampleByBytes(samples, maxSampleBytes)
 	b.t.reset() // empty: round 0 is all single-byte tokens
-	for round := 0; round < rounds; round++ {
+	for range rounds {
 		b.c.reset()
 		empty := len(b.t.symbols) == 0
 		for _, s := range scan {

--- a/internal/fsst/fsst.go
+++ b/internal/fsst/fsst.go
@@ -27,7 +27,7 @@ type symbol struct {
 
 // packVal returns the little-endian uint64 of b and its length mask.
 func packVal(b []byte) (val, mask uint64) {
-	for i := 0; i < len(b); i++ {
+	for i := range b {
 		val |= uint64(b[i]) << (8 * i)
 	}
 	if len(b) >= 8 {
@@ -93,7 +93,7 @@ func (t *SymbolTable) match(s []byte) (uint8, int) {
 	if len(s) >= 8 {
 		x = binary.LittleEndian.Uint64(s)
 	} else {
-		for i := 0; i < len(s); i++ {
+		for i := range s {
 			x |= uint64(s[i]) << (8 * i)
 		}
 	}
@@ -226,7 +226,7 @@ func UnmarshalSymbolTable(b []byte) (*SymbolTable, int, error) {
 	}
 	off := n
 	raw := make([][]byte, 0, cnt)
-	for i := uint64(0); i < cnt; i++ {
+	for range cnt {
 		if off >= len(b) {
 			return nil, 0, errBadTable
 		}

--- a/internal/fsst/fsst_test.go
+++ b/internal/fsst/fsst_test.go
@@ -29,7 +29,7 @@ func TestCompressDecompressRoundTrip(t *testing.T) {
 
 func TestRoundTripByteRange(t *testing.T) {
 	tbl := newTestTable("ab", "abc") // arbitrary symbols
-	for n := 0; n < 256; n++ {
+	for n := range 256 {
 		in := make([]byte, n)
 		for i := range in {
 			in[i] = byte((i * 7) ^ n)
@@ -54,7 +54,7 @@ func TestRoundTripEscapeByte(t *testing.T) {
 
 func TestBuildSymbolTableShrinksAndRoundTrips(t *testing.T) {
 	samples := make([][]byte, 0, 200)
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		samples = append(samples, []byte("GET /api/v1/users/"+string(rune('a'+i%26))+" HTTP/1.1"))
 	}
 	tbl := BuildSymbolTable(samples)

--- a/map_shape_test.go
+++ b/map_shape_test.go
@@ -306,7 +306,7 @@ func TestMapShape_Malformed(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Every truncation must error, never panic.
-	for cut := 0; cut < len(b); cut++ {
+	for cut := range b {
 		func() {
 			defer func() {
 				if r := recover(); r != nil {

--- a/qdf.go
+++ b/qdf.go
@@ -438,6 +438,7 @@ func unmarshalQuery(data []byte, out any, qp *queryPlan) error {
 	dec := decPool.Get().(*Decoder)
 	dec.buf = data
 	dec.i = 0
+	dec.depth = 0 // a prior depth-overflow decode leaks depth>0 (descend errors before its defer ascend); reset so a pooled decoder never carries a stale depth into the next decode
 	dec.headerRead = false
 	dec.mode = Fast
 	// colIndex is set fresh by readHeader; reset defensively so a pooled decoder never carries a stale flag.
@@ -467,6 +468,7 @@ func unmarshal(data []byte, out any, fields []string, noCopy bool) error {
 	dec := decPool.Get().(*Decoder)
 	dec.buf = data
 	dec.i = 0
+	dec.depth = 0 // a prior depth-overflow decode leaks depth>0 (descend errors before its defer ascend); reset so a pooled decoder never carries a stale depth into the next decode
 	dec.headerRead = false
 	dec.mode = Fast
 	dec.colIndex = false

--- a/qdf.go
+++ b/qdf.go
@@ -194,6 +194,11 @@ const (
 	// (the maxStateEntries scale) and drops it after a one-off larger decode so
 	// the pool never pins an outlier buffer.
 	maxRetainedDeltaScratch = 1 << 14
+	// maxRetainedWideScratch bounds the int32→int64 / uint32→uint64 widening
+	// scratch a pooled encoder keeps between calls (same ~16 k-element scale as
+	// the delta scratch); a one-off larger narrow-int slice is dropped so the
+	// pool never pins an outlier buffer.
+	maxRetainedWideScratch = 1 << 14
 )
 
 // Options is a bit-mask of per-call encoder feature toggles. A zero
@@ -341,6 +346,15 @@ var (
 func putEnc(enc *Encoder, pool *sync.Pool) {
 	if cap(enc.buf) > maxPooledBuf {
 		enc.buf = nil
+	}
+	// Don't pin a spike-sized widening scratch in the pool: a single huge
+	// []int32/[]uint32 field would otherwise keep its widened []int64/[]uint64
+	// resident on every pooled encoder forever (mirrors the buffer / delta cap).
+	if cap(enc.wideI64) > maxRetainedWideScratch {
+		enc.wideI64 = nil
+	}
+	if cap(enc.wideU64) > maxRetainedWideScratch {
+		enc.wideU64 = nil
 	}
 	pool.Put(enc)
 }

--- a/qdf_generic.go
+++ b/qdf_generic.go
@@ -61,6 +61,7 @@ func UnmarshalT[T any](data []byte, out *T) error {
 	dec := decPool.Get().(*Decoder)
 	dec.buf = data
 	dec.i = 0
+	dec.depth = 0 // reset stale depth from a prior depth-overflow decode (see unmarshal)
 	dec.headerRead = false
 	dec.mode = Fast
 	// Start from a clean pooled decoder: it is shared with Unmarshal /

--- a/qpack_fsst_test.go
+++ b/qpack_fsst_test.go
@@ -182,7 +182,7 @@ func genURLs(n int) []string {
 	methods := []string{"GET", "POST", "PUT", "DELETE"}
 	paths := []string{"/api/v1/users/", "/api/v1/orders/", "/static/img/", "/health/"}
 	out := make([]string, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		out[i] = methods[i%len(methods)] + " https://service.example.com" +
 			paths[i%len(paths)] + itoaTiny(i*7%100000) +
 			"?token=" + itoaTiny(i*2654435761&0xFFFFFF) + " HTTP/1.1"
@@ -192,7 +192,7 @@ func genURLs(n int) []string {
 
 func genRandom(n int) []string {
 	out := make([]string, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		var b [24]byte
 		x := uint32(i)*2654435761 + 1
 		for j := range b {

--- a/qpack_gorilla.go
+++ b/qpack_gorilla.go
@@ -342,6 +342,14 @@ func (d *Decoder) readPackedGorillaFloat64Slice() ([]float64, error) {
 				return nil, ErrShortBuffer
 			}
 			mb := mbLen64 + 1
+			// A well-formed window always has lz + mb <= 64 (lz + mb + tz = 64).
+			// Reject a hostile stream where it exceeds the word width before the
+			// unsigned `64 - lz64 - mb` underflows: that would make the shift
+			// below collapse to 0 (silent wrong value) and poison prevTZ for the
+			// rest of the slice.
+			if lz64+mb > 64 {
+				return nil, ErrInvalidLength
+			}
 			tz := 64 - lz64 - mb
 			mbBits, ok := br.readBits(uint8(mb))
 			if !ok {
@@ -406,6 +414,11 @@ func (d *Decoder) readPackedGorillaFloat32Slice() ([]float32, error) {
 				return nil, ErrShortBuffer
 			}
 			mb := mbLen64 + 1
+			// As in the float64 path: a valid window has lz + mb <= 32; reject a
+			// hostile stream before the unsigned subtraction underflows.
+			if lz64+mb > 32 {
+				return nil, ErrInvalidLength
+			}
 			tz := 32 - lz64 - mb
 			mbBits, ok := br.readBits(uint8(mb))
 			if !ok {

--- a/qpack_gorilla_hostile_test.go
+++ b/qpack_gorilla_hostile_test.go
@@ -1,0 +1,90 @@
+package qdf
+
+import (
+	"math"
+	"testing"
+)
+
+// TestGorillaHostileWindowRejected pins the fix for the Gorilla new-window
+// underflow: a malformed bitstream whose leading-zeros + meaningful-bits exceed
+// the float word width (lz+mb > 64 / > 32) must be rejected, not silently
+// decoded to a wrong value (the unsigned `width - lz - mb` underflowed, the
+// shift collapsed to 0, and prevTZ was poisoned for the rest of the slice).
+func TestGorillaHostileWindowRejected(t *testing.T) {
+	t.Run("float64", func(t *testing.T) {
+		var buf []byte
+		buf = append(buf, qpackKindFloat64) // tag already consumed upstream
+		buf = appendUvarint(buf, 2)         // n = 2
+		buf = appendU64(buf, math.Float64bits(1.0))
+		bw := bitWriter{}
+		bw.writeBit(true)        // ctl: this element differs
+		bw.writeBit(true)        // ctl2: new window
+		bw.writeBits(31, 5)      // lz64 = 31
+		bw.writeBits(63, 6)      // mbLen64 = 63 -> mb = 64; lz+mb = 95 > 64
+		bw.writeBits(0xABCD, 64) // meaningful-bits payload
+		total := bw.flush()
+		buf = appendUvarint(buf, uint64(total))
+		buf = append(buf, bw.buf...)
+
+		d := &Decoder{buf: buf}
+		if _, err := d.readPackedGorillaFloat64Slice(); err == nil {
+			t.Fatal("hostile lz+mb>64 window accepted (silent wrong decode); want error")
+		}
+	})
+	t.Run("float32", func(t *testing.T) {
+		var buf []byte
+		buf = append(buf, qpackKindFloat32)
+		buf = appendUvarint(buf, 2)
+		buf = appendU64(buf, uint64(math.Float32bits(1.0))) // header reads w=4 bytes via readU32
+		bw := bitWriter{}
+		bw.writeBit(true)        // differs
+		bw.writeBit(true)        // new window
+		bw.writeBits(15, 4)      // lz64 = 15
+		bw.writeBits(31, 5)      // mbLen64 = 31 -> mb = 32; lz+mb = 47 > 32
+		bw.writeBits(0xABCD, 32) // payload
+		total := bw.flush()
+		buf = appendUvarint(buf, uint64(total))
+		buf = append(buf, bw.buf...)
+
+		d := &Decoder{buf: buf}
+		if _, err := d.readPackedGorillaFloat32Slice(); err == nil {
+			t.Fatal("hostile lz+mb>32 window accepted (silent wrong decode); want error")
+		}
+	})
+}
+
+// TestGorillaValidStillRoundTrips guards that the new window-width check does
+// not reject any legitimately-encoded Gorilla stream (a valid window always has
+// lz + mb <= word width).
+func TestGorillaValidStillRoundTrips(t *testing.T) {
+	type series struct {
+		F64 []float64 `qdf:"f64"`
+		F32 []float32 `qdf:"f32"`
+	}
+	in := series{
+		F64: make([]float64, 256),
+		F32: make([]float32, 256),
+	}
+	v := 1000.0
+	for i := range in.F64 {
+		v += 0.5 + float64(i%7)*0.01 // smooth-ish -> Gorilla XOR windows
+		in.F64[i] = v
+		in.F32[i] = float32(v)
+	}
+	buf, err := Marshal(in, OptCompression) // Gorilla fires under OptCompression
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out series
+	if err := Unmarshal(buf, &out); err != nil {
+		t.Fatal(err)
+	}
+	for i := range in.F64 {
+		if math.Float64bits(out.F64[i]) != math.Float64bits(in.F64[i]) {
+			t.Fatalf("f64[%d] = %v, want %v", i, out.F64[i], in.F64[i])
+		}
+		if math.Float32bits(out.F32[i]) != math.Float32bits(in.F32[i]) {
+			t.Fatalf("f32[%d] = %v, want %v", i, out.F32[i], in.F32[i])
+		}
+	}
+}

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -431,13 +431,7 @@ func (e *Encoder) encodeStringMapShaped(rv reflect.Value, keyType, valType refle
 		for it.Next() {
 			keyHolder.SetIterKey(it) // SetIterKey reuses the holder; it.Key() would alloc
 			k := keyHolder.String()
-			found := false
-			for _, name := range order {
-				if name == k {
-					found = true
-					break
-				}
-			}
+			found := slices.Contains(order, k)
 			if !found {
 				return false
 			}
@@ -1229,8 +1223,8 @@ func noPointers(t reflect.Type) bool {
 	case reflect.Array:
 		return noPointers(t.Elem())
 	case reflect.Struct:
-		for i := 0; i < t.NumField(); i++ {
-			if !noPointers(t.Field(i).Type) {
+		for field := range t.Fields() {
+			if !noPointers(field.Type) {
 				return false
 			}
 		}

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -672,12 +672,20 @@ func encodeSliceFloat64(e *Encoder, p unsafe.Pointer) error {
 			// the common smooth-data path still encodes Gorilla once.
 			if gorCodec, _ := pickF64Codec(s); gorCodec == qpackGorilla {
 				start := len(e.buf)
+				hdrBefore, flagBefore := e.headerOut, e.headerFlagAt
 				e.writePackedGorillaFloat64Slice(s)
 				gorActual := len(e.buf) - start
 				if gorActual < rawEst && (!alpWins || alpEst >= gorActual) {
 					return nil
 				}
-				e.buf = e.buf[:start] // Gorilla did not win — roll back
+				// Gorilla did not win — roll back. writePackedGorilla* may have
+				// emitted the stream header (top-level first write); truncating to
+				// `start` drops those bytes, but writeHeader's headerOut latch would
+				// then suppress the fallback's header and produce a headerless,
+				// undecodable stream. Restore the pre-attempt header state so the
+				// raw/ALP fallback re-emits the header when it was rolled away.
+				e.buf = e.buf[:start]
+				e.headerOut, e.headerFlagAt = hdrBefore, flagBefore
 			}
 			if alpWins {
 				e.writePackedALPFloat64Slice(s, plan)

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -198,13 +198,38 @@ func decodeSliceInt(d *Decoder, p unsafe.Pointer) error {
 	*(*[]int)(p) = out
 	return nil
 }
+
+// widenI64 promotes s into the encoder's reused int64 widening scratch and
+// returns the filled slice. The result is valid only until the next widenI64
+// call on the same encoder; the QPack int32 path consumes it (pick + emit)
+// before any such call, so a single buffer serves every []int32 field.
+func (e *Encoder) widenI64(s []int32) []int64 {
+	if cap(e.wideI64) < len(s) {
+		e.wideI64 = make([]int64, len(s))
+	}
+	w := e.wideI64[:len(s)]
+	for i, v := range s {
+		w[i] = int64(v)
+	}
+	return w
+}
+
+// widenU64 is the uint32→uint64 analogue of widenI64.
+func (e *Encoder) widenU64(s []uint32) []uint64 {
+	if cap(e.wideU64) < len(s) {
+		e.wideU64 = make([]uint64, len(s))
+	}
+	w := e.wideU64[:len(s)]
+	for i, v := range s {
+		w[i] = uint64(v)
+	}
+	return w
+}
+
 func encodeSliceInt32(e *Encoder, p unsafe.Pointer) error {
 	s := *(*[]int32)(p)
 	if e.qpack {
-		w := make([]int64, len(s))
-		for i, v := range s {
-			w[i] = int64(v)
-		}
+		w := e.widenI64(s)
 		codec, mn, forBits, first, minDelta, deltaBits, pforBits, bestCost := pickI64Codec(w)
 		// Never-worse floor: native int32-raw is 4 B/elem vs the picker's 8 B/elem
 		// uint64-raw baseline. Emit the widened codec only when it beats native
@@ -413,10 +438,7 @@ func decodeSliceInt64(d *Decoder, p unsafe.Pointer) error {
 func encodeSliceUint32(e *Encoder, p unsafe.Pointer) error {
 	s := *(*[]uint32)(p)
 	if e.qpack {
-		w := make([]uint64, len(s))
-		for i, v := range s {
-			w[i] = uint64(v)
-		}
+		w := e.widenU64(s)
 		codec, mn, forBits, first, minDelta, deltaBits, pforBits, bestCost := pickU64Codec(w)
 		// Never-worse floor: the picker scores codecs against the uint64-raw
 		// 8 B/elem baseline, but the native form for a uint32 is 4 B/elem. Emit

--- a/testdata/fuzz/FuzzRoundTrip_Float64Slice/19981bffc2abbaf1
+++ b/testdata/fuzz/FuzzRoundTrip_Float64Slice/19981bffc2abbaf1
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("A")


### PR DESCRIPTION
#### Perf — the headline change

The QPack slice encoders promote `[]int32` / `[]uint32` to `[]int64` / `[]uint64`
so the int64/uint64 codec pickers can score them. Each field did a fresh
`make([]int64, len)` / `make([]uint64, len)` per encode — on a narrow-int-heavy
payload that is the **dominant encode allocation** (`LargePayload` QPack profile:
`encodeSliceInt32` = 31 % of alloc objects, 115 MB of alloc space).

Reuse a per-encoder widening buffer (`wideI64` / `wideU64`). The
`widen → pick → emit` sequence is atomic (no nested slice encode runs between the
fill and the last read), so one buffer per element type safely serves every
narrow-int slice field in a message. Bounded on return to the encoder pool
(`maxRetainedWideScratch`) so a one-off huge column is not pinned.

Measured (`LargePayload` encode):

| preset  | allocs/op       | B/op            |
|---------|-----------------|-----------------|
| qpack   | 31 105 → **19** | −1.9 MB (−6 %)  |
| dense   | 31 160 → **74** | −1.9 MB (−8 %)  |

`ns/op` ≈ 8 % faster from the dropped GC churn. **Wire format unchanged** (decode
and golden fixtures untouched); the `[]int64` / `[]uint64` paths are unaffected.

#### Correctness fixes found during the pre-PR bug hunt

A multi-agent review + a fuzz sweep surfaced four issues (each validated against
a concrete repro before fixing):

1. **`fix(gorilla)` — hostile-window underflow.** The Gorilla XOR float decoders
   compute the trailing-zero count as the unsigned `width − lz − mb`. A malformed
   stream with `lz + mb > width` underflowed, collapsing `mbBits << tz` to 0 — a
   **silent wrong value** plus a poisoned `prevTZ` cascading through the slice, no
   error returned. Now rejected with `ErrInvalidLength` (float64 > 64, float32 >
   32); a valid encoder never trips it.

2. **`fix(encode)` — header dropped on a losing Gorilla rollback** *(pre-existing,
   found by `FuzzRoundTrip_Float64Slice`)*. `encodeSliceFloat64` emits Gorilla
   speculatively and rolls the buffer back when raw/ALP wins. On a top-level slice
   the Gorilla write had lazily emitted the stream header inside the rolled-back
   region; the truncation dropped the bytes but the `headerOut` latch stayed set,
   so the fallback produced a **headerless, undecodable stream** (`bad magic`).
   Fixed by restoring `headerOut` / `headerFlagAt` across the rollback.

3. **`fix(decode)` — depth leak on pooled return.** `descend()` increments before
   the caller registers `defer ascend()`, so a depth-overflow decode unwinds to
   `depth = 1`; the pooled dispatch paths did not reset it, shrinking the next
   decode's nesting budget. Now reset at decode setup in all three paths.

4. **`test(encode)`** — the widen-scratch test asserted an absolute alloc count
   (flaky under `-race`); rewritten to a deterministic mechanism + integration
   check that runs identically with or without the race detector.

#### Deferred (not in this PR)

`pickI64Codec` / `pickU64Codec` do not update the returned `bestCost` when PFOR
wins, so the narrow-int never-worse floor can emit native int32-raw instead of a
smaller PFOR form. This is a **size miss, not a correctness bug** (the
never-worse-vs-raw contract holds and decode is correct) and it **changes the
wire** for affected columns, so it belongs in its own measure-first PR (with
golden regeneration), not here.

### Verification

- `go test -race ./...` and `go test ./...` green; `golangci-lint` 0 issues.
- Fuzz sweep (`Float64Slice`, `Float32Slice`, `Compression`, `AllModesAgree`)
  clean; the `Float64Slice` crasher is committed as a regression corpus entry.
- Golden fixtures unchanged (wire format is identical).