### PR TITLE
fix: asymmetric Marshaler/Unmarshaler clobber + decoder intern-count cap

### DIFF
--- a/decoder_read.go
+++ b/decoder_read.go
@@ -296,6 +296,13 @@ func (d *Decoder) readStringBytes() ([]byte, error) {
 		if d.state == nil {
 			d.state = newDecState()
 		}
+		// A conforming encoder caps the intern table at maxInternEntries so ids
+		// stay below the 0xFFFF MRU/LRU sentinel; a hostile stream claiming more
+		// records would assign id 0xFFFF and corrupt the side-cache chains.
+		// Reject it (mirrors the encoder-side cap).
+		if len(d.state.values) >= maxInternEntries {
+			return nil, ErrInvalidLength
+		}
 		// Register the bytes as-is; they alias the input. If the caller
 		// later turns this into a copy, the table still references the alias
 		// which is fine for the lifetime of the buffer.

--- a/oom_protection_test.go
+++ b/oom_protection_test.go
@@ -169,6 +169,24 @@ func TestOOM_CheckLengthRejectsImpossible(t *testing.T) {
 	}
 }
 
+// TestOOM_InternRecordCountCapped pins the decoder-side parity of the encoder's
+// intern-table cap: a hostile stream with more than maxInternEntries interned
+// records would assign id 0xFFFF, colliding with the MRU/LRU sentinel and
+// corrupting the side caches. A conforming encoder never emits this (it caps and
+// inlines), so the records are hand-crafted as an array of empty interned
+// strings. Decode must reject, not corrupt.
+func TestOOM_InternRecordCountCapped(t *testing.T) {
+	buf := append(mkHeader(), tagArr32)
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(maxInternEntries+1))
+	for i := 0; i <= maxInternEntries; i++ {
+		buf = append(buf, tagInternStr, 0x00) // empty interned string
+	}
+	var out []string
+	if err := Unmarshal(buf, &out); err == nil {
+		t.Fatal("decoder accepted more than maxInternEntries interned records")
+	}
+}
+
 // TestOOM_ZeroWidthConstantCount pins the fix for the constant-value integer
 // codecs (FOR/Delta-FOR/PFor/Dict with bitsPer == 0). They carry an EMPTY
 // packed body, so the per-element byte bound that guards the bitsPer > 0 path

--- a/qdf_direct_test.go
+++ b/qdf_direct_test.go
@@ -86,6 +86,65 @@ type okUnmarshaler struct{}
 
 func (okUnmarshaler) UnmarshalQDF(src []byte) (int, error) { return 2, nil }
 
+// marshalOnly implements ONLY Marshaler. Its MarshalQDF writes a sentinel
+// string, distinct from the map a structural encode of the struct would emit.
+type marshalOnly struct{ X int }
+
+func (marshalOnly) MarshalQDF(dst []byte) ([]byte, error) {
+	e := NewEncoderOnBuf(dst, Fast)
+	if len(dst) >= 5 && dst[0] == Magic0 && dst[1] == Magic1 && dst[2] == Magic2 {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	e.WriteString("SENTINEL-ENC")
+	return e.Bytes(), nil
+}
+
+// unmarshalOnly implements ONLY Unmarshaler (pointer receiver). Its UnmarshalQDF
+// ignores the wire and sets a sentinel, distinct from what a structural decode
+// would read.
+type unmarshalOnly struct{ X int }
+
+func (u *unmarshalOnly) UnmarshalQDF(src []byte) (int, error) {
+	u.X = 999
+	return len(src), nil
+}
+
+// TestAsymmetricMarshaler_NotOverwritten pins that a type implementing only one
+// of Marshaler/Unmarshaler keeps its custom codec for that direction. fillDesc's
+// structural switch unconditionally set both encode and decode, clobbering the
+// custom method unless both were present.
+func TestAsymmetricMarshaler_NotOverwritten(t *testing.T) {
+	// Marshaler-only: custom encode must run (writes a bare string), not the
+	// structural map encode.
+	b, err := Marshal(marshalOnly{X: 7}, OptSpeed)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var s string
+	if err := Unmarshal(b, &s); err != nil {
+		t.Fatalf("custom MarshalQDF was overwritten by structural encode: %v", err)
+	}
+	if s != "SENTINEL-ENC" {
+		t.Fatalf("custom MarshalQDF output = %q, want SENTINEL-ENC", s)
+	}
+
+	// Unmarshaler-only: structural encode (writes {x:7}), custom decode must run
+	// and set the sentinel 999 rather than reading 7 off the wire.
+	eb, err := Marshal(unmarshalOnly{X: 7}, OptSpeed)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out unmarshalOnly
+	if err := Unmarshal(eb, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.X != 999 {
+		t.Fatalf("custom UnmarshalQDF was overwritten by structural decode: X=%d, want 999", out.X)
+	}
+}
+
 // directSample is a minimal hand-rolled Marshaler / Unmarshaler used
 // to exercise MarshalDirect / UnmarshalDirect without pulling in the
 // separate codegen_test module. Wire layout: id varint, then a string.

--- a/reflect_desc.go
+++ b/reflect_desc.go
@@ -111,6 +111,12 @@ func fillDesc(td *typeDesc, t reflect.Type, ctx *buildCtx) error {
 	if td.encode != nil && td.decode != nil {
 		return nil
 	}
+	// A type may implement only ONE of Marshaler/Unmarshaler (the documented
+	// asymmetric case: encode structurally, decode via UnmarshalQDF, or vice
+	// versa). The structural switch below unconditionally sets BOTH td.encode
+	// and td.decode, so snapshot the custom codec and restore it afterward for
+	// the direction it implements — otherwise the custom method is clobbered.
+	customEnc, customDec := td.encode, td.decode
 
 	switch t.Kind() {
 	case reflect.Bool:
@@ -224,6 +230,14 @@ func fillDesc(td *typeDesc, t reflect.Type, ctx *buildCtx) error {
 		td.decode = decodeStruct(td)
 	default:
 		return ErrUnsupported
+	}
+	// Restore a custom Marshaler/Unmarshaler for the direction it implements;
+	// the structural codec above stands in only for the missing direction.
+	if customEnc != nil {
+		td.encode = customEnc
+	}
+	if customDec != nil {
+		td.decode = customDec
 	}
 	return nil
 }


### PR DESCRIPTION
Off `main` (`6bf4335`). Two commits; full cert green (race `./...` +
`-tags qdf_simd` + `golangci-lint` 0 issues; the codegen module builds/tests
clean). Both fixes validated RED→GREEN.

Surfaced by a 3-agent sweep of the type-descriptor build, the OptColumnIndex
seek layer, and the decode-side intern cache. The column-index/seek layer and
the typeDesc cycle/race/cache-key handling came back clean.

## Commits

### 1. `fix(reflect)` — preserve a custom codec for an asymmetric Marshaler/Unmarshaler  🔴 wrong wire
`fillDesc` sets `td.encode` from a Marshaler impl and `td.decode` from an
Unmarshaler impl, then short-circuits only when BOTH are present. A type
implementing just one side — the documented asymmetric case (encode structurally,
decode via `UnmarshalQDF`, or vice versa) — fell through to the structural
switch, which unconditionally reassigns BOTH `td.encode` and `td.decode`,
silently clobbering the custom method. A Marshaler-only type was then encoded
structurally (wrong wire, custom `MarshalQDF` never ran); an Unmarshaler-only
type's `UnmarshalQDF` was replaced by the structural decoder — directly
contradicting the `marshaler.go` doc.

Snapshot the custom encode/decode before the switch and restore the implemented
direction afterward; the structural codec stands in only for the missing side.
`TestAsymmetricMarshaler_NotOverwritten` covers both directions (validated
RED→GREEN). The bug was masked because the only existing marshaler test type
implements both methods, always hitting the short-circuit.

### 2. `fix(decode)` — cap decoder intern-record count below the 0xFFFF sentinel  🟠 hostile-input
The encoder caps the intern table at `maxInternEntries` so assigned ids stay
below the `0xFFFF` MRU/LRU sentinel, but the decoder appended an intern record
for every `tagInternStr`/`tagInternBin` with no matching cap. A hostile stream
with more than `maxInternEntries` interned records (which a conforming encoder
never emits — it inlines past the cap) would assign id `0xFFFF`, colliding with
the sentinel and corrupting the MRU ring / LRU links so later state-refs
mis-resolve. Reject the over-cap record with `ErrInvalidLength`, mirroring the
encoder gate. `TestOOM_InternRecordCountCapped` pins it with a hand-crafted
over-cap stream.

## Test plan
- `go test -race ./...` — green
- `go test -tags qdf_simd ./...` — green
- `golangci-lint run ./...` — 0 issues
- `(cd internal/codegen_test && go test ./...)` — green

## Context
This is the 5th sweep in the bug-hunt campaign; returns are diminishing (both
findings here are niche — asymmetric-marshaler is a rare type shape, the intern
cap is hostile-input-only).