### PR TITLE
fix(columnar): nil-slice panic on a `[]byte` column that is projected and predicated

### DIFF
--- a/columnar.go
+++ b/columnar.go
@@ -1070,11 +1070,26 @@ func (cv *colVals) evalDense(term *predTerm, n int, mask []uint64) {
 		}
 	case colKindString:
 		for i := range n {
-			if term.pStr(cv.s[i]) {
+			if term.pStr(cv.strAt(i)) {
 				setBit(mask, i)
 			}
 		}
 	}
+}
+
+// strAt returns row i's string for predicate evaluation, sourcing it from the
+// []byte materialization (cv.bs) when the column was projected into a []byte
+// target field (cv.s left nil). The string is transient — handed to the
+// predicate only — so aliasing the owned cv.bs[i] copy is safe and alloc-free.
+func (cv *colVals) strAt(i int) string {
+	if cv.s != nil {
+		return cv.s[i]
+	}
+	b := cv.bs[i]
+	if len(b) == 0 {
+		return ""
+	}
+	return unsafe.String(unsafe.SliceData(b), len(b))
 }
 
 // evalNullable is eval for a nullable column: an absent row never matches.
@@ -1112,7 +1127,7 @@ func (cv *colVals) evalNullable(term *predTerm, n int, mask []uint64) {
 		}
 	case colKindString:
 		for i := range n {
-			if getBit(cv.present, i) && term.pStr(cv.s[i]) {
+			if getBit(cv.present, i) && term.pStr(cv.strAt(i)) {
 				setBit(mask, i)
 			}
 		}

--- a/columnar_query_bytecol_test.go
+++ b/columnar_query_bytecol_test.go
@@ -1,0 +1,45 @@
+package qdf
+
+import (
+	"bytes"
+	"testing"
+)
+
+type qByteRec struct {
+	Name []byte `qdf:"name"`
+	Code int32  `qdf:"code"`
+}
+
+// TestQueryByteColumnPredicate guards the case where a []byte column is BOTH
+// projected (decoded into cv.bs, leaving cv.s nil) AND referenced by a string
+// predicate. The predicate eval indexed cv.s[i] unconditionally and panicked on
+// the nil slice; it must read the value from cv.bs instead.
+func TestQueryByteColumnPredicate(t *testing.T) {
+	const n = 32
+	in := make([]qByteRec, n)
+	for i := range in {
+		if i%2 == 0 {
+			in[i].Name = []byte("keep")
+		} else {
+			in[i].Name = []byte("drop")
+		}
+		in[i].Code = int32(i)
+	}
+	buf, err := Marshal(&in, OptBalanced|OptColumnIndex)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var out []qByteRec
+	if err := Unmarshal(buf, &out, Where("name", func(s string) bool { return s == "keep" })); err != nil {
+		t.Fatalf("query decode: %v", err)
+	}
+	if len(out) != n/2 {
+		t.Fatalf("got %d rows, want %d", len(out), n/2)
+	}
+	for _, r := range out {
+		if !bytes.Equal(r.Name, []byte("keep")) {
+			t.Fatalf("predicate let through %q", r.Name)
+		}
+	}
+}


### PR DESCRIPTION
## The bug (HIGH — panic on valid input)

A `[]byte` struct field decodes columnar as `colKindString` (a `[]byte` column
and a `string` column share the same on-wire kind). Under a query:

- the projection callback marks the column `isByte`, so `decodeColumnVals`
  materializes it into `cv.bs` and leaves `cv.s == nil`;
- but the predicate eval (`evalDense` / `evalNullable`, the `colKindString` arm)
  indexed `cv.s[i]` unconditionally.

So a `[]byte` column that is **both projected and referenced by a string
predicate** panicked with `index out of range [0] with length 0` on valid input:

```go
type Rec struct { Name []byte `qdf:"name"`; Code int32 `qdf:"code"` }
buf, _ := qdf.Marshal(&recs, qdf.OptBalanced|qdf.OptColumnIndex)
var out []Rec
_ = qdf.Unmarshal(buf, &out, qdf.Where("name", func(s string) bool { return s == "keep" }))
// panic: columnar.go:1073
```

A predicate-only `[]byte` column was safe (it decodes into `cv.s`); the panic
needed the column to be *both* in the projection and in the predicate. This
surfaced from the `string`↔`[]byte` columnar interchange added earlier — the
query eval path was not updated for the `[]byte` materialization.

## The fix

Source the predicate string from `cv.bs` (aliasing the owned copy — alloc-free,
the string is handed only to the transient predicate) when `cv.s` is nil, via a
new `colVals.strAt` helper used by both eval paths. Regression test combines a
`[]byte` field with a `Where(string-predicate)` query.

## How it was found

A four-agent read-only bug sweep of the whole codebase, each finding then
RED-verified by hand from a clean tree:

- **Newest code** (`[N]byte` flat-blob, decode arena, the modernize sweep) — CLEAN
  (interchange, length-checks, named-byte types, pool-leak, the `slices.Backward`
  value-copy trap all verified; `markUnknown` correctly *not* modernized).
- **Encode/decode core + hostile input** — CLEAN (round-trip oracles, 3.8M fuzz
  execs, every wire-length-driven `make` bounded before alloc, pool-reset complete).
- **Columnar / qpack / rANS / FSST / bitpack codecs** — this bug, plus everything
  else CLEAN (never-larger gates, reused-scratch underfill, hostile-frame bounds).
- **Reflect map/slice, stream, Marshaler/direct/generic, descOf, decodeAny** —
  CLEAN (1.8M fuzz, map-entry aliasing, stream broken-latch, cycle-safe publish).