### PR TITLE
fix: reflect map slice-value aliasing + nested Unmarshaler cursor guard

### DIFF
--- a/map_shape_test.go
+++ b/map_shape_test.go
@@ -6,6 +6,80 @@ import (
 	"testing"
 )
 
+// TestDecodeMap_SliceValuesNotAliased pins that a reflect-decoded map whose
+// value type is a slice NOT in the fast-path set ([]int8 here) gives each entry
+// its own backing array. The decode value holder is reused across entries, and
+// reuseOrMakeSlice keeps a cap>=n backing, so without a per-entry reset every
+// map value aliased the last slice decoded — silent corruption.
+func TestDecodeMap_SliceValuesNotAliased(t *testing.T) {
+	in := map[int][]int8{
+		1: {1, 2, 3},
+		2: {4, 5, 6},
+		3: {7, 8, 9},
+		4: {10},
+		5: {11, 12, 13, 14, 15},
+	}
+	for _, opts := range []Options{OptSpeed, OptBalanced} {
+		b, err := Marshal(in, opts)
+		if err != nil {
+			t.Fatalf("opts=%v marshal: %v", opts, err)
+		}
+		var out map[int][]int8
+		if err := Unmarshal(b, &out); err != nil {
+			t.Fatalf("opts=%v unmarshal: %v", opts, err)
+		}
+		if !equalMapIntSlice8(in, out) {
+			t.Fatalf("opts=%v: map slice values aliased/garbled:\n in =%v\n out=%v", opts, in, out)
+		}
+	}
+}
+
+// TestDecodeMap_ShapeSliceValuesNotAliased is the same hazard through the
+// tagMapShape (OptMapShape) decode branch, which uses a pooled value holder.
+func TestDecodeMap_ShapeSliceValuesNotAliased(t *testing.T) {
+	in := map[string][]int8{"alpha": {1, 2}, "beta": {3, 4, 5}, "gamma": {6}}
+	b, err := Marshal(in, OptBalanced|OptMapShape)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string][]int8
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != len(in) {
+		t.Fatalf("len %d != %d", len(out), len(in))
+	}
+	for k, av := range in {
+		bv := out[k]
+		if len(av) != len(bv) {
+			t.Fatalf("key %q len %d != %d", k, len(bv), len(av))
+		}
+		for i := range av {
+			if av[i] != bv[i] {
+				t.Fatalf("key %q [%d] = %d, want %d (aliased?)", k, i, bv[i], av[i])
+			}
+		}
+	}
+}
+
+func equalMapIntSlice8(a, b map[int][]int8) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if av[i] != bv[i] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 func TestOptMapShape_Bit(t *testing.T) {
 	if OptMapShape == 0 {
 		t.Fatal("OptMapShape must be a nonzero bit")

--- a/marshaler.go
+++ b/marshaler.go
@@ -38,10 +38,23 @@ type UnmarshalerOpts interface {
 // method fall back to a copying decode. Used by decodeUnmarshaler and by
 // cmd/qdfgen-generated code; exported for the latter.
 func UnmarshalNested(u Unmarshaler, src []byte, noCopy bool) (int, error) {
-	if noCopy {
-		if uo, ok := u.(UnmarshalerOpts); ok {
-			return uo.UnmarshalQDFOpts(src, true)
-		}
+	var n int
+	var err error
+	if uo, ok := u.(UnmarshalerOpts); ok && noCopy {
+		n, err = uo.UnmarshalQDFOpts(src, true)
+	} else {
+		n, err = u.UnmarshalQDF(src)
 	}
-	return u.UnmarshalQDF(src)
+	if err != nil {
+		return n, err
+	}
+	// Guard the parent cursor against a misbehaving Unmarshaler. Both the
+	// reflect path (decodeUnmarshaler) and the generated code advance the
+	// parent decoder by the returned count; a count larger than the nested
+	// buffer (or negative) would push the cursor out of bounds and panic the
+	// next read. Reject it as a short/invalid buffer instead.
+	if n < 0 || n > len(src) {
+		return 0, ErrShortBuffer
+	}
+	return n, nil
 }

--- a/qdf_direct.go
+++ b/qdf_direct.go
@@ -31,7 +31,7 @@ func MarshalDirect[T Marshaler](v T) ([]byte, error) {
 	}
 	cloned := slices.Clone(out)
 	enc.buf = out[:0]
-	encPool.Put(enc)
+	putEnc(enc, &encPool) // cap a spike-sized buffer/scratch before pooling
 	return cloned, nil
 }
 
@@ -47,11 +47,11 @@ func AppendMarshalDirect[T Marshaler](dst []byte, v T) ([]byte, error) {
 	out, err := v.MarshalQDF(enc.buf)
 	if err != nil {
 		enc.buf = nil
-		encPool.Put(enc)
+		putEnc(enc, &encPool)
 		return dst, err
 	}
 	enc.buf = nil
-	encPool.Put(enc)
+	putEnc(enc, &encPool) // out is the caller's; cap any spike-sized scratch
 	return out, nil
 }
 

--- a/qdf_direct_test.go
+++ b/qdf_direct_test.go
@@ -54,6 +54,38 @@ func TestInternCapClampedBelowSentinel(t *testing.T) {
 	}
 }
 
+// lyingUnmarshaler reports consuming more bytes than the buffer holds.
+type lyingUnmarshaler struct{}
+
+func (lyingUnmarshaler) UnmarshalQDF(src []byte) (int, error) { return len(src) + 100, nil }
+
+// negConsumeUnmarshaler reports a negative byte count.
+type negConsumeUnmarshaler struct{}
+
+func (negConsumeUnmarshaler) UnmarshalQDF([]byte) (int, error) { return -5, nil }
+
+// TestUnmarshalNested_RejectsBadConsumeCount pins that UnmarshalNested rejects a
+// nested Unmarshaler that over- or under-reports bytes consumed. Both the reflect
+// path and generated code advance the parent cursor by this count, so a bogus
+// value would push the cursor out of bounds and panic the next read.
+func TestUnmarshalNested_RejectsBadConsumeCount(t *testing.T) {
+	if _, err := UnmarshalNested(lyingUnmarshaler{}, []byte{1, 2, 3}, false); err == nil {
+		t.Fatal("UnmarshalNested accepted an over-consume count")
+	}
+	if _, err := UnmarshalNested(negConsumeUnmarshaler{}, []byte{1, 2, 3}, false); err == nil {
+		t.Fatal("UnmarshalNested accepted a negative consume count")
+	}
+	// A well-behaved count is still passed through.
+	if n, err := UnmarshalNested(okUnmarshaler{}, []byte{1, 2, 3}, false); err != nil || n != 2 {
+		t.Fatalf("well-behaved UnmarshalNested: n=%d err=%v, want 2,nil", n, err)
+	}
+}
+
+// okUnmarshaler consumes a valid prefix.
+type okUnmarshaler struct{}
+
+func (okUnmarshaler) UnmarshalQDF(src []byte) (int, error) { return 2, nil }
+
 // directSample is a minimal hand-rolled Marshaler / Unmarshaler used
 // to exercise MarshalDirect / UnmarshalDirect without pulling in the
 // separate codegen_test module. Wire layout: id varint, then a string.

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -517,6 +517,12 @@ func decodeMap(t reflect.Type, k, v *typeDesc) func(*Decoder, unsafe.Pointer) er
 			defer d.state.mapDec.release(pooled)
 			for _, name := range names {
 				kh.SetString(name)
+				// Reset the value holder each entry: a slice-backed value type
+				// would otherwise have its backing array reused across entries
+				// (reuseOrMakeSlice keeps a cap>=n backing), so every map value
+				// would alias the last one decoded. Zeroing forces a fresh
+				// MakeSlice per entry. Keys can't contain slices (comparable).
+				vh.SetZero()
 				if err := v.decode(d, vp); err != nil {
 					return err
 				}
@@ -547,6 +553,11 @@ func decodeMap(t reflect.Type, k, v *typeDesc) func(*Decoder, unsafe.Pointer) er
 			if err := k.decode(d, kp); err != nil {
 				return err
 			}
+			// Reset the value holder each entry so a slice-backed value type does
+			// not reuse the previous entry's backing array (reuseOrMakeSlice keeps
+			// a cap>=n backing) and alias every map value onto the last one. Keys
+			// can't contain slices (map keys are comparable), so kv needs no reset.
+			vv.SetZero()
 			if err := v.decode(d, vp); err != nil {
 				return err
 			}


### PR DESCRIPTION
Off `main` (`da5e607`). Three commits; full cert green (race `./...` +
`-tags qdf_simd` + `golangci-lint` 0 issues; the codegen module builds/tests
clean). Both fixes validated RED→GREEN.

Surfaced by a 4-agent sweep of the marshaler-dispatch, reflect-map, and
codec-picker/numeric-scalar paths. The pickers and numeric scalar paths came
back clean.

## Commits

### 1. `fix(decode)` — give each map entry its own slice backing  🔴 corruption
The reflect map decoder reuses one value holder across all entries (a deliberate
hoist that avoids a per-entry `reflect.New`). When the value type is a slice NOT
in the decode fast-path set (e.g. `[]int8`, `[]int16`, `[]NamedT`, `[][]T`,
`[]struct{...}`, or a struct/array containing such a slice), the slice decoder
routes through `reuseOrMakeSlice`, which reuses an existing `cap>=n` backing
array. Across map entries that backing is the *previous* entry's value, so after
`SetMapIndex` copies the slice header into the map, every value ends up aliasing
the last slice decoded — silent data corruption.

This is distinct from the legitimate slice-reuse optimization, which targets a
caller-pre-sized top-level or struct-field slice; across independent map entries
there is no caller backing to reuse, so the reuse was never correct here.

Zero the value holder before each entry (both the plain `decodeMap` loop and the
`tagMapShape`/`OptMapShape` branch) so `reuseOrMakeSlice` allocates a fresh
backing per value. Keys need no reset — map keys are comparable and cannot
contain a slice. `TestDecodeMap_SliceValuesNotAliased` and its `OptMapShape`
twin pin both branches under `OptSpeed` and `OptBalanced` (validated RED→GREEN).

### 2. `fix(decode)` — reject a nested Unmarshaler that mis-reports bytes  🔴 panic
Both the reflect path (`decodeUnmarshaler`) and cmd/qdfgen-generated code advance
the parent decoder's cursor by the byte count a nested `UnmarshalQDF` returns.
That count was trusted unconditionally, so a hand-written or buggy `Unmarshaler`
returning more bytes than the nested buffer holds (or a negative count) pushed
the parent cursor past the end of the buffer; the next field's `RemainingBytes` /
`d.buf[d.i:]` then panicked with slice-bounds-out-of-range instead of erroring.

Validate the count once in the shared `UnmarshalNested` entry point (covering
both callers): reject `n < 0 || n > len(src)` with `ErrShortBuffer`.
`TestUnmarshalNested_RejectsBadConsumeCount` pins over- and under-consume and the
well-behaved pass-through (validated RED→GREEN).

### 3. `perf(encode)` — cap pooled buffer/scratch in the Direct marshal helpers
`MarshalDirect`'s success path and both `AppendMarshalDirect` paths returned the
borrowed encoder to the pool with a bare `encPool.Put`, bypassing `putEnc`. A
single large payload therefore pinned its spike-sized buffer (and any widened
`wideI64`/`wideU64` scratch) in the pool forever, since `putEnc` is what drops
over-cap buffers. Route all three through `putEnc`, matching `MarshalDirect`'s
own error path.

## Test plan
- `go test -race ./...` — green
- `go test -tags qdf_simd ./...` — green
- `golangci-lint run ./...` — 0 issues
- `(cd internal/codegen_test && go test ./...)` — green (nested decode exercises
  the UnmarshalNested guard)