### PR TITLE
perf(decode): three safe allocation reductions on opt-in compression paths

### DIFF
--- a/decode_scratch_reuse_test.go
+++ b/decode_scratch_reuse_test.go
@@ -1,0 +1,89 @@
+package qdf
+
+// Regression guards for the deltaScratch reuse in readPackedALPFloat64Slice
+// (qpack_alp.go) and readStringColumnDict (qpack_strdict.go). Both switched a
+// per-call make([]uint64, n) to the shared d.deltaScratch. The hazard class is
+// reused-buffer under-fill / stale-data leak: if the bit-unpack did not fully
+// overwrite the n reused slots, prior-call garbage would surface as wrong
+// decoded values. These tests PRE-DIRTY deltaScratch with a sentinel and assert
+// the decode is still bit-exact, turning an order-dependent heisenbug into a
+// deterministic check.
+
+import (
+	"math"
+	"testing"
+)
+
+const scratchDirt = uint64(0xDEADBEEFDEADBEEF)
+
+func dirtyScratch(d *Decoder, n int) {
+	d.deltaScratch = make([]uint64, n)
+	for i := range d.deltaScratch {
+		d.deltaScratch[i] = scratchDirt
+	}
+}
+
+func TestDeltaScratchReuse_ALPNoStaleLeak(t *testing.T) {
+	for _, s := range [][]float64{
+		alpFixtureQuantized(),
+		alpFixtureSmoothQuantized(),
+	} {
+		plan, _, ok := alpPlanFloat64(s)
+		if !ok {
+			continue
+		}
+		e := NewEncoderWith(OptCompression)
+		e.writePackedALPFloat64Slice(s, plan)
+		payload := e.buf[5:]
+
+		d := &Decoder{buf: payload}
+		dirtyScratch(d, len(s)+128) // larger than n, all sentinel
+		d.i = 1
+		got, err := d.readPackedALPFloat64Slice()
+		if err != nil {
+			t.Fatalf("decode error: %v", err)
+		}
+		if len(got) != len(s) {
+			t.Fatalf("len %d != %d", len(got), len(s))
+		}
+		for i := range s {
+			if math.Float64bits(got[i]) != math.Float64bits(s[i]) {
+				t.Fatalf("idx %d: stale-scratch leak — got %#x want %#x",
+					i, math.Float64bits(got[i]), math.Float64bits(s[i]))
+			}
+		}
+	}
+}
+
+func TestDeltaScratchReuse_StrDictNoStaleLeak(t *testing.T) {
+	// Low-cardinality strings so the dictionary codec fires (count >= 2).
+	pool := []string{"alpha", "bravo", "charlie", "delta"}
+	n := 1500
+	strs := make([]string, n)
+	for i := range strs {
+		strs[i] = pool[(i*7)%len(pool)]
+	}
+
+	e := NewEncoderWith(OptBalanced &^ OptRANS)
+	if !e.tryWriteStringColumnDict(strs) {
+		t.Skip("dict codec declined for this input")
+	}
+
+	// tryWriteStringColumnDict calls writeHeader first (5-byte QDF header), so
+	// the tagColStrDict lands at offset 5 — land the cursor on the tag.
+	d := &Decoder{buf: e.buf, i: 5}
+	dirtyScratch(d, n+128) // sentinel-fill before decode
+	table, idx, err := d.readStringColumnDict(n)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(idx) != n {
+		t.Fatalf("idx len %d != %d", len(idx), n)
+	}
+	for i := range strs {
+		if int(idx[i]) >= len(table) || table[idx[i]] != strs[i] {
+			t.Fatalf("idx %d: stale-scratch leak — got %q want %q",
+				i, table[idx[i]], strs[i])
+		}
+	}
+}

--- a/internal/rans/rans.go
+++ b/internal/rans/rans.go
@@ -82,15 +82,16 @@ func buildFreqs(src []byte) (freq [256]uint32, cum [257]uint32) {
 	return freq, cum
 }
 
-// buildSlot returns the 4096-entry slot->symbol lookup for decode.
-func buildSlot(cum *[257]uint32) *[scale]byte {
-	var slot [scale]byte
+// buildSlot fills the 4096-entry slot->symbol lookup for decode into the
+// caller-provided array. Taking the destination by pointer (rather than
+// returning a fresh array) lets the caller keep slot on its stack frame: a
+// returned &slot would force the 4 KiB array to the heap on every Decode.
+func buildSlot(cum *[257]uint32, slot *[scale]byte) {
 	for s := range 256 {
 		for c := cum[s]; c < cum[s+1]; c++ {
 			slot[c] = byte(s)
 		}
 	}
-	return &slot
 }
 
 // encodeStream rANS-encodes src and returns the stream: 4-byte little-endian
@@ -195,8 +196,9 @@ func Decode(src []byte, n int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	slot := buildSlot(&cum)
-	return decodeStream(src[used:], &freq, slot, &cum, n)
+	var slot [scale]byte
+	buildSlot(&cum, &slot)
+	return decodeStream(src[used:], &freq, &slot, &cum, n)
 }
 
 // appendUvarint / uvarint are local LEB128 helpers (kept self-contained so the

--- a/qpack_alp.go
+++ b/qpack_alp.go
@@ -234,7 +234,15 @@ func (d *Decoder) readPackedALPFloat64Slice() ([]float64, error) {
 	out := make([]float64, n)
 	if width > 0 {
 		bodyBytes := int((n64*uint64(width) + 7) / 8)
-		packed := make([]uint64, n)
+		// Reuse the shared transient unpack scratch (as readPackedDictUint64Slice
+		// does): packed is fully written by Unpack before any read, only consumed
+		// into out, never aliased into the returned slice. This branch runs only
+		// when width > 0, so Unpack always writes all n slots — the width == 0
+		// constant path below never touches deltaScratch, so no stale-tail leak.
+		if cap(d.deltaScratch) < n {
+			d.deltaScratch = make([]uint64, n)
+		}
+		packed := d.deltaScratch[:n]
 		bitpack.Unpack(packed, d.buf[d.i:d.i+bodyBytes], width)
 		d.i += bodyBytes
 		for i := range out {

--- a/qpack_strdict.go
+++ b/qpack_strdict.go
@@ -207,7 +207,15 @@ func (d *Decoder) readStringColumnDict(n int) (table []string, idx []uint32, err
 	body := d.buf[d.i : d.i+bodyBytes]
 	d.i += bodyBytes
 	idx = make([]uint32, n)
-	tmp := make([]uint64, n)
+	// Reuse the shared transient unpack scratch (as readPackedDictUint64Slice
+	// does): tmp holds the bit-unpacked dictionary indices, fully written by
+	// Unpack below before any read, and only mapped into idx — never aliased
+	// into the returned slices. count >= 2 ⇒ bits >= 1 (checked above), so
+	// Unpack always writes all n slots; no stale-tail under-fill is possible.
+	if cap(d.deltaScratch) < n {
+		d.deltaScratch = make([]uint64, n)
+	}
+	tmp := d.deltaScratch[:n]
 	bitpack.Unpack(tmp, body, bits)
 	for i, v := range tmp {
 		if v >= c64 {


### PR DESCRIPTION
Three logic-preserving, wire-identical allocation cuts found by a line-by-line
sweep plus empirical escape analysis (`go build -gcflags=-m=2`). All changes are
decode-side, behaviour-preserving, and gated by existing tests; none touches the
wire format or any decoded value.

## Changes

### 1. Reuse `deltaScratch` in the string-dictionary unpack (`qpack_strdict.go`)
`readStringColumnDict` allocated a fresh `make([]uint64, n)` per call to hold the
bit-unpacked dictionary indices. It now reuses the shared, pooled
`d.deltaScratch` — exactly the pattern `readPackedDictUint64Slice` already uses.
The buffer is fully written by `bitpack.Unpack` before any read and never aliased
into a returned slice. `count >= 2 ⇒ bits >= 1`, so `Unpack` always writes all `n`
slots (no stale-tail under-fill possible).

### 2. Reuse `deltaScratch` in the ALP float unpack (`qpack_alp.go`)
`readPackedALPFloat64Slice` had the same per-call `make([]uint64, n)` for the
packed mantissas; switched to `d.deltaScratch`. The reuse sits inside the
`width > 0` branch, which always `Unpack`s all `n` slots; the `width == 0`
constant path never touches the scratch.

### 3. Keep the rANS decode slot table on the stack (`internal/rans/rans.go`)
`buildSlot` returned `&slot`, forcing the 4096-byte slot→symbol lookup array to
the heap on **every** `rans.Decode` (once per `OptCompression` message body).
`decodeStream` already proved the array does not escape — only the `return`
pinned it. `buildSlot` now fills a caller-provided array; `Decode` declares
`var slot [scale]byte` on its own frame. The array is zero-initialised each call
exactly like the old fresh heap array, so behaviour is identical. Escape analysis
now reports `slot does not escape`.

## Measured (AllocsPerRun, pooled/persistent decoder)

| path | before | after |
|---|---|---|
| ALP decode (n=1024) | 2.0 allocs/op | **1.0** |
| strdict round-trip (2000 rows) | 38 allocs/op | **35** |
| rans.Decode (n=4000) | 2.0 allocs/op | **1.0** |

All three paths fire only under opt-in `OptCompression` columns/frames; the hot
`OptBalanced` encode/decode path is unchanged (it was already at its allocation
floor — confirmed by escape analysis: every remaining heap escape there is the
output buffer, a once-per-type cached plan, a once-per-decoder pool object, or a
caller-owned result).

## Safety / no-regression

- **Wire & values identical** — decode-only buffer reuse and a heap→stack move;
  no encoder or format change. Golden, matrix, columnar, compression and
  round-trip suites all green.
- **Under-fill hazard covered** — switching `make()` to a reused buffer is the
  classic stale-data trap. New `decode_scratch_reuse_test.go` pre-dirties
  `deltaScratch` with a `0xDEADBEEF` sentinel and asserts bit-exact decode for
  both strdict and ALP, turning an order-dependent heisenbug into a deterministic
  guard. The rANS `var` array is zero-initialised by the language each call.
- **Verified** — `-gcflags=-m=2` confirms the rANS array no longer escapes; full
  package suite + `internal/rans` tests + `-race` on the affected paths + the
  realistic AD/Logs round-trip bench-module tests all pass.

## Out of scope (backlog)

A few more rare-path candidates were identified but deferred as higher-risk /
lower-ROI: a `[]colVals` slab in the query-pushdown path, the ALP **encode**
scratch (needs an explicit `clear()` to preserve the exception-slot-zero
invariant), and pooled scratch for the Gorilla/FSST encoders.