### PR TITLE
feat: Gorilla codec for the float32 slice encode path

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -112,6 +112,13 @@ type Encoder struct {
 	// reader skip columns without decoding them.
 	colIndex bool
 
+	// pairPred / mtf cache OptPairPred / OptMTF (both on in OptBalanced) so the
+	// hot Dense state-ref emit path tests a bool field instead of re-running
+	// opts.Has() several times per repeated value. Set in applyOpts, cleared in
+	// Reset — same pattern as qpack/rans/fsst/colIndex.
+	pairPred bool
+	mtf      bool
+
 	// headerFlagAt is the byte offset of the header flag byte in e.buf,
 	// recorded by writeHeader so encodeColumnar can backpatch FlagColIndex
 	// only when it actually emits a column index.
@@ -170,6 +177,8 @@ func (e *Encoder) applyOpts(opts Options) {
 	e.rans = opts.Has(OptRANS)
 	e.colIndex = opts.Has(OptColumnIndex)
 	e.fsst = e.qpack && opts.Has(OptFSST)
+	e.pairPred = opts.Has(OptPairPred)
+	e.mtf = opts.Has(OptMTF)
 }
 
 // DefaultMaxDepth caps reflect-path pointer/struct recursion. Set
@@ -203,6 +212,10 @@ func NewEncoder(mode Mode) *Encoder {
 		e.state = newEncState()
 		e.opts = OptBalanced
 		e.qpack = true
+		// OptBalanced includes OptPairPred | OptMTF; mirror them onto the cached
+		// flags this constructor sets by hand (it bypasses applyOpts).
+		e.pairPred = true
+		e.mtf = true
 	} else {
 		e.opts = OptSpeed
 	}
@@ -253,6 +266,8 @@ func (e *Encoder) Reset() {
 	e.rans = false
 	e.colIndex = false
 	e.fsst = false
+	e.pairPred = false
+	e.mtf = false
 	e.fsstDict = nil
 	// Drop any PreIntern entries — they reference caller-supplied
 	// backing pointers that are not safe to assume valid across a
@@ -515,7 +530,7 @@ func (e *Encoder) WriteString(s string) {
 						id := e.preIntern[i].id
 						if st.lastID == id {
 							e.buf = append(e.buf, tagStateRepeat)
-							if e.opts.Has(OptPairPred) {
+							if e.pairPred {
 								st.pairRecord(id, id)
 							}
 							return
@@ -537,7 +552,7 @@ func (e *Encoder) WriteString(s string) {
 			// most common Dense hit avoids the non-inlinable call.
 			if st.lastID == id {
 				e.buf = append(e.buf, tagStateRepeat)
-				if e.opts.Has(OptPairPred) {
+				if e.pairPred {
 					st.pairRecord(id, id)
 				}
 				return
@@ -548,7 +563,7 @@ func (e *Encoder) WriteString(s string) {
 		e.buf = append(e.buf, tagInternStr)
 		e.buf = appendUvarint(e.buf, uint64(len(s)))
 		e.buf = appendString(e.buf, s)
-		if st.lastID != lruInvalidID && e.opts.Has(OptPairPred) {
+		if st.lastID != lruInvalidID && e.pairPred {
 			st.pairRecord(st.lastID, id)
 		}
 		st.lastID = id
@@ -580,7 +595,7 @@ func (e *Encoder) WriteString(s string) {
 // chain stays in sync.
 func (e *Encoder) emitStateRef(id uint32) {
 	st := e.state
-	pairOn := e.opts.Has(OptPairPred)
+	pairOn := e.pairPred
 	if st.lastID == id {
 		e.buf = append(e.buf, tagStateRepeat)
 		if pairOn {
@@ -635,7 +650,7 @@ func (e *Encoder) emitStateRef(id uint32) {
 	// rank is necessarily ≥ 128 so the raw form would be picked
 	// anyway; we skip the walk entirely and emit raw.
 	idLen := uvarintLen(uint64(id))
-	if e.opts.Has(OptMTF) {
+	if e.mtf {
 		if rank, ok := st.mruRank(id); ok {
 			st.lruMoveFront(id)
 			if rankLen := uvarintLen(uint64(rank)); rankLen < idLen {
@@ -708,7 +723,7 @@ func (e *Encoder) WriteBytes(b []byte) {
 		if ok {
 			if st.lastID == id {
 				e.buf = append(e.buf, tagStateRepeat)
-				if e.opts.Has(OptPairPred) {
+				if e.pairPred {
 					st.pairRecord(id, id)
 				}
 				return
@@ -719,7 +734,7 @@ func (e *Encoder) WriteBytes(b []byte) {
 		e.buf = append(e.buf, tagInternBin)
 		e.buf = appendUvarint(e.buf, uint64(len(b)))
 		e.buf = append(e.buf, b...)
-		if st.lastID != lruInvalidID && e.opts.Has(OptPairPred) {
+		if st.lastID != lruInvalidID && e.pairPred {
 			st.pairRecord(st.lastID, id)
 		}
 		st.lastID = id

--- a/fuzz_property_test.go
+++ b/fuzz_property_test.go
@@ -65,6 +65,12 @@ func (r *fuzzReader) f64raw() float64 {
 	return math.Float64frombits(r.u64())
 }
 
+// f32raw returns the float32 bit-for-bit without normalising NaN/Inf/−0, so
+// float32 fuzz targets exercise the full IEEE-754 space.
+func (r *fuzzReader) f32raw() float32 {
+	return math.Float32frombits(r.u32())
+}
+
 // boundedLen takes a fuzz-driven byte and clamps it to [0, max].
 func (r *fuzzReader) boundedLen(max int) int {
 	b := r.u8()
@@ -211,6 +217,43 @@ func FuzzRoundTrip_Float64Slice(f *testing.F) {
 			if !floatSliceEqual(in, out) {
 				t.Fatalf("opts=%d []float64 bits NOT preserved:\n in =%v\n out=%v\n inbits =%x\n outbits=%x",
 					opts, in, out, floatBits64(in), floatBits64(out))
+			}
+		}
+	})
+}
+
+// FuzzRoundTrip_Float32Slice mirrors the float64 target for the float32 Gorilla
+// path: every value must survive bit-exactly under every mode, including
+// OptGorillaFloat where the new float32 Gorilla codec fires (and its
+// never-larger rollback to raw).
+func FuzzRoundTrip_Float32Slice(f *testing.F) {
+	f.Add([]byte{0})
+	f.Add(make([]byte, 64))
+	f.Add([]byte{0x00, 0x00, 0xC0, 0x7F}) // float32 quiet NaN
+	f.Add([]byte{0x00, 0x00, 0x80, 0x7F}) // +Inf
+	f.Add([]byte{0x00, 0x00, 0x80, 0xFF}) // -Inf
+	f.Add([]byte{0x00, 0x00, 0x00, 0x80}) // -0
+	f.Fuzz(func(t *testing.T, data []byte) {
+		r := newFuzzReader(data)
+		n := r.boundedLen(256)
+		in := make([]float32, n)
+		for i := range in {
+			in[i] = r.f32raw()
+		}
+		for _, opts := range []Options{OptSpeed, OptQPack, OptBalanced, OptCompression, OptQPack | OptGorillaFloat} {
+			buf, err := Marshal(in, opts)
+			if err != nil {
+				t.Fatalf("opts=%d marshal: %v", opts, err)
+			}
+			var out []float32
+			if err := Unmarshal(buf, &out); err != nil {
+				t.Fatalf("opts=%d unmarshal: %v", opts, err)
+			}
+			if n == 0 {
+				continue
+			}
+			if !f32bitsEqual(in, out) {
+				t.Fatalf("opts=%d []float32 bits NOT preserved:\n in =%v\n out=%v", opts, in, out)
 			}
 		}
 	})

--- a/gorilla_float32_test.go
+++ b/gorilla_float32_test.go
@@ -1,0 +1,131 @@
+package qdf
+
+import (
+	"math"
+	"testing"
+)
+
+// (f32bitsEqual lives in float_edge_codec_test.go — bit-exact []float32 compare.)
+
+// rawF32Wire is the size writePackedFloat32Slice would emit (tag+kind+uvarint+4n),
+// excluding the shared stream header — the never-larger reference.
+func rawF32Wire(n int) int { return 2 + uvarintLen(uint64(n)) + n*4 }
+
+func smoothF32(n int) []float32 {
+	s := make([]float32, n)
+	v := float32(1000.0)
+	for i := range s {
+		v += 0.0009765625 // 1/1024: small, exponent-stable step
+		s[i] = v
+	}
+	return s
+}
+
+// TestGorillaF32_RoundTrip checks bit-exact round-trip through the Gorilla
+// float32 path (OptCompression enables it) across a spread of shapes, including
+// the NaN / Inf / -0.0 / repeat edge cases the XOR codec must preserve.
+func TestGorillaF32_RoundTrip(t *testing.T) {
+	cases := map[string][]float32{
+		"empty":        {},
+		"single":       {3.14},
+		"tiny":         {1, 2, 3, 4, 5},
+		"smooth16":     smoothF32(16),
+		"smooth1000":   smoothF32(1000),
+		"all_equal":    {7, 7, 7, 7, 7, 7, 7, 7, 7, 7},
+		"with_zero":    {0, 0, 1, 0, 2, 0, 0, 0, 3, 0},
+		"neg_zero":     {math.Float32frombits(1 << 31), 0, math.Float32frombits(1 << 31)},
+		"nan_inf":      {float32(math.NaN()), float32(math.Inf(1)), float32(math.Inf(-1)), 1, 2, 3, 4, 5},
+		"random_ish":   {1.1, -9999.5, 0.0001, 42, -0.5, 1e9, -1e-9, 3, 8, 13},
+		"large_smooth": smoothF32(5000),
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			b, err := Marshal(in, OptCompression)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var out []float32
+			if err := Unmarshal(b, &out); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			// Nil-vs-empty: an empty input round-trips to a zero-length slice.
+			if len(in) == 0 {
+				if len(out) != 0 {
+					t.Fatalf("empty: got len %d", len(out))
+				}
+				return
+			}
+			if !f32bitsEqual(in, out) {
+				t.Fatalf("round-trip mismatch:\n in =%v\n out=%v", in, out)
+			}
+		})
+	}
+}
+
+// TestGorillaF32_ShrinksSmooth is the measure-first win check, isolating
+// Gorilla's contribution: OptBalanced|OptGorillaFloat enables the float32
+// Gorilla path WITHOUT the OptRANS/OptFSST final pass that OptCompression layers
+// on top (which would otherwise frame the value region and hide the tag). On
+// smooth data Gorilla must fire (tag present) and shrink the wire vs both raw
+// and the no-Gorilla baseline.
+func TestGorillaF32_ShrinksSmooth(t *testing.T) {
+	const gorOnly = OptBalanced | OptGorillaFloat
+	in := smoothF32(2000)
+
+	b, err := Marshal(in, gorOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, err := Marshal(in, OptBalanced) // no Gorilla → raw float32
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := rawF32Wire(len(in))
+	got := len(b) - 5 // drop the 5-byte stream header to compare against raw body
+	if got >= raw {
+		t.Fatalf("Gorilla did not shrink smooth float32: got %d >= raw %d", got, raw)
+	}
+	if len(b) >= len(base) {
+		t.Fatalf("Gorilla not smaller than no-Gorilla baseline: %d >= %d", len(b), len(base))
+	}
+	t.Logf("smooth float32 n=%d: gorilla=%d raw=%d baseline=%d (%.1f%% of raw)",
+		len(in), got, raw, len(base), 100*float64(got)/float64(raw))
+	// Confirm the Gorilla tag fired (value region starts right after the 5-byte
+	// header when no entropy pass is layered on) — not a silent raw fallback.
+	if len(b) < 7 || b[5] != tagPackGorilla || b[6] != qpackKindFloat32 {
+		t.Fatalf("expected tagPackGorilla/float32 at value start, got %#x %#x", b[5], b[6])
+	}
+}
+
+// TestGorillaF32_NeverLarger checks the never-larger gate: high-entropy float32
+// must NOT inflate beyond the raw encoding (Gorilla rolls back to raw).
+func TestGorillaF32_NeverLarger(t *testing.T) {
+	// Pseudo-random-ish high-entropy float32 (no fixed seed needed; the values
+	// are deterministic and adversarial to XOR delta).
+	in := make([]float32, 1000)
+	x := uint32(0x9e3779b9)
+	for i := range in {
+		x ^= x << 13
+		x ^= x >> 17
+		x ^= x << 5
+		in[i] = math.Float32frombits(x)
+	}
+	// Isolate the Gorilla gate (no rANS/FSST pass on top, which could mask it).
+	b, err := Marshal(in, OptBalanced|OptGorillaFloat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := len(b) - 5
+	raw := rawF32Wire(len(in))
+	if got > raw {
+		t.Fatalf("never-larger violated: high-entropy gorilla=%d > raw=%d", got, raw)
+	}
+	// And it still round-trips.
+	var out []float32
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !f32bitsEqual(in, out) {
+		t.Fatal("high-entropy round-trip mismatch")
+	}
+}

--- a/qpack.go
+++ b/qpack.go
@@ -453,6 +453,45 @@ func pickF64Codec(s []float64) (qpackCodec, int) {
 	return qpackRaw, rawBytes
 }
 
+// pickF32Codec is the float32 twin of pickF64Codec: it projects Gorilla's
+// average bits-per-element from a sample prefix and recommends Gorilla only when
+// that projection is comfortably below the raw 32 bits/elem. Raw bytes are exact
+// (tag + kind + uvarint(n) + 4n); the Gorilla figure is an estimate — the caller
+// emits Gorilla for real and re-checks against raw, so this only decides whether
+// the attempt is worth making. The XOR window uses 4-bit leading-zero / 5-bit
+// meaningful-bit fields here (vs 5/6 for float64), so the per-new-window control
+// overhead is ~11 bits.
+func pickF32Codec(s []float32) (qpackCodec, int) {
+	n := len(s)
+	rawBytes := 2 + uvarintLen(uint64(n)) + n*4
+	if n < 8 {
+		// Gorilla's fixed overhead (kind + first u32 + numBits varuint) dominates
+		// on tiny slices.
+		return qpackRaw, rawBytes
+	}
+	probe := min(32, n-1)
+	var total uint64
+	prev := math.Float32bits(s[0])
+	for i := 1; i <= probe; i++ {
+		cur := math.Float32bits(s[i])
+		x := cur ^ prev
+		if x == 0 {
+			total++ // repeat: one control bit
+		} else {
+			meaningful := uint64(32 - bits.LeadingZeros32(x) - bits.TrailingZeros32(x))
+			total += meaningful + 11
+		}
+		prev = cur
+	}
+	avgBits := total / uint64(probe)
+	gorBytes := 2 + uvarintLen(uint64(n)) + 4 + (int(avgBits)*n+7)/8
+	// Keep the same 75%-of-raw threshold as float64 (48/64): 24/32.
+	if avgBits+1 < 24 {
+		return qpackGorilla, gorBytes
+	}
+	return qpackRaw, rawBytes
+}
+
 // QPack codec helpers. Each codec emits a single self-described tagged
 // payload that replaces the per-element tag stream for one slice. The
 // codecs are opt-in (Encoder.SetQPack); decoders accept the new tags

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -646,7 +646,7 @@ func encodeStruct(td *typeDesc) func(*Encoder, unsafe.Pointer) error {
 			e.buf = append(e.buf, tagMapShape)
 			e.buf = appendUvarint(e.buf, 0) // 0 ⇒ declaration follows
 			e.buf = appendUvarint(e.buf, uint64(n))
-			pairOn := e.opts.Has(OptPairPred)
+			pairOn := e.pairPred
 			for i := range fields {
 				f := &fields[i]
 				if len(f.name) >= e.minIntern && int(st.internLoad) < e.maxStateEntries {
@@ -686,7 +686,7 @@ func encodeStruct(td *typeDesc) func(*Encoder, unsafe.Pointer) error {
 		if e.opts.Has(OptDense) && e.state != nil {
 			e.WriteMapHeader(n)
 			st := e.state
-			pairOn := e.opts.Has(OptPairPred)
+			pairOn := e.pairPred
 			for i := range fields {
 				f := &fields[i]
 				if len(f.name) >= e.minIntern && int(st.internLoad) < e.maxStateEntries {

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -606,6 +606,30 @@ func decodeSliceUint64(d *Decoder, p unsafe.Pointer) error {
 func encodeSliceFloat32(e *Encoder, p unsafe.Pointer) error {
 	s := *(*[]float32)(p)
 	if e.qpack {
+		// Mirror encodeSliceFloat64's Gorilla branch (float32 has no ALP). The
+		// projection from pickF32Codec is only a hint, so emit Gorilla for real,
+		// measure it, and keep it solely when it actually beat raw — a true
+		// never-larger gate. The rollback re-emits raw only on the rare lose case,
+		// so the common smooth-data path encodes Gorilla once.
+		if e.gorillaFloat {
+			if gorCodec, _ := pickF32Codec(s); gorCodec == qpackGorilla {
+				rawExact := 2 + uvarintLen(uint64(len(s))) + len(s)*4
+				start := len(e.buf)
+				hdrBefore, flagBefore := e.headerOut, e.headerFlagAt
+				e.writePackedGorillaFloat32Slice(s)
+				if len(e.buf)-start < rawExact {
+					return nil
+				}
+				// Gorilla did not win — roll back. writePackedGorilla* may have
+				// emitted the stream header on a top-level first write; truncating to
+				// start drops it, and writeHeader's headerOut latch would then
+				// suppress the raw fallback's header and produce a headerless,
+				// undecodable stream. Restore the pre-attempt header state so the raw
+				// fallback re-emits the header when it was rolled away.
+				e.buf = e.buf[:start]
+				e.headerOut, e.headerFlagAt = hdrBefore, flagBefore
+			}
+		}
 		e.writePackedFloat32Slice(s)
 		return nil
 	}

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -685,7 +685,12 @@ func encodeSliceFloat64(e *Encoder, p unsafe.Pointer) error {
 		// strictly beats both alternatives — pure-smooth floats keep Gorilla,
 		// and nothing grows the wire.
 		if e.gorillaFloat {
-			rawEst := 12 + len(s)*8
+			// Exact raw size (tag + kind + uvarint(n) + 8n), matching what
+			// writePackedFloat64Slice emits. A looser fixed estimate (e.g.
+			// 12+8n) over-counts raw by up to ~10 bytes and could keep Gorilla
+			// when it is marginally LARGER than raw; the exact figure makes the
+			// never-larger gate tight, mirroring the float32 path.
+			rawEst := 2 + uvarintLen(uint64(len(s))) + len(s)*8
 			plan, alpEst, alpOK := alpPlanFloat64(s) // ALP estimate is a safe upper bound
 			alpWins := alpOK && alpEst < rawEst
 			// pickF64Codec only projects Gorilla from a sample prefix, which can


### PR DESCRIPTION
Off `main` (`03f8cbf`). One commit; full cert green (race `./...` +
`-tags qdf_simd` + `golangci-lint` 0 issues + fuzz). Wire-affecting but additive
and never-larger.

## What

`OptGorillaFloat`'s doc already promised Gorilla for "`[]float64` (and
`[]float32`)", and the float32 XOR writer/reader
(`writePackedGorillaFloat32Slice` / `readPackedGorillaFloat32Slice`) already
existed — but `encodeSliceFloat32` never called the writer, so float32 slices
always encoded raw-LE. This completes the intended symmetry.

`encodeSliceFloat32` now mirrors `encodeSliceFloat64`'s Gorilla branch (float32
has no ALP):

- A new `pickF32Codec` projects the XOR cost from a 32-element sample (the
  float32 twin of `pickF64Codec`: `Float32bits`, 32-bit width, 4-bit/5-bit XOR
  window, 75%-of-raw threshold).
- When it recommends Gorilla, the encoder emits Gorilla for real, measures it,
  and keeps it **only when it actually beat the exact raw size**
  (`2 + uvarint(n) + 4n`) — a true never-larger gate with the same header-latch
  rollback the float64 path uses.

Decode and `Skip` already handled `tagPackGorilla`/float32, so this is
encode-only. The wire change is additive: Gorilla fires only when it shrinks the
output, and high-entropy float32 rolls back to raw and never grows.

## Measured (isolated)

`OptBalanced|OptGorillaFloat` (no rANS/FSST layered on top), smooth float32
n=2000:

| codec | bytes |
|-------|-------|
| raw (no Gorilla) | 8009 |
| **Gorilla** | **3761** (47% of raw, **−53%**) |

High-entropy float32 falls back to raw and never inflates. Under full
`OptCompression` (Gorilla → rANS → FSST) the same input lands at 1705 bytes.

## Tests
- `TestGorillaF32_RoundTrip` — bit-exact (`Float32bits`) across smooth / NaN /
  +Inf / -Inf / -0 / repeat / empty / single / tiny / large.
- `TestGorillaF32_ShrinksSmooth` — the isolated win + the Gorilla tag actually
  fired (not a silent raw fallback).
- `TestGorillaF32_NeverLarger` — high-entropy float32 never exceeds raw.
- `FuzzRoundTrip_Float32Slice` — new target across all modes (408k execs clean).
- The previously-vacuous F32 leg of `TestGorillaValidStillRoundTrips` now
  actually exercises the codec.

## Test plan
- `go test -race ./...` — green
- `go test -tags qdf_simd ./...` — green
- `golangci-lint run ./...` — 0 issues
- `go test -fuzz FuzzRoundTrip_Float32Slice` / `FuzzRoundTrip_Compression` — clean
