### PR TITLE
fix: Skip() DoS guard + Dense state-table desync fixes

### DIFF
--- a/decode_depth_test.go
+++ b/decode_depth_test.go
@@ -5,6 +5,37 @@ import (
 	"testing"
 )
 
+// TestSkip_DepthGuard_NoStackOverflow drives the hostile deeply-nested payload
+// through the Skip() path: the deep array is the value of an UNKNOWN struct
+// field, which the reflect struct decoder skips rather than materializes. Before
+// Skip got its own descend/ascend guard this recursed unbounded and crashed the
+// process with `fatal error: stack overflow` — the reflect path's depth guard
+// does not cover the Skip subtree.
+func TestSkip_DepthGuard_NoStackOverflow(t *testing.T) {
+	enc := NewEncoder(Fast)
+	enc.EnsureHeader()
+	enc.WriteMapHeader(1)
+	enc.WriteString("unknown") // not a field of target → value is Skip()'d
+	depth := DefaultMaxDepth + 100
+	for range depth {
+		enc.WriteArrayHeader(1)
+	}
+	enc.WriteNil()
+	buf := append([]byte(nil), enc.Bytes()...)
+
+	type target struct {
+		Known int `qdf:"known"`
+	}
+	var out target
+	err := Unmarshal(buf, &out)
+	if err == nil {
+		t.Fatal("expected an error skipping an over-deep unknown field, got nil")
+	}
+	if !errors.Is(err, ErrCycleDetected) {
+		t.Logf("got error %v (acceptable as long as it is not a crash)", err)
+	}
+}
+
 // TestDecode_DepthGuard_NoStackOverflow builds a hostile deeply-nested payload
 // (arrays nested past DefaultMaxDepth) by driving the low-level Encoder, which
 // bypasses the encoder's own recursion guard. Before the decode depth guard

--- a/decoder_skip.go
+++ b/decoder_skip.go
@@ -1,7 +1,18 @@
 package qdf
 
 // Skip advances past one value without materializing it.
+//
+// Skip recurses through nested arrays and maps, so it bounds nesting depth via
+// descend/ascend exactly like the reflect decode path: an unknown struct field
+// whose value is a deeply-nested array is skipped here, and without this guard a
+// hostile payload of N nested arrays would overflow the goroutine stack (an
+// unrecoverable fatal error). The recursive d.Skip() calls below re-enter this
+// guard, so every level is counted.
 func (d *Decoder) Skip() error {
+	if err := d.descend(); err != nil {
+		return err
+	}
+	defer d.ascend()
 	t, err := d.peekTag()
 	if err != nil {
 		return err

--- a/encoder.go
+++ b/encoder.go
@@ -369,6 +369,9 @@ func (e *Encoder) SetIntern(min int, cap int) {
 		e.minIntern = min
 	}
 	if cap > 0 {
+		if cap > maxInternEntries {
+			cap = maxInternEntries // keep max id below the 0xFFFF uint16 sentinel
+		}
 		e.maxStateEntries = cap
 	}
 }
@@ -662,6 +665,14 @@ func (e *Encoder) emitStateRef(id uint32) {
 // be eligible. Use for fields known to be unique per message.
 func (e *Encoder) WriteStringInline(s string) {
 	e.writeHeader()
+	// In Dense mode the decoder resets lastID to invalid on every inline string
+	// read, so the encoder must do the same here — otherwise a later repeated
+	// value emits tagStateRepeat against a lastID the decoder has already
+	// dropped, desyncing the state tables (silent wrong value or
+	// ErrUnknownStateID). Mirrors WriteString's own inline fallthrough.
+	if e.opts.Has(OptDense) && e.state != nil {
+		e.state.lastID = lruInvalidID
+	}
 	e.writeStringInline(s)
 }
 

--- a/qdf_direct_test.go
+++ b/qdf_direct_test.go
@@ -6,6 +6,54 @@ import (
 	"testing"
 )
 
+// TestWriteStringInline_DenseLastIDSync pins that WriteStringInline keeps the
+// Dense state machine in lockstep with the decoder. The decoder resets lastID to
+// invalid on every inline string read; the encoder must mirror that, otherwise a
+// later repeated value emits tagStateRepeat against a lastID the decoder already
+// dropped — desyncing into a wrong value or ErrUnknownStateID.
+func TestWriteStringInline_DenseLastIDSync(t *testing.T) {
+	enc := NewEncoder(Dense)
+	enc.EnsureHeader()
+	enc.WriteString("AAAAAAAA")       // intern id 0
+	enc.WriteString("BBBBBBBB")       // intern id 1, becomes lastID
+	enc.WriteStringInline("CCCCCCCC") // forced inline: must invalidate lastID
+	enc.WriteString("BBBBBBBB")       // repeat of id 1
+	buf := append([]byte(nil), enc.Bytes()...)
+
+	dec := NewDecoderOnBuf(buf)
+	want := []string{"AAAAAAAA", "BBBBBBBB", "CCCCCCCC", "BBBBBBBB"}
+	for i, w := range want {
+		got, err := dec.ReadString()
+		if err != nil {
+			t.Fatalf("ReadString[%d]: %v", i, err)
+		}
+		if got != w {
+			t.Fatalf("ReadString[%d] = %q, want %q", i, got, w)
+		}
+	}
+}
+
+// TestInternCapClampedBelowSentinel pins that the intern-table cap can never
+// admit id 0xFFFF, which the MRU ring and LRU links reserve as their
+// empty/no-neighbour sentinel. A larger cap would let the 65536th interned
+// string take id 0xFFFF and corrupt the chains.
+func TestInternCapClampedBelowSentinel(t *testing.T) {
+	e := NewEncoder(Dense)
+	e.SetIntern(0, 1<<20) // absurd cap; must clamp
+	if e.maxStateEntries > maxInternEntries {
+		t.Fatalf("SetIntern cap not clamped: %d > %d", e.maxStateEntries, maxInternEntries)
+	}
+	if e.maxStateEntries-1 >= 0xFFFF {
+		t.Fatalf("max assignable id %d collides with sentinel 0xFFFF", e.maxStateEntries-1)
+	}
+	// The stream encoder caps its own table and must obey the same ceiling.
+	var buf bytes.Buffer
+	se := NewStreamEncoder(&buf, Dense)
+	if se.enc.maxStateEntries > maxInternEntries {
+		t.Fatalf("stream encoder cap %d exceeds ceiling %d", se.enc.maxStateEntries, maxInternEntries)
+	}
+}
+
 // directSample is a minimal hand-rolled Marshaler / Unmarshaler used
 // to exercise MarshalDirect / UnmarshalDirect without pulling in the
 // separate codegen_test module. Wire layout: id varint, then a string.

--- a/state.go
+++ b/state.go
@@ -257,6 +257,16 @@ func (c *mapHolderCache) release(pooled bool) {
 
 const lruInvalidID = ^uint32(0)
 
+// maxInternEntries is the hard ceiling on the intern-table size. Intern ids are
+// packed into uint16 fields in the MRU ring and the LRU prev/next links, with
+// 0xFFFF reserved as the "empty / no-neighbour" sentinel (mruEmpty,
+// lruLink16Invalid). The largest assignable id must therefore stay below 0xFFFF.
+// The assign gate is `internLoad < maxStateEntries`, so capping maxStateEntries
+// at 0xFFFF yields a max id of 0xFFFE — one below the sentinel. A larger cap
+// would let id 0xFFFF collide with the sentinel and corrupt the LRU/MRU chains
+// (silent wrong-string resolution on later state-refs).
+const maxInternEntries = 0xFFFF
+
 func newEncState() *encState {
 	// arena is zero-value initialised here — its slab is lazily
 	// allocated on first Put (see internarena.Arena.Put).

--- a/stream.go
+++ b/stream.go
@@ -51,7 +51,7 @@ func NewStreamEncoder(w io.Writer, mode Mode) *StreamEncoder {
 // across Encode calls so back-references span the whole stream.
 func NewStreamEncoderWith(w io.Writer, opts Options) *StreamEncoder {
 	buf := bufpool.Get(4096)
-	enc := &Encoder{buf: (*buf)[:0], minIntern: 4, maxStateEntries: 1 << 16, maxDepth: DefaultMaxDepth}
+	enc := &Encoder{buf: (*buf)[:0], minIntern: 4, maxStateEntries: maxInternEntries, maxDepth: DefaultMaxDepth}
 	enc.applyOpts(opts)
 	// The column index is a single-message feature: it backpatches the header
 	// flag at a fixed offset, which a stream's shared/reused buffer invalidates


### PR DESCRIPTION
Off `main` (`fb2ba4c`). Three commits, each a self-contained bug fix; full cert
green (race `./...` + `-tags qdf_simd` + `golangci-lint` 0 issues). Every fix was
validated RED→GREEN.

Three real bugs surfaced by a 4-agent sweep of the less-trodden hot paths
(string-intern table, core wire framing, Dense state machine, columnar core).
The columnar core came back clean.

## Commits

### 1. `fix(decode)` — bound `Skip()` recursion depth  🔴 DoS
`Skip()` recurses through nested arrays and maps but never entered the
descend/ascend depth guard, unlike the reflect decode path. An unknown struct
field whose value is N nested arrays is skipped via `Skip()`, so a hostile
payload of deeply-nested arrays drove N stack frames into an unrecoverable
`fatal error: stack overflow` — a remote crash. The existing depth-guard tests
only covered `decodeAny` (guarded); the `Skip` subtree was not.

Wrap `Skip` in `descend()` / `defer ascend()`; the recursive `d.Skip()` calls
re-enter the guard, so every level is counted and an over-deep payload returns
`ErrCycleDetected` instead of crashing. `TestSkip_DepthGuard_NoStackOverflow`
drives the deep nest through the unknown-field `Skip` path (validated RED→GREEN:
crashes/fails without the guard, returns the error with it).

### 2. `fix(encode)` — invalidate `lastID` in `WriteStringInline` under Dense  🔴 corruption
The decoder resets its Dense `lastID` to invalid on every inline string read, but
the public `WriteStringInline` did not mirror that — unlike `WriteString`'s own
inline fallthrough and the reflect paths. After a forced-inline value the encoder
kept the stale `lastID`, so a later repeated value emitted `tagStateRepeat`
against an id the decoder had already dropped: the repeat decoded as the wrong
string or failed with `ErrUnknownStateID`.

Drop `lastID` to `lruInvalidID` before the inline write when `OptDense` is set.
`TestWriteStringInline_DenseLastIDSync` pins the AAAA / BBBB / inline / BBBB
sequence under Dense (validated RED→GREEN: `ErrUnknownStateID` without the fix).
The bug was masked because the only prior `WriteStringInline` test ran in Fast
mode, where inline == plain.

### 3. `fix(state)` — clamp intern-table cap below the 0xFFFF uint16 sentinel  🟠 latent corruption
Intern ids are packed into uint16 fields in the MRU ring and the LRU prev/next
links, with `0xFFFF` reserved as the empty/no-neighbour sentinel. The assign gate
is `internLoad < maxStateEntries`, so a cap of `1<<16` (the stream encoder's
setting) lets the 65536th interned string take id `0xFFFF`, colliding with the
sentinel and corrupting the LRU/MRU chains — silent wrong-string resolution on
later state-refs. `SetIntern` also accepted an arbitrarily large user cap with no
ceiling.

Add `maxInternEntries` (`0xFFFF`) — capping there yields a max id of `0xFFFE`,
one below the sentinel — and apply it in `SetIntern` and the stream encoder.
`TestInternCapClampedBelowSentinel` pins the clamp and the invariant.

## Test plan
- `go test -race ./...` — green
- `go test -tags qdf_simd ./...` — green
- `golangci-lint run ./...` — 0 issues

## Notes
Sweep also flagged two LOW non-bugs left alone per measure-first: `readUvarint`
accepts non-canonical 10-byte varints (malleability only — every caller re-bounds
the result), and `internarena.Len`/`BytesUsed` are unused debug helpers.