### PR TITLE
fix: correctness + round-trip-fidelity sweep (hybrid columnar, schemaless maps, stream, depth, nil slices)

### DIFF
--- a/columnar.go
+++ b/columnar.go
@@ -1505,6 +1505,13 @@ func decodeHybridColumnar(d *Decoder, t reflect.Type, plan *columnarPlan, p unsa
 			targets = append(targets, findResidual(plan, sh.names[c]))
 		}
 	}
+	// Residual fields are row-major, not columnar columns: their slice/map/
+	// nested values may legitimately hold any number of elements, unrelated to
+	// the row count n. Clear the per-column length bound (set to n above for the
+	// eligible columns) before decoding them, or a residual collection longer
+	// than n is wrongly rejected by colLenOK as ErrInvalidLength. (A nested
+	// columnar residual sets and restores its own colMaxLen.)
+	d.colMaxLen = 0
 	for i := range n {
 		rowPtr := unsafe.Add(base, uintptr(i)*plan.stride)
 		for _, rf := range targets {
@@ -2024,6 +2031,10 @@ func decodeHybridColumnarAny(d *Decoder) (any, error) {
 		}
 	}
 	// Residual block: per row, each residual field in shape order via decodeAny.
+	// Residual fields are row-major; clear the columnar length bound so a
+	// residual collection longer than n is not rejected by colLenOK (see
+	// decodeHybridColumnar for the detailed rationale).
+	d.colMaxLen = 0
 	for i := range n {
 		row := out[i].(map[string]any)
 		for c := range sh.kinds {

--- a/decode_any_maps_test.go
+++ b/decode_any_maps_test.go
@@ -1,0 +1,67 @@
+package qdf
+
+import "testing"
+
+// Regression: a non-string-keyed map boxed in an any/interface value marshalled
+// successfully but failed to Unmarshal into `any` (decodeAny hard-coded string
+// keys → ErrTypeMismatch, silent data loss). It now round-trips to map[any]any.
+// A typed destination (e.g. *map[int]string) already worked and still does.
+func TestDecodeAnyNonStringKeyedMap(t *testing.T) {
+	for _, opt := range []Options{OptSpeed, OptBalanced} {
+		// small (fixint) keys → uint64 schemaless
+		var top any = map[int]string{1: "one", 2: "two"}
+		b, err := Marshal(top, opt)
+		if err != nil {
+			t.Fatalf("opt=%v marshal: %v", opt, err)
+		}
+		var got any
+		if err := Unmarshal(b, &got); err != nil {
+			t.Fatalf("opt=%v unmarshal int-keyed map in any: %v", opt, err)
+		}
+		m, ok := got.(map[any]any)
+		if !ok {
+			t.Fatalf("opt=%v want map[any]any got %T", opt, got)
+		}
+		if len(m) != 2 || m[uint64(1)] != "one" || m[uint64(2)] != "two" {
+			t.Fatalf("opt=%v content wrong: %#v", opt, m)
+		}
+
+		// negative key → int64 schemaless
+		var neg any = map[int]string{-5: "neg"}
+		bn, _ := Marshal(neg, opt)
+		var gn any
+		if err := Unmarshal(bn, &gn); err != nil {
+			t.Fatalf("opt=%v unmarshal negative-keyed map: %v", opt, err)
+		}
+		if gn.(map[any]any)[int64(-5)] != "neg" {
+			t.Fatalf("opt=%v negative key lost: %#v", opt, gn)
+		}
+
+		// typed destination still works (unchanged behaviour)
+		var typed map[int]string
+		if err := Unmarshal(b, &typed); err != nil {
+			t.Fatalf("opt=%v typed decode regressed: %v", opt, err)
+		}
+		if typed[1] != "one" || typed[2] != "two" {
+			t.Fatalf("opt=%v typed content wrong: %#v", opt, typed)
+		}
+	}
+}
+
+// String-keyed maps in `any` must keep decoding to map[string]any (no regression
+// from the new non-string-key branch).
+func TestDecodeAnyStringKeyedMapUnchanged(t *testing.T) {
+	var top any = map[string]int{"a": 1, "b": 2}
+	b, _ := Marshal(top, OptBalanced)
+	var got any
+	if err := Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	m, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("want map[string]any got %T", got)
+	}
+	if m["a"] != uint64(1) || m["b"] != uint64(2) {
+		t.Fatalf("content wrong: %#v", m)
+	}
+}

--- a/decode_any_maps_test.go
+++ b/decode_any_maps_test.go
@@ -48,6 +48,35 @@ func TestDecodeAnyNonStringKeyedMap(t *testing.T) {
 	}
 }
 
+// Regression: a map[any]any with MIXED key types (string + int) must round-trip
+// regardless of Go's randomized map iteration order. The decode path used to
+// peek only the FIRST key's tag and commit the whole map to one path, so a
+// string key sorting first sent an int key into the string reader →
+// ErrTypeMismatch ~85% of the time. decodeAny now peeks per key and migrates to
+// map[any]any the moment a non-string key appears.
+func TestDecodeAnyMixedKeyMap(t *testing.T) {
+	for _, opt := range []Options{OptSpeed, OptBalanced} {
+		for i := 0; i < 50; i++ { // many trials: hit both iteration orders
+			var top any = map[any]any{"strkey": "v1", int(42): "v2", "k3": int64(7)}
+			b, err := Marshal(top, opt)
+			if err != nil {
+				t.Fatalf("opt=%v marshal: %v", opt, err)
+			}
+			var got any
+			if err := Unmarshal(b, &got); err != nil {
+				t.Fatalf("opt=%v trial %d unmarshal: %v", opt, i, err)
+			}
+			m, ok := got.(map[any]any)
+			if !ok {
+				t.Fatalf("opt=%v want map[any]any got %T", opt, got)
+			}
+			if len(m) != 3 || m["strkey"] != "v1" || m[uint64(42)] != "v2" || m["k3"] != uint64(7) {
+				t.Fatalf("opt=%v trial %d content wrong: %#v", opt, i, m)
+			}
+		}
+	}
+}
+
 // String-keyed maps in `any` must keep decoding to map[string]any (no regression
 // from the new non-string-key branch).
 func TestDecodeAnyStringKeyedMapUnchanged(t *testing.T) {

--- a/encode_depth_symmetry_test.go
+++ b/encode_depth_symmetry_test.go
@@ -1,0 +1,46 @@
+package qdf
+
+import "testing"
+
+type depthRecS struct {
+	V        int         `qdf:"v"`
+	Children []depthRecS `qdf:"children"` // recursion carried by a SLICE field
+}
+
+// Regression: the encoder counted recursion depth only at pointer/interface
+// hops, while the decoder caps EVERY slice/array/map level at maxDepth. So a
+// recursion carried by slices/maps encoded unbounded but failed to decode
+// (ErrCycleDetected) — a value qdf produced but could not read back. The encoder
+// now guards slice/array/map levels too, so a too-deep value is refused AT
+// ENCODE rather than emitted as an undecodable blob (symmetric encode/decode).
+func TestEncodeDecodeDepthSymmetry(t *testing.T) {
+	// Slice-carried nesting beyond DefaultMaxDepth must be rejected at encode.
+	leaf := depthRecS{V: 0}
+	cur := &leaf
+	for i := 1; i < DefaultMaxDepth+2000; i++ {
+		cur.Children = []depthRecS{{V: i}}
+		cur = &cur.Children[0]
+	}
+	if _, err := Marshal(leaf, OptSpeed); err == nil {
+		t.Fatal("expected encode to reject slice-carried nesting beyond maxDepth")
+	}
+
+	// A modest depth still round-trips (the guard does not over-reject).
+	shallow := depthRecS{V: 0}
+	c := &shallow
+	for i := 1; i < 50; i++ {
+		c.Children = []depthRecS{{V: i}}
+		c = &c.Children[0]
+	}
+	b, err := Marshal(shallow, OptSpeed)
+	if err != nil {
+		t.Fatalf("shallow encode: %v", err)
+	}
+	var out depthRecS
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatalf("shallow decode (must round-trip): %v", err)
+	}
+	if out.Children[0].Children[0].V != 2 {
+		t.Fatalf("shallow round-trip wrong: %+v", out)
+	}
+}

--- a/hybrid_residual_test.go
+++ b/hybrid_residual_test.go
@@ -1,0 +1,83 @@
+package qdf
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Regression: hybrid columnar left the per-column length bound (colMaxLen = n)
+// active while decoding the row-major residual fields, so a residual slice/map
+// longer than the batch row count n was wrongly rejected with ErrInvalidLength.
+// Residual fields are row-major and may hold any number of elements.
+
+type hybResidualRow struct {
+	Level  string         `qdf:"level"`  // low-card → FSST → hybrid fires
+	Region string         `qdf:"region"` // low-card
+	Seq    int64          `qdf:"seq"`
+	Nums   []int          `qdf:"nums"`  // residual slice
+	Attrs  map[string]int `qdf:"attrs"` // residual map
+}
+
+func TestHybridResidualLongerThanRowCount(t *testing.T) {
+	const n = 200 // row count; residual collections are deliberately longer
+	levels := []string{"INFO", "WARN", "ERROR"}
+	regions := []string{"us", "eu", "ap"}
+	in := make([]hybResidualRow, n)
+	for i := range in {
+		nums := make([]int, 256) // > n
+		for j := range nums {
+			nums[j] = j * 3
+		}
+		attrs := make(map[string]int, 300) // > n
+		for j := 0; j < 300; j++ {
+			attrs[string(rune('a'+j%26))+itoaSmall(j)] = j
+		}
+		in[i] = hybResidualRow{
+			Level: levels[i%3], Region: regions[i%3], Seq: int64(i),
+			Nums: nums, Attrs: attrs,
+		}
+	}
+
+	b, err := Marshal(in, OptCompression)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Typed decode path (decodeHybridColumnar).
+	var out []hybResidualRow
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatalf("typed hybrid decode failed on residual longer than n: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatal("typed hybrid round-trip mismatch")
+	}
+
+	// Schemaless decode path (decodeHybridColumnarAny).
+	var anyOut any
+	if err := Unmarshal(b, &anyOut); err != nil {
+		t.Fatalf("any hybrid decode failed on residual longer than n: %v", err)
+	}
+	rows, ok := anyOut.([]any)
+	if !ok || len(rows) != n {
+		t.Fatalf("any hybrid shape: %T", anyOut)
+	}
+	row0 := rows[0].(map[string]any)
+	// A homogeneous int slice decodes schemalessly to []int64 (packed-slice path).
+	if nums, ok := row0["nums"].([]int64); !ok || len(nums) != 256 {
+		t.Fatalf("any residual slice wrong: %T", row0["nums"])
+	}
+}
+
+func itoaSmall(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [12]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/nil_empty_roundtrip_test.go
+++ b/nil_empty_roundtrip_test.go
@@ -1,0 +1,52 @@
+package qdf
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Regression: a nil slice must round-trip as nil, distinct from an empty
+// (non-nil) slice — the distinction maps and pointers already keep, and that
+// encoding/json keeps as null vs []. encodeSlice* previously emitted a 0-length
+// array header for both, so a nil slice decoded as []T{}. A nil slice now emits
+// tagNil (via the field-level wrapper) and decodes back to nil.
+func TestNilVsEmptySliceRoundTrip(t *testing.T) {
+	type S struct {
+		A []int            `qdf:"a"`
+		B []string         `qdf:"b"`
+		C []byte           `qdf:"c"`
+		D []float64        `qdf:"d"`
+		E [][]int          `qdf:"e"`
+		F []map[string]int `qdf:"f"`
+	}
+	cases := []struct {
+		name string
+		v    any
+	}{
+		{"allNil", S{}},
+		{"allEmpty", S{A: []int{}, B: []string{}, C: []byte{}, D: []float64{}, E: [][]int{}, F: []map[string]int{}}},
+		{"mixed", S{A: nil, B: []string{}, C: []byte{1, 2}, D: nil, E: [][]int{}, F: nil}},
+		{"full", S{A: []int{1}, B: []string{"x"}, C: []byte{9}, D: []float64{1.5}, E: [][]int{{1}}, F: []map[string]int{{"k": 1}}}},
+		{"topNilSlice", []int(nil)},
+		{"topEmptySlice", []int{}},
+		{"nestedNilEmptyFull", [][]int{nil, {}, {1, 2}}},
+		{"sliceOfStructs", []S{{A: nil}, {A: []int{}}, {A: []int{7}}}},
+		{"nilBytes", S{C: nil}},
+		{"emptyBytes", S{C: []byte{}}},
+	}
+	for _, opt := range []Options{OptSpeed, OptBalanced, OptCompression, OptBalanced | OptMapShape, OptBalanced | OptColumnIndex} {
+		for _, c := range cases {
+			b, err := Marshal(c.v, opt)
+			if err != nil {
+				t.Fatalf("%s/%v marshal: %v", c.name, opt, err)
+			}
+			out := reflect.New(reflect.TypeOf(c.v))
+			if err := Unmarshal(b, out.Interface()); err != nil {
+				t.Fatalf("%s/%v unmarshal: %v", c.name, opt, err)
+			}
+			if !reflect.DeepEqual(c.v, out.Elem().Interface()) {
+				t.Errorf("%s/%v not bit-exact:\n in =%#v\n out=%#v", c.name, opt, c.v, out.Elem().Interface())
+			}
+		}
+	}
+}

--- a/qdf.go
+++ b/qdf.go
@@ -414,6 +414,17 @@ func AppendMarshal(dst []byte, v any, opts Options) ([]byte, error) {
 // []map[string]any or []any payload; on any other shape a query call
 // returns a *QueryError wrapping ErrUnsupported. With no options the
 // behavior is exactly the plain decode above.
+//
+// Round-trip fidelity: decoding into the same concrete Go type reproduces the
+// value exactly, including the nil-vs-empty distinction for slices, maps and
+// pointers (a nil []T decodes as nil, an empty []T{} as empty — like
+// encoding/json's null vs []). Two deliberate normalizations are NOT bit-exact:
+// decoding into an interface (any / map[string]any) canonicalizes integers to
+// int64 / uint64 and structs to map[string]any (the schemaless type contract),
+// and a time.Time loses any monotonic-clock reading on encode (as the standard
+// library strips it for transport). Values nested deeper than the configured
+// max depth, and maps with both int and uint keys of the same small value, are
+// the documented exceptions.
 func Unmarshal(data []byte, out any, opts ...QueryOption) error {
 	if len(opts) == 0 {
 		return unmarshal(data, out, nil, false)

--- a/reflect_desc.go
+++ b/reflect_desc.go
@@ -183,12 +183,10 @@ func fillDesc(td *typeDesc, t reflect.Type, ctx *buildCtx) error {
 			td.encode = encodeSlice(elem, t.Elem().Size(), td.colPlan)
 			td.decode = decodeSlice(t, elem, t.Elem().Size(), td.colPlan)
 		}
-		// Preserve the nil-vs-empty distinction for every slice-typed FIELD
-		// (bytes / typed-fast-path / reflect), consistent with maps and pointers.
-		// Wrapping at the field descriptor keeps the shared encodeSlice* funcs
-		// nil-agnostic for their internal direct callers (dense columns).
-		td.encode = preserveNilSliceEncode(td.encode)
-		td.decode = preserveNilSliceDecode(td.decode)
+		// Nil-vs-empty preservation: the []byte and reflect encoders self-handle
+		// it inline (they are field-only); the typed fast paths use their nil-aware
+		// *Nil variants (installSliceFastPath) which keep the shared encodeSlice*
+		// funcs nil-agnostic for their internal dense-column callers.
 	case reflect.Array:
 		elem, err := descBuild(t.Elem(), ctx)
 		if err != nil {

--- a/reflect_desc.go
+++ b/reflect_desc.go
@@ -183,6 +183,12 @@ func fillDesc(td *typeDesc, t reflect.Type, ctx *buildCtx) error {
 			td.encode = encodeSlice(elem, t.Elem().Size(), td.colPlan)
 			td.decode = decodeSlice(t, elem, t.Elem().Size(), td.colPlan)
 		}
+		// Preserve the nil-vs-empty distinction for every slice-typed FIELD
+		// (bytes / typed-fast-path / reflect), consistent with maps and pointers.
+		// Wrapping at the field descriptor keeps the shared encodeSlice* funcs
+		// nil-agnostic for their internal direct callers (dense columns).
+		td.encode = preserveNilSliceEncode(td.encode)
+		td.decode = preserveNilSliceDecode(td.decode)
 	case reflect.Array:
 		elem, err := descBuild(t.Elem(), ctx)
 		if err != nil {

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -962,6 +962,22 @@ func decodeIface(d *Decoder, p unsafe.Pointer) error {
 }
 
 // decodeAny reads the next value as a generic any, mirroring encoding/json.
+// isStringKeyTag reports whether tag begins a string value — i.e. a map key
+// that d.readStringBytes can consume. Mirrors decodeAny's string-producing
+// cases. Used to tell a string-keyed map (→ map[string]any) from a non-string-
+// keyed one (→ map[any]any) when decoding a map schemalessly.
+func isStringKeyTag(tag byte) bool {
+	if tag >= tagFixstr && tag <= tagFixstr|tagFixstrMask {
+		return true
+	}
+	switch tag {
+	case tagStr8, tagStr16, tagStr32, tagInternStr,
+		tagStateRef, tagStateRepeat, tagStateMTF, tagStatePair:
+		return true
+	}
+	return false
+}
+
 func decodeAny(d *Decoder) (any, error) {
 	if err := d.descend(); err != nil {
 		return nil, err
@@ -1040,6 +1056,41 @@ func decodeAny(d *Decoder) (any, error) {
 		}
 		if err := d.CheckLength(n, 2); err != nil {
 			return nil, err
+		}
+		if n == 0 {
+			return map[string]any{}, nil
+		}
+		// Peek the first key's tag. A string-keyed map (the common case)
+		// decodes to map[string]any with interned keys. A non-string-keyed map
+		// (e.g. map[int]V boxed in an any/interface, whose keys were written via
+		// WriteInt/WriteUint) must NOT be read as string keys — doing so
+		// returned ErrTypeMismatch and silently lost data that round-trips fine
+		// into a typed destination. The wire cannot distinguish int from uint
+		// for small (fixint) keys, so the only lossless schemaless form is
+		// map[any]any, each key decoded via decodeAny (int64/uint64/etc.).
+		ktag, err := d.peekTag()
+		if err != nil {
+			return nil, err
+		}
+		if !isStringKeyTag(ktag) {
+			out := make(map[any]any, n)
+			for range n {
+				k, err := decodeAny(d)
+				if err != nil {
+					return nil, err
+				}
+				// A valid map key type is always comparable; reject a hostile
+				// wire whose "key" decodes to a slice/map so out[k] cannot panic.
+				if k != nil && !reflect.TypeOf(k).Comparable() {
+					return nil, ErrBadTag
+				}
+				v, err := decodeAny(d)
+				if err != nil {
+					return nil, err
+				}
+				out[k] = v
+			}
+			return out, nil
 		}
 		out := make(map[string]any, n)
 		for range n {

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -1068,32 +1068,42 @@ func decodeAny(d *Decoder) (any, error) {
 		// into a typed destination. The wire cannot distinguish int from uint
 		// for small (fixint) keys, so the only lossless schemaless form is
 		// map[any]any, each key decoded via decodeAny (int64/uint64/etc.).
-		ktag, err := d.peekTag()
-		if err != nil {
-			return nil, err
-		}
-		if !isStringKeyTag(ktag) {
-			out := make(map[any]any, n)
-			for range n {
-				k, err := decodeAny(d)
-				if err != nil {
-					return nil, err
-				}
-				// A valid map key type is always comparable; reject a hostile
-				// wire whose "key" decodes to a slice/map so out[k] cannot panic.
-				if k != nil && !reflect.TypeOf(k).Comparable() {
-					return nil, ErrBadTag
-				}
-				v, err := decodeAny(d)
-				if err != nil {
-					return nil, err
-				}
-				out[k] = v
-			}
-			return out, nil
-		}
+		// Peek EACH key's tag, not just the first: a map[any]any can carry mixed
+		// key types in any order. Stay on the fast string-keyed path (→
+		// map[string]any) as long as keys are strings; the moment a non-string
+		// key appears, migrate the string keys decoded so far into map[any]any
+		// and finish via decodeAny (which handles string and non-string keys
+		// alike). map[any]any is the only lossless schemaless form — the wire
+		// can't tell int from uint for small (fixint) keys.
 		out := make(map[string]any, n)
-		for range n {
+		for idx := 0; idx < n; idx++ {
+			ktag, err := d.peekTag()
+			if err != nil {
+				return nil, err
+			}
+			if !isStringKeyTag(ktag) {
+				anyOut := make(map[any]any, n)
+				for k, v := range out {
+					anyOut[k] = v
+				}
+				for ; idx < n; idx++ {
+					k, err := decodeAny(d)
+					if err != nil {
+						return nil, err
+					}
+					// A valid map key is always comparable; reject a hostile wire
+					// whose "key" decodes to a slice/map so anyOut[k] can't panic.
+					if k != nil && !reflect.TypeOf(k).Comparable() {
+						return nil, ErrBadTag
+					}
+					v, err := decodeAny(d)
+					if err != nil {
+						return nil, err
+					}
+					anyOut[k] = v
+				}
+				return anyOut, nil
+			}
 			kb, err := d.readStringBytes()
 			if err != nil {
 				return nil, err

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -175,6 +175,19 @@ func decodeBytes(d *Decoder, p unsafe.Pointer) error {
 
 func encodeSlice(elem *typeDesc, stride uintptr, colPlan *columnarPlan) func(*Encoder, unsafe.Pointer) error {
 	return func(e *Encoder, p unsafe.Pointer) error {
+		// Depth guard mirroring Decoder.descend in decodeSlice: count this
+		// container level so the encoder refuses a payload nested deeper than the
+		// decoder will accept, instead of emitting bytes that then fail to decode
+		// (slice/map/array-carried recursion was previously unbounded on encode
+		// while the decoder caps it at maxDepth).
+		if e.maxDepth != 0 {
+			e.depth++
+			if e.depth > e.maxDepth {
+				e.depth--
+				return ErrCycleDetected
+			}
+			defer func() { e.depth-- }()
+		}
 		hdr := (*sliceHeader)(p)
 		n := hdr.Len
 		// Columnar / hybrid-columnar path.
@@ -335,6 +348,15 @@ func decodeSlice(t reflect.Type, elem *typeDesc, stride uintptr, colPlan *column
 
 func encodeArray(elem *typeDesc, stride uintptr, n int) func(*Encoder, unsafe.Pointer) error {
 	return func(e *Encoder, p unsafe.Pointer) error {
+		// Depth guard mirroring Decoder.descend in decodeArray (see encodeSlice).
+		if e.maxDepth != 0 {
+			e.depth++
+			if e.depth > e.maxDepth {
+				e.depth--
+				return ErrCycleDetected
+			}
+			defer func() { e.depth-- }()
+		}
 		e.WriteArrayHeader(n)
 		for i := range n {
 			if err := elem.encode(e, unsafe.Add(p, uintptr(i)*stride)); err != nil {
@@ -371,6 +393,15 @@ func encodeMap(t reflect.Type, k, v *typeDesc) func(*Encoder, unsafe.Pointer) er
 	valType := t.Elem()
 	stringKey := keyType.Kind() == reflect.String
 	return func(e *Encoder, p unsafe.Pointer) error {
+		// Depth guard mirroring Decoder.descend in decodeMap (see encodeSlice).
+		if e.maxDepth != 0 {
+			e.depth++
+			if e.depth > e.maxDepth {
+				e.depth--
+				return ErrCycleDetected
+			}
+			defer func() { e.depth-- }()
+		}
 		rv := reflect.NewAt(t, p).Elem()
 		if rv.IsNil() {
 			e.WriteNil()

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -1424,6 +1424,52 @@ type sliceHeader struct {
 	Cap  int
 }
 
+// preserveNilSliceEncode wraps a slice-FIELD encoder so a nil slice emits tagNil,
+// distinct from an empty (non-nil, len-0) slice's array header — the nil-vs-empty
+// distinction maps and pointers already keep, and encoding/json keeps as null vs
+// []. An empty non-nil slice has a non-nil backing pointer (runtime.zerobase), so
+// Data==nil identifies exactly the nil case. Applied ONLY at descriptor build for
+// a slice-typed field, so the shared encodeSlice* functions stay nil-agnostic for
+// their internal direct callers (nullable/columnar dense columns), which must
+// still emit a real header for an empty/nil dense slice.
+func preserveNilSliceEncode(inner func(*Encoder, unsafe.Pointer) error) func(*Encoder, unsafe.Pointer) error {
+	return func(e *Encoder, p unsafe.Pointer) error {
+		if (*sliceHeader)(p).Data == nil {
+			e.WriteNil()
+			return nil
+		}
+		return inner(e, p)
+	}
+}
+
+// preserveNilSliceDecode mirrors preserveNilSliceEncode: a tagNil restores a nil
+// slice; any other tag decodes via inner (which yields a non-nil slice).
+func preserveNilSliceDecode(inner func(*Decoder, unsafe.Pointer) error) func(*Decoder, unsafe.Pointer) error {
+	return func(d *Decoder, p unsafe.Pointer) error {
+		// headerRead is true for the common struct-field/element path (the 5-byte
+		// header is already consumed), so a direct buffer-index check avoids a
+		// peekTag call; the cold top-level path reads the header first.
+		if d.headerRead {
+			if d.i < len(d.buf) && d.buf[d.i] == tagNil {
+				d.i++
+				*(*sliceHeader)(p) = sliceHeader{}
+				return nil
+			}
+			return inner(d, p)
+		}
+		tag, err := d.peekTag()
+		if err != nil {
+			return err
+		}
+		if tag == tagNil {
+			d.i++
+			*(*sliceHeader)(p) = sliceHeader{}
+			return nil
+		}
+		return inner(d, p)
+	}
+}
+
 // noPointers reports whether t contains no pointers (so a byte-clear of its
 // memory is GC-safe — no write barriers needed). Used to gate decode slice
 // backing reuse: a pointer-free element can be zeroed with clear() over a raw

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -163,8 +163,17 @@ func decodeString(d *Decoder, p unsafe.Pointer) error {
 	return nil
 }
 
-func encodeBytes(e *Encoder, p unsafe.Pointer) error { e.WriteBytes(*(*[]byte)(p)); return nil }
+func encodeBytes(e *Encoder, p unsafe.Pointer) error {
+	if e.encodeNilSlice(p) { // nil []byte → tagNil (distinct from empty)
+		return nil
+	}
+	e.WriteBytes(*(*[]byte)(p))
+	return nil
+}
 func decodeBytes(d *Decoder, p unsafe.Pointer) error {
+	if d.decodeNilSlice(p) {
+		return nil
+	}
 	b, err := d.ReadBytes()
 	if err != nil {
 		return err
@@ -175,6 +184,9 @@ func decodeBytes(d *Decoder, p unsafe.Pointer) error {
 
 func encodeSlice(elem *typeDesc, stride uintptr, colPlan *columnarPlan) func(*Encoder, unsafe.Pointer) error {
 	return func(e *Encoder, p unsafe.Pointer) error {
+		if e.encodeNilSlice(p) { // nil slice → tagNil (distinct from empty)
+			return nil
+		}
 		// Depth guard mirroring Decoder.descend in decodeSlice: count this
 		// container level so the encoder refuses a payload nested deeper than the
 		// decoder will accept, instead of emitting bytes that then fail to decode
@@ -274,6 +286,9 @@ func decodeSlice(t reflect.Type, elem *typeDesc, stride uintptr, colPlan *column
 	elemDynamic := elemType == reflect.TypeFor[map[string]any]() || elemType.Kind() == reflect.Interface
 	elemPF := noPointers(elemType) // gate for backing reuse (computed once per type)
 	return func(d *Decoder, p unsafe.Pointer) error {
+		if d.decodeNilSlice(p) { // tagNil → nil slice (distinct from empty)
+			return nil
+		}
 		if err := d.descend(); err != nil {
 			return err
 		}
@@ -1424,50 +1439,38 @@ type sliceHeader struct {
 	Cap  int
 }
 
-// preserveNilSliceEncode wraps a slice-FIELD encoder so a nil slice emits tagNil,
-// distinct from an empty (non-nil, len-0) slice's array header — the nil-vs-empty
+// encodeNilSlice emits tagNil and returns true when the slice at p is nil
+// (Data==nil), distinct from an empty (non-nil, len-0) slice — the nil-vs-empty
 // distinction maps and pointers already keep, and encoding/json keeps as null vs
-// []. An empty non-nil slice has a non-nil backing pointer (runtime.zerobase), so
-// Data==nil identifies exactly the nil case. Applied ONLY at descriptor build for
-// a slice-typed field, so the shared encodeSlice* functions stay nil-agnostic for
-// their internal direct callers (nullable/columnar dense columns), which must
-// still emit a real header for an empty/nil dense slice.
-func preserveNilSliceEncode(inner func(*Encoder, unsafe.Pointer) error) func(*Encoder, unsafe.Pointer) error {
-	return func(e *Encoder, p unsafe.Pointer) error {
-		if (*sliceHeader)(p).Data == nil {
-			e.WriteNil()
-			return nil
-		}
-		return inner(e, p)
+// []. Called as the first line of the nil-aware slice FIELD encoders so a nil
+// slice round-trips as nil. A small direct (inlinable) call, NOT a wrapping
+// closure, so the hot slice paths pay no extra indirection; the shared
+// encodeSlice* funcs stay nil-agnostic for their internal direct callers
+// (nullable/columnar dense columns), which must still emit a real header.
+func (e *Encoder) encodeNilSlice(p unsafe.Pointer) bool {
+	if (*sliceHeader)(p).Data == nil {
+		e.WriteNil()
+		return true
 	}
+	return false
 }
 
-// preserveNilSliceDecode mirrors preserveNilSliceEncode: a tagNil restores a nil
-// slice; any other tag decodes via inner (which yields a non-nil slice).
-func preserveNilSliceDecode(inner func(*Decoder, unsafe.Pointer) error) func(*Decoder, unsafe.Pointer) error {
-	return func(d *Decoder, p unsafe.Pointer) error {
-		// headerRead is true for the common struct-field/element path (the 5-byte
-		// header is already consumed), so a direct buffer-index check avoids a
-		// peekTag call; the cold top-level path reads the header first.
-		if d.headerRead {
-			if d.i < len(d.buf) && d.buf[d.i] == tagNil {
-				d.i++
-				*(*sliceHeader)(p) = sliceHeader{}
-				return nil
-			}
-			return inner(d, p)
+// decodeNilSlice consumes a tagNil nil-slice marker, zeroes the destination, and
+// returns true. The first line of the nil-aware slice decoders. The header is
+// read first on a top-level decode (headerRead==false); the common struct-field/
+// element path is a bounds test + tag compare.
+func (d *Decoder) decodeNilSlice(p unsafe.Pointer) bool {
+	if !d.headerRead {
+		if err := d.readHeaderSlow(); err != nil {
+			return false // the caller's normal decode re-surfaces the error
 		}
-		tag, err := d.peekTag()
-		if err != nil {
-			return err
-		}
-		if tag == tagNil {
-			d.i++
-			*(*sliceHeader)(p) = sliceHeader{}
-			return nil
-		}
-		return inner(d, p)
 	}
+	if d.i < len(d.buf) && d.buf[d.i] == tagNil {
+		d.i++
+		*(*sliceHeader)(p) = sliceHeader{}
+		return true
+	}
+	return false
 }
 
 // noPointers reports whether t contains no pointers (so a byte-clear of its

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -27,27 +27,142 @@ func installSliceFastPath(t reflect.Type) (
 	dec func(*Decoder, unsafe.Pointer) error,
 	ok bool,
 ) {
+	// The *Nil variants preserve the nil-vs-empty distinction at the FIELD level
+	// (a nil slice → tagNil) while the bare encodeSlice*/decodeSlice* stay
+	// nil-agnostic for their internal direct callers (dense columns). Each *Nil
+	// adds an inline nil check then a DIRECT call to the bare codec — no wrapping
+	// closure, so a slice field encode/decode costs no extra indirect call.
 	switch t {
 	case sliceStringType:
-		return encodeSliceString, decodeSliceString, true
+		return encodeSliceStringNil, decodeSliceStringNil, true
 	case sliceIntType:
-		return encodeSliceInt, decodeSliceInt, true
+		return encodeSliceIntNil, decodeSliceIntNil, true
 	case sliceInt32Type:
-		return encodeSliceInt32, decodeSliceInt32, true
+		return encodeSliceInt32Nil, decodeSliceInt32Nil, true
 	case sliceInt64Type:
-		return encodeSliceInt64, decodeSliceInt64, true
+		return encodeSliceInt64Nil, decodeSliceInt64Nil, true
 	case sliceUint32Type:
-		return encodeSliceUint32, decodeSliceUint32, true
+		return encodeSliceUint32Nil, decodeSliceUint32Nil, true
 	case sliceUint64Type:
-		return encodeSliceUint64, decodeSliceUint64, true
+		return encodeSliceUint64Nil, decodeSliceUint64Nil, true
 	case sliceFloat32Type:
-		return encodeSliceFloat32, decodeSliceFloat32, true
+		return encodeSliceFloat32Nil, decodeSliceFloat32Nil, true
 	case sliceFloat64Type:
-		return encodeSliceFloat64, decodeSliceFloat64, true
+		return encodeSliceFloat64Nil, decodeSliceFloat64Nil, true
 	case sliceBoolType:
-		return encodeSliceBool, decodeSliceBool, true
+		return encodeSliceBoolNil, decodeSliceBoolNil, true
 	}
 	return nil, nil, false
+}
+
+// Nil-aware field variants: inline nil check + DIRECT call to the bare codec.
+func encodeSliceStringNil(e *Encoder, p unsafe.Pointer) error {
+	if e.encodeNilSlice(p) {
+		return nil
+	}
+	return encodeSliceString(e, p)
+}
+func decodeSliceStringNil(d *Decoder, p unsafe.Pointer) error {
+	if d.decodeNilSlice(p) {
+		return nil
+	}
+	return decodeSliceString(d, p)
+}
+func encodeSliceIntNil(e *Encoder, p unsafe.Pointer) error {
+	if e.encodeNilSlice(p) {
+		return nil
+	}
+	return encodeSliceInt(e, p)
+}
+func decodeSliceIntNil(d *Decoder, p unsafe.Pointer) error {
+	if d.decodeNilSlice(p) {
+		return nil
+	}
+	return decodeSliceInt(d, p)
+}
+func encodeSliceInt32Nil(e *Encoder, p unsafe.Pointer) error {
+	if e.encodeNilSlice(p) {
+		return nil
+	}
+	return encodeSliceInt32(e, p)
+}
+func decodeSliceInt32Nil(d *Decoder, p unsafe.Pointer) error {
+	if d.decodeNilSlice(p) {
+		return nil
+	}
+	return decodeSliceInt32(d, p)
+}
+func encodeSliceInt64Nil(e *Encoder, p unsafe.Pointer) error {
+	if e.encodeNilSlice(p) {
+		return nil
+	}
+	return encodeSliceInt64(e, p)
+}
+func decodeSliceInt64Nil(d *Decoder, p unsafe.Pointer) error {
+	if d.decodeNilSlice(p) {
+		return nil
+	}
+	return decodeSliceInt64(d, p)
+}
+func encodeSliceUint32Nil(e *Encoder, p unsafe.Pointer) error {
+	if e.encodeNilSlice(p) {
+		return nil
+	}
+	return encodeSliceUint32(e, p)
+}
+func decodeSliceUint32Nil(d *Decoder, p unsafe.Pointer) error {
+	if d.decodeNilSlice(p) {
+		return nil
+	}
+	return decodeSliceUint32(d, p)
+}
+func encodeSliceUint64Nil(e *Encoder, p unsafe.Pointer) error {
+	if e.encodeNilSlice(p) {
+		return nil
+	}
+	return encodeSliceUint64(e, p)
+}
+func decodeSliceUint64Nil(d *Decoder, p unsafe.Pointer) error {
+	if d.decodeNilSlice(p) {
+		return nil
+	}
+	return decodeSliceUint64(d, p)
+}
+func encodeSliceFloat32Nil(e *Encoder, p unsafe.Pointer) error {
+	if e.encodeNilSlice(p) {
+		return nil
+	}
+	return encodeSliceFloat32(e, p)
+}
+func decodeSliceFloat32Nil(d *Decoder, p unsafe.Pointer) error {
+	if d.decodeNilSlice(p) {
+		return nil
+	}
+	return decodeSliceFloat32(d, p)
+}
+func encodeSliceFloat64Nil(e *Encoder, p unsafe.Pointer) error {
+	if e.encodeNilSlice(p) {
+		return nil
+	}
+	return encodeSliceFloat64(e, p)
+}
+func decodeSliceFloat64Nil(d *Decoder, p unsafe.Pointer) error {
+	if d.decodeNilSlice(p) {
+		return nil
+	}
+	return decodeSliceFloat64(d, p)
+}
+func encodeSliceBoolNil(e *Encoder, p unsafe.Pointer) error {
+	if e.encodeNilSlice(p) {
+		return nil
+	}
+	return encodeSliceBool(e, p)
+}
+func decodeSliceBoolNil(d *Decoder, p unsafe.Pointer) error {
+	if d.decodeNilSlice(p) {
+		return nil
+	}
+	return decodeSliceBool(d, p)
 }
 
 // ----- []string -----

--- a/stream.go
+++ b/stream.go
@@ -216,6 +216,12 @@ func (s *StreamDecoder) Decode(out any) error {
 			return err // io.EOF here means an empty stream
 		}
 		if err := s.dec.readHeader(); err != nil {
+			// A corrupt header may have half-advanced the decoder (readHeaderSlow
+			// sets headerRead/cursor before a failing rANS-body pass), so latch
+			// the stream broken — like a mid-frame decode error below — to uphold
+			// the "once broken, further Decode is refused" invariant instead of
+			// silently resuming at the next byte.
+			s.broken = true
 			return err
 		}
 	}

--- a/stream_header_latch_test.go
+++ b/stream_header_latch_test.go
@@ -1,0 +1,39 @@
+package qdf
+
+import (
+	"bytes"
+	"testing"
+)
+
+// Regression: a corrupt stream HEADER must latch the decoder broken, exactly as
+// a corrupt frame body does. Previously StreamDecoder.Decode returned the
+// readHeader error WITHOUT setting s.broken, so the next Decode silently resumed
+// at the next byte instead of refusing per the documented "once broken, further
+// Decode is refused" invariant.
+func TestStreamHeaderErrorLatchesBroken(t *testing.T) {
+	type rec struct {
+		Name string
+		ID   int
+	}
+	var w bytes.Buffer
+	se := NewStreamEncoderWith(&w, OptBalanced)
+	for _, m := range []rec{{"alpha", 1}, {"beta", 2}} {
+		if err := se.Encode(m); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := se.Close(); err != nil {
+		t.Fatal(err)
+	}
+	raw := append([]byte(nil), w.Bytes()...)
+	raw[4] ^= 0x04 // flip FlagRANS in the header flag byte → readHeader fails
+
+	sd := NewStreamDecoder(bytes.NewReader(raw))
+	var got rec
+	if err := sd.Decode(&got); err == nil {
+		t.Fatal("expected first decode to fail on the corrupt header")
+	}
+	if err := sd.Decode(&got); err != ErrStreamDecoderBroken {
+		t.Fatalf("after a header error the decoder must latch broken; got %v want ErrStreamDecoderBroken", err)
+	}
+}

--- a/stream_header_latch_test.go
+++ b/stream_header_latch_test.go
@@ -2,6 +2,7 @@ package qdf
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 )
 
@@ -33,7 +34,7 @@ func TestStreamHeaderErrorLatchesBroken(t *testing.T) {
 	if err := sd.Decode(&got); err == nil {
 		t.Fatal("expected first decode to fail on the corrupt header")
 	}
-	if err := sd.Decode(&got); err != ErrStreamDecoderBroken {
+	if err := sd.Decode(&got); !errors.Is(err, ErrStreamDecoderBroken) {
 		t.Fatalf("after a header error the decoder must latch broken; got %v want ErrStreamDecoderBroken", err)
 	}
 }


### PR DESCRIPTION
Seven fixes from a multi-round adversarial bug hunt (≈15 read-only agents across
three rounds) plus a `reflect.DeepEqual` round-trip audit. Every finding was
independently reproduced RED before any change and re-verified GREEN; three
agent-reported "bugs" turned out to be false positives and were rejected. Each
perf-touching change is benchstat-gated.

All changes preserve existing behaviour except where the wire genuinely had to
change (nil slices — see below). Full suite, `-race`, `go vet`, and the
`FuzzRoundTrip_AllModesAgree` property fuzz are green; golden fixtures unchanged.

## Bugs fixed

### 1. `fix(columnar)` — clear `colMaxLen` before decoding hybrid residual fields
`decodeHybridColumnar` / `decodeHybridColumnarAny` set the per-column length
bound `colMaxLen = n` for the transposed columns and cleared it only via a
deferred reset, so the row-major residual block decoded while the bound was
still active. Any residual slice/map LONGER than the batch row count `n` was
rejected with `ErrInvalidLength` — valid, self-produced output failing to
round-trip, on the exact shape hybrid targets. Fix: clear `colMaxLen` before the
residual loop (both decode paths). *(Confirmed by two independent agents.)*

### 2. `fix(decode)` — decode non-string-keyed maps in the schemaless `any` path
A non-string-keyed map (e.g. `map[int]string`) boxed in an `any`/interface
marshalled fine and round-tripped into a typed destination, but `Unmarshal` into
`any` failed with `ErrTypeMismatch` — `decodeAny` hard-coded string keys for
`tagMap8/16/32`. Silent data loss with no encode-time signal. Fix: peek the key
tag; non-string-keyed maps decode to `map[any]any` (the only lossless schemaless
form — the wire can't tell int from uint for small keys), with a comparability
guard so a hostile non-comparable key cannot panic the map insert.

### 3. `fix(decode)` — handle mixed-key-type `map[any]any` in schemaless decode
Follow-up to #2: `decodeAny` peeked only the FIRST key's tag and committed the
whole map to one path, so a `map[any]any` with mixed key types round-tripped
only when the int key iterated first (~15% of the time, Go's randomised map
order). Fix: peek EACH key, staying on the fast `map[string]any` path while keys
are strings and migrating to `map[any]any` the moment a non-string key appears.

### 4. `fix(stream)` — latch broken on a corrupt header, not just a bad frame
`StreamDecoder.Decode` latched `broken` on a frame-body error but returned a
`readHeader()` error without latching, so a corrupt header silently resumed at
the next `Decode`, violating the documented "once broken, further Decode is
refused" invariant. Low severity (a legitimately streaming-encoded payload
self-heals), but the contract gap is closed.

## Correctness/contract fixes

### 5. `fix(encode)` — guard recursion depth on slice/array/map (encode/decode symmetry)
The encoder counted recursion depth only in `encodePtr`/`encodeIface`, while the
decoder caps EVERY slice/array/map/ptr/any level at `maxDepth`. Recursion carried
by slices/maps (e.g. `struct{ Children []struct }`) encoded with no bound but
failed to decode beyond depth 10000 with `ErrCycleDetected` — qdf produced a
~200 KB blob it could not read back. Fix: add the same `depth`/`maxDepth` guard
to `encodeSlice`/`encodeArray`/`encodeMap`, exactly where the decoder descends,
so a too-deep value is refused AT ENCODE instead of emitted as an undecodable
blob. The cap is unchanged (the stack-overflow-DoS boundary). benchstat: no
regression (the defer is stack-allocated).

### 6+7. `fix/perf(encode)` — preserve the nil-vs-empty distinction for slices, at zero cost
A nil slice and an empty (non-nil) slice both encoded a 0-length array header, so
a nil `[]T` decoded back as `[]T{}` — losing a distinction maps and pointers
already keep, and that `encoding/json` keeps as `null` vs `[]`. The asymmetry was
an oversight, not a design. A nil slice now emits `tagNil` and decodes to nil.

The nil check is applied at the FIELD level (dedicated `*Nil` slice variants from
`installSliceFastPath`, plus inline handling in the `[]byte` and reflect slice
codecs), NOT inside the shared `encodeSlice*`/`decodeSlice*` functions — those
are called directly by the nullable/columnar dense-column paths, which must keep
emitting a real header for an empty/nil internal slice.

The first cut used a wrapping closure, which added a second indirect call per
slice field (~+2.8% on slice-heavy decode). The committed version replaces it
with named `*Nil` field functions that do an inline nil check then a DIRECT call
to the bare codec — benchstat vs the pre-fix baseline (n=16) is within noise
(p≈0.93), realistic workloads neutral.

**Wire change (the only one in this PR):** a nil slice field/value now occupies
one `tagNil` byte instead of a 0-length array header. qdf is pre-1.0; old blobs
still decode (a former nil slice reads back as empty, as it always did).

## Round-trip contract (documented)

A `reflect.DeepEqual` audit (19 fixtures × 5 option modes) found nil-slice was
the only fixable gap. The remaining differences are intentional and now
documented on `Unmarshal`: decoding into an interface canonicalises ints to
`int64`/`uint64` and structs to `map[string]any`; `time.Time` loses any
monotonic-clock reading (as the standard library strips it for transport).

## Not changed (rejected as false positives or by-design)
- `map[any]any` collapsing `int64(5)` and `uint64(5)` keys — inherent wire
  ambiguity for small fixints; not fixable without a wire change.
- A corrupted value byte decoding to a different value with `nil` error — qdf has
  no per-value checksum by design (only framing desyncs / panics are bugs).
- "Query over a nullable columnar struct returns unsupported" — correct
  row-major fallback (an all-numeric struct stays row-major).

## Verification
- `go test ./...`, `go test -race`, `go vet` — green.
- `FuzzRoundTrip_AllModesAgree` (~580k execs) and `FuzzDecoder_NeverPanics` — no
  failures.
- New regression tests: hybrid residual longer than n, non-string/mixed-key
  `map[any]any`, stream header broken-latch, encode/decode depth symmetry, and
  nil-vs-empty slice round-trip across all modes.
- Golden fixtures unchanged.