### PR TITLE
perf(encode,decode): [N]byte arrays as a flat binary blob

### DIFF
--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -733,6 +733,12 @@ func (g *gen) emitEncodeSlice(w io.Writer, expr string, s *types.Slice, indent s
 
 func (g *gen) emitEncodeArray(w io.Writer, expr string, a *types.Array, indent string) error {
 	elem := a.Elem()
+	// [N]byte fast path: one flat binary blob (matches the reflect encoder), not
+	// N tagged elements. Smaller wire for real byte data, single memcpy.
+	if b, ok := elem.Underlying().(*types.Basic); ok && b.Kind() == types.Uint8 {
+		fmt.Fprintf(w, "%se.WriteBytes(%s[:])\n", indent, expr)
+		return nil
+	}
 	fmt.Fprintf(w, "%se.WriteArrayHeader(%d)\n", indent, a.Len())
 	loopVar := g.fresh("i")
 	fmt.Fprintf(w, "%sfor %s := range %s {\n", indent, loopVar, expr)
@@ -979,6 +985,18 @@ func (g *gen) emitDecodeSlice(w io.Writer, lhs string, s *types.Slice, indent st
 
 func (g *gen) emitDecodeArray(w io.Writer, lhs string, a *types.Array, indent string) error {
 	elem := a.Elem()
+	// [N]byte fast path: read the flat blob straight into the inline array via
+	// one length-checked memcpy (matches the reflect decoder), zero allocation.
+	if b, ok := elem.Underlying().(*types.Basic); ok && b.Kind() == types.Uint8 {
+		bv := g.fresh("ab")
+		fmt.Fprintf(w, "%s{\n", indent)
+		fmt.Fprintf(w, "%s\t%s, err := d.ReadStringBytes()\n", indent, bv)
+		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%s\tif len(%s) != %d {\n%s\t\treturn 0, qdf.ErrTypeMismatch\n%s\t}\n", indent, bv, a.Len(), indent, indent)
+		fmt.Fprintf(w, "%s\tcopy(%s[:], %s)\n", indent, lhs, bv)
+		fmt.Fprintf(w, "%s}\n", indent)
+		return nil
+	}
 	fmt.Fprintf(w, "%s{\n", indent)
 	nVar := g.fresh("n")
 	fmt.Fprintf(w, "%s\t%s, err := d.ReadArrayHeader()\n", indent, nVar)

--- a/fixedbytearray_test.go
+++ b/fixedbytearray_test.go
@@ -1,0 +1,63 @@
+package qdf
+
+import (
+	"testing"
+)
+
+type idRec struct {
+	Trace [16]byte `qdf:"trace"`
+	Span  [8]byte  `qdf:"span"`
+}
+
+// TestFixedByteArrayCompact asserts a [N]byte array field encodes as one
+// contiguous binary blob (like []byte) instead of N tagged elements — so real
+// ID bytes (0..255, half of them >=128) do not bloat to ~2 bytes each — and
+// decodes in place with zero allocation, bit-exact.
+func TestFixedByteArrayCompact(t *testing.T) {
+	var in idRec
+	for i := range in.Trace {
+		in.Trace[i] = byte(0x80 + i) // high bytes: per-element encoding would double them
+	}
+	for i := range in.Span {
+		in.Span[i] = byte(0xF0 + i)
+	}
+
+	// Equivalent struct with []byte fields = the exact flat-bin target wire.
+	type idRecSlice struct {
+		Trace []byte `qdf:"trace"`
+		Span  []byte `qdf:"span"`
+	}
+	ref := idRecSlice{Trace: in.Trace[:], Span: in.Span[:]}
+
+	for _, opt := range []Options{OptSpeed, OptBalanced, OptCompression} {
+		buf, err := Marshal(&in, opt)
+		if err != nil {
+			t.Fatalf("opt %d marshal: %v", opt, err)
+		}
+		refBuf, _ := Marshal(&ref, opt)
+		// A [N]byte field must encode to the SAME flat blob as a []byte of length
+		// N — not N tagged elements (which double every byte >= 128).
+		if len(buf) != len(refBuf) {
+			t.Fatalf("opt %d: [N]byte wire %d != []byte wire %d — not a flat blob", opt, len(buf), len(refBuf))
+		}
+
+		var out idRec
+		if err := Unmarshal(buf, &out); err != nil {
+			t.Fatalf("opt %d unmarshal: %v", opt, err)
+		}
+		if out != in {
+			t.Fatalf("opt %d round-trip mismatch", opt)
+		}
+	}
+
+	// Decode allocates nothing for the array bodies (they land in the inline
+	// struct array), only whatever the decoder framing needs.
+	buf, _ := Marshal(&in, OptSpeed)
+	allocs := testing.AllocsPerRun(100, func() {
+		var out idRec
+		_ = Unmarshal(buf, &out)
+	})
+	if allocs > 1 {
+		t.Fatalf("decode allocs = %.0f, want <=1 (array bodies must not allocate)", allocs)
+	}
+}

--- a/reflect_desc.go
+++ b/reflect_desc.go
@@ -213,6 +213,16 @@ func fillDesc(td *typeDesc, t reflect.Type, ctx *buildCtx) error {
 		// *Nil variants (installSliceFastPath) which keep the shared encodeSlice*
 		// funcs nil-agnostic for their internal dense-column callers.
 	case reflect.Array:
+		// [N]byte fast path: encode/decode as one contiguous binary blob (flat,
+		// memcpy) instead of N tagged elements — far smaller wire for real byte
+		// data and zero-alloc in-place decode. Covers fixed-width IDs (trace/span
+		// ids, UUIDs) and any named byte type ([N]MyByte, since Kind stays Uint8).
+		if t.Elem().Kind() == reflect.Uint8 {
+			n := t.Len()
+			td.encode = encodeFixedByteArray(n)
+			td.decode = decodeFixedByteArray(n)
+			break
+		}
 		elem, err := descBuild(t.Elem(), ctx)
 		if err != nil {
 			return err

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -370,6 +370,37 @@ func decodeSlice(t reflect.Type, elem *typeDesc, stride uintptr, colPlan *column
 	}
 }
 
+// encodeFixedByteArray encodes a fixed [N]byte array as ONE contiguous binary
+// blob (identical wire to a []byte of length N), not N tagged elements. Real ID
+// bytes are uniformly 0..255; the generic per-element path costs ~2 bytes for
+// every byte >= 128, so a [16]byte trace id bloats to ~32 wire bytes — this
+// writes a flat 16 plus a tiny bin header. One memcpy, no per-element calls.
+//
+//go:nosplit
+func encodeFixedByteArray(n int) func(*Encoder, unsafe.Pointer) error {
+	return func(e *Encoder, p unsafe.Pointer) error {
+		e.WriteBytes(unsafe.Slice((*byte)(p), n))
+		return nil
+	}
+}
+
+// decodeFixedByteArray reads the blob written by encodeFixedByteArray straight
+// into the struct's inline [N]byte storage — one length-checked memcpy, zero
+// allocation (the array lives in the caller's struct, never on the heap).
+func decodeFixedByteArray(n int) func(*Decoder, unsafe.Pointer) error {
+	return func(d *Decoder, p unsafe.Pointer) error {
+		b, err := d.readStringBytes()
+		if err != nil {
+			return err
+		}
+		if len(b) != n {
+			return ErrTypeMismatch
+		}
+		copy(unsafe.Slice((*byte)(p), n), b)
+		return nil
+	}
+}
+
 func encodeArray(elem *typeDesc, stride uintptr, n int) func(*Encoder, unsafe.Pointer) error {
 	return func(e *Encoder, p unsafe.Pointer) error {
 		// Depth guard mirroring Decoder.descend in decodeArray (see encodeSlice).


### PR DESCRIPTION
Fixes a silent inefficiency in how fixed-size byte arrays (`[16]byte`,
`[32]byte`, …) are serialized. Type-driven, no flag, no API change — applies in
every mode and on the reflect path and the codegen path alike.

## The problem

A `[N]byte` field was encoded through the generic array path: an array header
plus **N tagged elements**. Each element is a byte (0–255); every byte `>= 128`
encodes as a 2-byte `tagUint8`, so a `[16]byte` of real data (UUID, hash, raw
id) bloated to up to ~32 wire bytes and cost 16 per-element encode/decode calls
each way.

## The fix

Encode and decode a `[N]byte` as **one contiguous binary blob** — byte-identical
wire to a `[]byte` of length N:

- **Encode:** a single `WriteBytes(arr[:])` (one memcpy), no per-element loop.
- **Decode:** one length-checked memcpy straight into the struct's inline array
  — **zero allocation** (the array lives in the caller's struct, never on the
  heap).

Applies to any array whose element kind is `uint8`, including named byte types
(`[N]MyByte`). Both `reflect_desc`/`reflect_encode` (reflect path) and
`cmd/qdfgen` (generated `MarshalQDF`/`UnmarshalQDF`) emit the blob form, so
generated and reflect wire stay consistent.

## Measured (i7-9750H, Go 1.26)

A `{ Trace [16]byte; Span [8]byte }` record on real high-byte data:

| | before (per-element) | after (flat blob) |
| --- | ---: | ---: |
| wire | 68 B | **46 B** (−32%) |
| encode | — | ~220 ns, 1 alloc |
| decode | — | ~278 ns, 1 alloc |

A `[N]byte` field now produces **byte-identical wire to a `[]byte` of length N**
(string ↔ bytes ↔ fixed-array interchange holds).

## Who benefits

Any struct with fixed-width byte fields — UUIDs, trace/span ids stored raw,
hashes, fixed keys. They were silently paying ~2× wire and N per-element calls;
now they pack tightly and decode allocation-free.

## Compatibility

Wire change for `[N]byte` fields (pre-1.0). The only serialized `[N]byte` in the
test suite is a stress-test `[4096]byte`; its round-trip stays green because
encode and decode change together. A regression test
(`fixedbytearray_test.go`) asserts the flat-blob wire (equal to the `[]byte`
form), bit-exact round-trip across Speed/Balanced/Compression, and `<= 1` decode
alloc.

## Testing

Full suite + `go test -race` (root + bench), `golangci-lint` (0 issues, root and
qdfgen), and the `internal/codegen_test` regen + race phases all green.

## Not in this PR

The "use `[16]byte` instead of a 32-char hex string for trace/span ids" guidance
is a separate user-side data choice (raw 16 bytes vs hex text) — this PR only
fixes how `[N]byte` itself is encoded. Strings are already wire-optimal
(`fixstr` is a 1-byte tag), so there is no string-to-array auto-conversion here.