### PR TITLE
fix: any/interface cycle guard, decodeAny QPack slices, columnar field skip

### DIFF
--- a/bug_sweep6_test.go
+++ b/bug_sweep6_test.go
@@ -1,0 +1,232 @@
+package qdf
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"testing"
+)
+
+// TestEncode_InterfaceCycle_NoStackOverflow pins the depth guard on the dynamic
+// (interface) encode path. encodePtr guards static *T cycles, but a cycle routed
+// through an any-typed field re-entered the reflect machinery via encodeIface
+// without bumping the depth counter → unbounded recursion → fatal stack
+// overflow. It must now return ErrCycleDetected.
+func TestEncode_InterfaceCycle_NoStackOverflow(t *testing.T) {
+	type ifaceNode struct {
+		V    int `qdf:"v"`
+		Next any `qdf:"next"`
+	}
+	a := &ifaceNode{V: 1}
+	a.Next = a // self-cycle through the any field
+	if _, err := Marshal(a, OptBalanced); !errors.Is(err, ErrCycleDetected) {
+		t.Fatalf("want ErrCycleDetected, got %v", err)
+	}
+	// Mutual cycle A -> B -> A through any fields.
+	b := &ifaceNode{V: 2}
+	a.Next = b
+	b.Next = a
+	if _, err := Marshal(a, OptBalanced); !errors.Is(err, ErrCycleDetected) {
+		t.Fatalf("mutual: want ErrCycleDetected, got %v", err)
+	}
+}
+
+// TestDecodeAny_PackedSlices pins that a numeric/bool slice carried by an
+// any-typed field round-trips under the QPack-enabled modes. decodeAny had no
+// case for the tagPack* tags and returned ErrBadTag, so any interface{} value
+// holding such a slice failed to decode under the default OptBalanced.
+func TestDecodeAny_PackedSlices(t *testing.T) {
+	type Box struct {
+		V any `qdf:"v"`
+	}
+	// Incompressible int32/uint32 stay raw-LE at their native width (kind
+	// Int32/Uint32) rather than widening — decodeAny must handle those kinds too.
+	i32 := make([]int32, 50)
+	u32 := make([]uint32, 50)
+	x := uint32(0x9e3779b9)
+	for i := range i32 {
+		x ^= x << 13
+		x ^= x >> 17
+		x ^= x << 5
+		i32[i] = int32(x)
+		u32[i] = x
+	}
+	cases := []any{
+		[]int64{100, 101, 102, 103, 104, 105, 106, 107, 108, 109},
+		[]uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		[]float64{1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5},
+		[]float32{1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5},
+		[]bool{true, false, true, false, true, false, true, false, true, false},
+		i32,
+		u32,
+	}
+	for _, opts := range []Options{OptQPack, OptBalanced, OptCompression} {
+		for _, v := range cases {
+			b, err := Marshal(Box{V: v}, opts)
+			if err != nil {
+				t.Fatalf("opts=%d %T marshal: %v", opts, v, err)
+			}
+			var out Box
+			if err := Unmarshal(b, &out); err != nil {
+				t.Fatalf("opts=%d %T unmarshal: %v", opts, v, err)
+			}
+			if !reflect.DeepEqual(v, out.V) {
+				t.Fatalf("opts=%d %T: decoded != original\n in =%#v\n out=%#v (%T)", opts, v, v, out.V, out.V)
+			}
+		}
+	}
+
+	// Float edge cases (NaN / ±Inf / -0) must round-trip BIT-exactly through the
+	// any path. reflect.DeepEqual mishandles NaN, so compare via Float*bits.
+	negZero64 := math.Copysign(0, -1)
+	negZero32 := float32(math.Copysign(0, -1))
+	f64 := []float64{math.NaN(), math.Inf(1), math.Inf(-1), negZero64, 1.5, 2.5, 3.5, 4.5}
+	f32 := []float32{float32(math.NaN()), float32(math.Inf(1)), float32(math.Inf(-1)), negZero32, 1.5, 2.5, 3.5, 4.5}
+	bitsEq64 := func(a, b []float64) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if math.Float64bits(a[i]) != math.Float64bits(b[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	for _, opts := range []Options{OptQPack, OptBalanced, OptCompression} {
+		b, _ := Marshal(Box{V: f64}, opts)
+		var o64 Box
+		if err := Unmarshal(b, &o64); err != nil {
+			t.Fatalf("opts=%d f64 edge unmarshal: %v", opts, err)
+		}
+		if !bitsEq64(f64, o64.V.([]float64)) {
+			t.Fatalf("opts=%d f64 edge bits NOT preserved: %#v", opts, o64.V)
+		}
+		b, _ = Marshal(Box{V: f32}, opts)
+		var o32 Box
+		if err := Unmarshal(b, &o32); err != nil {
+			t.Fatalf("opts=%d f32 edge unmarshal: %v", opts, err)
+		}
+		if !f32bitsEqual(f32, o32.V.([]float32)) {
+			t.Fatalf("opts=%d f32 edge bits NOT preserved: %#v", opts, o32.V)
+		}
+	}
+}
+
+// TestDecodeAny_HostileConstantSliceBounded pins that the QPack-slice support in
+// decodeAny cannot be driven into a multi-GB allocation by a tiny hostile header.
+// A constant-value codec (bitsPer == 0) carries an empty body, so its element
+// count is bounded only by qpackMaxStandaloneCount; decoding such a slice through
+// the schemaless any path (the fuzzer's map[string]any / []any target) must reject
+// an over-cap count instead of allocating count*8 bytes. (This guards the OOM the
+// decodeAny QPack support newly exposed to the any-decode path.)
+func TestDecodeAny_HostileConstantSliceBounded(t *testing.T) {
+	// QDF header + map8{1} + key "x" + value = tagPackFor, kind=uint64, bits=0,
+	// min=0, n = qpackMaxStandaloneCount+1 (empty body — a ~16-byte header).
+	buf := append(mkHeader(), tagMap8, 0x01)
+	buf = append(buf, tagFixstr|0x01, 'x')
+	buf = append(buf, tagPackFor, qpackKindUint64, 0x00, 0x00)
+	buf = appendUvarint(buf, uint64(qpackMaxStandaloneCount)+1)
+	var m map[string]any
+	if err := Unmarshal(buf, &m); err == nil {
+		t.Fatal("decodeAny accepted an over-cap constant slice (multi-GB make hazard)")
+	}
+	// A small constant slice still decodes fine through the any path.
+	ok := append(mkHeader(), tagMap8, 0x01)
+	ok = append(ok, tagFixstr|0x01, 'y')
+	ok = append(ok, tagPackFor, qpackKindUint64, 0x00, 0x07) // min=7
+	ok = appendUvarint(ok, 4)
+	var m2 map[string]any
+	if err := Unmarshal(ok, &m2); err != nil {
+		t.Fatalf("small constant slice in any wrongly rejected: %v", err)
+	}
+	if got, _ := m2["y"].([]uint64); len(got) != 4 || got[0] != 7 {
+		t.Fatalf("small constant slice in any decoded wrong: %#v", m2["y"])
+	}
+}
+
+// TestOOM_DictHugeCountBoundedBeforeMake pins that a dictionary-coded integer
+// slice with bitsPer > 0 bounds its element count against the remaining buffer
+// BEFORE allocating. The reader previously ran make([]T, n) ahead of that check,
+// so a ~tiny header (count=2 distinct values, then a huge n with no body) drove
+// a multi-GB allocation — found via the any decode path the fuzzer reaches.
+func TestOOM_DictHugeCountBoundedBeforeMake(t *testing.T) {
+	for _, kind := range []byte{qpackKindInt64, qpackKindUint64} {
+		buf := append(mkHeader(), tagPackDict, kind)
+		buf = appendUvarint(buf, 2)     // 2 distinct values ⇒ bitsForDistinct(2)=1
+		buf = appendUvarint(buf, 0)     // table[0] (zigzag/raw 0)
+		buf = appendUvarint(buf, 2)     // table[1]
+		buf = appendUvarint(buf, 1<<30) // n = 1G elements, but no index body follows
+		var outI []int64
+		var outU []uint64
+		var err error
+		if kind == qpackKindInt64 {
+			err = Unmarshal(buf, &outI)
+		} else {
+			err = Unmarshal(buf, &outU)
+		}
+		if err == nil {
+			t.Fatalf("kind=%#x: huge dict count accepted (multi-GB make hazard)", kind)
+		}
+	}
+}
+
+// TestSkip_ColumnarUnknownField pins that an unknown []struct field encoded in
+// the columnar (tagColStruct) form is skipped correctly during schema-evolution
+// decode. Skip had no tagColStruct case and returned ErrBadTag, aborting the
+// whole decode and losing every trailing field.
+func TestSkip_ColumnarUnknownField(t *testing.T) {
+	type item struct {
+		A int32  `qdf:"a"`
+		B string `qdf:"b"`
+	}
+	type full struct {
+		Items []item `qdf:"items"`
+		Tail  string `qdf:"tail"`
+	}
+	in := full{Tail: "after-columnar"}
+	// 1000 distinct rows so the columnar probe actually picks the columnar form
+	// (tagColStruct) under both OptBalanced and OptCompression — verified below.
+	for i := 0; i < 1000; i++ {
+		in.Items = append(in.Items, item{A: int32(i), B: fmt.Sprintf("s%d", i)})
+	}
+	// A target that drops Items → the Items value routes through Skip(tagColStruct).
+	type partial struct {
+		Tail string `qdf:"tail"`
+	}
+	for _, opts := range []Options{OptBalanced, OptCompression} {
+		b, err := Marshal(in, opts)
+		if err != nil {
+			t.Fatalf("opts=%d marshal: %v", opts, err)
+		}
+		// Guard against a silently-vacuous test: the field MUST be columnar.
+		hasCol := false
+		for _, x := range b {
+			if x == tagColStruct {
+				hasCol = true
+				break
+			}
+		}
+		if !hasCol {
+			t.Fatalf("opts=%d: Items did not encode columnar — test would not exercise Skip(tagColStruct)", opts)
+		}
+		var out partial
+		if err := Unmarshal(b, &out); err != nil {
+			t.Fatalf("opts=%d unmarshal (columnar skip): %v", opts, err)
+		}
+		if out.Tail != in.Tail {
+			t.Fatalf("opts=%d: Tail=%q want %q — columnar skip desynced the stream", opts, out.Tail, in.Tail)
+		}
+		// Control: decoding into the FULL struct must reproduce the columnar data
+		// identically (proves the payload Skip walked over is itself sound, and
+		// that skipping it consumed exactly as many bytes as decoding it).
+		var fullOut full
+		if err := Unmarshal(b, &fullOut); err != nil {
+			t.Fatalf("opts=%d full unmarshal: %v", opts, err)
+		}
+		if !reflect.DeepEqual(in, fullOut) {
+			t.Fatalf("opts=%d: full round-trip mismatch (columnar data not identical)", opts)
+		}
+	}
+}

--- a/decoder_skip.go
+++ b/decoder_skip.go
@@ -596,6 +596,19 @@ func (d *Decoder) Skip() error {
 			}
 		}
 		return nil
+	case tagColStruct:
+		// A columnar []struct payload reached Skip — an unknown struct-slice
+		// field under OptBalanced/OptCompression (schema evolution). Decode it
+		// via the any path and discard the result: that advances the cursor
+		// exactly and replays the shape-table (and any per-column) state a real
+		// decode would, keeping later state-refs in sync — a byte-only skip
+		// could not. Uses the map-path row ceiling (maxColumnarAnyElems); a
+		// skipped columnar field with more rows than that is rejected rather
+		// than skipped, which is far above any realistic schema-evolution batch.
+		if _, err := decodeColumnarAny(d); err != nil {
+			return err
+		}
+		return nil
 	}
 	return ErrBadTag
 }

--- a/qpack_dict.go
+++ b/qpack_dict.go
@@ -203,23 +203,28 @@ func (d *Decoder) readPackedDictUint64Slice() ([]uint64, error) {
 		return nil, ErrInvalidLength
 	}
 	if bitsPer == 0 && n64 > qpackMaxStandaloneCount {
-		// Single distinct value (count == 1 ⇒ bitsPer == 0): empty index
-		// body, so no per-element bound exists. Cap before make().
+		// Single distinct value (count == 1 ⇒ bitsPer == 0): empty index body,
+		// no per-element bound. Cap before make() (columnar bounded by colLenOK).
 		return nil, ErrInvalidLength
 	}
 	n := int(n64)
-	out := make([]uint64, n)
 	if bitsPer == 0 {
+		out := make([]uint64, n)
 		v := table[0]
 		for i := range out {
 			out[i] = v
 		}
 		return out, nil
 	}
+	// bitsPer > 0: the index body is n*bitsPer bits. Bound n against the
+	// remaining buffer BEFORE allocating — the original order ran make() first,
+	// so a tiny header claiming a huge n drove a multi-GB allocation before this
+	// check could reject it.
 	rem := uint64(len(d.buf) - d.i)
 	if n64 > rem*8/uint64(bitsPer) {
 		return nil, ErrShortBuffer
 	}
+	out := make([]uint64, n)
 	bodyBytes := (n*bitsPer + 7) >> 3
 	body := d.buf[d.i : d.i+bodyBytes]
 	d.i += bodyBytes
@@ -265,23 +270,27 @@ func (d *Decoder) readPackedDictInt64Slice() ([]int64, error) {
 		return nil, ErrInvalidLength
 	}
 	if bitsPer == 0 && n64 > qpackMaxStandaloneCount {
-		// Single distinct value (count == 1 ⇒ bitsPer == 0): empty index
-		// body, so no per-element bound exists. Cap before make().
+		// Single distinct value (count == 1 ⇒ bitsPer == 0): empty index body,
+		// no per-element bound. Cap before make() (columnar bounded by colLenOK).
 		return nil, ErrInvalidLength
 	}
 	n := int(n64)
-	out := make([]int64, n)
 	if bitsPer == 0 {
+		out := make([]int64, n)
 		v := table[0]
 		for i := range out {
 			out[i] = v
 		}
 		return out, nil
 	}
+	// bitsPer > 0: bound n against the remaining buffer BEFORE allocating — the
+	// original order ran make() first, so a tiny header claiming a huge n drove
+	// a multi-GB allocation before this check could reject it.
 	rem := uint64(len(d.buf) - d.i)
 	if n64 > rem*8/uint64(bitsPer) {
 		return nil, ErrShortBuffer
 	}
+	out := make([]int64, n)
 	bodyBytes := (n*bitsPer + 7) >> 3
 	body := d.buf[d.i : d.i+bodyBytes]
 	d.i += bodyBytes

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -899,6 +899,20 @@ func encodeIface(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
+	// Bound recursion through the dynamic (interface) dispatch. encodePtr guards
+	// the static *T path, but a cycle routed through an any-typed field re-enters
+	// the reflect machinery here without touching that counter; without this a
+	// self-referential graph (a.Next = a, Next any) recurses unbounded into a
+	// fatal stack overflow. This is the interface chokepoint — every []any /
+	// map[K]any / any-field recursion funnels through it.
+	if e.maxDepth != 0 {
+		e.depth++
+		if e.depth > e.maxDepth {
+			e.depth--
+			return ErrCycleDetected
+		}
+		defer func() { e.depth-- }()
+	}
 	return encodeReflect(e, iv)
 }
 func decodeIface(d *Decoder, p unsafe.Pointer) error {
@@ -1064,8 +1078,68 @@ func decodeAny(d *Decoder) (any, error) {
 	case tagTimestamp:
 		sec, nsec, err := d.ReadTimestamp()
 		return time.Unix(sec, int64(nsec)).UTC(), err
+	case tagPackBool:
+		// A bool slice encoded under OptQPack. Decode into a typed []bool.
+		var s []bool
+		if err := decodeSliceBool(d, unsafe.Pointer(&s)); err != nil {
+			return nil, err
+		}
+		return s, nil
+	case tagPackRaw, tagPackFor, tagPackDeltaFor, tagPackRLE,
+		tagPackDict, tagPackPFor, tagPackGorilla, tagPackALP:
+		// A numeric slice encoded under OptQPack/OptBalanced/OptCompression.
+		// Without these cases decodeAny fell through to ErrBadTag, so any
+		// interface{}/map[string]any value holding such a slice failed to
+		// decode. Materialise into the matching typed slice (the values
+		// round-trip; the int codecs widen to 64-bit on the wire).
+		return decodeAnyPackedSlice(d)
 	}
 	return nil, ErrBadTag
+}
+
+// decodeAnyPackedSlice materialises a QPack-encoded numeric slice into a typed
+// slice for the generic any decode path. The tag (still at d.i) is followed by a
+// one-byte kind that selects the element family/width: integer codecs widen to
+// 64-bit (Int64/Uint64), floats stay Float32/Float64 — the four kinds the
+// encoder emits for these tags. The typed decodeSlice* helper re-peeks the tag
+// and handles every pack variant for that element type.
+func decodeAnyPackedSlice(d *Decoder) (any, error) {
+	if d.i+1 >= len(d.buf) {
+		return nil, ErrShortBuffer
+	}
+	switch d.buf[d.i+1] {
+	case qpackKindInt64:
+		var s []int64
+		err := decodeSliceInt64(d, unsafe.Pointer(&s))
+		return s, err
+	case qpackKindInt32:
+		// raw-LE preserves the native width (the bit-packing codecs widen to
+		// Int64); int32 slices that don't compress land here.
+		var s []int32
+		err := decodeSliceInt32(d, unsafe.Pointer(&s))
+		return s, err
+	case qpackKindUint64:
+		var s []uint64
+		err := decodeSliceUint64(d, unsafe.Pointer(&s))
+		return s, err
+	case qpackKindUint32:
+		var s []uint32
+		err := decodeSliceUint32(d, unsafe.Pointer(&s))
+		return s, err
+	case qpackKindFloat64:
+		var s []float64
+		err := decodeSliceFloat64(d, unsafe.Pointer(&s))
+		return s, err
+	case qpackKindFloat32:
+		var s []float32
+		err := decodeSliceFloat32(d, unsafe.Pointer(&s))
+		return s, err
+	default:
+		// Narrower kinds (Int8/Int16/Uint8/Uint16) never reach a pack tag — they
+		// encode as a plain array (or []byte for uint8), handled by decodeAny's
+		// array/bin cases — so any other kind is malformed input.
+		return nil, ErrBadTag
+	}
 }
 
 func encodeTime(e *Encoder, p unsafe.Pointer) error {

--- a/testdata/fuzz/FuzzDecoder_NeverPanics/aa045c4439ba954e
+++ b/testdata/fuzz/FuzzDecoder_NeverPanics/aa045c4439ba954e
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("QDF\x010\xd5\f\xe0\x0500000\xed\a\v000000J0000\xeb\xeb\xeb\xeb\xec0")


### PR DESCRIPTION
Off `main`. Three correctness fixes from a sweep of the structural-leaf, columnar
string-dict/RLE, and Skip↔decode-parity paths; full cert green (race `./...` +
`-tags qdf_simd` + `golangci-lint` 0 issues + fuzz). All validated RED→GREEN with
round-trip identity checks.

## Commits

### 1. `fix` — harden the any/interface encode and decode paths
- **Encode cycle DoS:** `encodePtr` guards static `*T` cycles, but a cycle through
  an `any`-typed field re-entered the reflect machinery via `encodeIface →
  encodeReflect` without bumping the depth counter → unbounded recursion → fatal
  stack overflow. Guard at `encodeIface` (the dynamic-dispatch chokepoint) →
  `ErrCycleDetected`.
- **Decode missing QPack tags:** `decodeAny` had no case for the `tagPack*` tags,
  so a numeric/bool slice in an `interface{}` / `map[string]any` value failed with
  `ErrBadTag` under OptQPack/OptBalanced/OptCompression (the default). Added: bool
  → `[]bool`; numerics dispatch on the kind byte into the matching typed slice.
  The bit-packing codecs widen ints to Int64/Uint64, but **raw-LE preserves the
  native width**, so Int32/Uint32 (incompressible 32-bit slices) are handled too,
  alongside Float32/Float64; narrower kinds never reach a pack tag (plain array /
  []byte). Values round-trip identically (the int32 case was a gap caught while
  verifying decode==encode identity).

### 2. `fix(decode)` — skip an unknown columnar (tagColStruct) field
`Skip()` handled every value tag except `tagColStruct`, so an unknown `[]struct`
field encoded columnar (the probe picks it for larger struct slices under
OptBalanced/OptCompression) returned `ErrBadTag`, aborting the whole decode and
losing every trailing field — the common schema-evolution case. Skip it by
decoding via the any path and discarding: advances the cursor exactly and replays
the shape-table state a real decode would (a byte-only skip could not).

### 3. `test` — round-trip identity coverage
`TestDecodeAny_PackedSlices` (int64/uint64/int32/uint32/float64/float32/bool via
DeepEqual + NaN/Inf/-0 bit-exact, under all three QPack modes),
`TestSkip_ColumnarUnknownField` (asserts the field is actually columnar — no
vacuous pass — then that a trailing field survives AND the full struct
round-trips identically), `TestEncode_InterfaceCycle_NoStackOverflow` (self +
mutual any-cycles).

## Test plan
- `go test -race ./...` — green
- `go test -tags qdf_simd ./...` — green
- `golangci-lint run ./...` — 0 issues
- `go test -fuzz` AllModesAgree / Decoder_NeverPanics — clean