### PR TITLE
fix(query): guard Not() of a non-predicate option against a panic

### DIFF
--- a/query.go
+++ b/query.go
@@ -225,8 +225,14 @@ func simplifyCond(n *condNode) *condNode {
 		return n
 	}
 	if n.op == condNot {
+		// An err-bearing Not built from a non-predicate option (e.g. Not(Select))
+		// carries no kid; keep it verbatim so firstCondErr surfaces its error.
+		// Indexing kids[0] here would panic.
+		if len(n.kids) == 0 {
+			return n
+		}
 		c := simplifyCond(n.kids[0])
-		if c.op == condNot { // Not(Not(x)) -> x
+		if c.op == condNot && len(c.kids) > 0 { // Not(Not(x)) -> x
 			return c.kids[0]
 		}
 		return &condNode{op: condNot, kids: []*condNode{c}, err: n.err}

--- a/query_test.go
+++ b/query_test.go
@@ -149,6 +149,34 @@ func TestSelectInCombinator_Unsupported(t *testing.T) {
 	}
 }
 
+// TestNotOfSelect_Unsupported pins that a Not wrapping a non-predicate option
+// (a Select, which carries no node) returns ErrUnsupported instead of panicking.
+// simplifyCond's condNot branch indexed kids[0] unconditionally, so the err-Not
+// (built with nil kids) crashed before firstCondErr could surface the error —
+// both directly and through the Not(Not(...)) double-negation unwrap.
+func TestNotOfSelect_Unsupported(t *testing.T) {
+	type Row struct {
+		A int32 `qdf:"a"`
+	}
+	rows := make([]Row, 40)
+	for i := range rows {
+		rows[i].A = int32(i)
+	}
+	buf, _ := Marshal(rows, OptBalanced|OptColumnIndex)
+	var out []Row
+
+	if err := Unmarshal(buf, &out, Not(Select("a"))); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("Not(Select): want ErrUnsupported, got %v", err)
+	}
+	if err := Unmarshal(buf, &out, Not(Not(Select("a")))); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("Not(Not(Select)): want ErrUnsupported, got %v", err)
+	}
+	// Also reachable nested inside a combinator.
+	if err := Unmarshal(buf, &out, And(Where("a", func(v int32) bool { return v > 0 }), Not(Select("a")))); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("And(pred, Not(Select)): want ErrUnsupported, got %v", err)
+	}
+}
+
 func TestEmptyAndNoPanic(t *testing.T) {
 	type Row struct {
 		A int32 `qdf:"a"`


### PR DESCRIPTION
Off `main` (`5f06976`, the merged code-cleanup-v2). Single commit; full cert
green (race `./...` + `-tags qdf_simd` + `golangci-lint` 0 issues).

## The bug

`Not(opt)` with a non-predicate option — e.g. `Not(Select("x"))` — builds a
`condNot` node that carries an `ErrUnsupported` but has **no kid** (`Select`
produces a projection, not a predicate node). `simplifyCond` runs *before*
`firstCondErr`, and its `condNot` branch indexed `kids[0]` unconditionally, so
the err-bearing `Not` crashed with `index out of range [0] with length 0`
instead of returning `ErrUnsupported`.

Three reachable shapes panicked:
- `Not(Select("x"))` — the err-Not is the root.
- `Not(Not(Select("x")))` — the double-negation unwrap dereferenced the inner
  err-Not's missing kid.
- `And(Where(...), Not(Select("x")))` — the err-Not sits inside a combinator.

## The fix

Guard the empty-kids case in both spots of `simplifyCond`'s `condNot` branch
(the initial `kids[0]` index and the `Not(Not(x)) -> x` unwrap), keeping the
node verbatim so `firstCondErr` surfaces `ErrUnsupported` cleanly.

`TestNotOfSelect_Unsupported` pins all three shapes (validated RED→GREEN: the
test panics without the guard, returns `ErrUnsupported` with it).

## Test plan
- `go test -race ./...` — green
- `go test -tags qdf_simd ./...` — green
- `golangci-lint run ./...` — 0 issues

## Context
Found during a 5-agent codec sweep (gorilla / rANS / FSST / ALP / query /
nullable-columns / stream-framing). The query panic was the only real bug; the
other findings were clean or non-exploitable LOW hardening (left alone per
measure-first).
