### PR TITLE
perf: small alloc / loop-pass cleanups in the codec hot paths (no wire change)

### DIFF
--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -466,10 +467,8 @@ func (g *gen) pushPath(name string) error {
 	if len(g.path) >= maxNestingDepth {
 		return fmt.Errorf("nesting depth %d exceeds limit (cycle through value types?)", len(g.path))
 	}
-	for _, p := range g.path {
-		if p == name {
-			return fmt.Errorf("cycle detected: %s -> ... -> %s through value-typed fields; use a pointer", strings.Join(g.path, " -> "), name)
-		}
+	if slices.Contains(g.path, name) {
+		return fmt.Errorf("cycle detected: %s -> ... -> %s through value-typed fields; use a pointer", strings.Join(g.path, " -> "), name)
 	}
 	g.path = append(g.path, name)
 	return nil

--- a/columnar.go
+++ b/columnar.go
@@ -82,6 +82,12 @@ type colColumn struct {
 type columnarPlan struct {
 	cols   []colColumn
 	stride uintptr // struct size, for base + i*stride addressing
+	// colNames / colKinds mirror cols[].name / cols[].kind as standalone slices,
+	// precomputed once at build so encodeColumnar hands them to the shape
+	// lookup/declare without rebuilding a transient pair every batch. The plan is
+	// immutable after build, so the slice the shape table retains stays valid.
+	colNames []string
+	colKinds []colKind
 }
 
 // columnarMinElems is the smallest slice length worth transposing; below it
@@ -149,7 +155,13 @@ func buildColumnarPlan(td *typeDesc) *columnarPlan {
 		}
 		cols = append(cols, colColumn{name: f.name, offset: f.offset, kind: ck, width: w, isByte: isByte, elemType: elemType})
 	}
-	return &columnarPlan{cols: cols, stride: td.rType.Size()}
+	names := make([]string, len(cols))
+	kinds := make([]colKind, len(cols))
+	for i := range cols {
+		names[i] = cols[i].name
+		kinds[i] = cols[i].kind
+	}
+	return &columnarPlan{cols: cols, stride: td.rType.Size(), colNames: names, colKinds: kinds}
 }
 
 // colShapeDeclare registers a new columnar shape (names + kinds) on the encoder
@@ -392,13 +404,7 @@ func (e *Encoder) encodeColumnar(plan *columnarPlan, base unsafe.Pointer, n int)
 	e.buf = append(e.buf, tagColStruct)
 	e.buf = appendUvarint(e.buf, uint64(n))
 
-	names := make([]string, len(plan.cols))
-	kinds := make([]colKind, len(plan.cols))
-	for i := range plan.cols {
-		names[i] = plan.cols[i].name
-		kinds[i] = plan.cols[i].kind
-	}
-	if id := st.colShapeFor(names, kinds); id != 0 {
+	if id := st.colShapeFor(plan.colNames, plan.colKinds); id != 0 {
 		e.buf = appendUvarint(e.buf, uint64(id))
 	} else {
 		e.buf = appendUvarint(e.buf, 0)
@@ -407,7 +413,7 @@ func (e *Encoder) encodeColumnar(plan *columnarPlan, base unsafe.Pointer, n int)
 			e.WriteString(plan.cols[i].name)
 			e.buf = append(e.buf, byte(plan.cols[i].kind))
 		}
-		st.colShapeDeclare(names, kinds)
+		st.colShapeDeclare(plan.colNames, plan.colKinds)
 	}
 
 	idxAt := -1
@@ -1457,7 +1463,8 @@ func decodeColumnarAny(d *Decoder) (any, error) {
 		// column-length index present we advance past the whole column body
 		// without decoding (the perf path); without it we still must decode to
 		// stay in sync, but the value is simply not stored below.
-		if !d.wantField(name) && colLens != nil {
+		want := d.wantField(name)
+		if !want && colLens != nil {
 			if d.i+int(colLens[c]) > len(d.buf) {
 				return nil, ErrShortBuffer
 			}
@@ -1467,7 +1474,7 @@ func decodeColumnarAny(d *Decoder) (any, error) {
 		// store is false only on the no-index skip path: the column body still
 		// has to be decoded to keep the cursor in sync, but its values are
 		// dropped rather than boxed into the row maps.
-		store := d.wantField(name)
+		store := want
 		if sh.kinds[c].isNullable() {
 			vals, err := d.decodeNullableColumnAny(sh.kinds[c], n)
 			if err != nil {

--- a/map_shape.go
+++ b/map_shape.go
@@ -43,8 +43,7 @@ func mapStringShapeOrder[V any](e *Encoder, m map[string]V) []string {
 	for k := range m {
 		setHash += internKeyHash(k) // commutative: order-independent
 	}
-	if id, ok := st.mapShapeFind(setHash, n); ok {
-		order := st.mapShapeKeys(id)
+	if id, order, ok := st.mapShapeFindKeys(setHash, n); ok {
 		if len(order) == n && mapHasAll(m, order) {
 			st.lastMapShapeID, st.lastMapShapeKeys = id, order
 			e.buf = append(e.buf, tagMapShape)

--- a/map_shape_test.go
+++ b/map_shape_test.go
@@ -25,29 +25,29 @@ func TestOptMapShape_Bit(t *testing.T) {
 
 func TestEncStateMapShape_Registry(t *testing.T) {
 	st := newEncState()
-	if _, ok := st.mapShapeFind(0x1234, 2); ok {
+	if _, _, ok := st.mapShapeFindKeys(0x1234, 2); ok {
 		t.Fatal("empty registry must miss")
 	}
 	keys := []string{"client", "version"} // canonical (sorted)
 	st.mapShapeRegister(0x1234, 2, keys, 7)
-	id, ok := st.mapShapeFind(0x1234, 2)
+	id, got, ok := st.mapShapeFindKeys(0x1234, 2)
 	if !ok || id != 7 {
 		t.Fatalf("find = (%d,%v), want (7,true)", id, ok)
 	}
-	if got := st.mapShapeKeys(7); len(got) != 2 || got[0] != "client" || got[1] != "version" {
-		t.Fatalf("mapShapeKeys = %v", got)
+	if len(got) != 2 || got[0] != "client" || got[1] != "version" {
+		t.Fatalf("findKeys keys = %v", got)
 	}
 	// Length disambiguates a setHash collision across different set sizes.
-	if _, ok := st.mapShapeFind(0x1234, 3); ok {
+	if _, _, ok := st.mapShapeFindKeys(0x1234, 3); ok {
 		t.Fatal("len mismatch must miss")
 	}
 	// Register mutates nothing the caller owns: caller slice change must not leak.
 	keys[0] = "MUTATED"
-	if got := st.mapShapeKeys(7); got[0] != "client" {
+	if _, got, ok := st.mapShapeFindKeys(0x1234, 2); !ok || got[0] != "client" {
 		t.Fatal("mapShapeRegister must clone keys")
 	}
 	st.reset()
-	if _, ok := st.mapShapeFind(0x1234, 2); ok {
+	if _, _, ok := st.mapShapeFindKeys(0x1234, 2); ok {
 		t.Fatal("reset must clear the registry")
 	}
 }

--- a/qpack_dict.go
+++ b/qpack_dict.go
@@ -218,7 +218,13 @@ func (d *Decoder) readPackedDictUint64Slice() ([]uint64, error) {
 	bodyBytes := (n*bitsPer + 7) >> 3
 	body := d.buf[d.i : d.i+bodyBytes]
 	d.i += bodyBytes
-	idx := make([]uint64, n)
+	// Reuse the shared transient unpack scratch (as the Delta+FOR readers do):
+	// idx holds the bit-unpacked dictionary indices, fully written by Unpack and
+	// only read to map table->out, never aliased into the returned slice.
+	if cap(d.deltaScratch) < n {
+		d.deltaScratch = make([]uint64, n)
+	}
+	idx := d.deltaScratch[:n]
 	bitpack.Unpack(idx, body, bitsPer)
 	for i, k := range idx {
 		if k >= uint64(count) {
@@ -269,7 +275,12 @@ func (d *Decoder) readPackedDictInt64Slice() ([]int64, error) {
 	bodyBytes := (n*bitsPer + 7) >> 3
 	body := d.buf[d.i : d.i+bodyBytes]
 	d.i += bodyBytes
-	idx := make([]uint64, n)
+	// Reuse the shared transient unpack scratch (mirrors readPackedDictUint64Slice
+	// and the Delta+FOR readers); idx is fully written then mapped into out.
+	if cap(d.deltaScratch) < n {
+		d.deltaScratch = make([]uint64, n)
+	}
+	idx := d.deltaScratch[:n]
 	bitpack.Unpack(idx, body, bitsPer)
 	for i, k := range idx {
 		if k >= uint64(count) {

--- a/qpack_pfor.go
+++ b/qpack_pfor.go
@@ -71,18 +71,17 @@ func (e *Encoder) writePackedPForUint64Slice(s []uint64, mn uint64, b int) {
 	out = append(out, make([]byte, bodyBytes)...)
 	body := out[start : start+bodyBytes]
 	var chunk [64]uint64
+	excN := 0
 	for i := 0; i < n; i += len(chunk) {
 		end := min(i+len(chunk), n)
 		for j, v := range s[i:end] {
-			chunk[j] = (v - mn) & mask
+			d := v - mn
+			chunk[j] = d & mask
+			if pforIsException(d, b) {
+				excN++ // counted in the pack pass — same d=v-mn, no second scan
+			}
 		}
 		bitpack.PackChunk(body, chunk[:end-i], b, i)
-	}
-	excN := 0
-	for _, v := range s {
-		if pforIsException(v-mn, b) {
-			excN++
-		}
 	}
 	out = appendUvarint(out, uint64(excN))
 	prev := 0
@@ -159,18 +158,17 @@ func (e *Encoder) writePackedPForInt64Slice(s []int64, mn int64, b int) {
 	out = append(out, make([]byte, bodyBytes)...)
 	body := out[start : start+bodyBytes]
 	var chunk [64]uint64
+	excN := 0
 	for i := 0; i < n; i += len(chunk) {
 		end := min(i+len(chunk), n)
 		for j, v := range s[i:end] {
-			chunk[j] = (uint64(v) - mnU) & mask
+			d := uint64(v) - mnU
+			chunk[j] = d & mask
+			if pforIsException(d, b) {
+				excN++ // folded into the pack pass (same delta, no second scan)
+			}
 		}
 		bitpack.PackChunk(body, chunk[:end-i], b, i)
-	}
-	excN := 0
-	for _, v := range s {
-		if pforIsException(uint64(v)-mnU, b) {
-			excN++
-		}
 	}
 	out = appendUvarint(out, uint64(excN))
 	prev := 0

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -453,8 +453,7 @@ func (e *Encoder) encodeStringMapShaped(rv reflect.Value, keyType, valType refle
 		keyHolder.SetIterKey(iter) // reuse holder; iter.Key() would alloc
 		setHash += internKeyHash(keyHolder.String())
 	}
-	if id, ok := st.mapShapeFind(setHash, n); ok {
-		order := st.mapShapeKeys(id)
+	if id, order, ok := st.mapShapeFindKeys(setHash, n); ok {
 		if len(order) == n && hasAll(order) {
 			st.lastMapShapeID, st.lastMapShapeKeys = id, order
 			e.buf = append(e.buf, tagMapShape)

--- a/state.go
+++ b/state.go
@@ -428,27 +428,19 @@ func (e *encState) shapeDeclareEnc() uint32 {
 	return e.shapeCount
 }
 
-// mapShapeFind returns the bound shape ID for a key-set identified by its
-// order-independent setHash and count n. The caller MUST still verify the
-// actual keys against the binding (mapShapeKeys) before reuse — setHash is not
-// collision-proof.
-func (e *encState) mapShapeFind(setHash uint64, n int) (uint32, bool) {
+// mapShapeFindKeys looks up an interned map key-set by its order-independent
+// (setHash, n) identity and returns its wire id and canonical key order in a
+// single scan — callers need both, so this folds the former mapShapeFind +
+// mapShapeKeys id-keyed second pass into one. The caller still verifies the
+// actual keys against the returned order before reuse (setHash is not
+// collision-proof).
+func (e *encState) mapShapeFindKeys(setHash uint64, n int) (id uint32, keys []string, ok bool) {
 	for i := range e.mapShapes {
 		if e.mapShapes[i].setHash == setHash && e.mapShapes[i].n == n {
-			return e.mapShapes[i].id, true
+			return e.mapShapes[i].id, e.mapShapes[i].keys, true
 		}
 	}
-	return 0, false
-}
-
-// mapShapeKeys returns the canonical key order for a bound shape ID, or nil.
-func (e *encState) mapShapeKeys(id uint32) []string {
-	for i := range e.mapShapes {
-		if e.mapShapes[i].id == id {
-			return e.mapShapes[i].keys
-		}
-	}
-	return nil
+	return 0, nil, false
 }
 
 // mapShapeRegister binds a key-set to a shape ID. keys must be the canonical


### PR DESCRIPTION
Behavior- and wire-identical micro-optimizations surfaced by a code-quality
review of the encode/decode hot paths. Each removes an allocation, a redundant
full pass, or a duplicate scan; none changes the wire format or any
encoded/decoded value (golden fixtures unchanged). A parallel correctness
bug-hunt over the float/time/entropy codecs and the query/columnar/maps paths
found nothing — these are pure cleanups.

#### 1. `perf(decode)` — dict readers reuse the shared unpack scratch

`readPackedDictUint64Slice` / `readPackedDictInt64Slice` allocated a fresh
`make([]uint64, n)` per call just to hold the bit-unpacked dictionary indices,
then mapped them through the table into the (separately allocated) result. The
Delta+FOR readers already reuse `d.deltaScratch` for the same transient-unpack
role; do the same here. `idx` is fully written by `Unpack` and only read to
index `table -> out`, never aliased into the returned slice — decode-value
identical, one fewer allocation per dict-coded integer column decode.

#### 2. `perf(encode)` — fold the PFOR exception count into the pack pass

`writePackedPForUint64Slice` / `writePackedPForInt64Slice` ran a dedicated O(n)
scan purely to count exceptions before emitting the count, on top of the pack
pass that already computes the same `v - mn` per element. Count in the pack
pass and drop the standalone loop. Wire order and the count value are unchanged
(count still written after the body, before the exception list), so the output
is byte-for-byte identical — it just removes one full pass per PFOR-encoded
slice.

#### 3. `perf(encode)` — precompute columnar shape names/kinds + hoist wantField

`encodeColumnar` rebuilt a `(names, kinds)` pair from `plan.cols` on every batch
only to hand it to the shape lookup/declare. The plan is immutable after build,
so precompute the two slices once in `buildColumnarPlan` and reuse them —
removing a per-batch O(columns) build loop from the encode hot path. The shape
table only reads them (`colShapeFor`) or retains the immutable reference
(`colShapeDeclare`), so behavior and wire bytes are unchanged. Also hoists the
duplicate `d.wantField(name)` call in `decodeColumnarAny` (evaluated twice per
column on the selective `map[string]any` path) into one bool.

#### 4. `refactor(encode)` — fuse mapShapeFind + mapShapeKeys

The map-shape-change branch looked a key-set up by `(setHash, n)` to get its id,
then scanned the same registry again by id to fetch its keys. Callers always
need both, so `mapShapeFindKeys` returns `(id, keys, ok)` from a single scan —
a readability win plus one fewer registry pass on the shape-change path.

#### Scope note

These are CPU / loop-iteration / allocation-count cleanups, not macro-benchmark
wins: the encode/decode paths are already lean (columnar encode ~3 allocs/op,
escape analysis already stack-allocates the per-batch shape slices), so the
gains are in work avoided on specific paths (dict decode, PFOR encode, map-shape
churn), not headline numbers. One candidate — aliasing the input buffer for
byte-typed query columns instead of copying — was **rejected** as a use-after-free
hazard (the rest of decode returns owned data; making one narrow path alias the
caller's buffer is the wrong trade).

### Verification

- `go test -race ./...` and `go test ./...` green; `golangci-lint` 0 issues.
- Golden fixtures unchanged (wire is byte-identical).
- Fuzz sweep (`Int64Slice`, `Uint64Slice`, `StructTriad`, `MapStringInt`,
  `AllModesAgree`) clean — exercises the PFOR/dict/shape/columnar paths touched.