### PR TITLE
perf(state): adaptive retention of pooled scratch across messages

### DIFF
--- a/bench/realistic_ad_bench_test.go
+++ b/bench/realistic_ad_bench_test.go
@@ -1,0 +1,46 @@
+package bench
+
+import (
+	"testing"
+
+	qdf "github.com/alex60217101990/qdf"
+)
+
+// Focused encode/decode benchmarks on the realistic AD dataset, for pprof.
+
+func benchADEncode(b *testing.B, opt qdf.Options) {
+	users := makeADUsers(5000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink []byte
+	for b.Loop() {
+		blob, err := qdf.Marshal(users, opt)
+		if err != nil {
+			b.Fatal(err)
+		}
+		sink = blob
+	}
+	_ = sink
+}
+
+func benchADDecode(b *testing.B, opt qdf.Options) {
+	users := makeADUsers(5000)
+	blob, err := qdf.Marshal(users, opt)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(int64(len(blob)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		var out []ADUser
+		if err := qdf.Unmarshal(blob, &out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRealisticAD_Encode_Balanced(b *testing.B)    { benchADEncode(b, qdf.OptBalanced) }
+func BenchmarkRealisticAD_Decode_Balanced(b *testing.B)    { benchADDecode(b, qdf.OptBalanced) }
+func BenchmarkRealisticAD_Encode_Compression(b *testing.B) { benchADEncode(b, qdf.OptCompression) }
+func BenchmarkRealisticAD_Decode_Compression(b *testing.B) { benchADDecode(b, qdf.OptCompression) }

--- a/bench/realistic_ad_test.go
+++ b/bench/realistic_ad_test.go
@@ -500,3 +500,79 @@ func maxU(a, b uint64) uint64 {
 	}
 	return b
 }
+
+// TestRealisticAD_SmallSteadyNoRegression guards that the common SMALL-message
+// workload (a handful of users per Marshal — the bread-and-butter case the
+// pool was originally tuned for) is unaffected by adaptive retention: it
+// round-trips bit-exactly and encodes in a low, stable number of allocations
+// per op. A small message never grows the intern table past the soft cap, so
+// the retention policy is inert here — this test fails loudly if a future
+// change makes the small path pay for the large-path machinery.
+func TestRealisticAD_SmallSteadyNoRegression(t *testing.T) {
+	small := makeADUsers(8) // tiny batch, internLoad stays far under the cap
+
+	// Correctness across modes.
+	for _, opt := range []qdf.Options{qdf.OptSpeed, qdf.OptBalanced, qdf.OptCompression} {
+		blob := mustMarshal(t, small, opt)
+		var out []ADUser
+		if err := qdf.Unmarshal(blob, &out); err != nil {
+			t.Fatalf("decode opt=%v: %v", opt, err)
+		}
+		if !reflect.DeepEqual(small, out) {
+			t.Fatalf("small round-trip mismatch opt=%v", opt)
+		}
+	}
+
+	// Steady-state encode allocations: low and stable. AllocsPerRun reuses the
+	// pooled encoder across 1000 runs, so a per-message realloc regression
+	// (e.g. dropping+rebuilding a table every message) would spike this.
+	encAllocs := testing.AllocsPerRun(1000, func() {
+		if _, err := qdf.Marshal(small, qdf.OptBalanced); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Logf("small (8-user) OptBalanced encode: %.0f allocs/op", encAllocs)
+	if encAllocs > 40 {
+		t.Fatalf("small-message encode allocs/op regressed: %.0f (>40)", encAllocs)
+	}
+}
+
+// TestRealisticAD_Bursty exercises the burst→quiet pattern the retention
+// policy is designed around: a big batch followed by many small ones, repeated.
+// It must round-trip every message correctly, and the process RSS must not run
+// away (retention is bounded by the streak + sync.Pool GC eviction).
+func TestRealisticAD_Bursty(t *testing.T) {
+	big := makeADUsers(5000)
+	small := makeADUsers(5)
+
+	runtime.GC()
+	rssStart := maxRSSBytes()
+
+	for round := range 12 {
+		// One big batch.
+		blob := mustMarshal(t, big, qdf.OptBalanced)
+		var bout []ADUser
+		if err := qdf.Unmarshal(blob, &bout); err != nil {
+			t.Fatalf("round %d big decode: %v", round, err)
+		}
+		if !reflect.DeepEqual(big, bout) {
+			t.Fatalf("round %d big round-trip mismatch", round)
+		}
+		// Then a run of small ones (drives the release streak).
+		for s := range 10 {
+			sb := mustMarshal(t, small, qdf.OptBalanced)
+			var sout []ADUser
+			if err := qdf.Unmarshal(sb, &sout); err != nil {
+				t.Fatalf("round %d small %d decode: %v", round, s, err)
+			}
+			if !reflect.DeepEqual(small, sout) {
+				t.Fatalf("round %d small %d round-trip mismatch", round, s)
+			}
+		}
+	}
+
+	runtime.GC()
+	rssEnd := maxRSSBytes()
+	t.Logf("bursty RSS (Getrusage Maxrss high-water): start=%.1f MB end=%.1f MB",
+		float64(rssStart)/(1<<20), float64(rssEnd)/(1<<20))
+}

--- a/bench/realistic_ad_test.go
+++ b/bench/realistic_ad_test.go
@@ -1,0 +1,502 @@
+package bench
+
+// Realistic Active-Directory-style round-trip test.
+//
+// This is a *test*, not a benchmark: it verifies that a realistic
+// directory-export workload round-trips bit-exactly across every
+// encoding option combination, and — as a side effect — reports
+// realistic memory/throughput numbers gathered with Go runtime tools
+// (runtime.MemStats for allocation churn, syscall.Getrusage for the
+// process RSS high-water mark, time for wall-clock throughput).
+//
+// Run it with:
+//
+//	go test -v -run TestRealisticAD ./bench
+//
+// The dataset models an OU dump: every user has high-cardinality unique
+// fields (objectGUID, UPN, mail, phone, employeeID), names/surnames that
+// repeat occasionally (drawn from syllable pools), and group membership /
+// department / title that repeat moderately ("groups, not too frequent").
+// That cardinality mix is exactly where Dense/dict/intern codecs earn
+// their keep, so the numbers reflect a real directory sync, not a
+// synthetic best/worst case.
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+
+	qdf "github.com/alex60217101990/qdf"
+)
+
+// ADUser mirrors the attributes you would pull from an LDAP/AD user object.
+type ADUser struct {
+	ObjectGUID  string            `qdf:"objectGUID"`             // unique, high-card
+	SAM         string            `qdf:"sAMAccountName"`         // semi-unique
+	UPN         string            `qdf:"userPrincipalName"`      // unique
+	Email       string            `qdf:"mail"`                   // unique
+	FirstName   string            `qdf:"givenName"`              // occasional repeats
+	LastName    string            `qdf:"sn"`                     // occasional repeats
+	DisplayName string            `qdf:"displayName"`            // occasional repeats
+	Department  string            `qdf:"department"`             // moderate repeats
+	Title       string            `qdf:"title"`                  // moderate repeats
+	Company     string            `qdf:"company"`                // very repeated
+	Office      string            `qdf:"physicalDeliveryOffice"` // moderate repeats
+	Enabled     bool              `qdf:"enabled"`                // boolean
+	LogonCount  int32             `qdf:"logonCount"`             // small int
+	WhenCreated int64             `qdf:"whenCreated"`            // timestamp
+	LastLogon   int64             `qdf:"lastLogonTimestamp"`     // timestamp
+	PwdLastSet  int64             `qdf:"pwdLastSet"`             // timestamp
+	MemberOf    []string          `qdf:"memberOf"`               // group DNs, moderate repeats
+	Attrs       map[string]string `qdf:"attrs"`                  // stable key-set, mixed-card values
+}
+
+// makeADUsers builds a deterministic directory export of n users.
+func makeADUsers(n int) []ADUser {
+	r := rand.New(rand.NewPCG(0x41445553, 0x65727300)) // "ADUS","ers\0"
+
+	// Name syllable pools -> ~750 first / ~900 last combos => names repeat
+	// only occasionally across a few-thousand-user org.
+	firstA := []string{"Al", "Bri", "Cas", "Dan", "El", "Fra", "Gab", "Han", "Iv", "Jo",
+		"Kar", "Li", "Mar", "Nat", "Ol", "Pa", "Qui", "Ra", "Sa", "Ta",
+		"Um", "Vi", "Wen", "Xa", "Yu", "Za", "Be", "Ce", "Do", "Em"}
+	firstB := []string{"an", "ana", "el", "ena", "ia", "ian", "ie", "in", "ina", "is",
+		"ius", "on", "or", "ra", "ric", "sa", "son", "ta", "us", "var",
+		"wen", "ya", "yn", "za", "o"}
+	lastA := []string{"Ander", "Bred", "Clark", "Dun", "East", "Fish", "Green", "Hart", "Iver", "Jack",
+		"Kels", "Lan", "Mart", "Nor", "Owen", "Park", "Quin", "Reed", "Smith", "Tann",
+		"Up", "Vance", "Walk", "Xin", "York", "Zim", "Brook", "Cald", "Drake", "Ellis"}
+	lastB := []string{"son", "sen", "field", "ton", "man", "berg", "ford", "wood", "worth", "ley",
+		"by", "dale", "stone", "well", "ham", "ric", "gard", "mann", "strom", "ski",
+		"ovic", "er", "s", "y", "o", "a", "is", "en", "ino", "ez"}
+
+	departments := []string{"Engineering", "Sales", "Marketing", "Finance", "HR", "Legal",
+		"Operations", "Support", "IT", "Security", "Research", "Procurement",
+		"Facilities", "QA", "Design", "Data", "Product", "Compliance",
+		"Payroll", "Logistics", "PR", "Training", "Audit", "Strategy"}
+	titles := []string{"Engineer", "Senior Engineer", "Staff Engineer", "Manager", "Director",
+		"VP", "Analyst", "Senior Analyst", "Specialist", "Coordinator",
+		"Lead", "Architect", "Consultant", "Associate", "Administrator",
+		"Technician", "Representative", "Officer", "Supervisor", "Intern",
+		"Principal", "Advisor", "Strategist", "Auditor", "Recruiter",
+		"Accountant", "Designer", "Scientist", "Planner", "Clerk",
+		"Executive", "Partner"}
+	companies := []string{"Contoso", "Contoso EU", "Contoso APAC", "Fabrikam", "Fabrikam Labs"}
+	offices := []string{"NYC-1", "NYC-2", "SF-1", "SF-2", "LON-1", "LON-2", "BER-1", "TOK-1",
+		"SYD-1", "TOR-1", "CHI-1", "AUS-1", "SEA-1", "BOS-1", "MIA-1", "DEN-1",
+		"PAR-1", "AMS-1", "DUB-1", "SGP-1", "HKG-1", "MUM-1", "SAO-1", "MEX-1"}
+	countries := []string{"US", "GB", "DE", "FR", "JP", "AU", "CA", "BR", "IN", "SG",
+		"NL", "IE", "MX", "ES", "IT", "SE", "PL", "CH", "AE", "ZA"}
+	cities := []string{"New York", "San Francisco", "London", "Berlin", "Tokyo", "Sydney",
+		"Toronto", "Chicago", "Austin", "Seattle", "Boston", "Miami",
+		"Denver", "Paris", "Amsterdam", "Dublin", "Singapore", "Mumbai",
+		"Sao Paulo", "Mexico City", "Madrid", "Milan", "Stockholm", "Zurich"}
+
+	// Group DN pool: 400 distinct security groups -> moderate membership overlap.
+	const nGroups = 400
+	groups := make([]string, nGroups)
+	for i := range groups {
+		groups[i] = fmt.Sprintf("CN=SG-%03d,OU=Groups,DC=corp,DC=contoso,DC=com", i)
+	}
+	// Manager DN pool: 120 managers.
+	const nMgr = 120
+	managers := make([]string, nMgr)
+	for i := range managers {
+		managers[i] = fmt.Sprintf("CN=Mgr-%03d,OU=Users,DC=corp,DC=contoso,DC=com", i)
+	}
+
+	hexd := "0123456789abcdef"
+	hex32 := func() string {
+		b := make([]byte, 32)
+		for i := range b {
+			b[i] = hexd[r.IntN(16)]
+		}
+		return string(b)
+	}
+
+	// Plausible AD epoch range (~2018..2024 in seconds).
+	const tBase = 1514764800 // 2018-01-01
+	const tSpan = 220752000  // ~7 years
+
+	out := make([]ADUser, n)
+	for i := range out {
+		first := firstA[r.IntN(len(firstA))] + firstB[r.IntN(len(firstB))]
+		last := lastA[r.IntN(len(lastA))] + lastB[r.IntN(len(lastB))]
+		sam := fmt.Sprintf("%c%s%d", first[0]|0x20, lowerASCII(last), i%10000)
+		upn := sam + "@corp.contoso.com"
+
+		created := int64(tBase + r.IntN(tSpan))
+		lastLogon := created + int64(r.IntN(tSpan))
+		pwdSet := created + int64(r.IntN(int(lastLogon-created)+1))
+
+		// Membership: 2..6 groups.
+		k := 2 + r.IntN(5)
+		mo := make([]string, k)
+		for j := range mo {
+			mo[j] = groups[r.IntN(nGroups)]
+		}
+
+		attrs := map[string]string{
+			"employeeID":      fmt.Sprintf("E%06d", r.IntN(900000)+100000),
+			"costCenter":      fmt.Sprintf("CC-%03d", r.IntN(60)),
+			"manager":         managers[r.IntN(nMgr)],
+			"co":              countries[r.IntN(len(countries))],
+			"l":               cities[r.IntN(len(cities))],
+			"telephoneNumber": fmt.Sprintf("+1-%03d-555-%04d", r.IntN(900)+100, r.IntN(10000)),
+		}
+
+		out[i] = ADUser{
+			ObjectGUID:  hex32(),
+			SAM:         sam,
+			UPN:         upn,
+			Email:       upn,
+			FirstName:   first,
+			LastName:    last,
+			DisplayName: first + " " + last,
+			Department:  departments[r.IntN(len(departments))],
+			Title:       titles[r.IntN(len(titles))],
+			Company:     companies[r.IntN(len(companies))],
+			Office:      offices[r.IntN(len(offices))],
+			Enabled:     r.IntN(100) < 92, // ~8% disabled
+			LogonCount:  int32(r.IntN(5000)),
+			WhenCreated: created,
+			LastLogon:   lastLogon,
+			PwdLastSet:  pwdSet,
+			MemberOf:    mo,
+			Attrs:       attrs,
+		}
+	}
+	return out
+}
+
+func lowerASCII(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] |= 0x20
+		}
+	}
+	return string(b)
+}
+
+// phaseStat holds the runtime-measured numbers for one encode or decode phase.
+type phaseStat struct {
+	wire       int
+	nsPerOp    float64
+	allocPerOp uint64 // bytes allocated per op (runtime.MemStats.TotalAlloc delta)
+	objsPerOp  uint64 // allocations per op (runtime.MemStats.Mallocs delta)
+}
+
+// datasetCardinality reports distinct-value counts so the test output proves
+// the dataset has the intended cardinality mix (unique IDs, occasional name
+// repeats, moderate group/department repeats) rather than a degenerate one.
+func datasetCardinality(users []ADUser) string {
+	guid := map[string]struct{}{}
+	first := map[string]struct{}{}
+	last := map[string]struct{}{}
+	dept := map[string]struct{}{}
+	grp := map[string]struct{}{}
+	for i := range users {
+		u := &users[i]
+		guid[u.ObjectGUID] = struct{}{}
+		first[u.FirstName] = struct{}{}
+		last[u.LastName] = struct{}{}
+		dept[u.Department] = struct{}{}
+		for _, g := range u.MemberOf {
+			grp[g] = struct{}{}
+		}
+	}
+	n := float64(len(users))
+	return fmt.Sprintf("distinct: guid=%d(%.2f/user) first=%d last=%d dept=%d group=%d",
+		len(guid), float64(len(guid))/n, len(first), len(last), len(dept), len(grp))
+}
+
+// RSS high-water is read via the shared maxRSSBytes helper
+// (memory_compare_test.go) — syscall.Getrusage, no cgo, no deps.
+
+func measureEncode(t *testing.T, v any, opt qdf.Options, iters int) (phaseStat, []byte) {
+	t.Helper()
+	b, err := qdf.Marshal(v, opt) // warm up + size
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	var m0, m1 runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m0)
+	start := time.Now()
+	for i := range iters {
+		b, err = qdf.Marshal(v, opt)
+		if err != nil {
+			t.Fatalf("encode iter %d: %v", i, err)
+		}
+	}
+	el := time.Since(start)
+	runtime.ReadMemStats(&m1)
+
+	s := phaseStat{
+		wire:       len(b),
+		nsPerOp:    float64(el.Nanoseconds()) / float64(iters),
+		allocPerOp: (m1.TotalAlloc - m0.TotalAlloc) / uint64(iters),
+		objsPerOp:  (m1.Mallocs - m0.Mallocs) / uint64(iters),
+	}
+	return s, b
+}
+
+func measureDecode[T any](t *testing.T, data []byte, iters int) (phaseStat, T) {
+	t.Helper()
+	var out T
+	if err := qdf.Unmarshal(data, &out); err != nil { // warm up
+		t.Fatalf("decode: %v", err)
+	}
+
+	var m0, m1 runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m0)
+	start := time.Now()
+	for i := range iters {
+		var d T
+		if err := qdf.Unmarshal(data, &d); err != nil {
+			t.Fatalf("decode iter %d: %v", i, err)
+		}
+		out = d
+	}
+	el := time.Since(start)
+	runtime.ReadMemStats(&m1)
+
+	s := phaseStat{
+		wire:       len(data),
+		nsPerOp:    float64(el.Nanoseconds()) / float64(iters),
+		allocPerOp: (m1.TotalAlloc - m0.TotalAlloc) / uint64(iters),
+		objsPerOp:  (m1.Mallocs - m0.Mallocs) / uint64(iters),
+	}
+	return s, out
+}
+
+func TestRealisticAD_EncodeDecode(t *testing.T) {
+	n := 5000
+	iters := 12
+	if testing.Short() {
+		n, iters = 800, 3
+	}
+	users := makeADUsers(n)
+
+	combos := []struct {
+		name string
+		opt  qdf.Options
+	}{
+		{"Speed", qdf.OptSpeed},
+		{"Balanced", qdf.OptBalanced},
+		{"Balanced+MapShape", qdf.OptBalanced | qdf.OptMapShape},
+		{"Balanced+ColumnIndex", qdf.OptBalanced | qdf.OptColumnIndex},
+		{"Compression", qdf.OptCompression},
+		{"Compression+MapShape+ColIdx", qdf.OptCompression | qdf.OptMapShape | qdf.OptColumnIndex},
+	}
+
+	// Reference logical size: the OptSpeed wire is the codec-free serialization
+	// of the dataset — the same logical bytes every mode must traverse. Using it
+	// (not each mode's own compressed wire) as the throughput denominator keeps
+	// the MB/s metric apples-to-apples: a mode that compresses harder produces
+	// fewer wire bytes but does NOT process less logical data, so dividing by its
+	// own shrunken wire would falsely report it as "slower".
+	refBlob, err := qdf.Marshal(users, qdf.OptSpeed)
+	if err != nil {
+		t.Fatalf("reference encode: %v", err)
+	}
+	refMB := float64(len(refBlob)) / (1 << 20)
+	mbps := func(ns float64) float64 { return refMB / (ns / 1e9) }
+	mrecs := func(ns float64) float64 { return float64(n) / (ns / 1e9) / 1e6 }
+
+	rssStart := maxRSSBytes()
+	t.Logf("AD directory export: %d users, iters=%d (GOOS=%s GOMAXPROCS=%d)",
+		n, iters, runtime.GOOS, runtime.GOMAXPROCS(0))
+	t.Logf("  %s", datasetCardinality(users))
+	t.Logf("  reference logical size (OptSpeed wire) = %.2f MB; throughput MB/s is vs this fixed size",
+		refMB)
+	t.Logf("%-30s %8s %6s | %8s %8s %8s %7s | %8s %8s %8s %7s",
+		"opt-combo", "wireKB", "ratio",
+		"encMrec/s", "enc_MB/s", "enc_KB", "enc_obj",
+		"decMrec/s", "dec_MB/s", "dec_KB", "dec_obj")
+
+	for _, c := range combos {
+		es, blob := measureEncode(t, users, c.opt, iters)
+		ds, decoded := measureDecode[[]ADUser](t, blob, iters)
+
+		if !reflect.DeepEqual(users, decoded) {
+			t.Fatalf("round-trip mismatch for %q (wire=%d bytes)", c.name, es.wire)
+		}
+
+		t.Logf("%-30s %8.1f %6.2f | %8.2f %8.1f %8.1f %7d | %8.2f %8.1f %8.1f %7d",
+			c.name,
+			float64(es.wire)/1024, float64(len(refBlob))/float64(es.wire),
+			mrecs(es.nsPerOp), mbps(es.nsPerOp), float64(es.allocPerOp)/1024, es.objsPerOp,
+			mrecs(ds.nsPerOp), mbps(ds.nsPerOp), float64(ds.allocPerOp)/1024, ds.objsPerOp,
+		)
+	}
+
+	rssEnd := maxRSSBytes()
+	t.Logf("process RSS (Getrusage Maxrss high-water): start=%.1f MB  end=%.1f MB  growth=%.1f MB",
+		float64(rssStart)/(1<<20), float64(rssEnd)/(1<<20),
+		(float64(rssEnd)-float64(rssStart))/(1<<20))
+	t.Logf("note: enc_KB/dec_KB = bytes allocated per op (TotalAlloc delta); " +
+		"RSS is a process-wide high-water mark, monotonic across phases")
+}
+
+// ADUserFlat is ADUser with the two columnar-disqualifying fields removed
+// (MemberOf []string, Attrs map[string]string). Every remaining field is a
+// scalar / string / timestamp, so buildColumnarPlan accepts it and the
+// []ADUserFlat batch encodes via the columnar transpose. This is the headroom
+// probe for hybrid columnar: the delta between the full row-major struct and
+// this flat columnar struct, on the same scalar/string data, is what a hybrid
+// (transpose eligible columns, keep map/slice row-wise) would unlock.
+type ADUserFlat struct {
+	ObjectGUID  string `qdf:"objectGUID"`
+	SAM         string `qdf:"sAMAccountName"`
+	UPN         string `qdf:"userPrincipalName"`
+	Email       string `qdf:"mail"`
+	FirstName   string `qdf:"givenName"`
+	LastName    string `qdf:"sn"`
+	DisplayName string `qdf:"displayName"`
+	Department  string `qdf:"department"`
+	Title       string `qdf:"title"`
+	Company     string `qdf:"company"`
+	Office      string `qdf:"physicalDeliveryOffice"`
+	Enabled     bool   `qdf:"enabled"`
+	LogonCount  int32  `qdf:"logonCount"`
+	WhenCreated int64  `qdf:"whenCreated"`
+	LastLogon   int64  `qdf:"lastLogonTimestamp"`
+	PwdLastSet  int64  `qdf:"pwdLastSet"`
+}
+
+func flattenAD(users []ADUser) []ADUserFlat {
+	out := make([]ADUserFlat, len(users))
+	for i := range users {
+		u := &users[i]
+		out[i] = ADUserFlat{
+			ObjectGUID: u.ObjectGUID, SAM: u.SAM, UPN: u.UPN, Email: u.Email,
+			FirstName: u.FirstName, LastName: u.LastName, DisplayName: u.DisplayName,
+			Department: u.Department, Title: u.Title, Company: u.Company, Office: u.Office,
+			Enabled: u.Enabled, LogonCount: u.LogonCount,
+			WhenCreated: u.WhenCreated, LastLogon: u.LastLogon, PwdLastSet: u.PwdLastSet,
+		}
+	}
+	return out
+}
+
+// TestRealisticAD_FlatColumnar_Headroom measures the columnar path on the
+// flat AD struct and prints it next to the full row-major struct, so the gain
+// hybrid columnar would bring to AD-shaped data is visible. It also ASSERTS
+// the columnar transpose actually engaged (OptColumnIndex changes the wire
+// only for columnar payloads; if the wire is identical, columnar did not fire
+// and the probe is meaningless).
+func TestRealisticAD_FlatColumnar_Headroom(t *testing.T) {
+	n := 5000
+	iters := 12
+	if testing.Short() {
+		n, iters = 800, 3
+	}
+	full := makeADUsers(n)
+	flat := flattenAD(full)
+
+	// Prove columnar engaged for the flat struct: the column-length index is
+	// emitted only on a columnar payload, so it must change the wire size.
+	noIdx, err := qdf.Marshal(flat, qdf.OptBalanced)
+	if err != nil {
+		t.Fatalf("encode flat: %v", err)
+	}
+	withIdx, err := qdf.Marshal(flat, qdf.OptBalanced|qdf.OptColumnIndex)
+	if err != nil {
+		t.Fatalf("encode flat+idx: %v", err)
+	}
+	columnar := len(noIdx) != len(withIdx)
+	t.Logf("flat columnar engaged: %v (Balanced wire=%d, +ColumnIndex wire=%d)",
+		columnar, len(noIdx), len(withIdx))
+	if !columnar {
+		t.Fatalf("expected []ADUserFlat to encode columnar (ColumnIndex changed nothing) — "+
+			"buildColumnarPlan or columnarProbe rejected it; wire=%d", len(noIdx))
+	}
+
+	refFlat, _ := qdf.Marshal(flat, qdf.OptSpeed)
+	refMB := float64(len(refFlat)) / (1 << 20)
+	mbps := func(ns float64) float64 { return refMB / (ns / 1e9) }
+
+	combos := []struct {
+		name string
+		opt  qdf.Options
+	}{
+		{"Speed", qdf.OptSpeed},
+		{"Balanced", qdf.OptBalanced},
+		{"Balanced+ColumnIndex", qdf.OptBalanced | qdf.OptColumnIndex},
+		{"Compression", qdf.OptCompression},
+	}
+
+	t.Logf("FLAT (columnar-eligible) AD: %d users, ref logical=%.2f MB", n, refMB)
+	t.Logf("%-24s %8s %6s | %8s %8s %7s | %8s %8s %7s",
+		"opt-combo", "wireKB", "ratio", "enc_MB/s", "enc_KB", "enc_obj",
+		"dec_MB/s", "dec_KB", "dec_obj")
+	for _, c := range combos {
+		es, blob := measureEncode(t, flat, c.opt, iters)
+		ds, decoded := measureDecode[[]ADUserFlat](t, blob, iters)
+		if !reflect.DeepEqual(flat, decoded) {
+			t.Fatalf("flat round-trip mismatch for %q", c.name)
+		}
+		t.Logf("%-24s %8.1f %6.2f | %8.1f %8.1f %7d | %8.1f %8.1f %7d",
+			c.name, float64(es.wire)/1024, float64(len(refFlat))/float64(es.wire),
+			mbps(es.nsPerOp), float64(es.allocPerOp)/1024, es.objsPerOp,
+			mbps(ds.nsPerOp), float64(ds.allocPerOp)/1024, ds.objsPerOp)
+	}
+
+	// Hybrid-columnar headroom estimate at Balanced.
+	//
+	//   full   = all 17 fields, row-major (today's behaviour for AD)
+	//   flat   = 15 scalar/string fields, columnar
+	//   resid  = the 2 disqualifying fields (MemberOf []string, Attrs map),
+	//            row-major — what hybrid would still encode per-row
+	//
+	// hybrid ≈ flat (columnar columns) + resid (row-major tail). Comparing
+	// that estimate to `full` isolates the columnar win from the mere removal
+	// of the map/slice fields.
+	resid := make([]ADUserResidual, n)
+	for i := range full {
+		resid[i] = ADUserResidual{MemberOf: full[i].MemberOf, Attrs: full[i].Attrs}
+	}
+
+	fullDec, _ := measureDecode[[]ADUser](t, mustMarshal(t, full, qdf.OptBalanced), iters)
+	flatDec, _ := measureDecode[[]ADUserFlat](t, mustMarshal(t, flat, qdf.OptBalanced), iters)
+	residDec, _ := measureDecode[[]ADUserResidual](t, mustMarshal(t, resid, qdf.OptBalanced), iters)
+
+	hybridObj := flatDec.objsPerOp + residDec.objsPerOp
+	hybridKB := float64(flatDec.allocPerOp+residDec.allocPerOp) / 1024
+	t.Logf("Balanced decode head-to-head (isolating columnar from map/slice removal):")
+	t.Logf("  FULL row-major (today) : %d obj / %.0f KB", fullDec.objsPerOp, float64(fullDec.allocPerOp)/1024)
+	t.Logf("  FLAT columnar (15 cols): %d obj / %.0f KB", flatDec.objsPerOp, float64(flatDec.allocPerOp)/1024)
+	t.Logf("  RESID row-major (2 fld): %d obj / %.0f KB", residDec.objsPerOp, float64(residDec.allocPerOp)/1024)
+	t.Logf("  HYBRID est (flat+resid): %d obj / %.0f KB  => %.1fx fewer decode allocs vs full",
+		hybridObj, hybridKB, float64(fullDec.objsPerOp)/float64(maxU(hybridObj, 1)))
+}
+
+// ADUserResidual holds only the columnar-disqualifying fields of ADUser — the
+// per-row tail a hybrid columnar encoder would keep row-major.
+type ADUserResidual struct {
+	MemberOf []string          `qdf:"memberOf"`
+	Attrs    map[string]string `qdf:"attrs"`
+}
+
+func mustMarshal(t *testing.T, v any, opt qdf.Options) []byte {
+	t.Helper()
+	b, err := qdf.Marshal(v, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func maxU(a, b uint64) uint64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/shrink_test.go
+++ b/shrink_test.go
@@ -209,6 +209,46 @@ func TestShrink_BurstThenSteadyState(t *testing.T) {
 	}
 }
 
+// No-regression guard: a SMALL steady workload (internLoad always under the
+// soft cap) must behave exactly as before the adaptive-retention change — the
+// table is reused in place across resets, never reallocated and never released
+// to the init size. The retain/release branches added by the change only fire
+// for over-cap arrays, so for small messages the policy is inert.
+func TestShrink_SmallSteadyIsInert(t *testing.T) {
+	st := newEncState()
+	const perMsg = 200 // well under maxRetainedIDs
+	fill := func(cycle int) {
+		for i := range perMsg {
+			st.lookupOrAssign(fmt.Sprintf("c%02d-small-%04d", cycle, i))
+		}
+	}
+	// Warm up to the steady-state table size.
+	fill(0)
+	st.reset()
+	fill(1)
+	warmCap := cap(st.internTable)
+	warmLRU := cap(st.lruLink)
+	if warmCap > maxRetainedIDs*2 {
+		t.Fatalf("test premise: small workload should stay under cap, got internTable cap=%d", warmCap)
+	}
+
+	// Many cycles: cap must stay put — no realloc churn, no drop-to-init,
+	// no streak-driven release (the arrays never exceeded the cap).
+	for c := range 30 {
+		st.reset()
+		fill(c + 2)
+		if got := cap(st.internTable); got != warmCap {
+			t.Fatalf("cycle %d: internTable cap changed (realloc/drop churn): warm=%d got=%d", c, warmCap, got)
+		}
+		if got := cap(st.lruLink); got != warmLRU {
+			t.Fatalf("cycle %d: lruLink cap changed: warm=%d got=%d", c, warmLRU, got)
+		}
+	}
+	if st.internTable == nil || st.lruLink == nil {
+		t.Fatal("small steady workload wrongly released under-cap backings")
+	}
+}
+
 // Helper exported only for this test — internarena.DefaultRetainBytes
 // is the public const; alias here for readability inside the package.
 func internarenaRetainBytes() int { return internarenaDefaultRetainBytes }

--- a/shrink_test.go
+++ b/shrink_test.go
@@ -6,14 +6,19 @@ import (
 	"testing"
 )
 
-// shrink_test.go pins the bounded-memory contract added with the
-// arena + state shrink-on-Reset machinery. The encoder / decoder
-// pools must NOT pin spike memory forever; a long-running service
-// with bursty traffic stays at the steady-state working set, not
-// at the historical peak.
+// shrink_test.go pins the ADAPTIVE-retention contract of the encoder /
+// decoder state pools (state.go reset()).
+//
+// The contract changed from "drop oversized backings on the very next
+// reset" to "retain them while the workload stays large, release only
+// after retainReleaseStreak consecutive small messages." This lets a
+// STEADY high-cardinality / large-batch workload (AD / log / telemetry
+// sync) amortize the table allocation instead of reallocating every
+// message, while a one-off burst followed by quiet still returns to the
+// steady-state working set (and sync.Pool's GC eviction bounds idle
+// retention regardless).
 
-// Encoder Reset after a spike must drop the over-cap state. Verify
-// at the encState level (the lowest layer that holds the buckets).
+// A single small lookup still registers after a burst+release cycle.
 func TestShrink_EncStateRebuildsBigMap(t *testing.T) {
 	st := newEncState()
 	for i := range maxRetainedIDs + 100 {
@@ -27,58 +32,92 @@ func TestShrink_EncStateRebuildsBigMap(t *testing.T) {
 	if int(st.internLoad) != 0 {
 		t.Fatalf("reset did not clear ids: %d", int(st.internLoad))
 	}
-	// After shrink the map header was replaced with a fresh one;
-	// adding a single entry should not grow the buckets back to
-	// the pre-shrink size in a single step.
 	st.lookupOrAssign("post-shrink")
 	if int(st.internLoad) != 1 {
 		t.Fatalf("post-shrink lookup did not register: %d", int(st.internLoad))
 	}
 }
 
-// LRU slices must shrink when their cap exceeded the threshold.
-func TestShrink_EncStateDropsLRUOverCap(t *testing.T) {
+// Core amortization guarantee: under a SUSTAINED large workload the intern
+// table is retained across resets (cleared in place), never rebuilt to the
+// init size — so steady-state encoding pays no per-message table regrow.
+func TestShrink_SteadyLargeRetainsInternTable(t *testing.T) {
+	st := newEncState()
+	var capAfterFirst int
+	for cycle := range 20 {
+		for i := range maxRetainedIDs + 200 { // large every cycle
+			st.lookupOrAssign(fmt.Sprintf("c%02d-key-%05d", cycle, i))
+		}
+		st.reset()
+		if cycle == 0 {
+			capAfterFirst = cap(st.internTable)
+		}
+	}
+	if cap(st.internTable) <= internTableInitSize {
+		t.Fatalf("steady-large intern table was rebuilt to init size (no amortization): cap=%d", cap(st.internTable))
+	}
+	if cap(st.internTable) < capAfterFirst {
+		t.Fatalf("steady-large intern table shrank under sustained load: first=%d last=%d",
+			capAfterFirst, cap(st.internTable))
+	}
+}
+
+// LRU slice: retained on the first post-burst reset, released after the
+// workload stays small for retainReleaseStreak consecutive messages.
+func TestShrink_EncStateReleasesLRUAfterStreak(t *testing.T) {
 	st := newEncState()
 	for i := range maxRetainedLRUCap + 64 {
 		st.lookupOrAssign(fmt.Sprintf("lru-%05d", i))
 	}
 	if cap(st.lruLink) <= maxRetainedLRUCap {
-		t.Fatalf("test premise: lruPrev should exceed cap (%d), got %d",
+		t.Fatalf("test premise: lruLink should exceed cap (%d), got %d",
 			maxRetainedLRUCap, cap(st.lruLink))
 	}
+	burstCap := cap(st.lruLink)
+
+	// First reset right after the burst RETAINS (internLoad was large).
 	st.reset()
-	if st.lruLink != nil {
-		t.Fatalf("reset did not drop oversized lruPrev: cap=%d", cap(st.lruLink))
+	if cap(st.lruLink) != burstCap {
+		t.Fatalf("lruLink dropped on first post-burst reset (should retain): burst=%d post=%d",
+			burstCap, cap(st.lruLink))
+	}
+	// After retainReleaseStreak small (internLoad==0) resets, release.
+	for range retainReleaseStreak {
+		st.reset()
 	}
 	if st.lruLink != nil {
-		t.Fatalf("reset did not drop oversized lruNext: cap=%d", cap(st.lruLink))
+		t.Fatalf("lruLink not released after %d small resets: cap=%d", retainReleaseStreak, cap(st.lruLink))
 	}
 }
 
-// pairPred slice shrink — same contract as LRU.
-func TestShrink_EncStateDropsPairPredOverCap(t *testing.T) {
+// pairPred slice — same retain-then-release contract as LRU.
+func TestShrink_EncStateReleasesPairPredAfterStreak(t *testing.T) {
 	st := newEncState()
-	// Drive pairPred to grow past the cap by interning many keys
-	// and recording pair transitions between them.
 	for i := range maxRetainedPairCap + 64 {
 		st.lookupOrAssign(fmt.Sprintf("pair-%05d", i))
 	}
-	// Force pair records — record a pair for the highest prev id
-	// so pairPred slice is grown to that length.
 	last := uint32(int(st.internLoad) - 1)
 	st.pairRecord(last, last-1)
 	if cap(st.pairPred) <= maxRetainedPairCap {
 		t.Fatalf("test premise: pairPred should exceed cap (%d), got %d",
 			maxRetainedPairCap, cap(st.pairPred))
 	}
+	burstCap := cap(st.pairPred)
+
 	st.reset()
+	if cap(st.pairPred) != burstCap {
+		t.Fatalf("pairPred dropped on first post-burst reset (should retain): burst=%d post=%d",
+			burstCap, cap(st.pairPred))
+	}
+	for range retainReleaseStreak {
+		st.reset()
+	}
 	if st.pairPred != nil {
-		t.Fatalf("reset did not drop oversized pairPred: cap=%d", cap(st.pairPred))
+		t.Fatalf("pairPred not released after %d small resets: cap=%d", retainReleaseStreak, cap(st.pairPred))
 	}
 }
 
-// Steady-state workload must NOT trigger shrink. Encoder pool stays
-// warm without the per-Reset reallocation cost.
+// Steady-state SMALL workload must not grow caps unexpectedly (reuse in place).
 func TestShrink_EncStateKeepsCapsUnderThreshold(t *testing.T) {
 	st := newEncState()
 	for i := range 100 {
@@ -87,34 +126,21 @@ func TestShrink_EncStateKeepsCapsUnderThreshold(t *testing.T) {
 	preIDs := int(st.internLoad)
 	preLRU := cap(st.lruLink)
 	st.reset()
-	// After reset the map must still be the same instance (no
-	// rebuild because we were under the cap). Test this indirectly:
-	// the underlying buckets keep their capacity, so the cap hint
-	// for a future insert is the same.
 	if preIDs > maxRetainedIDs {
 		t.Skipf("steady-state breached maxRetainedIDs (%d > %d)", preIDs, maxRetainedIDs)
 	}
 	st.lookupOrAssign("after-reset")
-	// A clear()'d Go map keeps its allocation count under
-	// lightweight reuse — re-running the steady-state loop after
-	// reset should not trigger any new bucket growth past the
-	// pre-existing cap.
 	for i := range 100 {
 		st.lookupOrAssign(fmt.Sprintf("steady-after-%05d", i))
 	}
 	if cap(st.lruLink) > preLRU*2 {
-		t.Fatalf("lruPrev cap grew unexpectedly: pre=%d post=%d", preLRU, cap(st.lruLink))
+		t.Fatalf("lruLink cap grew unexpectedly: pre=%d post=%d", preLRU, cap(st.lruLink))
 	}
 }
 
-// Decoder Reset must shrink symmetrically. Drive the values slice
-// past the cap by decoding a huge intern-heavy buffer, then verify
-// reset drops the backing array.
-func TestShrink_DecStateDropsValuesOverCap(t *testing.T) {
+// Decoder values slice — retain-then-release, driven by len(d.values).
+func TestShrink_DecStateReleasesValuesAfterStreak(t *testing.T) {
 	d := newDecState()
-	// Manually pump value entries past the cap. Append until the
-	// slice exceeds maxRetainedIDs in capacity, mirroring what the
-	// decoder does when reading a stream with many interned items.
 	for i := range maxRetainedIDs + 64 {
 		d.append(fmt.Appendf(nil, "dec-val-%05d", i))
 	}
@@ -122,51 +148,56 @@ func TestShrink_DecStateDropsValuesOverCap(t *testing.T) {
 		t.Fatalf("test premise: values cap should exceed %d, got %d",
 			maxRetainedIDs, cap(d.values))
 	}
+	burstCap := cap(d.values)
+
 	d.reset()
+	if cap(d.values) != burstCap {
+		t.Fatalf("values dropped on first post-burst reset (should retain): burst=%d post=%d",
+			burstCap, cap(d.values))
+	}
+	for range retainReleaseStreak {
+		d.reset()
+	}
 	if d.values != nil {
-		t.Fatalf("decoder reset did not drop oversized values: cap=%d", cap(d.values))
+		t.Fatalf("decoder values not released after %d small resets: cap=%d", retainReleaseStreak, cap(d.values))
 	}
 	if d.lruLink != nil {
-		t.Fatalf("decoder reset did not drop lruPrev under oversized cap")
+		t.Fatalf("decoder lruLink not released after streak")
 	}
 }
 
-// Integration view of the shrink contract: a SAME encState that
-// went through a burst-grow → reset → steady-state cycle MUST come
-// out of reset with caps no larger than the soft caps. The pool's
-// eviction policy (sync.Pool drops items at GC time) makes a
-// HeapAlloc-based assertion unreliable; instead, inspect the
-// state directly across one full cycle.
+// Integration view: a SAME encState through burst-grow → retain → quiet →
+// release. Memory is held across the first quiet reset (amortization) and
+// returned only after the streak elapses.
 func TestShrink_BurstThenSteadyState(t *testing.T) {
 	st := newEncState()
-	// Burst phase: blow past every threshold.
 	for i := range maxRetainedIDs + 64 {
 		st.lookupOrAssign(fmt.Sprintf("burst-%05d-%s", i, strings.Repeat("z", 16)))
 	}
-	st.pairRecord(uint32(int(st.internLoad)-1), 0) // grow pairPred too
+	st.pairRecord(uint32(int(st.internLoad)-1), 0)
 
-	// Snapshot the burst-peak state.
-	burstIDs := int(st.internLoad)
 	burstLRUCap := cap(st.lruLink)
 	burstPairCap := cap(st.pairPred)
 	burstArena := st.arena.BytesUsed()
 	t.Logf("burst peak: ids=%d lruCap=%d pairCap=%d arenaUsed=%d KiB",
-		burstIDs, burstLRUCap, burstPairCap, burstArena/1024)
+		int(st.internLoad), burstLRUCap, burstPairCap, burstArena/1024)
 
-	// Reset — must shrink at least one of the over-cap structures.
+	// First post-burst reset retains the grown LRU/pair backings.
 	st.reset()
-
-	// Steady-state phase: small workload, must not regrow.
-	for i := range 100 {
-		st.lookupOrAssign(fmt.Sprintf("steady-%05d", i))
+	if burstLRUCap > maxRetainedLRUCap && cap(st.lruLink) != burstLRUCap {
+		t.Fatalf("lruLink dropped on first post-burst reset: burst=%d post=%d", burstLRUCap, cap(st.lruLink))
 	}
 
-	// Post-shrink invariants. The map and slices may NOT carry the
-	// burst-time capacity any longer; either they were rebuilt to
-	// a small size or they grew naturally to fit the steady-state
-	// workload only.
+	// Quiet phase: small messages for the full streak → release.
+	for range retainReleaseStreak {
+		for i := range 100 {
+			st.lookupOrAssign(fmt.Sprintf("steady-%05d", i))
+		}
+		st.reset()
+	}
+
 	if cap(st.lruLink) >= burstLRUCap && burstLRUCap > maxRetainedLRUCap {
-		t.Fatalf("lruPrev cap did not shrink after burst→reset: burst=%d post=%d",
+		t.Fatalf("lruLink cap did not shrink after burst→quiet: burst=%d post=%d",
 			burstLRUCap, cap(st.lruLink))
 	}
 	if cap(st.pairPred) >= burstPairCap && burstPairCap > maxRetainedPairCap {

--- a/state.go
+++ b/state.go
@@ -315,11 +315,12 @@ const (
 
 	// maxRetainedColScratch hard-caps the row-count-scaled columnar scratch
 	// arrays (colScratch*, colDictTable, colMaskScratch, fsstScratch): a
-	// backing larger than this is dropped even mid-streak, bounding worst-case
-	// pooled memory after a one-off giant columnar batch. The intern/LRU/pair
-	// arrays need no such ceiling — maxStateEntries (≤ 0xFFFF) already bounds
-	// them to ~1-4 MB.
-	maxRetainedColScratch = 1 << 20
+	// backing larger than this is dropped, bounding worst-case pooled memory
+	// after a one-off giant columnar batch. 1<<17 (131072 rows) covers any
+	// realistic batch while capping the per-encoder pin at ~2 MB for the
+	// []string scratch (16 B/elem). The intern/LRU/pair arrays need no such
+	// ceiling — maxStateEntries (≤ 0xFFFF) already bounds them to ~1-4 MB.
+	maxRetainedColScratch = 1 << 17
 )
 
 func (e *encState) reset() {

--- a/state.go
+++ b/state.go
@@ -193,6 +193,10 @@ type encState struct {
 	// column to avoid a per-column map allocation.
 	strDictMap map[string]uint32
 
+	// retainStreak counts consecutive small (sub-cap) messages for the
+	// adaptive-retention policy in reset(). Cold — touched once per reset.
+	retainStreak uint8
+
 	// arena owns the byte storage that backs every intern key the
 	// encoder allocates — accessed only on intern miss, kept at the
 	// end so the hot fields above share earlier cache lines.
@@ -297,54 +301,90 @@ const (
 	maxRetainedLRUCap   = 4096
 	maxRetainedPairCap  = 4096
 	maxRetainedShapeCap = 1024
+
+	// retainReleaseStreak governs adaptive retention (see encState.reset /
+	// decState.reset). A pooled state RETAINS oversized backing arrays —
+	// clearing them in place instead of dropping them to nil — while
+	// consecutive messages stay large, so a steady high-cardinality /
+	// large-batch workload amortizes the table allocation instead of
+	// reallocating every single message (the dominant encode-alloc cost on
+	// AD/log/telemetry batches). Only after this many consecutive SMALL
+	// (sub-cap) messages does it conclude the burst subsided and release the
+	// memory. sync.Pool's GC-driven eviction bounds idle retention regardless.
+	retainReleaseStreak = 8
+
+	// maxRetainedColScratch hard-caps the row-count-scaled columnar scratch
+	// arrays (colScratch*, colDictTable, colMaskScratch, fsstScratch): a
+	// backing larger than this is dropped even mid-streak, bounding worst-case
+	// pooled memory after a one-off giant columnar batch. The intern/LRU/pair
+	// arrays need no such ceiling — maxStateEntries (≤ 0xFFFF) already bounds
+	// them to ~1-4 MB.
+	maxRetainedColScratch = 1 << 20
 )
 
 func (e *encState) reset() {
-	// Intern table shrink. The flat hash table doubles when load
-	// exceeds 0.5; long-running services that occasionally take a
-	// burst payload would otherwise pin the high-water-mark table
-	// to the pool forever. Drop oversized backing arrays here; in
-	// the steady-state path the table fits below the cap and only
-	// gets memcleared (cheap), which keeps the slot pages warm.
+	// Adaptive retention. A pooled encoder that just handled a large
+	// (high-cardinality / wide-batch) message would, under a fixed cap, drop
+	// its grown backing arrays and reallocate them from scratch on the very
+	// next message — so a STEADY large workload (AD / log / telemetry sync)
+	// never amortizes the table allocation and pays a full table regrow every
+	// message (the dominant encode-alloc cost measured on such batches).
+	// Instead we keep the intern/LRU/pair/shape backings (clearing them in
+	// place) while messages stay large, releasing only after
+	// retainReleaseStreak consecutive small messages. The decision is driven
+	// by internLoad — the count of strings interned THIS message, a true
+	// per-message demand signal (the retained cap would stay large forever
+	// and never let the streak advance). The row-scaled columnar scratch is
+	// governed separately by a hard ceiling (maxRetainedColScratch): retained
+	// up to it, dropped above, so a one-off giant batch can't pin unbounded
+	// memory. The intern/LRU/pair arrays are already bounded by
+	// maxStateEntries; sync.Pool's GC eviction caps idle retention regardless.
+	if int(e.internLoad) > maxRetainedIDs {
+		e.retainStreak = 0
+	} else if e.retainStreak < retainReleaseStreak {
+		e.retainStreak++
+	}
+	release := e.retainStreak >= retainReleaseStreak
+
+	// Intern table. Clear (zero every slot — internSlot{} is the empty
+	// sentinel) to reuse in place; drop the backing only when releasing.
 	//
-	// Order: clear / rebuild BEFORE arena.Reset. The slot.key
-	// fields alias arena bytes; arena.Reset rolls cursors back and
-	// the next Put overwrites the prior payload area, so any
-	// surviving aliased key would read garbage.
-	if cap(e.internTable) > maxRetainedIDs*2 {
+	// Order: clear / rebuild BEFORE arena.Reset. The slot.key fields alias
+	// arena bytes; arena.Reset rolls cursors back and the next Put overwrites
+	// the prior payload area, so any surviving aliased key would read garbage.
+	if cap(e.internTable) > maxRetainedIDs*2 && release {
 		e.internTable = make([]internSlot, internTableInitSize)
 	} else {
-		clear(e.internTable) // zero every slot (internSlot{} is the empty sentinel)
+		clear(e.internTable)
 	}
 	e.internLoad = 0
 	e.arena.Reset() // Arena has its own watermark, see internarena.
 
 	e.lastID = lruInvalidID
 	e.lruHead = lruInvalidID
-	if cap(e.lruLink) > maxRetainedLRUCap {
+	if cap(e.lruLink) > maxRetainedLRUCap && release {
 		e.lruLink = nil
 	} else {
 		e.lruLink = e.lruLink[:0]
 	}
 
-	// pairPred slice: clear in place if under the cap (memclr-fast
-	// because the empty sentinel is zero), drop the backing array
-	// otherwise.
-	if cap(e.pairPred) > maxRetainedPairCap {
+	// pairPred slice: clear in place (memclr-fast because the empty sentinel
+	// is zero); drop the backing array only when releasing.
+	if cap(e.pairPred) > maxRetainedPairCap && release {
 		e.pairPred = nil
 	} else {
 		clear(e.pairPred)
 	}
 
 	e.shapeCount = 0
-	if cap(e.shapeBindings) > maxRetainedShapeCap {
+	if cap(e.shapeBindings) > maxRetainedShapeCap && release {
 		e.shapeBindings = nil
 	} else {
 		e.shapeBindings = e.shapeBindings[:0]
 	}
 	e.lastShapeTd = nil
 	e.lastShapeID = 0
-	if cap(e.mapShapes) > maxRetainedShapeCap {
+	if cap(e.mapShapes) > maxRetainedShapeCap && release {
 		e.mapShapes = nil
 	} else {
 		e.mapShapes = e.mapShapes[:0]
@@ -353,40 +393,40 @@ func (e *encState) reset() {
 	e.lastMapShapeKeys = nil
 	e.mapEnc = mapHolderCache{}
 
-	if cap(e.colShapeNames) > maxRetainedShapeCap {
+	if cap(e.colShapeNames) > maxRetainedShapeCap && release {
 		e.colShapeNames = nil
 		e.colShapeKinds = nil
 	} else {
 		e.colShapeNames = e.colShapeNames[:0]
 		e.colShapeKinds = e.colShapeKinds[:0]
 	}
-	if cap(e.colScratchI64) > maxRetainedIDs {
+	// Row-scaled columnar scratch: retained across batches (amortizes a steady
+	// columnar workload, whose row count is independent of internLoad), dropped
+	// only past the hard ceiling so a one-off giant batch can't pin unbounded
+	// memory. sync.Pool's GC eviction reclaims it when the encoder goes idle.
+	if cap(e.colScratchI64) > maxRetainedColScratch {
 		e.colScratchI64, e.colScratchU64, e.colScratchF64, e.colScratchBool = nil, nil, nil, nil
 	}
-	// FSST compressed-bytes scratch can grow to the largest string column seen;
-	// drop it past the retention cap so the pool does not pin multi-MB buffers
-	// (mirrors the numeric scratch policy above).
-	if cap(e.fsstScratch) > maxRetainedIDs {
+	if cap(e.fsstScratch) > maxRetainedColScratch {
 		e.fsstScratch = nil
 		e.fsstLens = nil
 	}
 	// String-column scratch: []string slices retain header references that pin
-	// the caller's string memory across a pool recycle, and strDictMap grows to
-	// the largest column's distinct count. clear() drops the pinned headers;
-	// the backings are dropped past the retention cap (same policy as above).
-	if cap(e.colScratchStr) > maxRetainedIDs {
+	// the caller's string memory across a pool recycle. clear() drops those
+	// headers while keeping the backing; drop the backing only past the ceiling.
+	if cap(e.colScratchStr) > maxRetainedColScratch {
 		e.colScratchStr = nil
 	} else {
 		clear(e.colScratchStr)
 		e.colScratchStr = e.colScratchStr[:0]
 	}
-	if cap(e.colDictTable) > maxRetainedIDs {
+	if cap(e.colDictTable) > maxRetainedColScratch {
 		e.colDictTable = nil
 	} else {
 		clear(e.colDictTable)
 		e.colDictTable = e.colDictTable[:0]
 	}
-	if cap(e.colMaskScratch) > maxRetainedIDs {
+	if cap(e.colMaskScratch) > maxRetainedColScratch {
 		e.colMaskScratch = nil
 	} else {
 		e.colMaskScratch = e.colMaskScratch[:0]
@@ -817,6 +857,10 @@ type decState struct {
 	// mapDec pools reflect holders for the generic (reflect) string-keyed map
 	// decode path so it does not reflect.New per map entry (OptMapShape).
 	mapDec mapHolderCache
+
+	// retainStreak counts consecutive small (sub-cap) messages for the
+	// adaptive-retention policy in reset(). Cold — touched once per reset.
+	retainStreak uint8
 }
 
 func newDecState() *decState {
@@ -833,10 +877,23 @@ func newDecState() *decState {
 }
 
 func (d *decState) reset() {
-	// Symmetric to encState.reset's water-mark policy: shrink
-	// excess capacity back when a prior cycle grew past the soft
-	// cap, otherwise reuse the existing slices in place.
-	if cap(d.values) > maxRetainedIDs {
+	// Symmetric to encState.reset's adaptive-retention policy: retain grown
+	// backing arrays (reuse in place) while messages stay large so a steady
+	// large-batch decode workload amortizes the table allocation, releasing
+	// only after retainReleaseStreak consecutive small messages. The decision
+	// is driven by len(d.values) — the count of intern records decoded THIS
+	// message, a true per-message demand signal (the retained cap would stay
+	// large forever and never let the streak advance). Row-scaled columnar
+	// scratch is governed by the hard ceiling; the id-bounded tables are
+	// already bounded by maxStateEntries. See encState.reset for rationale.
+	if len(d.values) > maxRetainedIDs {
+		d.retainStreak = 0
+	} else if d.retainStreak < retainReleaseStreak {
+		d.retainStreak++
+	}
+	release := d.retainStreak >= retainReleaseStreak
+
+	if cap(d.values) > maxRetainedIDs && release {
 		d.values = nil
 		d.stringValues = nil
 	} else {
@@ -845,30 +902,32 @@ func (d *decState) reset() {
 	}
 	d.lastID = lruInvalidID
 	d.lruHead = lruInvalidID
-	if cap(d.lruLink) > maxRetainedLRUCap {
+	if cap(d.lruLink) > maxRetainedLRUCap && release {
 		d.lruLink = nil
 	} else {
 		d.lruLink = d.lruLink[:0]
 	}
-	if cap(d.pairPred) > maxRetainedPairCap {
+	if cap(d.pairPred) > maxRetainedPairCap && release {
 		d.pairPred = nil
 	} else {
 		clear(d.pairPred)
 	}
-	if cap(d.shapes) > maxRetainedShapeCap {
+	if cap(d.shapes) > maxRetainedShapeCap && release {
 		d.shapes = nil
 	} else {
 		d.shapes = d.shapes[:0]
 	}
-	if cap(d.colShapes) > maxRetainedShapeCap {
+	if cap(d.colShapes) > maxRetainedShapeCap && release {
 		d.colShapes = nil
 	} else {
 		d.colShapes = d.colShapes[:0]
 	}
-	if cap(d.colScratchI64) > maxRetainedIDs {
+	// Row-scaled columnar scratch: ceiling-only (independent of the intern
+	// streak), reclaimed when idle by sync.Pool GC.
+	if cap(d.colScratchI64) > maxRetainedColScratch {
 		d.colScratchI64, d.colScratchU64, d.colScratchF64, d.colScratchBool = nil, nil, nil, nil
 	}
-	if cap(d.colLenScratch) > maxRetainedIDs {
+	if cap(d.colLenScratch) > maxRetainedColScratch {
 		d.colLenScratch = nil
 	}
 	for i := range d.mruRing {

--- a/state.go
+++ b/state.go
@@ -898,6 +898,15 @@ func (d *decState) reset() {
 		d.values = nil
 		d.stringValues = nil
 	} else {
+		// Retain the backing, but clear() first: d.values entries are []byte
+		// aliasing the previous message's input (wire) buffer, and
+		// stringValues entries are prior decoded-string headers. A bare [:0]
+		// keeps those headers live in the tail, pinning the previous caller's
+		// input buffer (and decoded strings) from GC for the lifetime of the
+		// pooled decoder. clear() drops the headers before reuse — mirrors the
+		// encoder's colScratchStr treatment. memclr only, no allocation.
+		clear(d.values)
+		clear(d.stringValues)
 		d.values = d.values[:0]
 		d.stringValues = d.stringValues[:0]
 	}


### PR DESCRIPTION
A pooled encoder/decoder that just handled a **large, high-cardinality**
message (AD/LDAP sync, log/telemetry batches) used to **drop its grown
backing arrays** (intern table, LRU/pair predictor, columnar scratch, decoder
value table) on the *very next* `reset()` whenever their cap exceeded a fixed
soft cap — then reallocate them from scratch on the following message. So a
**steady** large workload never amortized the table allocation: it paid a full
intern-table + LRU + pair regrow **every single message**.

This change makes retention **adaptive**:

- **intern table / LRU / pair / shapes** are kept (cleared in place) while the
  workload stays large, released only after `retainReleaseStreak = 8`
  consecutive **small** messages. The decision is driven by a **true
  per-message demand signal** — `internLoad` on encode, `len(values)` on
  decode — *not* the retained cap (which would stay large forever and never
  let the streak advance). These arrays are already bounded by
  `maxStateEntries` (≤ 0xFFFF → ~1–4 MB), so they need no hard ceiling.
- **row-scaled columnar scratch** (`colScratch*`, `colDictTable`,
  `colMaskScratch`, `fsstScratch`, `colLenScratch`) is retained up to a hard
  ceiling `maxRetainedColScratch = 1<<20` and dropped above it, so a one-off
  giant batch can't pin unbounded memory.

`sync.Pool`'s GC-driven eviction bounds idle retention regardless, so the
original "don't pin spike memory forever" intent is preserved — memory still
returns to the steady-state working set after a burst.

## Why (measured)

Realistic Active-Directory directory-export workload (5000 users, row-major
reflect path, `OptBalanced`), clean A/B on the same machine:

| phase  | metric    | main      | this PR   | delta    |
|--------|-----------|-----------|-----------|----------|
| encode | B/op      | 5 998 711 | 3 379 344 | **−44%** |
| encode | allocs/op | 77        | 27        | **−65%** |
| decode | B/op      | 8 233 467 | 4 794 183 | **−42%** |

(decode alloc *count* is unchanged — it is dominated by per-string copies,
which is `WithNoCopy`'s domain, not this change; the bytes saved are the
no-longer-reallocated value/LRU/pair backing arrays.) Wall-clock improved
slightly in lockstep (less GC), within laptop thermal noise.

## Correctness

- New per-state `retainStreak uint8` (cold, touched once per `reset`).
- `shrink_test.go` rewritten to the new contract: a backing is **retained** on
  the first post-burst reset and **released** only after the streak elapses;
  added `TestShrink_SteadyLargeRetainsInternTable` pinning the amortization
  guarantee (sustained large load never rebuilds the table to init size).
- All retained arrays are cleared/resliced before reuse (verified: `clear()`
  before `arena.Reset()` for the intern table's arena-aliased keys; `clear()`
  drops pinned caller-string headers for `colScratchStr`/`colDictTable`;
  numeric scratch is always re-`[:0]`-appended by its writer).
- Cert green: `go vet`, `golangci-lint` (0 issues), `-race`, `-tags qdf_simd`,
  codegen module, `FuzzRoundTrip_AllModesAgree` (1.7M execs), realistic AD
  round-trip across every option combo, small-steady no-regression
  (3 allocs/op) + bursty (bounded RSS) guards. (`FuzzDecoder_NeverPanics`
  parallel OOM is the known environmental artifact — saved input passes
  standalone.)

## Also in this PR

A realistic **Active-Directory workload test + benchmarks**
(`bench/realistic_ad_test.go`, `bench/realistic_ad_bench_test.go`): a
deterministic AD dataset (unique GUIDs/UPNs, occasional name repeats, moderate
group/department repeats) round-tripped bit-exactly across every option combo,
reporting allocation churn (`runtime.MemStats`), process RSS
(`syscall.Getrusage`) and reference-size-normalized throughput. This is the
workload that motivates and validates the retention change.