### PR TITLE
perf: cut compression-encode allocations (FSST training + ALP) and tighten struct layout

### DIFF
--- a/columnar.go
+++ b/columnar.go
@@ -859,7 +859,6 @@ func (d *Decoder) readColShape(maxN int) (colShapeRead, error) {
 // present marks which rows carry a value (dense expanded to length n); a row
 // whose present bit is 0 is a nil/zero row.
 type colVals struct {
-	kind    colKind
 	i64     []int64
 	u64     []uint64
 	f64     []float64
@@ -868,6 +867,7 @@ type colVals struct {
 	bs      [][]byte
 	ts      []time.Time // colKindTime only
 	present []uint64    // nullable only; nil otherwise
+	kind    colKind     // 1-byte tail: kept last so it adds no padding before the slices
 }
 
 // decodeColumnVals decodes a column body (length n) of the given kind into a

--- a/encoder.go
+++ b/encoder.go
@@ -63,6 +63,11 @@ type Encoder struct {
 	state     *encState
 	headerOut bool
 
+	// alpScratch is a reused FOR-mantissa staging buffer for the ALP float
+	// writer (mirrors the decoder's deltaScratch). Lives on the Encoder, not
+	// encState, so the row-major float path reuses it without needing a state.
+	alpScratch []uint64
+
 	// opts is the bit-mask of feature toggles. mode and qpack are
 	// derived from it at configure time so the hot path can stay on
 	// fast bool / Mode compares; the rest of the codecs (MTF, Pair,
@@ -251,6 +256,12 @@ func NewEncoderOnBuf(buf []byte, mode Mode) *Encoder {
 // SetQPack after Reset.
 func (e *Encoder) Reset() {
 	e.buf = e.buf[:0]
+	// Row-scaled ALP staging scratch: retain across batches, drop only past the
+	// hard ceiling so a one-off giant float slice can't pin unbounded memory.
+	// Pure []uint64 (no pointers) so no clear is needed.
+	if cap(e.alpScratch) > maxRetainedColScratch {
+		e.alpScratch = nil
+	}
 	e.headerOut = false
 	if e.state != nil {
 		e.state.reset()

--- a/internal/fsst/build.go
+++ b/internal/fsst/build.go
@@ -103,6 +103,7 @@ type Builder struct {
 	c    *counter
 	cand []candidate
 	keys []symKey
+	scan [][]byte // reused sample-prefix header for the trim case
 	t    SymbolTable
 }
 
@@ -129,7 +130,7 @@ func (b *Builder) Build(samples [][]byte) *SymbolTable {
 // decide columnar-vs-row-major), while the encoder uses the full buildRounds
 // for the table it actually emits.
 func (b *Builder) BuildRounds(samples [][]byte, rounds int) *SymbolTable {
-	scan := sampleByBytes(samples, maxSampleBytes)
+	scan := b.sampleByBytes(samples, maxSampleBytes)
 	b.t.reset() // empty: round 0 is all single-byte tokens
 	for range rounds {
 		b.c.reset()
@@ -137,9 +138,13 @@ func (b *Builder) BuildRounds(samples [][]byte, rounds int) *SymbolTable {
 		for _, s := range scan {
 			tokenizeCount(&b.t, s, b.c, empty)
 		}
-		b.keys = topCandidates(b.c, b.cand[:0], b.keys[:0])
+		b.keys, b.cand = topCandidates(b.c, b.cand[:0], b.keys[:0])
 		b.t.fillFromKeys(b.keys)
 	}
+	// Drop the []byte views into the caller's strings so a pooled Builder does
+	// not pin that memory until its next Build (the trim path retains them in
+	// b.scan). cand/keys are value types (no pointers) and need no such clear.
+	clear(b.scan)
 	return &b.t
 }
 
@@ -193,17 +198,18 @@ func (t *SymbolTable) fillFromKeys(keys []symKey) {
 // must not make training O(that string)). Deterministic; never mutates the
 // caller's backing data (it shallow-copies the small header slice only when it
 // has to trim).
-func sampleByBytes(samples [][]byte, budget int) [][]byte {
+func (b *Builder) sampleByBytes(samples [][]byte, budget int) [][]byte {
 	total := 0
 	for i := range samples {
 		total += len(samples[i])
 		if total >= budget {
 			over := total - budget
 			if over > 0 && over < len(samples[i]) {
-				trimmed := make([][]byte, i+1)
-				copy(trimmed, samples[:i+1])
-				trimmed[i] = samples[i][:len(samples[i])-over]
-				return trimmed
+				// Reuse the Builder's scan header instead of allocating a fresh
+				// [][]byte every train; the trimmed prefix is read-only here.
+				b.scan = append(b.scan[:0], samples[:i+1]...)
+				b.scan[i] = samples[i][:len(samples[i])-over]
+				return b.scan
 			}
 			return samples[:i+1]
 		}
@@ -238,7 +244,9 @@ func tokenizeCount(t *SymbolTable, s []byte, c *counter, empty bool) {
 // topCandidates selects the top-255 candidate keys by gain = freq*len, with a
 // deterministic total order (gain desc, len desc, packed-bytes asc). The cand
 // and keys scratch slices are caller-owned and reused across rounds.
-func topCandidates(c *counter, cand []candidate, keys []symKey) []symKey {
+// It returns keys plus the (possibly grown) cand backing so the caller can
+// retain it across rounds/Build calls and avoid re-growing the candidate slice.
+func topCandidates(c *counter, cand []candidate, keys []symKey) ([]symKey, []candidate) {
 	for _, i := range c.usedIdx { // only occupied slots, not the whole 8192-wide table
 		k := c.keys[i]
 		if k.n == 0 || k.n > maxSymLen {
@@ -266,7 +274,7 @@ func topCandidates(c *counter, cand []candidate, keys []symKey) []symKey {
 	for i := range cand {
 		keys = append(keys, cand[i].k)
 	}
-	return keys
+	return keys, cand
 }
 
 // candLess reports whether a outranks b: higher gain, then longer symbol, then

--- a/qpack_alp.go
+++ b/qpack_alp.go
@@ -152,8 +152,15 @@ func (e *Encoder) writePackedALPFloat64Slice(s []float64, plan alpFloatPlan) {
 	ie := alpInv10[plan.d]
 
 	if plan.width > 0 {
-		// Pack I_i - forMin; exceptions occupy a 0 slot.
-		packed := make([]uint64, n)
+		// Pack I_i - forMin; exceptions occupy a 0 slot. Reuse pooled scratch
+		// instead of a per-call make; clear is REQUIRED because exception slots
+		// are never written in the loop below and must read back as 0 (a reused
+		// buffer would otherwise leak a prior column's mantissa into them).
+		if cap(e.alpScratch) < n {
+			e.alpScratch = make([]uint64, n)
+		}
+		packed := e.alpScratch[:n]
+		clear(packed)
 		for i, v := range s {
 			I := int64(math.RoundToEven(v * pe))
 			if math.Float64bits(float64(I)*ie) == math.Float64bits(v) {

--- a/query.go
+++ b/query.go
@@ -20,12 +20,12 @@ type Queryable interface {
 // evaluation is a direct typed call with zero per-value interface boxing.
 type predTerm struct {
 	field string
-	want  colKind
 	pI64  func(int64) bool
 	pU64  func(uint64) bool
 	pF64  func(float64) bool
 	pStr  func(string) bool
 	pBool func(bool) bool
+	want  colKind // 1-byte tail: kept last to avoid padding before the func pointers
 }
 
 // QueryOption configures a filtering/projecting Unmarshal. Construct with Where,
@@ -52,10 +52,10 @@ const (
 // construction misuse (e.g. a Select passed into a combinator) surfaced at
 // buildQueryPlan time.
 type condNode struct {
-	op   condOp
 	term *predTerm
 	kids []*condNode
 	err  error
+	op   condOp // 1-byte tail: kept last to avoid padding before the pointer fields
 }
 
 // Where keeps only rows whose field column satisfies pred. T must match the
@@ -347,11 +347,11 @@ func matchedIndices(b []uint64, n int, dst []int) []int {
 // indexed by int, avoiding the per-node allocations and pointer hashing a
 // map[*condNode]… would cost on a small tree.
 type cnode struct {
-	op   condOp
 	term *predTerm // leaf only
 	kids []int     // child ids (And/Or: n; Not: 1)
 	col  int       // leaf only: resolved wire column index (-1 until resolved)
 	cv   *colVals  // leaf only: decoded column values (nil until bound)
+	op   condOp    // 1-byte tails kept last to avoid padding before the pointers above
 	unk  bool      // subtree can produce SQL UNKNOWN (contains a nullable leaf)
 }
 

--- a/reflect_desc.go
+++ b/reflect_desc.go
@@ -11,7 +11,6 @@ import (
 // typeDesc is the compiled descriptor for a reflect.Type. Looked up via the
 // typeCache map keyed by the Type's runtime pointer (cheap and stable).
 type typeDesc struct {
-	kind    reflect.Kind
 	rType   reflect.Type
 	fields  []fieldDesc   // structs only
 	elem    *typeDesc     // slice/array/map-value/ptr
@@ -24,6 +23,9 @@ type typeDesc struct {
 	encode func(e *Encoder, p unsafe.Pointer) error
 	decode func(d *Decoder, p unsafe.Pointer) error
 
+	// kind / marshalerKind are 1-byte tails kept last so they share one word
+	// instead of forcing padding ahead of the 8-byte pointer fields above.
+	kind reflect.Kind
 	// marshalerKind: 0=none, 1=Marshaler interface, 2=encoding.TextMarshaler-ish (future)
 	marshalerKind uint8
 }


### PR DESCRIPTION
Three commits, all output-bit-identical and benchstat-gated. They cut the
allocations the `OptCompression` encode path makes per column — first in FSST
table training, then in the ALP float writer — and remove real struct padding
the `fieldalignment` analyzer flagged. Full suite, `go vet`, race on the FSST /
columnar / hybrid paths, and the round-trip + fuzz suites are green.

These follow up the earlier `perf/columnar-encode-len-probe` work (FSST sample
pool + `CompressedLen` probe), which is already merged.

## Commits

### 1. `perf(fsst)` — reuse training scratch to cut high-cardinality encode allocations
FSST table training re-grew two scratch buffers on every `Build`, which on a
high-cardinality string column (thousands of candidate symbols — exactly where
FSST is chosen) dominated the columnar-encode allocation:

- `topCandidates` appended into the Builder's `cand` buffer but returned only
  the `keys`, so a candidate set larger than the initial cap reallocated a fresh
  backing every call and the grown capacity was never retained. Return `cand`
  too and store it back on the Builder.
- `sampleByBytes` allocated a fresh `[][]byte` header whenever it trimmed the
  sample prefix to the byte budget (every train on a column above the budget).
  Make it a Builder method reusing a pooled `b.scan` header; `clear` the
  `[]byte` views at end of training so a pooled Builder never pins caller string
  memory across a recycle.

Training is deterministic — only scratch lifetime changed; `FuzzFSSTRoundTrip`
clean over ~96k execs. benchstat over the compression encode set:
**B/op geomean −66 %** (OTLP_4x512 −84 %, Logs_1024 −75 %), **allocs/op
geomean −33 %** (OTLP_4x512 −63 %), sec/op −3 % (OTLP_4x512 −6.5 %).

### 2. `perf(encode)` — pool the ALP mantissa staging buffer
`writePackedALPFloat64Slice` allocated a fresh `[]uint64` per float column to
stage the FOR-coded mantissas before `bitpack.Pack` — one make per ALP column,
the dominant ALP encode allocation on a multi-column float batch. The decoder
already reuses `d.deltaScratch` for the symmetric step; the encoder did not.

Add a reused `e.alpScratch` buffer on the Encoder (not `encState` — the
row-major float path has no state), row-scaled with the same
retain-then-drop-past-ceiling discipline as the columnar scratch. `clear()`
before the fill is REQUIRED: exception slots are never written and must read
back as 0, so a reused buffer would otherwise leak a prior column's mantissa
into them (`go-reused-buffer-underfill`).

Bit-identical (`FuzzRoundTrip_Float64Slice` clean over ~610k execs; IoT
round-trip unchanged). benchstat `IoT_128x512/encode/qdf_compression`:
**allocs/op 112 → 88 (−21 %)**, sec/op −3.4 %, wire unchanged.

### 3. `perf(layout)` — drop padding by moving 1-byte tail fields last
`fieldalignment` flagged structs whose 1-byte enum/kind field sat ahead of
8-byte pointer/slice fields, forcing a padding slot. Moving the 1-byte field to
the tail removes the padding with no logic change (fields are by name; all
composite literals are keyed):

- `typeDesc` 104 → 96 B (`kind` to the tail beside `marshalerKind`)
- `colVals`  208 → 200 B (`kind` after the slices)
- `cnode`     64 → 56 B (`op`/`unk` 1-byte tails grouped)
- `predTerm`, `condNode`: 1-byte field moved to tail for consistency (no size
  change — pointer-scan-span only).

Deliberately NOT touched: `encState` / `decState` / `Encoder` / `Decoder` carry
a documented hot-field cache layout ("hot scalars first share a cache line"),
where reordering for a few bytes of padding on a pooled singleton would split
the intentional grouping. The residual `fieldalignment` notes on those and on
per-query short-lived nodes are pointer-scan-span only, with no measurable
benefit. (`fieldalignment -fix` was avoided — it strips field comments; all
reorders here were done by hand.)

## Measurements (benchstat, laptop; allocs/op is the deterministic signal)

| benchmark | metric | before → after |
|---|---|---|
| OTLP_4x512/encode/compression | allocs/op | 86.5 → 32 (−63 %) |
| OTLP_4x512/encode/compression | B/op | −84 % |
| Logs_1024/encode/compression | B/op | −75 % |
| IoT_128x512/encode/compression | allocs/op | 112 → 88 (−21 %) |
| FSST set | B/op geomean | −66 % |

Wire size unchanged across all of them. (FSST symbol-table training is map-order
non-deterministic *across processes*, so reported wire size jitters a few bytes
between fresh runs on `main` itself — independent of these changes.)

## Testing
- `go test ./...`, `go vet ./...` green; `-race` on FSST/columnar/hybrid green.
- `FuzzFSSTRoundTrip` (~96k) and `FuzzRoundTrip_Float64Slice` (~610k) clean.
- struct reorders verified via `unsafe.Sizeof` (real size drops) and full suite.