### PR TITLE
docs(decode): DECODE-PERF.md — the four decode-allocation levers

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,11 @@ out, err := qdf.AppendMarshal(out[:0], v)
 Pair with a goroutine-local buffer to drop the per-call allocation
 entirely.
 
+> **Decode performance levers** — the four ways to cut decode allocations
+> (decode fewer fields, `[N]byte` ids, `WithNoCopy`, `WithArena`), with measured
+> numbers and when to use each, are collected in
+> **[`docs/DECODE-PERF.md`](docs/DECODE-PERF.md)**.
+
 ### Zero-copy decode (`WithNoCopy`)
 
 Decode is allocation-bound: copying each string/`[]byte` body out of the

--- a/docs/DECODE-PERF.md
+++ b/docs/DECODE-PERF.md
@@ -1,0 +1,128 @@
+# Decode performance: the four levers
+
+Decode is allocation-bound, not CPU-bound: on a string-heavy payload ~96 % of
+the allocations are string/`[]byte` bodies copied out of the wire buffer. The
+default decode copies (safe, owned results) and is already at its floor for that
+contract. Four opt-in levers cut the copies further. **None changes the default
+behavior** — you reach for them per call / per type / per field.
+
+Pick by how your data and your buffers are shaped:
+
+| Lever | Cuts | Cost / when |
+| --- | --- | --- |
+| Decode fewer fields | the copy of every field you don't ask for | free — just declare a smaller struct |
+| `[N]byte` for IDs | wire size + the string alloc for fixed-width ids | free — change the field type |
+| `WithNoCopy` | every copy (aliases the input) | input must outlive the result and not be reused |
+| `WithArena` | per-string allocs across an epoch | caller scopes an arena (see [ARENA.md](ARENA.md)) |
+
+---
+
+## 1. Decode fewer fields (subset-struct projection)
+
+The decoder skips any wire field that the target struct does not declare — it
+advances past the value without copying it. So to read a subset of a record,
+decode into a struct that contains **only the fields you want**:
+
+```go
+// Wire was produced from a 7-field LogEntry. Read just two of them:
+type LogView struct {
+    Level string `qdf:"level"`
+    Trace string `qdf:"trace"`
+}
+
+var v LogView
+_ = qdf.Unmarshal(buf, &v)   // svc/host/span/msg/... are Skip()'d, never copied
+```
+
+Measured (7-field record): full decode **7 allocs**, the 2-field view **3
+allocs** — the four unread string fields cost nothing. Works on the reflect path
+and on codegen types (the generated decoder `Skip()`s unknown keys). The wire is
+unchanged; this is purely a decode-side choice of target type.
+
+Use it whenever a consumer only needs some columns (routing on one field,
+filtering, projecting for a downstream system). It is the row-major analog of
+[`Select` / predicate pushdown](PREDICATE-PUSHDOWN.md) for columnar payloads.
+
+---
+
+## 2. Fixed-width ids as `[N]byte`
+
+A trace id / span id / UUID / hash is fixed-width binary. Storing it as a hex
+**string** doubles the data (32 hex chars for 16 bytes) and costs a string alloc
+on decode. Declaring the field as a fixed byte array stores the raw bytes and
+decodes in place:
+
+```go
+type Span struct {
+    TraceID [16]byte `qdf:"trace_id"`   // 16 raw bytes, not 32 hex chars
+    SpanID  [8]byte  `qdf:"span_id"`
+}
+```
+
+A `[N]byte` field encodes as one flat binary blob (identical wire to a `[]byte`
+of length N) and decodes with a single memcpy straight into the struct's inline
+array — **zero allocation**. Versus a 32-char hex string for the same id: wire
+**43 → 27 bytes** on the record, and no decoded-string alloc. Type-driven, works
+in every mode, no flag.
+
+(If you must keep the id as a Go `string`, it is already wire-optimal — a short
+string is a 1-byte-tag blob. The win here is choosing raw bytes over hex text,
+not a different encoding.)
+
+---
+
+## 3. Zero-copy decode (`WithNoCopy`)
+
+`WithNoCopy()` returns string/`[]byte` values that **alias the input buffer**
+instead of copying — near-zero allocations, roughly 2× faster on string-heavy
+batches.
+
+```go
+// data must outlive `out` and must NOT be reused/mutated while `out` is in use.
+var out LogBatch
+_ = qdf.Unmarshal(data, &out, qdf.WithNoCopy())
+```
+
+Measured on a 1000-row string-heavy batch: **7002 → 3 allocs/op, ~−38 % B/op,
+~1.8× faster** (411 µs → 226 µs).
+
+> ⚠️ The decoded values point INTO `data`. Safe when the input is **owned and
+> not recycled** — an mmap, a file read fully into memory, or a buffer you
+> allocate fresh per message and let live as long as the decoded value (the GC
+> keeps it alive through the aliasing headers). UNSAFE on a pooled / reused
+> buffer (e.g. a `sync.Pool` request body): the aliases dangle the moment the
+> buffer is reused — a use-after-free the race detector cannot catch. This is
+> why it is opt-in.
+
+For a `Decoder`/`StreamDecoder` you drive yourself, use `SetNoCopy(true)`.
+
+---
+
+## 4. Decode arena (`WithArena`)
+
+When the wire buffer is **recycled** (so `WithNoCopy` is unsafe) but you still
+want to cut per-string allocations, pass a [`qdf.Arena`](ARENA.md): it copies
+the strings out (so the buffer can return to its pool immediately) but into one
+dense bump block per epoch instead of one allocation per string.
+
+```go
+a := qdf.NewArena()
+for i, msg := range batch {
+    _ = qdf.Unmarshal(msg, &out[i], qdf.WithArena(a))
+}
+// out's strings live in `a`; the GC frees it when out is dropped.
+```
+
+Measured (telemetry log batch ×1000, epoch loop): **−35 % time, allocs
+3502 → 3**. Safe by default (owned arena, GC-managed); see
+[`docs/ARENA.md`](ARENA.md) for the full lifetime contract and the off→on tables
+across realistic corpora.
+
+---
+
+## Combining
+
+These compose: a subset struct with `[N]byte` id fields, decoded with
+`WithNoCopy` (owned input) or `WithArena` (pooled input), reads the minimum data
+with the minimum copies. The default — plain `Unmarshal` into the full struct —
+stays safe and unchanged when you reach for none of them.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -967,6 +967,10 @@ moves into "scan one arena slab" instead.
 
 ### Zero-copy decode (`WithNoCopy` / `SetNoCopy`)
 
+> The four decode-allocation levers — decode fewer fields, `[N]byte` ids,
+> `WithNoCopy`, `WithArena` — are collected with a when-to-use table in
+> [`DECODE-PERF.md`](DECODE-PERF.md).
+
 Decode is allocation/GC-bound: profiling attributes ~99.85 % of decode
 allocations to `ReadString` copying string bodies out of the buffer
 (encode, by contrast, is already 3 allocs/op via the pooled output


### PR DESCRIPTION
Decode is allocation-bound: on a string-heavy payload ~96 % of the allocations
are string/`[]byte` bodies copied out of the wire. qdf has four opt-in ways to
cut those copies — but **three of them were already supported and undocumented**,
so users were paying for copies they could have skipped for free.

This PR adds `docs/DECODE-PERF.md` collecting all four, with measured numbers and
a when-to-use table, and links it from the README and `docs/GUIDE.md`.

## The four levers

| Lever | Cuts | Cost | Status |
| --- | --- | --- | --- |
| **Decode fewer fields** (subset struct) | the copy of every field you don't declare | free | already worked — undocumented |
| **`[N]byte` ids** | wire size + the id string alloc | free (change field type) | shipped |
| **`WithNoCopy`** | every copy (aliases input) | input must outlive result, not be reused | shipped |
| **`WithArena`** | per-string allocs across an epoch | caller scopes an arena | shipped |

The two that were free-but-undocumented:

- **Subset-struct projection.** The decoder `Skip()`s any wire field the target
  struct does not declare — it advances past the value without copying. So
  decoding into a struct with only the wanted fields reads a projection for free.
  Measured: a 7-field record decodes in 7 allocs; a 2-field view of the same wire
  in 3 (the four unread strings cost nothing). Works on reflect and codegen.
- **The fresh-buffer-safe case of `WithNoCopy`.** It is safe — and free — when
  the input is owned and not recycled (mmap, a file read into memory, or a buffer
  allocated fresh per message), not only the "long-lived mmap" case the prior
  docs emphasized. The hazard is buffer *reuse*, not buffer lifetime.

## What's in the doc

- One section per lever: what it does, the code, measured before/after, and the
  exact safety condition.
- A pick-by-data-shape table at the top.
- A "combining" note (subset + `[N]byte` ids + `WithNoCopy`/`WithArena` compose).

## Why it matters

The decode-allocation work (arena, noCopy, `[N]byte`) shipped over several PRs;
this is the single page a user lands on to find "how do I make decode faster",
and it surfaces the two zero-effort wins they would otherwise miss. No code, no
behavior change.