### PR TITLE
fix(stream): poison the decoder after a mid-frame decode error

### DIFF
--- a/state.go
+++ b/state.go
@@ -304,9 +304,7 @@ func (e *encState) reset() {
 	if cap(e.internTable) > maxRetainedIDs*2 {
 		e.internTable = make([]internSlot, internTableInitSize)
 	} else {
-		for i := range e.internTable {
-			e.internTable[i] = internSlot{}
-		}
+		clear(e.internTable) // zero every slot (internSlot{} is the empty sentinel)
 	}
 	e.internLoad = 0
 	e.arena.Reset() // Arena has its own watermark, see internarena.

--- a/stream.go
+++ b/stream.go
@@ -28,6 +28,12 @@ type StreamEncoder struct {
 // so the stream must be abandoned (the valid prefix may still be flushed).
 var ErrStreamBroken = errors.New("qdf: stream encoder broken by a prior mid-message error")
 
+// ErrStreamDecoderBroken is returned by StreamDecoder.Decode after a previous
+// Decode failed mid-message: the read cursor and the shared dense state can no
+// longer be trusted (subsequent frames would misparse), so the stream must be
+// abandoned.
+var ErrStreamDecoderBroken = errors.New("qdf: stream decoder broken by a prior mid-message error")
+
 // NewStreamEncoder returns a stream encoder backed by w. Dense mode
 // activates the full balanced codec set (OptBalanced); Fast mode
 // emits raw tagged bytes (OptSpeed). For finer per-stream tuning,
@@ -150,6 +156,12 @@ type StreamDecoder struct {
 	r   io.Reader
 	dec *Decoder
 	buf *[]byte
+	// broken mirrors StreamEncoder.broken: a mid-frame decode error (or a frame
+	// whose body the value did not consume exactly) leaves the read cursor inside
+	// the failed frame and the shared dense state (intern table, LRU, shapes)
+	// partially advanced — every later frame would misparse. Once broken, further
+	// Decode is refused rather than returning silently wrong values.
+	broken bool
 }
 
 // NewStreamDecoder returns a stream decoder reading from r.
@@ -176,6 +188,9 @@ func (s *StreamDecoder) Decode(out any) error {
 	if s.dec == nil {
 		return io.ErrClosedPipe
 	}
+	if s.broken {
+		return ErrStreamDecoderBroken
+	}
 	// Consume the one-per-stream header before the first frame.
 	if !s.dec.headerRead {
 		if err := s.fill(5, true); err != nil {
@@ -198,11 +213,16 @@ func (s *StreamDecoder) Decode(out any) error {
 	}
 	start := s.dec.i
 	if err := decodeReflect(s.dec, out); err != nil {
+		// The cursor is left partway through the frame and the dense state is
+		// half-advanced; poison the stream so the next Decode fails cleanly
+		// instead of misparsing the rest of this frame as new frames.
+		s.broken = true
 		return err
 	}
 	// The value must consume exactly the framed length; a mismatch means a
 	// corrupt or hostile frame, so reject it instead of desyncing the stream.
 	if s.dec.i-start != framelen {
+		s.broken = true
 		return ErrInvalidLength
 	}
 	return nil

--- a/stream_broken_test.go
+++ b/stream_broken_test.go
@@ -1,0 +1,75 @@
+package qdf
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+// TestStream_DecodeErrorPoisons pins the fix for the mid-frame desync: when a
+// Decode fails partway through a frame (here, decoding a struct frame into an
+// incompatible target), the read cursor and shared dense state are left
+// inconsistent. The decoder must refuse further Decodes with
+// ErrStreamDecoderBroken instead of misparsing the rest of the frame as new
+// frames and returning silently wrong values.
+func TestStream_DecodeErrorPoisons(t *testing.T) {
+	type Evt struct {
+		Country string `qdf:"country"`
+		City    string `qdf:"city"`
+		ID      int    `qdf:"id"`
+	}
+	var w bytes.Buffer
+	enc := NewStreamEncoder(&w, Dense)
+	for i := 0; i < 3; i++ {
+		if err := enc.Encode(Evt{Country: "Lithuania", City: "Vilnius", ID: i}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dec := NewStreamDecoder(bytes.NewReader(w.Bytes()))
+	// Decode the first frame into an incompatible target to force a mid-frame
+	// error (a struct frame cannot decode into *int).
+	var bad int
+	if err := dec.Decode(&bad); err == nil {
+		t.Skip("decoding a struct frame into *int did not error on this build; trigger no longer valid")
+	}
+	// The stream is now poisoned — the next Decode must fail cleanly, not return
+	// a garbage value or a spurious framing error.
+	var ev Evt
+	err := dec.Decode(&ev)
+	if !errors.Is(err, ErrStreamDecoderBroken) {
+		t.Fatalf("after a mid-frame decode error, next Decode = %v, want ErrStreamDecoderBroken (got ev=%+v)", err, ev)
+	}
+}
+
+// TestStream_CleanDecodeNotPoisoned guards the other side: a normal successful
+// decode sequence is never marked broken.
+func TestStream_CleanDecodeNotPoisoned(t *testing.T) {
+	type Evt struct {
+		Name string `qdf:"name"`
+		N    int    `qdf:"n"`
+	}
+	var w bytes.Buffer
+	enc := NewStreamEncoder(&w, Dense)
+	for i := 0; i < 5; i++ {
+		if err := enc.Encode(Evt{Name: "svc", N: i}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+	dec := NewStreamDecoder(bytes.NewReader(w.Bytes()))
+	for i := 0; i < 5; i++ {
+		var ev Evt
+		if err := dec.Decode(&ev); err != nil {
+			t.Fatalf("clean decode %d errored: %v", i, err)
+		}
+		if ev.N != i || ev.Name != "svc" {
+			t.Fatalf("frame %d = %+v", i, ev)
+		}
+	}
+}


### PR DESCRIPTION
A correctness fix found by a stream-state review, plus a one-line cleanup.

#### 1. `fix(stream)` — StreamDecoder desynced after a mid-frame decode error

`StreamDecoder.Decode` buffers a length-framed message, then `decodeReflect`
parses it in place. On an error partway through a frame (a type mismatch with
the target, a corrupt body, an unknown tag) the read cursor was left **inside**
the failed frame and the shared dense state (intern table, LRU, declared
shapes) was **half-advanced**. The error was returned, but the next `Decode`
resumed from that desynced cursor — misparsing the remainder of the failed
frame as new frame-length prefixes and returning either spurious framing errors
or **silently wrong values**, with the dense state diverged from the encoder.

`StreamEncoder` already guards this with a `broken` latch (it refuses further
`Encode` after a mid-message failure because its cross-message state can no
longer be trusted). The decoder had no equivalent. This mirrors it: on any
mid-frame decode error — or a frame whose value does not consume exactly the
framed length — the decoder is marked broken and every later `Decode` returns
`ErrStreamDecoderBroken` instead of undefined results. A clean decode sequence
is unaffected.

Validated with a regression test that reproduces the desync: before the fix, a
second `Decode` after a forced mid-frame error returns a spurious type-mismatch
and an empty value (the cursor walked into the frame body); after the fix it
returns `ErrStreamDecoderBroken`. A companion test pins that a normal multi-frame
decode is never poisoned.

#### 2. `refactor(encode)` — clear() the intern table on reset

Replace the per-slot zeroing loop in `encState.reset` with the `clear()` builtin
(`internSlot{}` is the empty sentinel) — same typed memclr, matching the pattern
already used for the other reset fields.

#### Notes on what was NOT included

A reviewer flagged the plain reflect `decodeMap` branch (2 `reflect.New` per map)
and some bitpack bounds-check-elimination reslices. The map-holder pooling was
**reverted** after measurement: every `map[string]*` value type has a codegen
fast path, so the reflect branch is rarely reached and no allocation win could
be demonstrated. The BCE reslices were skipped (scalar/SIMD divergence risk,
unmeasurable on a thermally-noisy laptop). Only changes with a real,
demonstrable effect ship here.

### Verification

- `go test -race ./...` and `go test ./...` green; `golangci-lint` 0 issues.
- All `Stream*` tests pass; the new poison/clean regression tests pin both sides.
- Fuzz (`StructTriad`) clean. No wire-format change (decode-robustness + a reset
  micro-cleanup only).
