### PR TITLE
feat(delta): structural Diff/Apply — keyed slices, baseline registry, columnar column-level diff

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -77,6 +77,12 @@ type Decoder struct {
 	// different decode target.
 	mapFreeList map[reflect.Type][]unsafe.Pointer
 
+	// keyIdx is a reused base-key→index map for keyed slice apply. It is cleared
+	// (entries dropped, backing kept) and rebuilt per keyed slice; the spike-sized
+	// backing is dropped on the apply reset path so a one-off huge slice never
+	// pins a large map across pooled reuse.
+	keyIdx map[string]int
+
 	// deltaScratch is a reused unpack buffer for the Delta+FOR readers: the
 	// bit-unpacked deltas are a transient intermediate (the prefix sum writes
 	// the retained out slice), so a per-call make is pure garbage. Grows to the

--- a/delta.go
+++ b/delta.go
@@ -196,6 +196,9 @@ func applyImpl[T any](base *T, patch []byte, arena *Arena) error {
 	if cap(dec.deltaScratch) > maxRetainedDeltaScratch {
 		dec.deltaScratch = nil
 	}
+	if len(dec.keyIdx) > 1<<16 {
+		dec.keyIdx = nil
+	}
 	decPool.Put(dec)
 	return err
 }

--- a/delta_apply.go
+++ b/delta_apply.go
@@ -45,6 +45,9 @@ func applyMerge(dec *Decoder, td *typeDesc, baseP unsafe.Pointer, depth int) err
 		if dec.i < len(dec.buf) && dec.buf[dec.i] == tagKeyedSlicePatch {
 			return applyKeyedSlice(dec, td, baseP, depth)
 		}
+		if dec.i < len(dec.buf) && dec.buf[dec.i] == tagColSlicePatch {
+			return applyColSlice(dec, td, baseP)
+		}
 		return applySlice(dec, td, baseP, depth)
 	case reflect.Array:
 		return applyArray(dec, td, baseP, depth)

--- a/delta_apply.go
+++ b/delta_apply.go
@@ -42,6 +42,9 @@ func applyMerge(dec *Decoder, td *typeDesc, baseP unsafe.Pointer, depth int) err
 		}
 		return applyStruct(dec, td.elem, ptr, depth+1)
 	case reflect.Slice:
+		if dec.i < len(dec.buf) && dec.buf[dec.i] == tagKeyedSlicePatch {
+			return applyKeyedSlice(dec, td, baseP, depth)
+		}
 		return applySlice(dec, td, baseP, depth)
 	case reflect.Array:
 		return applyArray(dec, td, baseP, depth)

--- a/delta_baseline.go
+++ b/delta_baseline.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"unsafe"
 	"weak"
+
+	"github.com/alex60217101990/qdf/internal/reflectutil"
 )
 
 var (
@@ -52,28 +54,40 @@ func (r *BaselineRegistry[T]) Len() int {
 	return len(r.m)
 }
 
-// deepClone returns a structural deep copy of *v: scalars/strings/[N]byte
-// copied by value; slices/maps/pointers/interfaces recursively allocated and
-// copied. It preserves nil-vs-empty (a nil slice/map stays nil, an empty
-// non-nil one stays empty non-nil) so the clone's fingerprint equals the
-// original's — which is correctness-critical, because Apply's baseFP check
-// would otherwise reject the cloned baseline.
+// deepClone returns a structural deep copy of *v. It walks the value by its
+// *typeDesc over unsafe.Pointer — the same idiom as fpHash / applyValue /
+// equalValue — rather than reflect.Value, so it shares the package's fast paths
+// and honors the qdf_reflect2 build tag (slice/map backing is allocated through
+// reflectutil, exactly as the decode path does).
 //
-// Struct cloning mirrors how fpHash hashes the struct, so the two never
-// disagree: a struct with qdf-visible fields is cloned field-by-field (its
-// unexported fields are left zero, which is safe because the fingerprint, like
-// the wire, ignores them); a fields-less struct — time.Time, a custom
-// Marshaler, or a struct with no exported fields — is copied whole by value,
-// because the fingerprint reads its real contents (the instant, the marshaled
-// form, or all fields) and a field-by-field clone would zero the unexported
-// internals (time.Time is entirely unexported) and fingerprint differently.
+// The clone is byte-for-byte equivalent in everything the fingerprint reads, so
+// it always fingerprints identically to its source — the invariant Apply's
+// baseFP check relies on. It preserves nil-vs-empty (a nil slice/map stays nil,
+// an empty non-nil one stays empty non-nil). Containers (slice/map/pointer) are
+// freshly allocated so Apply's in-place mutation of the clone never touches the
+// registered baseline.
 func deepClone[T any](v *T) *T {
 	out := new(T)
-	cloneValue(reflect.ValueOf(out).Elem(), reflect.ValueOf(v).Elem(), 0)
+	td, err := descOf(reflect.TypeFor[T]())
+	if err != nil || td == nil {
+		// Unsupported type: descOf failing means no patch can target it, so the
+		// clone is unreachable through Apply in practice. A plain value copy is the
+		// safe best effort.
+		*out = *v
+		return out
+	}
+	cloneValue(td, unsafe.Pointer(out), unsafe.Pointer(v), 0)
 	return out
 }
 
-func cloneValue(dst, src reflect.Value, depth int) {
+// cloneValue writes a deep copy of the value of type td at src into dst,
+// mirroring fpHash's structural walk so a clone always fingerprints identically
+// to its source. A pointer-free (pod) span is bulk-copied in one byte copy — no
+// GC write barrier needed, since it holds no pointers. Every pointer-bearing
+// write goes through a typed store (string, unsafe.Pointer) or reflect.Set, so
+// the GC write barrier fires; a raw byte copy is never used over a span that
+// contains pointers.
+func cloneValue(td *typeDesc, dst, src unsafe.Pointer, depth int) {
 	if depth > maxDeltaDepth {
 		// Mirror the diff/apply/fingerprint walks: stop instead of overflowing the
 		// (uncatchable) stack on a cyclic or pathologically deep structure. A
@@ -81,42 +95,20 @@ func cloneValue(dst, src reflect.Value, depth int) {
 		// rejects it with ErrPatchBaseMismatch — a clean error, never a crash.
 		return
 	}
-	switch src.Kind() {
-	case reflect.Pointer:
-		if src.IsNil() {
-			return
-		}
-		np := reflect.New(src.Type().Elem())
-		cloneValue(np.Elem(), src.Elem(), depth+1)
-		dst.Set(np)
+	if td.pod {
+		// Pointer-free: one byte copy reproduces every byte (scalars, tight
+		// arrays/structs, padded pointer-free structs) and is GC-safe.
+		sz := td.rType.Size()
+		copy(unsafe.Slice((*byte)(dst), sz), unsafe.Slice((*byte)(src), sz))
+		return
+	}
+	switch td.kind {
+	case reflect.String:
+		*(*string)(dst) = *(*string)(src) // typed string store: GC-barriered
 	case reflect.Slice:
-		if src.IsNil() {
-			return
-		}
-		n := src.Len()
-		ns := reflect.MakeSlice(src.Type(), n, n)
-		for i := range n {
-			cloneValue(ns.Index(i), src.Index(i), depth+1)
-		}
-		dst.Set(ns)
-	case reflect.Map:
-		if src.IsNil() {
-			return
-		}
-		nm := reflect.MakeMapWithSize(src.Type(), src.Len())
-		it := src.MapRange()
-		for it.Next() {
-			k := reflect.New(src.Type().Key()).Elem()
-			cloneValue(k, it.Key(), depth+1)
-			val := reflect.New(src.Type().Elem()).Elem()
-			cloneValue(val, it.Value(), depth+1)
-			nm.SetMapIndex(k, val)
-		}
-		dst.Set(nm)
+		cloneSlice(td, dst, src, depth)
 	case reflect.Array:
-		for i := range src.Len() {
-			cloneValue(dst.Index(i), src.Index(i), depth+1)
-		}
+		cloneArray(td, dst, src, depth)
 	case reflect.Struct:
 		// Mirror fpHash's struct dispatch. A struct the delta layer treats as
 		// fields-less (len(td.fields)==0: time.Time, a custom Marshaler, or a
@@ -125,30 +117,135 @@ func cloneValue(dst, src reflect.Value, depth int) {
 		// fields. Cloning such a struct field-by-field would skip its unexported
 		// fields (which is ALL of time.Time's wall/ext/loc), zeroing it and
 		// producing a clone whose fingerprint differs → ErrPatchBaseMismatch on a
-		// legitimate baseline. Copy it by value instead, which reproduces every
-		// field. (A shallow value copy is safe: Apply replaces such a value
-		// wholesale via the codec, never mutates its internals in place.)
-		if td, err := descOf(src.Type()); err == nil && len(td.fields) == 0 {
-			dst.Set(src)
+		// legitimate baseline. A typed value copy reproduces every field, is
+		// GC-safe, and shares no mutable structure Apply would touch in place
+		// (Apply replaces such a value wholesale via the codec).
+		if len(td.fields) == 0 {
+			reflect.NewAt(td.rType, dst).Elem().Set(reflect.NewAt(td.rType, src).Elem())
 			return
 		}
-		for i := range src.NumField() {
-			df := dst.Field(i)
-			if !df.CanSet() {
-				continue
+		for i := range td.fields {
+			f := &td.fields[i]
+			cloneValue(f.desc, unsafe.Add(dst, f.offset), unsafe.Add(src, f.offset), depth+1)
+		}
+	case reflect.Pointer:
+		sp := *(*unsafe.Pointer)(src)
+		if sp == nil {
+			return // nil pointer: dst already nil
+		}
+		elem := td.elem
+		if elem == nil {
+			elem, _ = descOf(td.rType.Elem())
+			if elem == nil {
+				return
 			}
-			cloneValue(df, src.Field(i), depth+1)
 		}
+		np := reflect.New(elem.rType) // GC-safe allocation of the pointee
+		cloneValue(elem, np.UnsafePointer(), sp, depth+1)
+		reflect.NewAt(td.rType, dst).Elem().Set(np) // typed pointer store: barriered
+	case reflect.Map:
+		cloneMap(td, dst, src, depth)
 	case reflect.Interface:
-		if src.IsNil() {
+		iv := reflect.NewAt(td.rType, src).Elem()
+		if iv.IsNil() {
 			return
 		}
-		ev := src.Elem()
-		nv := reflect.New(ev.Type()).Elem()
-		cloneValue(nv, ev, depth+1)
-		dst.Set(nv)
+		ev := iv.Elem() // dynamic value
+		edesc, derr := descOf(ev.Type())
+		if derr != nil || edesc == nil {
+			reflect.NewAt(td.rType, dst).Elem().Set(iv) // fallback: shallow box copy
+			return
+		}
+		srcBuf := reflect.New(ev.Type())
+		srcBuf.Elem().Set(ev) // addressable copy of the boxed value
+		dstBuf := reflect.New(ev.Type())
+		cloneValue(edesc, dstBuf.UnsafePointer(), srcBuf.UnsafePointer(), depth+1)
+		reflect.NewAt(td.rType, dst).Elem().Set(dstBuf.Elem()) // box the clone
 	default:
-		dst.Set(src)
+		// Exotic kinds (chan/func): a typed value copy (barriered, shallow).
+		reflect.NewAt(td.rType, dst).Elem().Set(reflect.NewAt(td.rType, src).Elem())
+	}
+}
+
+// cloneSlice deep-copies the slice at src into a freshly allocated backing at
+// dst, preserving nil-vs-empty.
+func cloneSlice(td *typeDesc, dst, src unsafe.Pointer, depth int) {
+	sh := (*sliceHeader)(src)
+	if sh.Data == nil {
+		return // nil slice stays nil (dst already zeroed)
+	}
+	n := sh.Len
+	reflectutil.MakeSlice(td.rType, n, dst) // reflect2-aware; non-nil even for n==0
+	if n == 0 {
+		return // empty-non-nil preserved
+	}
+	elem := td.elem
+	if elem == nil {
+		elem, _ = descOf(td.rType.Elem())
+		if elem == nil {
+			return
+		}
+	}
+	dsh := (*sliceHeader)(dst)
+	stride := td.rType.Elem().Size()
+	if elem.pod {
+		// Pointer-free elements: one bulk byte copy (GC-safe, holds no pointers).
+		copy(unsafe.Slice((*byte)(dsh.Data), uintptr(n)*stride),
+			unsafe.Slice((*byte)(sh.Data), uintptr(n)*stride))
+		return
+	}
+	for i := range n {
+		cloneValue(elem, unsafe.Add(dsh.Data, uintptr(i)*stride),
+			unsafe.Add(sh.Data, uintptr(i)*stride), depth+1)
+	}
+}
+
+// cloneArray deep-copies a non-pod array (a pod array took the byte-copy fast
+// path) element by element.
+func cloneArray(td *typeDesc, dst, src unsafe.Pointer, depth int) {
+	n := td.rType.Len()
+	elem := td.elem
+	if elem == nil {
+		elem, _ = descOf(td.rType.Elem())
+		if elem == nil {
+			return
+		}
+	}
+	stride := td.rType.Elem().Size()
+	for i := range n {
+		cloneValue(elem, unsafe.Add(dst, uintptr(i)*stride),
+			unsafe.Add(src, uintptr(i)*stride), depth+1)
+	}
+}
+
+// cloneMap deep-copies the map at src into a freshly allocated map at dst,
+// preserving nil-vs-empty. Keys are shared (a map key is immutable; Apply never
+// mutates one); values are deep-cloned, because Apply can mutate a value's inner
+// containers in place and must not reach through to the registered baseline.
+func cloneMap(td *typeDesc, dst, src unsafe.Pointer, depth int) {
+	mv := reflect.NewAt(td.rType, src).Elem()
+	if mv.IsNil() {
+		return // nil map stays nil
+	}
+	// Allocate through reflectutil so qdf_reflect2 swaps in the faster allocator,
+	// matching applyMap / the decode path.
+	reflectutil.MakeMap(td.rType, mv.Len(), dst)
+	dmv := reflect.NewAt(td.rType, dst).Elem()
+	valDesc := td.elem
+	if valDesc == nil {
+		valDesc, _ = descOf(td.rType.Elem())
+	}
+	if valDesc == nil {
+		dmv.Set(mv) // unsupported value type: shallow copy (still a fresh map)
+		return
+	}
+	valType := td.rType.Elem()
+	for it := mv.MapRange(); it.Next(); {
+		srcBuf := reflect.New(valType)
+		srcBuf.Elem().Set(it.Value()) // addressable copy of the value
+		dstBuf := reflect.New(valType)
+		cloneValue(valDesc, dstBuf.UnsafePointer(), srcBuf.UnsafePointer(), depth+1)
+		dmv.SetMapIndex(it.Key(), dstBuf.Elem())
 	}
 }
 

--- a/delta_baseline.go
+++ b/delta_baseline.go
@@ -140,3 +140,47 @@ func (r *BaselineRegistry[T]) fingerprint(v *T) uint64 {
 	}
 	return valueFingerprint(td, unsafe.Pointer(v))
 }
+
+// Apply resolves the patch's baseline (by its embedded baseFP) to a *T, applies
+// the patch onto a fresh deep copy of it, registers the result as a new
+// baseline (so it can base the next patch in the stream), and returns the new
+// *T. The caller should keep the returned pointer to chain further patches off
+// it; dropping it lets the GC reclaim it.
+//
+// Errors: ErrBaselineRequired (the patch carries no baseFP — produced with
+// OptDeltaNoBaseFingerprint), ErrBaselineEvicted (the baseline id is not
+// resolvable), plus any error from the underlying Apply.
+func (r *BaselineRegistry[T]) Apply(patch []byte) (*T, error) {
+	h, _, err := readPatchHeader(patch)
+	if err != nil {
+		return nil, err
+	}
+	if h.flags&flagPatchBaseFP == 0 {
+		return nil, ErrBaselineRequired
+	}
+	r.mu.Lock()
+	wp, ok := r.m[h.baseFP]
+	r.mu.Unlock()
+	var base *T
+	if ok {
+		base = wp.Value()
+	}
+	if base == nil {
+		if ok {
+			r.mu.Lock()
+			if cur, still := r.m[h.baseFP]; still && cur.Value() == nil {
+				delete(r.m, h.baseFP)
+			}
+			r.mu.Unlock()
+		}
+		return nil, ErrBaselineEvicted
+	}
+	clone := deepClone(base)
+	if err := Apply(clone, patch); err != nil {
+		return nil, err
+	}
+	r.mu.Lock()
+	r.m[r.fingerprint(clone)] = weak.Make(clone)
+	r.mu.Unlock()
+	return clone, nil
+}

--- a/delta_baseline.go
+++ b/delta_baseline.go
@@ -57,8 +57,16 @@ func (r *BaselineRegistry[T]) Len() int {
 // copied. It preserves nil-vs-empty (a nil slice/map stays nil, an empty
 // non-nil one stays empty non-nil) so the clone's fingerprint equals the
 // original's — which is correctness-critical, because Apply's baseFP check
-// would otherwise reject the cloned baseline. Unexported struct fields are not
-// supported (consistent with qdf encoding) and are left zero.
+// would otherwise reject the cloned baseline.
+//
+// Struct cloning mirrors how fpHash hashes the struct, so the two never
+// disagree: a struct with qdf-visible fields is cloned field-by-field (its
+// unexported fields are left zero, which is safe because the fingerprint, like
+// the wire, ignores them); a fields-less struct — time.Time, a custom
+// Marshaler, or a struct with no exported fields — is copied whole by value,
+// because the fingerprint reads its real contents (the instant, the marshaled
+// form, or all fields) and a field-by-field clone would zero the unexported
+// internals (time.Time is entirely unexported) and fingerprint differently.
 func deepClone[T any](v *T) *T {
 	out := new(T)
 	cloneValue(reflect.ValueOf(out).Elem(), reflect.ValueOf(v).Elem(), 0)
@@ -110,6 +118,20 @@ func cloneValue(dst, src reflect.Value, depth int) {
 			cloneValue(dst.Index(i), src.Index(i), depth+1)
 		}
 	case reflect.Struct:
+		// Mirror fpHash's struct dispatch. A struct the delta layer treats as
+		// fields-less (len(td.fields)==0: time.Time, a custom Marshaler, or a
+		// degenerate struct with no qdf-visible fields) is hashed as a whole — by
+		// its instant, its marshaled form, or via fpHashReflect over its real
+		// fields. Cloning such a struct field-by-field would skip its unexported
+		// fields (which is ALL of time.Time's wall/ext/loc), zeroing it and
+		// producing a clone whose fingerprint differs → ErrPatchBaseMismatch on a
+		// legitimate baseline. Copy it by value instead, which reproduces every
+		// field. (A shallow value copy is safe: Apply replaces such a value
+		// wholesale via the codec, never mutates its internals in place.)
+		if td, err := descOf(src.Type()); err == nil && len(td.fields) == 0 {
+			dst.Set(src)
+			return
+		}
 		for i := range src.NumField() {
 			df := dst.Field(i)
 			if !df.CanSet() {

--- a/delta_baseline.go
+++ b/delta_baseline.go
@@ -1,0 +1,49 @@
+package qdf
+
+import (
+	"errors"
+	"sync"
+	"weak"
+)
+
+var (
+	// ErrBaselineRequired is returned by (*BaselineRegistry).Apply when the
+	// patch carries no base fingerprint (the producer used
+	// OptDeltaNoBaseFingerprint), so its baseline cannot be content-addressed.
+	ErrBaselineRequired = errors.New("qdf: patch has no base fingerprint; baseline registry requires one")
+	// ErrBaselineEvicted is returned by (*BaselineRegistry).Apply when the
+	// patch's baseline id is not resolvable — it was never registered, or the
+	// caller dropped its strong reference and the GC reclaimed it.
+	ErrBaselineEvicted = errors.New("qdf: patch baseline not found in registry (never registered or GC-reclaimed)")
+)
+
+// BaselineRegistry is a consumer-side, content-addressed cache of recent
+// baselines of type T, used to apply a chain of patches in a state-sync stream
+// without threading the previous value by hand. It maps each baseline's content
+// fingerprint (the same value Diff embeds as baseFP) to a weak.Pointer, so the
+// GC reclaims any baseline the caller no longer references. The registry never
+// pins a baseline alive.
+//
+// A BaselineRegistry is safe for concurrent use.
+type BaselineRegistry[T any] struct {
+	mu sync.Mutex
+	m  map[uint64]weak.Pointer[T]
+}
+
+// NewBaselineRegistry returns an empty registry for baselines of type T.
+func NewBaselineRegistry[T any]() *BaselineRegistry[T] {
+	return &BaselineRegistry[T]{m: make(map[uint64]weak.Pointer[T])}
+}
+
+// Len reports the number of live (non-evicted) baselines, pruning dead weak
+// entries as a side effect.
+func (r *BaselineRegistry[T]) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id, wp := range r.m {
+		if wp.Value() == nil {
+			delete(r.m, id)
+		}
+	}
+	return len(r.m)
+}

--- a/delta_baseline.go
+++ b/delta_baseline.go
@@ -2,6 +2,7 @@ package qdf
 
 import (
 	"errors"
+	"reflect"
 	"sync"
 	"weak"
 )
@@ -46,4 +47,75 @@ func (r *BaselineRegistry[T]) Len() int {
 		}
 	}
 	return len(r.m)
+}
+
+// deepClone returns a structural deep copy of *v: scalars/strings/[N]byte
+// copied by value; slices/maps/pointers/interfaces recursively allocated and
+// copied. It preserves nil-vs-empty (a nil slice/map stays nil, an empty
+// non-nil one stays empty non-nil) so the clone's fingerprint equals the
+// original's — which is correctness-critical, because Apply's baseFP check
+// would otherwise reject the cloned baseline. Unexported struct fields are not
+// supported (consistent with qdf encoding) and are left zero.
+func deepClone[T any](v *T) *T {
+	out := new(T)
+	cloneValue(reflect.ValueOf(out).Elem(), reflect.ValueOf(v).Elem())
+	return out
+}
+
+func cloneValue(dst, src reflect.Value) {
+	switch src.Kind() {
+	case reflect.Pointer:
+		if src.IsNil() {
+			return
+		}
+		np := reflect.New(src.Type().Elem())
+		cloneValue(np.Elem(), src.Elem())
+		dst.Set(np)
+	case reflect.Slice:
+		if src.IsNil() {
+			return
+		}
+		n := src.Len()
+		ns := reflect.MakeSlice(src.Type(), n, n)
+		for i := range n {
+			cloneValue(ns.Index(i), src.Index(i))
+		}
+		dst.Set(ns)
+	case reflect.Map:
+		if src.IsNil() {
+			return
+		}
+		nm := reflect.MakeMapWithSize(src.Type(), src.Len())
+		it := src.MapRange()
+		for it.Next() {
+			k := reflect.New(src.Type().Key()).Elem()
+			cloneValue(k, it.Key())
+			val := reflect.New(src.Type().Elem()).Elem()
+			cloneValue(val, it.Value())
+			nm.SetMapIndex(k, val)
+		}
+		dst.Set(nm)
+	case reflect.Array:
+		for i := 0; i < src.Len(); i++ {
+			cloneValue(dst.Index(i), src.Index(i))
+		}
+	case reflect.Struct:
+		for i := 0; i < src.NumField(); i++ {
+			df := dst.Field(i)
+			if !df.CanSet() {
+				continue
+			}
+			cloneValue(df, src.Field(i))
+		}
+	case reflect.Interface:
+		if src.IsNil() {
+			return
+		}
+		ev := src.Elem()
+		nv := reflect.New(ev.Type()).Elem()
+		cloneValue(nv, ev)
+		dst.Set(nv)
+	default:
+		dst.Set(src)
+	}
 }

--- a/delta_baseline.go
+++ b/delta_baseline.go
@@ -30,11 +30,13 @@ var (
 type BaselineRegistry[T any] struct {
 	mu sync.Mutex
 	m  map[uint64]weak.Pointer[T]
+	td *typeDesc
 }
 
 // NewBaselineRegistry returns an empty registry for baselines of type T.
 func NewBaselineRegistry[T any]() *BaselineRegistry[T] {
-	return &BaselineRegistry[T]{m: make(map[uint64]weak.Pointer[T])}
+	td, _ := descOf(reflect.TypeFor[T]())
+	return &BaselineRegistry[T]{m: make(map[uint64]weak.Pointer[T]), td: td}
 }
 
 // Len reports the number of live (non-evicted) baselines, pruning dead weak
@@ -59,18 +61,25 @@ func (r *BaselineRegistry[T]) Len() int {
 // supported (consistent with qdf encoding) and are left zero.
 func deepClone[T any](v *T) *T {
 	out := new(T)
-	cloneValue(reflect.ValueOf(out).Elem(), reflect.ValueOf(v).Elem())
+	cloneValue(reflect.ValueOf(out).Elem(), reflect.ValueOf(v).Elem(), 0)
 	return out
 }
 
-func cloneValue(dst, src reflect.Value) {
+func cloneValue(dst, src reflect.Value, depth int) {
+	if depth > maxDeltaDepth {
+		// Mirror the diff/apply/fingerprint walks: stop instead of overflowing the
+		// (uncatchable) stack on a cyclic or pathologically deep structure. A
+		// truncated clone fingerprints differently, so Apply's baseFP check then
+		// rejects it with ErrPatchBaseMismatch — a clean error, never a crash.
+		return
+	}
 	switch src.Kind() {
 	case reflect.Pointer:
 		if src.IsNil() {
 			return
 		}
 		np := reflect.New(src.Type().Elem())
-		cloneValue(np.Elem(), src.Elem())
+		cloneValue(np.Elem(), src.Elem(), depth+1)
 		dst.Set(np)
 	case reflect.Slice:
 		if src.IsNil() {
@@ -79,7 +88,7 @@ func cloneValue(dst, src reflect.Value) {
 		n := src.Len()
 		ns := reflect.MakeSlice(src.Type(), n, n)
 		for i := range n {
-			cloneValue(ns.Index(i), src.Index(i))
+			cloneValue(ns.Index(i), src.Index(i), depth+1)
 		}
 		dst.Set(ns)
 	case reflect.Map:
@@ -90,15 +99,15 @@ func cloneValue(dst, src reflect.Value) {
 		it := src.MapRange()
 		for it.Next() {
 			k := reflect.New(src.Type().Key()).Elem()
-			cloneValue(k, it.Key())
+			cloneValue(k, it.Key(), depth+1)
 			val := reflect.New(src.Type().Elem()).Elem()
-			cloneValue(val, it.Value())
+			cloneValue(val, it.Value(), depth+1)
 			nm.SetMapIndex(k, val)
 		}
 		dst.Set(nm)
 	case reflect.Array:
 		for i := range src.Len() {
-			cloneValue(dst.Index(i), src.Index(i))
+			cloneValue(dst.Index(i), src.Index(i), depth+1)
 		}
 	case reflect.Struct:
 		for i := range src.NumField() {
@@ -106,7 +115,7 @@ func cloneValue(dst, src reflect.Value) {
 			if !df.CanSet() {
 				continue
 			}
-			cloneValue(df, src.Field(i))
+			cloneValue(df, src.Field(i), depth+1)
 		}
 	case reflect.Interface:
 		if src.IsNil() {
@@ -114,7 +123,7 @@ func cloneValue(dst, src reflect.Value) {
 		}
 		ev := src.Elem()
 		nv := reflect.New(ev.Type()).Elem()
-		cloneValue(nv, ev)
+		cloneValue(nv, ev, depth+1)
 		dst.Set(nv)
 	default:
 		dst.Set(src)
@@ -134,11 +143,10 @@ func (r *BaselineRegistry[T]) Register(v *T) uint64 {
 
 // fingerprint computes the content id of *v (identical to Diff's baseFP).
 func (r *BaselineRegistry[T]) fingerprint(v *T) uint64 {
-	td, err := descOf(reflect.TypeFor[T]())
-	if err != nil {
-		return 0
+	if r.td == nil {
+		return 0 // unsupported type; such a T can never produce a patch either
 	}
-	return valueFingerprint(td, unsafe.Pointer(v))
+	return valueFingerprint(r.td, unsafe.Pointer(v))
 }
 
 // Apply resolves the patch's baseline (by its embedded baseFP) to a *T, applies
@@ -150,6 +158,12 @@ func (r *BaselineRegistry[T]) fingerprint(v *T) uint64 {
 // Errors: ErrBaselineRequired (the patch carries no baseFP — produced with
 // OptDeltaNoBaseFingerprint), ErrBaselineEvicted (the baseline id is not
 // resolvable), plus any error from the underlying Apply.
+//
+// Because baselines are content-addressed by a 64-bit fingerprint, two distinct
+// values that happen to share a fingerprint (probability ~N²/2⁶⁴, negligible
+// for thousands of live baselines) collide on the same map key, and the later
+// registration overwrites the earlier one; the earlier baseline then resolves
+// as ErrBaselineEvicted even while the caller still holds it.
 func (r *BaselineRegistry[T]) Apply(patch []byte) (*T, error) {
 	h, _, err := readPatchHeader(patch)
 	if err != nil {

--- a/delta_baseline.go
+++ b/delta_baseline.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"reflect"
 	"sync"
+	"unsafe"
 	"weak"
 )
 
@@ -96,11 +97,11 @@ func cloneValue(dst, src reflect.Value) {
 		}
 		dst.Set(nm)
 	case reflect.Array:
-		for i := 0; i < src.Len(); i++ {
+		for i := range src.Len() {
 			cloneValue(dst.Index(i), src.Index(i))
 		}
 	case reflect.Struct:
-		for i := 0; i < src.NumField(); i++ {
+		for i := range src.NumField() {
 			df := dst.Field(i)
 			if !df.CanSet() {
 				continue
@@ -118,4 +119,24 @@ func cloneValue(dst, src reflect.Value) {
 	default:
 		dst.Set(src)
 	}
+}
+
+// Register stores v as a resolvable baseline and returns its content id — the
+// same fingerprint Diff embeds as baseFP. The registry holds v through a
+// weak.Pointer; the CALLER must keep v reachable for it to remain resolvable.
+func (r *BaselineRegistry[T]) Register(v *T) uint64 {
+	id := r.fingerprint(v)
+	r.mu.Lock()
+	r.m[id] = weak.Make(v)
+	r.mu.Unlock()
+	return id
+}
+
+// fingerprint computes the content id of *v (identical to Diff's baseFP).
+func (r *BaselineRegistry[T]) fingerprint(v *T) uint64 {
+	td, err := descOf(reflect.TypeFor[T]())
+	if err != nil {
+		return 0
+	}
+	return valueFingerprint(td, unsafe.Pointer(v))
 }

--- a/delta_baseline_test.go
+++ b/delta_baseline_test.go
@@ -74,3 +74,27 @@ func TestDeepCloneIndependent(t *testing.T) {
 		t.Error("mutating clone map touched original")
 	}
 }
+
+func TestRegisterIdMatchesDiffBaseFP(t *testing.T) {
+	r := NewBaselineRegistry[dnTop]()
+	v := gen[dnTop](7)
+	id := r.Register(&v)
+
+	patch, err := Diff(v, gen[dnTop](8), OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, _, err := readPatchHeader(patch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.flags&flagPatchBaseFP == 0 {
+		t.Fatal("patch unexpectedly has no baseFP")
+	}
+	if h.baseFP != id {
+		t.Fatalf("Register id %x != Diff baseFP %x", id, h.baseFP)
+	}
+	if got := r.Len(); got != 1 {
+		t.Fatalf("Len() = %d, want 1", got)
+	}
+}

--- a/delta_baseline_test.go
+++ b/delta_baseline_test.go
@@ -259,11 +259,12 @@ func TestBaselineApplyHostile(t *testing.T) {
 	r := NewBaselineRegistry[dnTop]()
 	base := gen[dnTop](1)
 	r.Register(&base)
-	seeds := [][]byte{nil, {}, {0x00}, []byte("not a patch at all")}
 	good, err := Diff(base, gen[dnTop](2), OptBalanced)
 	if err != nil {
 		t.Fatal(err)
 	}
+	seeds := make([][]byte, 0, 4+len(good))
+	seeds = append(seeds, nil, []byte{}, []byte{0x00}, []byte("not a patch at all"))
 	for i := range len(good) {
 		trunc := make([]byte, i)
 		copy(trunc, good[:i])

--- a/delta_baseline_test.go
+++ b/delta_baseline_test.go
@@ -297,3 +297,27 @@ func TestBaselineLenDropsToZero(t *testing.T) {
 		t.Fatalf("Len() = %d after release+GC, want 0 (registry must not pin)", got)
 	}
 }
+
+func FuzzBaselineApply(f *testing.F) {
+	base := gen[dnTop](1)
+	good, _ := Diff(base, gen[dnTop](2), OptBalanced)
+	f.Add(good)
+	f.Add([]byte{})
+	f.Add([]byte("garbage"))
+	f.Fuzz(func(t *testing.T, patch []byte) {
+		r := NewBaselineRegistry[dnTop]()
+		b := gen[dnTop](1)
+		r.Register(&b)
+		defer func() {
+			if rec := recover(); rec != nil {
+				t.Fatalf("panic on patch %x: %v", patch, rec)
+			}
+		}()
+		got, err := r.Apply(patch)
+		if err == nil && got == nil {
+			t.Fatal("Apply returned nil,nil")
+		}
+		runtime.KeepAlive(b)
+		runtime.KeepAlive(got)
+	})
+}

--- a/delta_baseline_test.go
+++ b/delta_baseline_test.go
@@ -254,3 +254,46 @@ func TestBaselineConcurrent(t *testing.T) {
 	wg.Wait()
 	runtime.KeepAlive(base)
 }
+
+func TestBaselineApplyHostile(t *testing.T) {
+	r := NewBaselineRegistry[dnTop]()
+	base := gen[dnTop](1)
+	r.Register(&base)
+	seeds := [][]byte{nil, {}, {0x00}, []byte("not a patch at all")}
+	good, err := Diff(base, gen[dnTop](2), OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range len(good) {
+		trunc := make([]byte, i)
+		copy(trunc, good[:i])
+		seeds = append(seeds, trunc)
+	}
+	for i, b := range seeds {
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					t.Fatalf("seed %d panicked: %v", i, rec)
+				}
+			}()
+			_, _ = r.Apply(b)
+		}()
+	}
+	runtime.KeepAlive(base)
+}
+
+func TestBaselineLenDropsToZero(t *testing.T) {
+	r := NewBaselineRegistry[dnTop]()
+	func() {
+		for i := range int64(16) {
+			v := gen[dnTop](i)
+			r.Register(&v)
+			runtime.KeepAlive(v)
+		}
+	}()
+	runtime.GC()
+	runtime.GC()
+	if got := r.Len(); got != 0 {
+		t.Fatalf("Len() = %d after release+GC, want 0 (registry must not pin)", got)
+	}
+}

--- a/delta_baseline_test.go
+++ b/delta_baseline_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"reflect"
 	"runtime"
+	"sync"
 	"testing"
 	"unsafe"
 )
@@ -219,4 +220,37 @@ func TestBaselineStreamChain(t *testing.T) {
 		}
 		runtime.KeepAlive(cur)
 	}
+}
+
+func TestBaselineConcurrent(t *testing.T) {
+	r := NewBaselineRegistry[dnTop]()
+	base := gen[dnTop](1)
+	r.Register(&base)
+	patch, err := Diff(base, gen[dnTop](2), OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	for g := range 8 {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range 200 {
+				switch i % 3 {
+				case 0:
+					v := gen[dnTop](int64(g*1000 + i))
+					r.Register(&v)
+					runtime.KeepAlive(v)
+				case 1:
+					if got, err := r.Apply(patch); err == nil {
+						runtime.KeepAlive(got)
+					}
+				case 2:
+					_ = r.Len()
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	runtime.KeepAlive(base)
 }

--- a/delta_baseline_test.go
+++ b/delta_baseline_test.go
@@ -39,6 +39,46 @@ func TestBaselineTimeFieldRoundTrip(t *testing.T) {
 	runtime.KeepAlive(s1)
 }
 
+func TestDeepCloneDeepIndependence(t *testing.T) {
+	type inner struct {
+		Xs []int
+	}
+	type outer struct {
+		P *inner
+		M map[string]*inner
+		S [][]int
+	}
+	v := outer{
+		P: &inner{Xs: []int{1, 2}},
+		M: map[string]*inner{"k": {Xs: []int{3, 4}}},
+		S: [][]int{{5, 6}},
+	}
+	c := deepClone(&v)
+	if !reflect.DeepEqual(*c, v) {
+		t.Fatal("deep clone not equal to original")
+	}
+	// Mutating every nested container in the clone must not touch the original.
+	c.P.Xs[0] = 99
+	c.M["k"].Xs[0] = 99
+	c.S[0][0] = 99
+	if v.P.Xs[0] != 1 {
+		t.Error("clone shares pointer-field backing with original")
+	}
+	if v.M["k"].Xs[0] != 3 {
+		t.Error("clone shares map-value backing with original")
+	}
+	if v.S[0][0] != 5 {
+		t.Error("clone shares nested-slice backing with original")
+	}
+	// The clone's pointer/map-value must be distinct allocations.
+	if c.P == v.P {
+		t.Error("clone pointer field aliases original pointer")
+	}
+	if c.M["k"] == v.M["k"] {
+		t.Error("clone map value aliases original map value")
+	}
+}
+
 func TestDeepCloneTimeField(t *testing.T) {
 	v := bnRegTimeStamped{ID: "a", TS: time.Unix(1700000000, 999).UTC()}
 	c := deepClone(&v)

--- a/delta_baseline_test.go
+++ b/delta_baseline_test.go
@@ -6,8 +6,53 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 	"unsafe"
 )
+
+// bnRegTimeStamped exercises the fields-less-struct clone path (time.Time is
+// entirely unexported): a field-by-field deepClone would zero it and the
+// baseFP check would reject every patch. See deepClone's struct handling.
+type bnRegTimeStamped struct {
+	ID   string
+	TS   time.Time
+	Tags []string
+}
+
+func TestBaselineTimeFieldRoundTrip(t *testing.T) {
+	r := NewBaselineRegistry[bnRegTimeStamped]()
+	s0 := bnRegTimeStamped{ID: "a", TS: time.Unix(1700000000, 12345).UTC(), Tags: []string{"x"}}
+	r.Register(&s0)
+	s1want := bnRegTimeStamped{ID: "b", TS: s0.TS.Add(90 * time.Minute), Tags: []string{"x", "y"}}
+	patch, err := Diff(s0, s1want, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s1, err := r.Apply(patch)
+	if err != nil {
+		t.Fatalf("Apply with time.Time field: %v", err)
+	}
+	if !reflect.DeepEqual(*s1, s1want) {
+		t.Fatalf("reconstructed = %+v, want %+v", *s1, s1want)
+	}
+	runtime.KeepAlive(s0)
+	runtime.KeepAlive(s1)
+}
+
+func TestDeepCloneTimeField(t *testing.T) {
+	v := bnRegTimeStamped{ID: "a", TS: time.Unix(1700000000, 999).UTC()}
+	c := deepClone(&v)
+	if !c.TS.Equal(v.TS) {
+		t.Fatalf("clone zeroed time.Time: orig=%v clone=%v", v.TS, c.TS)
+	}
+	td, err := descOf(reflect.TypeFor[bnRegTimeStamped]())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if valueFingerprint(td, unsafe.Pointer(&v)) != valueFingerprint(td, unsafe.Pointer(c)) {
+		t.Fatal("clone fingerprint differs from original for a time.Time-bearing type")
+	}
+}
 
 func TestBaselineRegistryEmpty(t *testing.T) {
 	r := NewBaselineRegistry[dnTop]()

--- a/delta_baseline_test.go
+++ b/delta_baseline_test.go
@@ -1,6 +1,7 @@
 package qdf
 
 import (
+	"errors"
 	"reflect"
 	"runtime"
 	"testing"
@@ -133,4 +134,18 @@ func TestBaselineApplyHappyPath(t *testing.T) {
 		t.Fatal("chained Apply result != expected")
 	}
 	runtime.KeepAlive(s1)
+}
+
+func TestBaselineApplyNoFingerprint(t *testing.T) {
+	r := NewBaselineRegistry[dnTop]()
+	s0 := gen[dnTop](1)
+	r.Register(&s0)
+	patch, err := Diff(s0, gen[dnTop](2), OptBalanced|OptDeltaNoBaseFingerprint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Apply(patch); !errors.Is(err, ErrBaselineRequired) {
+		t.Fatalf("Apply error = %v, want ErrBaselineRequired", err)
+	}
+	runtime.KeepAlive(s0)
 }

--- a/delta_baseline_test.go
+++ b/delta_baseline_test.go
@@ -2,6 +2,7 @@ package qdf
 
 import (
 	"reflect"
+	"runtime"
 	"testing"
 	"unsafe"
 )
@@ -21,7 +22,7 @@ func TestDeepCloneFidelity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for seed := int64(0); seed < 200; seed++ {
+	for seed := range int64(200) {
 		v := gen[dnTop](seed)
 		c := deepClone(&v)
 		if !reflect.DeepEqual(*c, v) {
@@ -97,4 +98,39 @@ func TestRegisterIdMatchesDiffBaseFP(t *testing.T) {
 	if got := r.Len(); got != 1 {
 		t.Fatalf("Len() = %d, want 1", got)
 	}
+}
+
+func TestBaselineApplyHappyPath(t *testing.T) {
+	r := NewBaselineRegistry[dnTop]()
+	s0 := gen[dnTop](1)
+	s1want := gen[dnTop](2)
+
+	r.Register(&s0)
+	patch, err := Diff(s0, s1want, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s1, err := r.Apply(patch)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !reflect.DeepEqual(*s1, s1want) {
+		t.Fatal("Apply result != expected new value")
+	}
+	if !reflect.DeepEqual(s0, gen[dnTop](1)) {
+		t.Fatal("Apply mutated the registered baseline")
+	}
+	s2want := gen[dnTop](3)
+	patch2, err := Diff(*s1, s2want, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := r.Apply(patch2)
+	if err != nil {
+		t.Fatalf("Apply chain step 2: %v", err)
+	}
+	if !reflect.DeepEqual(*s2, s2want) {
+		t.Fatal("chained Apply result != expected")
+	}
+	runtime.KeepAlive(s1)
 }

--- a/delta_baseline_test.go
+++ b/delta_baseline_test.go
@@ -1,0 +1,13 @@
+package qdf
+
+import "testing"
+
+func TestBaselineRegistryEmpty(t *testing.T) {
+	r := NewBaselineRegistry[dnTop]()
+	if r == nil {
+		t.Fatal("NewBaselineRegistry returned nil")
+	}
+	if got := r.Len(); got != 0 {
+		t.Fatalf("empty registry Len() = %d, want 0", got)
+	}
+}

--- a/delta_baseline_test.go
+++ b/delta_baseline_test.go
@@ -187,3 +187,36 @@ func TestBaselineApplyUnknownBaseline(t *testing.T) {
 		t.Fatalf("Apply of never-registered baseline = %v, want ErrBaselineEvicted", err)
 	}
 }
+
+func TestBaselineStreamChain(t *testing.T) {
+	tiers := []Options{OptSpeed, OptBalanced, OptCompression}
+	for _, tier := range tiers {
+		r := NewBaselineRegistry[dnTop]()
+		prev := gen[dnTop](1000)
+		cur := &prev
+		r.Register(cur)
+		for step := int64(1001); step < 1030; step++ {
+			next := gen[dnTop](step)
+			patch, err := Diff(*cur, next, tier)
+			if err != nil {
+				t.Fatalf("tier %v step %d Diff: %v", tier, step, err)
+			}
+			got, err := r.Apply(patch)
+			if err != nil {
+				t.Fatalf("tier %v step %d Apply: %v", tier, step, err)
+			}
+			if !reflect.DeepEqual(*got, next) {
+				t.Fatalf("tier %v step %d: reconstructed != expected", tier, step)
+			}
+			// The registry holds baselines through non-pinning weak pointers, so
+			// the baseline this step's patch is based on (*cur) must stay reachable
+			// until Apply has resolved it. Without this, the compiler treats cur as
+			// dead right after Diff reads it (the next op overwrites cur), letting
+			// the GC reclaim the intermediate baseline before Apply -> flaky
+			// ErrBaselineEvicted at a chain step. Keep cur live across Apply.
+			runtime.KeepAlive(cur)
+			cur = got
+		}
+		runtime.KeepAlive(cur)
+	}
+}

--- a/delta_baseline_test.go
+++ b/delta_baseline_test.go
@@ -1,6 +1,10 @@
 package qdf
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+)
 
 func TestBaselineRegistryEmpty(t *testing.T) {
 	r := NewBaselineRegistry[dnTop]()
@@ -9,5 +13,64 @@ func TestBaselineRegistryEmpty(t *testing.T) {
 	}
 	if got := r.Len(); got != 0 {
 		t.Fatalf("empty registry Len() = %d, want 0", got)
+	}
+}
+
+func TestDeepCloneFidelity(t *testing.T) {
+	td, err := descOf(reflect.TypeFor[dnTop]())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for seed := int64(0); seed < 200; seed++ {
+		v := gen[dnTop](seed)
+		c := deepClone(&v)
+		if !reflect.DeepEqual(*c, v) {
+			t.Fatalf("seed %d: clone not DeepEqual to original", seed)
+		}
+		fpV := valueFingerprint(td, unsafe.Pointer(&v))
+		fpC := valueFingerprint(td, unsafe.Pointer(c))
+		if fpV != fpC {
+			t.Fatalf("seed %d: clone fingerprint %x != original %x", seed, fpC, fpV)
+		}
+	}
+}
+
+func TestDeepCloneNilVsEmpty(t *testing.T) {
+	type S struct {
+		NilSlice   []int
+		EmptySlice []int
+		NilMap     map[string]int
+		EmptyMap   map[string]int
+	}
+	v := S{EmptySlice: []int{}, EmptyMap: map[string]int{}}
+	c := deepClone(&v)
+	if c.NilSlice != nil {
+		t.Error("nil slice became non-nil")
+	}
+	if c.EmptySlice == nil {
+		t.Error("empty slice became nil")
+	}
+	if c.NilMap != nil {
+		t.Error("nil map became non-nil")
+	}
+	if c.EmptyMap == nil {
+		t.Error("empty map became nil")
+	}
+}
+
+func TestDeepCloneIndependent(t *testing.T) {
+	type S struct {
+		Xs []int
+		M  map[string]int
+	}
+	v := S{Xs: []int{1, 2, 3}, M: map[string]int{"a": 1}}
+	c := deepClone(&v)
+	c.Xs[0] = 99
+	c.M["a"] = 99
+	if v.Xs[0] != 1 {
+		t.Error("mutating clone slice touched original")
+	}
+	if v.M["a"] != 1 {
+		t.Error("mutating clone map touched original")
 	}
 }

--- a/delta_baseline_test.go
+++ b/delta_baseline_test.go
@@ -149,3 +149,41 @@ func TestBaselineApplyNoFingerprint(t *testing.T) {
 	}
 	runtime.KeepAlive(s0)
 }
+
+func TestBaselineApplyEvicted(t *testing.T) {
+	r := NewBaselineRegistry[dnTop]()
+	s0 := gen[dnTop](1)
+	patch, err := Diff(s0, gen[dnTop](2), OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Register(&s0)
+	// Live strong ref → resolves.
+	if _, err := r.Apply(patch); err != nil {
+		t.Fatalf("Apply with live baseline: %v", err)
+	}
+	runtime.KeepAlive(s0)
+
+	// Separate registry whose only baseline goes out of scope → GC reclaims it.
+	r2 := NewBaselineRegistry[dnTop]()
+	func() {
+		local := gen[dnTop](1)
+		r2.Register(&local)
+	}()
+	runtime.GC()
+	runtime.GC()
+	if _, err := r2.Apply(patch); !errors.Is(err, ErrBaselineEvicted) {
+		t.Fatalf("Apply after GC = %v, want ErrBaselineEvicted", err)
+	}
+}
+
+func TestBaselineApplyUnknownBaseline(t *testing.T) {
+	r := NewBaselineRegistry[dnTop]()
+	patch, err := Diff(gen[dnTop](1), gen[dnTop](2), OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Apply(patch); !errors.Is(err, ErrBaselineEvicted) {
+		t.Fatalf("Apply of never-registered baseline = %v, want ErrBaselineEvicted", err)
+	}
+}

--- a/delta_columnar.go
+++ b/delta_columnar.go
@@ -1,0 +1,541 @@
+package qdf
+
+import (
+	"bytes"
+	"math/bits"
+	"reflect"
+	"time"
+	"unsafe"
+)
+
+// Columnar column-level diff. For an equal-length diff of a pure-columnar
+// []struct, group changes by column (sparse / arithmetic-delta / dense-whole
+// per column) and emit a tagColSlicePatch only when it is strictly smaller than
+// the positional patch (build-and-compare, never-larger). See
+// docs/superpowers/specs/2026-06-16-columnar-column-diff-design.md.
+
+// colDiffMode* are the per-column reconstruction modes in a tagColSlicePatch
+// body.
+const (
+	colDiffModeSparse     byte = 0 // changed-row indices + changed cells
+	colDiffModeDelta      byte = 1 // full per-row arithmetic delta (numeric/bool)
+	colDiffModeDenseWhole byte = 2 // whole new column re-shipped
+)
+
+// colDiffSparseNum/Den: a column with <= n*(Num/Den) changed cells prefers
+// sparse mode; otherwise delta/dense-whole. Benchstat-gated knob (Task 5).
+const (
+	colDiffSparseNum = 1
+	colDiffSparseDen = 4
+)
+
+// diffColumnarEligible reports whether a slice element type can use the
+// column-level diff: pure columnar (every field is a column, no residual).
+func diffColumnarEligible(elem *typeDesc) bool {
+	return elem != nil && elem.colPlan != nil && elem.colPlan.residual == nil
+}
+
+// colKindColumnDiffSupported reports whether a column's kind has a column-diff
+// encoder/decoder yet. (int/uint only in this phase; other kinds decline →
+// whole-slice falls back to the positional path.)
+func colKindColumnDiffSupported(col *colColumn) bool {
+	if col.kind.isNullable() {
+		return false
+	}
+	switch col.kind {
+	case colKindInt, colKindUint:
+		return true
+	default:
+		return false
+	}
+}
+
+// Benchstat (Intel i7-9750H, OptBalanced, clustered 1000-row batch, ~1/3 of one
+// int column changed; -benchmem -count=8): diff ~130 us/op, 22 KB, 23 allocs;
+// apply ~58 us/op, 25 KB, 3 allocs. Wire: column body 1007 B vs positional body
+// 3276 B (0.31x, a 3.25x shrink). The build-and-compare picker keeps the smaller
+// body, so the diff cost (positional build + column build) is paid only on an
+// eligible equal-length pure-columnar batch and the wire is never larger.
+// Decision: KEEP unconditionally — no pre-gate needed at this scale.
+//
+// diffColumnar attempts to write a tagColSlicePatch body that is smaller than
+// the positional body. It returns (true, nil) when it has placed the winning
+// body (column OR positional) into enc.buf, (false, nil) when an unsupported
+// column kind means the caller should fall back to the positional path, or
+// (false, err) on a real error. n == oldLen == newLen is guaranteed by the
+// caller. Exactly one body remains in enc.buf on a true return.
+func diffColumnar(enc *Encoder, elem *typeDesc, stride uintptr,
+	oldData, newData unsafe.Pointer, n, depth int) (bool, error) {
+	plan := elem.colPlan
+	if enc.state == nil {
+		enc.state = newEncState()
+	}
+	st := enc.state
+
+	// Detect which rows changed and, per column, which columns are affected. A
+	// column whose kind is not yet column-diff-supported forces a decline of the
+	// WHOLE slice only if it actually changed (an unchanged unsupported column
+	// emits nothing, so its presence is harmless). Decide before touching enc.buf.
+	st.deltaColBitmap = newChangedBitmap(st.deltaColBitmap, n)
+	markChangedRows(st.deltaColBitmap, plan, stride, oldData, newData, n)
+
+	// Build the positional body into enc.buf first (the comparison baseline).
+	posStart := len(enc.buf)
+	if err := diffElemsPositional(enc, elem, stride, oldData, n, newData, n, depth); err != nil {
+		return false, err
+	}
+	posLen := len(enc.buf) - posStart
+
+	body := st.deltaColBuf[:0]
+	body = append(body, tagColSlicePatch)
+	body = appendUvarint(body, uint64(n))
+	colCountPos := len(body)
+	body = appendUvarint(body, 0) // nChangedCols placeholder (single byte for <128 cols)
+	nChanged := 0
+	// Column codecs write through enc.buf; swap it to point at our scratch body,
+	// restore enc.buf afterward.
+	savedBuf := enc.buf
+	for ci := range plan.cols {
+		col := &plan.cols[ci]
+		rows := colChangedRows(st.deltaColRows, st.deltaColBitmap, col, stride, oldData, newData, n)
+		st.deltaColRows = rows
+		if len(rows) == 0 {
+			continue
+		}
+		if !colKindColumnDiffSupported(col) {
+			// A changed column we cannot encode → abandon the column patch; the
+			// positional body already in enc.buf handles the whole slice.
+			enc.buf = savedBuf
+			st.deltaColBuf = body[:0]
+			return true, nil
+		}
+		nChanged++
+		body = appendUvarint(body, uint64(ci))
+		mode := pickColMode(col, len(rows), n)
+		body = append(body, mode)
+		enc.buf = body
+		var err error
+		switch mode {
+		case colDiffModeSparse:
+			err = encodeSparseColumn(enc, col, stride, oldData, newData, rows)
+		case colDiffModeDelta:
+			err = encodeDeltaColumn(enc, col, stride, oldData, newData, n)
+		default:
+			err = ErrInvalidPatch
+		}
+		if err != nil {
+			enc.buf = savedBuf
+			st.deltaColBuf = body[:0]
+			return false, err
+		}
+		body = enc.buf
+	}
+	enc.buf = savedBuf
+	// Patch the nChangedCols count (always < 128 columns → single uvarint byte).
+	body[colCountPos] = byte(nChanged)
+	st.deltaColBuf = body
+
+	// Never-larger: keep the column body only if it strictly beats positional.
+	if len(body) < posLen {
+		enc.buf = enc.buf[:posStart]
+		enc.buf = append(enc.buf, body...)
+	}
+	// Otherwise the positional body already sits in enc.buf and wins. Either
+	// way exactly one body remains and the slice is handled.
+	return true, nil
+}
+
+// newChangedBitmap returns a []uint64 with ceil(n/64) words, reusing dst's
+// backing when large enough, cleared to zero.
+func newChangedBitmap(dst []uint64, n int) []uint64 {
+	words := (n + 63) >> 6
+	if cap(dst) >= words {
+		dst = dst[:words]
+		for i := range dst {
+			dst[i] = 0
+		}
+		return dst
+	}
+	return make([]uint64, words)
+}
+
+// markChangedRows sets bit i for every row whose bytes differ between old and
+// new. Returns true if any row changed. The pure-columnar element may carry
+// strings ([]byte/string columns make it non-POD), so compare per column rather
+// than assuming a flat byte span.
+func markChangedRows(bm []uint64, plan *columnarPlan, stride uintptr,
+	oldData, newData unsafe.Pointer, n int) bool {
+	any := false
+	for ci := range plan.cols {
+		col := &plan.cols[ci]
+		for i := range n {
+			if bm[i>>6]&(1<<(uint(i)&63)) != 0 {
+				continue // already marked by an earlier column
+			}
+			if !colCellEqual(col, stride, oldData, newData, i) {
+				bm[i>>6] |= 1 << (uint(i) & 63)
+				any = true
+			}
+		}
+	}
+	return any
+}
+
+// colChangedRows appends, in ascending order, the indices where col differs
+// between old and new, restricted to rows already flagged in bm (iterating bm
+// via bits.TrailingZeros64 word-skip). dst is reused.
+func colChangedRows(dst []int, bm []uint64, col *colColumn,
+	stride uintptr, oldData, newData unsafe.Pointer, n int) []int {
+	dst = dst[:0]
+	for w := range bm {
+		word := bm[w]
+		base := w << 6
+		for word != 0 {
+			b := bits.TrailingZeros64(word)
+			word &= word - 1
+			i := base + b
+			if i >= n {
+				break
+			}
+			if !colCellEqual(col, stride, oldData, newData, i) {
+				dst = append(dst, i)
+			}
+		}
+	}
+	return dst
+}
+
+// colCellEqual reports whether column col's cell i is byte/value-equal between
+// old and new.
+func colCellEqual(col *colColumn, stride uintptr, oldData, newData unsafe.Pointer, i int) bool {
+	off := uintptr(i)*stride + col.offset
+	op := unsafe.Add(oldData, off)
+	np := unsafe.Add(newData, off)
+	if col.kind.isNullable() {
+		return nullableCellEqual(col, op, np)
+	}
+	switch col.kind {
+	case colKindString:
+		if col.isByte {
+			return bytes.Equal(*(*[]byte)(op), *(*[]byte)(np))
+		}
+		return *(*string)(op) == *(*string)(np)
+	case colKindTime:
+		ot := (*time.Time)(op).UTC()
+		nt := (*time.Time)(np).UTC()
+		return ot.Unix() == nt.Unix() && ot.Nanosecond() == nt.Nanosecond()
+	default:
+		// pointer-free scalar: compare width bytes.
+		w := col.width
+		return bytes.Equal(unsafe.Slice((*byte)(op), w), unsafe.Slice((*byte)(np), w))
+	}
+}
+
+// nullableCellEqual compares two *T cells: both nil, or both non-nil with equal
+// pointees (string by value, otherwise width-bytes).
+func nullableCellEqual(col *colColumn, op, np unsafe.Pointer) bool {
+	pa := *(*unsafe.Pointer)(op)
+	pb := *(*unsafe.Pointer)(np)
+	if pa == nil || pb == nil {
+		return pa == pb
+	}
+	switch col.kind.base() {
+	case colKindString:
+		return *(*string)(pa) == *(*string)(pb)
+	default:
+		return bytes.Equal(unsafe.Slice((*byte)(pa), col.width), unsafe.Slice((*byte)(pb), col.width))
+	}
+}
+
+// pickColMode chooses the reconstruction mode for a column given how many of
+// its n cells changed. Size heuristic only — the top-level build-and-compare is
+// the never-larger guarantee.
+func pickColMode(col *colColumn, nChanged, n int) byte {
+	if nChanged*colDiffSparseDen <= n*colDiffSparseNum {
+		return colDiffModeSparse
+	}
+	switch col.kind {
+	case colKindInt, colKindUint, colKindBool:
+		return colDiffModeDelta
+	default:
+		return colDiffModeDenseWhole
+	}
+}
+
+// encodeSparseColumn writes nChanged, the gap-encoded ascending row indices, and
+// the changed cells as a length-nChanged subcolumn via the column codec.
+func encodeSparseColumn(enc *Encoder, col *colColumn,
+	stride uintptr, oldData, newData unsafe.Pointer, rows []int) error {
+	_ = oldData
+	enc.buf = appendUvarint(enc.buf, uint64(len(rows)))
+	prev := 0
+	for _, r := range rows {
+		enc.buf = appendUvarint(enc.buf, uint64(r-prev))
+		prev = r
+	}
+	st := enc.state
+	switch col.kind {
+	case colKindInt:
+		s := st.colScratchI64[:0]
+		for _, r := range rows {
+			s = append(s, loadIntCell(col, stride, newData, r))
+		}
+		st.colScratchI64 = s
+		return encodeSliceInt64(enc, unsafe.Pointer(&s))
+	case colKindUint:
+		s := st.colScratchU64[:0]
+		for _, r := range rows {
+			s = append(s, loadUintCell(col, stride, newData, r))
+		}
+		st.colScratchU64 = s
+		return encodeSliceUint64(enc, unsafe.Pointer(&s))
+	}
+	return ErrInvalidPatch
+}
+
+// encodeDeltaColumn writes the full-length per-row arithmetic delta column
+// (new[i] - old[i]). Unchanged cells are 0 → delta/FOR/RLE crush them.
+func encodeDeltaColumn(enc *Encoder, col *colColumn,
+	stride uintptr, oldData, newData unsafe.Pointer, n int) error {
+	st := enc.state
+	switch col.kind {
+	case colKindInt:
+		s := st.colScratchI64[:0]
+		for i := range n {
+			s = append(s, loadIntCell(col, stride, newData, i)-loadIntCell(col, stride, oldData, i))
+		}
+		st.colScratchI64 = s
+		return encodeSliceInt64(enc, unsafe.Pointer(&s))
+	case colKindUint:
+		s := st.colScratchU64[:0]
+		for i := range n {
+			s = append(s, loadUintCell(col, stride, newData, i)-loadUintCell(col, stride, oldData, i))
+		}
+		st.colScratchU64 = s
+		return encodeSliceUint64(enc, unsafe.Pointer(&s))
+	}
+	return ErrInvalidPatch
+}
+
+// loadIntCell / loadUintCell read a width-normalized scalar from a column cell.
+func loadIntCell(col *colColumn, stride uintptr, data unsafe.Pointer, i int) int64 {
+	p := unsafe.Add(data, uintptr(i)*stride+col.offset)
+	switch col.width {
+	case 1:
+		return int64(*(*int8)(p))
+	case 2:
+		return int64(*(*int16)(p))
+	case 4:
+		return int64(*(*int32)(p))
+	default:
+		return *(*int64)(p)
+	}
+}
+
+func loadUintCell(col *colColumn, stride uintptr, data unsafe.Pointer, i int) uint64 {
+	p := unsafe.Add(data, uintptr(i)*stride+col.offset)
+	switch col.width {
+	case 1:
+		return uint64(*(*uint8)(p))
+	case 2:
+		return uint64(*(*uint16)(p))
+	case 4:
+		return uint64(*(*uint32)(p))
+	default:
+		return *(*uint64)(p)
+	}
+}
+
+func storeIntCell(col *colColumn, stride uintptr, data unsafe.Pointer, i int, v int64) {
+	p := unsafe.Add(data, uintptr(i)*stride+col.offset)
+	switch col.width {
+	case 1:
+		*(*int8)(p) = int8(v)
+	case 2:
+		*(*int16)(p) = int16(v)
+	case 4:
+		*(*int32)(p) = int32(v)
+	default:
+		*(*int64)(p) = v
+	}
+}
+
+func storeUintCell(col *colColumn, stride uintptr, data unsafe.Pointer, i int, v uint64) {
+	p := unsafe.Add(data, uintptr(i)*stride+col.offset)
+	switch col.width {
+	case 1:
+		*(*uint8)(p) = uint8(v)
+	case 2:
+		*(*uint16)(p) = uint16(v)
+	case 4:
+		*(*uint32)(p) = uint32(v)
+	default:
+		*(*uint64)(p) = v
+	}
+}
+
+// applyColSlice applies a tagColSlicePatch onto the base slice at baseP. It does
+// not recurse (every column is a flat reconstruction), so it takes no depth.
+func applyColSlice(dec *Decoder, td *typeDesc, baseP unsafe.Pointer) error {
+	if dec.i >= len(dec.buf) || dec.buf[dec.i] != tagColSlicePatch {
+		return ErrInvalidPatch
+	}
+	dec.i++
+	elem := td.elem
+	if elem == nil {
+		elem, _ = descOf(td.rType.Elem())
+	}
+	if elem == nil || elem.colPlan == nil {
+		return ErrInvalidPatch
+	}
+	plan := elem.colPlan
+	n64, k := readUvarint(dec.buf[dec.i:])
+	if k <= 0 {
+		return ErrInvalidPatch
+	}
+	dec.i += k
+	bv := reflect.NewAt(td.rType, baseP).Elem()
+	if int64(n64) != int64(bv.Len()) {
+		return ErrInvalidPatch // equal-length invariant
+	}
+	n := int(n64)
+	base := (*sliceHeader)(baseP).Data
+	if dec.state == nil {
+		dec.state = newDecState()
+	}
+	nCols64, k2 := readUvarint(dec.buf[dec.i:])
+	if k2 <= 0 || nCols64 > uint64(len(plan.cols)) {
+		return ErrInvalidPatch
+	}
+	dec.i += k2
+	prevCol := -1
+	for range int(nCols64) {
+		colIdx64, k3 := readUvarint(dec.buf[dec.i:])
+		if k3 <= 0 || colIdx64 >= uint64(len(plan.cols)) {
+			return ErrInvalidPatch
+		}
+		dec.i += k3
+		if int(colIdx64) <= prevCol {
+			return ErrInvalidPatch // columns must be ascending, no duplicates
+		}
+		prevCol = int(colIdx64)
+		col := &plan.cols[colIdx64]
+		if dec.i >= len(dec.buf) {
+			return ErrInvalidPatch
+		}
+		mode := dec.buf[dec.i]
+		dec.i++
+		var err error
+		switch mode {
+		case colDiffModeSparse:
+			err = applySparseColumn(dec, plan, col, base, n)
+		case colDiffModeDelta:
+			err = applyDeltaColumn(dec, plan, col, base, n)
+		case colDiffModeDenseWhole:
+			err = dec.decodeColumnInto(base, plan, col, n)
+		default:
+			err = ErrInvalidPatch
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applySparseColumn reads nChanged, gap-decodes ascending row indices, decodes
+// the length-nChanged subcolumn, and scatters into base at those rows.
+//
+// Gap encoding: gap[0] = idx0, gap[j] = idx[j] - idx[j-1] (>= 1 for j>0).
+func applySparseColumn(dec *Decoder, plan *columnarPlan, col *colColumn, base unsafe.Pointer, n int) error {
+	nc64, k := readUvarint(dec.buf[dec.i:])
+	if k <= 0 || nc64 > uint64(n) {
+		return ErrInvalidPatch
+	}
+	dec.i += k
+	nc := int(nc64)
+	st := dec.state
+	rows := st.deltaColRows[:0]
+	prev := -1
+	for j := range nc {
+		gap, kg := readUvarint(dec.buf[dec.i:])
+		if kg <= 0 {
+			return ErrInvalidPatch
+		}
+		dec.i += kg
+		var idx int
+		if j == 0 {
+			idx = int(gap)
+		} else {
+			if gap == 0 {
+				return ErrInvalidPatch // non-ascending
+			}
+			idx = prev + int(gap)
+		}
+		if idx < 0 || idx >= n {
+			return ErrInvalidPatch
+		}
+		rows = append(rows, idx)
+		prev = idx
+	}
+	st.deltaColRows = rows
+	switch col.kind {
+	case colKindInt:
+		if err := decodeSliceInt64Into(dec, &st.colScratchI64); err != nil {
+			return err
+		}
+		s := st.colScratchI64
+		if len(s) != nc {
+			return ErrTypeMismatch
+		}
+		for j, r := range rows {
+			storeIntCell(col, plan.stride, base, r, s[j])
+		}
+	case colKindUint:
+		if err := decodeSliceUint64Into(dec, &st.colScratchU64); err != nil {
+			return err
+		}
+		s := st.colScratchU64
+		if len(s) != nc {
+			return ErrTypeMismatch
+		}
+		for j, r := range rows {
+			storeUintCell(col, plan.stride, base, r, s[j])
+		}
+	default:
+		return ErrInvalidPatch
+	}
+	return nil
+}
+
+// applyDeltaColumn reads the full-length delta column and adds it onto base.
+func applyDeltaColumn(dec *Decoder, plan *columnarPlan, col *colColumn, base unsafe.Pointer, n int) error {
+	st := dec.state
+	switch col.kind {
+	case colKindInt:
+		if err := decodeSliceInt64Into(dec, &st.colScratchI64); err != nil {
+			return err
+		}
+		s := st.colScratchI64
+		if len(s) != n {
+			return ErrTypeMismatch
+		}
+		for i := range n {
+			storeIntCell(col, plan.stride, base, i, loadIntCell(col, plan.stride, base, i)+s[i])
+		}
+	case colKindUint:
+		if err := decodeSliceUint64Into(dec, &st.colScratchU64); err != nil {
+			return err
+		}
+		s := st.colScratchU64
+		if len(s) != n {
+			return ErrTypeMismatch
+		}
+		for i := range n {
+			storeUintCell(col, plan.stride, base, i, loadUintCell(col, plan.stride, base, i)+s[i])
+		}
+	default:
+		return ErrInvalidPatch
+	}
+	return nil
+}

--- a/delta_columnar.go
+++ b/delta_columnar.go
@@ -40,15 +40,34 @@ func diffColumnarEligible(colPlan *columnarPlan) bool {
 }
 
 // colKindColumnDiffSupported reports whether a column's kind has a column-diff
-// encoder/decoder yet. (int/uint only in this phase; other kinds decline →
-// whole-slice falls back to the positional path.)
+// encoder/decoder. Nullable columns are dense-whole only (pickColMode forces
+// it).
+//
+// BLOCKED: string/[]byte columns (and nullable with a string base) are gated
+// OUT of the column path and fall back to the positional differ. They encode
+// through the stateful intern / state-table machinery (tagStateRef/tagStateMTF,
+// string-dict/FSST shape IDs), but diffColumnar's build-and-compare picker
+// builds the positional body AND the column body on the SAME encoder state. The
+// discarded loser's string emissions pollute enc.state's intern table, so the
+// kept body emits state-table refs the decoder never built → "unknown
+// state-table id" on Apply. The fix needs encoder-state isolation between the
+// two candidate builds (snapshot/restore, or measure positional on a throwaway
+// encoder and re-encode only the winner on the real one); this is a picker
+// design change beyond the per-kind extension and is not specified in the plan.
+// The stateless kinds (int/uint/float/float32/bool/time, nullable-scalar) are
+// unaffected and fully supported.
 func colKindColumnDiffSupported(col *colColumn) bool {
 	if col.kind.isNullable() {
-		return false
+		// Dense-whole only (pickColMode forces it). A string base re-ships through
+		// the stateful string column codec → same pollution hazard; gate it out.
+		return col.kind.base() != colKindString
 	}
 	switch col.kind {
-	case colKindInt, colKindUint:
+	case colKindInt, colKindUint, colKindFloat, colKindFloat32,
+		colKindBool, colKindTime:
 		return true
+	case colKindString:
+		return false // stateful intern codec; see the doc comment above (BLOCKED)
 	default:
 		return false
 	}
@@ -123,6 +142,8 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 			err = encodeSparseColumn(enc, col, stride, oldData, newData, rows)
 		case colDiffModeDelta:
 			err = encodeDeltaColumn(enc, col, stride, oldData, newData, n)
+		case colDiffModeDenseWhole:
+			err = enc.encodeOneColumn(plan, newData, col, n)
 		default:
 			err = ErrInvalidPatch
 		}
@@ -254,19 +275,25 @@ func nullableCellEqual(col *colColumn, op, np unsafe.Pointer) bool {
 // its n cells changed. Size heuristic only — the top-level build-and-compare is
 // the never-larger guarantee.
 func pickColMode(col *colColumn, nChanged, n int) byte {
+	if col.kind.isNullable() {
+		return colDiffModeDenseWhole // nullable: whole-column re-ship only
+	}
 	if nChanged*colDiffSparseDen <= n*colDiffSparseNum {
 		return colDiffModeSparse
 	}
 	switch col.kind {
 	case colKindInt, colKindUint, colKindBool:
 		return colDiffModeDelta
-	default:
+	default: // float, float32, string, []byte, time
 		return colDiffModeDenseWhole
 	}
 }
 
 // encodeSparseColumn writes nChanged, the gap-encoded ascending row indices, and
-// the changed cells as a length-nChanged subcolumn via the column codec.
+// the changed cells as a length-nChanged subcolumn via the column codec. Only
+// int/uint/bool reach this via sparse mode for some kinds; float/float32/string/
+// []byte/time can also be sparse (pickColMode returns sparse when changes are
+// few), but never delta.
 func encodeSparseColumn(enc *Encoder, col *colColumn,
 	stride uintptr, oldData, newData unsafe.Pointer, rows []int) error {
 	_ = oldData
@@ -292,6 +319,60 @@ func encodeSparseColumn(enc *Encoder, col *colColumn,
 		}
 		st.colScratchU64 = s
 		return encodeSliceUint64(enc, unsafe.Pointer(&s))
+	case colKindFloat:
+		s := st.colScratchF64[:0]
+		for _, r := range rows {
+			s = append(s, loadFloat64Field(newData, stride, col, r))
+		}
+		st.colScratchF64 = s
+		return encodeSliceFloat64(enc, unsafe.Pointer(&s))
+	case colKindFloat32:
+		s := st.colScratchU64[:0]
+		for _, r := range rows {
+			s = append(s, loadFloat32Bits(newData, stride, col, r))
+		}
+		st.colScratchU64 = s
+		return encodeSliceUint64(enc, unsafe.Pointer(&s))
+	case colKindBool:
+		s := st.colScratchBool[:0]
+		for _, r := range rows {
+			p := unsafe.Add(newData, uintptr(r)*stride+col.offset)
+			s = append(s, *(*bool)(p))
+		}
+		st.colScratchBool = s
+		return encodeSliceBool(enc, unsafe.Pointer(&s))
+	case colKindString:
+		if col.isByte {
+			// Producer/decoder contract: per-cell WriteBytes, decoded per-cell via
+			// readStringBytes() in applySparseColumn (NOT readStringColumn).
+			for _, r := range rows {
+				p := unsafe.Add(newData, uintptr(r)*stride+col.offset)
+				enc.WriteBytes(*(*[]byte)(p))
+			}
+			return nil
+		}
+		s := st.colScratchStr[:0]
+		for _, r := range rows {
+			s = append(s, loadStringField(newData, stride, col, r))
+		}
+		st.colScratchStr = s
+		enc.writeStringColumn(s)
+		return nil
+	case colKindTime:
+		sec := st.colScratchI64[:0]
+		nsec := st.colScratchU64[:0]
+		for _, r := range rows {
+			p := unsafe.Add(newData, uintptr(r)*stride+col.offset)
+			tt := (*time.Time)(p).UTC()
+			sec = append(sec, tt.Unix())
+			nsec = append(nsec, uint64(tt.Nanosecond()))
+		}
+		st.colScratchI64 = sec
+		st.colScratchU64 = nsec
+		if err := encodeSliceInt64(enc, unsafe.Pointer(&sec)); err != nil {
+			return err
+		}
+		return encodeSliceUint64(enc, unsafe.Pointer(&nsec))
 	}
 	return ErrInvalidPatch
 }
@@ -316,6 +397,16 @@ func encodeDeltaColumn(enc *Encoder, col *colColumn,
 		}
 		st.colScratchU64 = s
 		return encodeSliceUint64(enc, unsafe.Pointer(&s))
+	case colKindBool:
+		// changed-flag column: true where the cell flipped. Apply XORs base where set.
+		s := st.colScratchBool[:0]
+		for i := range n {
+			po := unsafe.Add(oldData, uintptr(i)*stride+col.offset)
+			pn := unsafe.Add(newData, uintptr(i)*stride+col.offset)
+			s = append(s, *(*bool)(po) != *(*bool)(pn))
+		}
+		st.colScratchBool = s
+		return encodeSliceBool(enc, unsafe.Pointer(&s))
 	}
 	return ErrInvalidPatch
 }
@@ -514,6 +605,84 @@ func applySparseColumn(dec *Decoder, plan *columnarPlan, col *colColumn, base un
 		for j, r := range rows {
 			storeUintCell(col, plan.stride, base, r, s[j])
 		}
+	case colKindFloat:
+		if err := decodeSliceFloat64Into(dec, &st.colScratchF64); err != nil {
+			return err
+		}
+		s := st.colScratchF64
+		if len(s) != nc {
+			return ErrTypeMismatch
+		}
+		for j, r := range rows {
+			storeFloat64(base, plan.stride, col, r, s[j])
+		}
+	case colKindFloat32:
+		if err := decodeSliceUint64Into(dec, &st.colScratchU64); err != nil {
+			return err
+		}
+		s := st.colScratchU64
+		if len(s) != nc {
+			return ErrTypeMismatch
+		}
+		for j, r := range rows {
+			storeFloat32Bits(base, plan.stride, col, r, s[j])
+		}
+	case colKindBool:
+		if err := decodeSliceBoolInto(dec, &st.colScratchBool); err != nil {
+			return err
+		}
+		s := st.colScratchBool
+		if len(s) != nc {
+			return ErrTypeMismatch
+		}
+		for j, r := range rows {
+			*(*bool)(unsafe.Add(base, uintptr(r)*plan.stride+col.offset)) = s[j]
+		}
+	case colKindString:
+		if col.isByte {
+			// Producer wrote per-cell WriteBytes → decode per-cell readStringBytes.
+			for _, r := range rows {
+				sb, err := dec.readStringBytes()
+				if err != nil {
+					return err
+				}
+				dp := unsafe.Add(base, uintptr(r)*plan.stride+col.offset)
+				*(*[]byte)(dp) = append([]byte(nil), sb...)
+			}
+		} else {
+			strs, err := dec.readStringColumn(nc)
+			if err != nil {
+				return err
+			}
+			if len(strs) != nc {
+				return ErrTypeMismatch
+			}
+			for j, r := range rows {
+				*(*string)(unsafe.Add(base, uintptr(r)*plan.stride+col.offset)) = strs[j]
+			}
+		}
+	case colKindTime:
+		if err := decodeSliceInt64Into(dec, &st.colScratchI64); err != nil {
+			return err
+		}
+		sec := st.colScratchI64 // distinct scratch from nsec (U64) → no copy needed
+		if len(sec) != nc {
+			return ErrTypeMismatch
+		}
+		if err := decodeSliceUint64Into(dec, &st.colScratchU64); err != nil {
+			return err
+		}
+		nsec := st.colScratchU64
+		if len(nsec) != nc {
+			return ErrTypeMismatch
+		}
+		if err := checkNsecColumn(nsec); err != nil {
+			return err
+		}
+		for j, r := range rows {
+			dp := unsafe.Add(base, uintptr(r)*plan.stride+col.offset)
+			*(*time.Time)(dp) = time.Unix(sec[j], int64(nsec[j])).UTC()
+		}
 	default:
 		return ErrInvalidPatch
 	}
@@ -545,6 +714,21 @@ func applyDeltaColumn(dec *Decoder, plan *columnarPlan, col *colColumn, base uns
 		}
 		for i := range n {
 			storeUintCell(col, plan.stride, base, i, loadUintCell(col, plan.stride, base, i)+s[i])
+		}
+	case colKindBool:
+		// changed-flag column: flip base where the flag is set.
+		if err := decodeSliceBoolInto(dec, &st.colScratchBool); err != nil {
+			return err
+		}
+		s := st.colScratchBool
+		if len(s) != n {
+			return ErrTypeMismatch
+		}
+		for i := range n {
+			if s[i] {
+				p := unsafe.Add(base, uintptr(i)*plan.stride+col.offset)
+				*(*bool)(p) = !*(*bool)(p)
+			}
 		}
 	default:
 		return ErrInvalidPatch

--- a/delta_columnar.go
+++ b/delta_columnar.go
@@ -29,10 +29,14 @@ const (
 	colDiffSparseDen = 4
 )
 
-// diffColumnarEligible reports whether a slice element type can use the
-// column-level diff: pure columnar (every field is a column, no residual).
-func diffColumnarEligible(elem *typeDesc) bool {
-	return elem != nil && elem.colPlan != nil && elem.colPlan.residual == nil
+// diffColumnarEligible reports whether a slice's columnar plan can use the
+// column-level diff: pure columnar (every field is a column, no residual) with
+// fewer than 128 columns. The 128 cap keeps the nChangedCols count a single
+// uvarint byte (nChanged <= len(cols) < 128 < 0x80), so the placeholder-patch
+// in diffColumnar is always valid; a struct with >=128 columns (pathological)
+// declines to the positional path.
+func diffColumnarEligible(colPlan *columnarPlan) bool {
+	return colPlan != nil && colPlan.residual == nil && len(colPlan.cols) < 128
 }
 
 // colKindColumnDiffSupported reports whether a column's kind has a column-diff
@@ -64,9 +68,8 @@ func colKindColumnDiffSupported(col *colColumn) bool {
 // column kind means the caller should fall back to the positional path, or
 // (false, err) on a real error. n == oldLen == newLen is guaranteed by the
 // caller. Exactly one body remains in enc.buf on a true return.
-func diffColumnar(enc *Encoder, elem *typeDesc, stride uintptr,
+func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintptr,
 	oldData, newData unsafe.Pointer, n, depth int) (bool, error) {
-	plan := elem.colPlan
 	if enc.state == nil {
 		enc.state = newEncState()
 	}
@@ -381,14 +384,12 @@ func applyColSlice(dec *Decoder, td *typeDesc, baseP unsafe.Pointer) error {
 		return ErrInvalidPatch
 	}
 	dec.i++
-	elem := td.elem
-	if elem == nil {
-		elem, _ = descOf(td.rType.Elem())
-	}
-	if elem == nil || elem.colPlan == nil {
+	// The columnar plan lives on the slice descriptor (td.colPlan), built by
+	// descBuild; it is not mirrored onto the element desc.
+	plan := td.colPlan
+	if plan == nil {
 		return ErrInvalidPatch
 	}
-	plan := elem.colPlan
 	n64, k := readUvarint(dec.buf[dec.i:])
 	if k <= 0 {
 		return ErrInvalidPatch
@@ -403,6 +404,12 @@ func applyColSlice(dec *Decoder, td *typeDesc, baseP unsafe.Pointer) error {
 	if dec.state == nil {
 		dec.state = newDecState()
 	}
+	// Bound every column codec's element claim to n (matches decodeColumnInto and
+	// the other columnar decode sites); applySparseColumn tightens it to nc for
+	// the subcolumn. Defends against an allocation-amplification patch.
+	savedColMax := dec.colMaxLen
+	dec.colMaxLen = n
+	defer func() { dec.colMaxLen = savedColMax }()
 	nCols64, k2 := readUvarint(dec.buf[dec.i:])
 	if k2 <= 0 || nCols64 > uint64(len(plan.cols)) {
 		return ErrInvalidPatch
@@ -479,6 +486,11 @@ func applySparseColumn(dec *Decoder, plan *columnarPlan, col *colColumn, base un
 		prev = idx
 	}
 	st.deltaColRows = rows
+	// The subcolumn has exactly nc elements; tighten the per-column bound so a
+	// codec cannot claim more than the changed-cell count before the len check.
+	savedColMax := dec.colMaxLen
+	dec.colMaxLen = nc
+	defer func() { dec.colMaxLen = savedColMax }()
 	switch col.kind {
 	case colKindInt:
 		if err := decodeSliceInt64Into(dec, &st.colScratchI64); err != nil {

--- a/delta_columnar.go
+++ b/delta_columnar.go
@@ -43,31 +43,30 @@ func diffColumnarEligible(colPlan *columnarPlan) bool {
 // encoder/decoder. Nullable columns are dense-whole only (pickColMode forces
 // it).
 //
-// BLOCKED: string/[]byte columns (and nullable with a string base) are gated
-// OUT of the column path and fall back to the positional differ. They encode
-// through the stateful intern / state-table machinery (tagStateRef/tagStateMTF,
-// string-dict/FSST shape IDs), but diffColumnar's build-and-compare picker
-// builds the positional body AND the column body on the SAME encoder state. The
-// discarded loser's string emissions pollute enc.state's intern table, so the
-// kept body emits state-table refs the decoder never built → "unknown
-// state-table id" on Apply. The fix needs encoder-state isolation between the
-// two candidate builds (snapshot/restore, or measure positional on a throwaway
-// encoder and re-encode only the winner on the real one); this is a picker
-// design change beyond the per-kind extension and is not specified in the plan.
-// The stateless kinds (int/uint/float/float32/bool/time, nullable-scalar) are
-// unaffected and fully supported.
+// String/[]byte columns are supported via the wire-stateless dict/raw codecs
+// (writeStringColumnStateless): those bodies ship their own table/indices and
+// touch e.state only for scratch, so they can be built on the shared encoder
+// state during diffColumnar's build-and-compare without polluting the intern
+// state table. The stateful intern fallback (e.WriteString) and FSST are never
+// used on this path.
+//
+// BLOCKED: nullable with a STRING base. encodeNullableColumn's string case calls
+// the stateful e.writeStringColumn (which can fall through to e.WriteString),
+// and nullable columns only have a dense-whole path (encodeOneColumn →
+// encodeNullableColumn), so there is no stateless route for it yet. It stays
+// gated out and falls back to the positional differ. All other nullable bases
+// (int/uint/float/float32/bool/time) are stateless and fully supported.
 func colKindColumnDiffSupported(col *colColumn) bool {
 	if col.kind.isNullable() {
 		// Dense-whole only (pickColMode forces it). A string base re-ships through
-		// the stateful string column codec → same pollution hazard; gate it out.
+		// the stateful nullable string codec (encodeNullableColumn → WriteString),
+		// for which there is no stateless route → gate it out.
 		return col.kind.base() != colKindString
 	}
 	switch col.kind {
 	case colKindInt, colKindUint, colKindFloat, colKindFloat32,
-		colKindBool, colKindTime:
+		colKindBool, colKindTime, colKindString:
 		return true
-	case colKindString:
-		return false // stateful intern codec; see the doc comment above (BLOCKED)
 	default:
 		return false
 	}
@@ -143,7 +142,21 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 		case colDiffModeDelta:
 			err = encodeDeltaColumn(enc, col, stride, oldData, newData, n)
 		case colDiffModeDenseWhole:
-			err = enc.encodeOneColumn(plan, newData, col, n)
+			if col.kind.base() == colKindString {
+				// encodeOneColumn's string path can hit the stateful intern fallback
+				// (writeStringColumn → WriteString) and pollute enc.state shared with
+				// the discarded positional body. Gather the whole column and emit a
+				// wire-stateless dict/raw body instead. Non-string kinds are stateless
+				// and use encodeOneColumn unchanged.
+				s := st.colScratchStr[:0]
+				for i := range n {
+					s = append(s, loadStringField(newData, stride, col, i))
+				}
+				st.colScratchStr = s
+				enc.writeStringColumnStateless(s)
+			} else {
+				err = enc.encodeOneColumn(plan, newData, col, n)
+			}
 		default:
 			err = ErrInvalidPatch
 		}
@@ -289,6 +302,21 @@ func pickColMode(col *colColumn, nChanged, n int) byte {
 	}
 }
 
+// writeStringColumnStateless emits a string column using only self-contained
+// codecs (dict or raw), never the stateful intern fallback (e.WriteString) or
+// FSST — safe to build on a shared encoder state during the column-diff
+// build-and-compare. The dict/raw bodies ship their own table/indices and read
+// e.state only for scratch, so the discarded loser body cannot pollute the
+// intern state table and the kept body never emits a state-table ref the decoder
+// did not build. Decode is automatic: decodeColumnInto/readStringColumn dispatch
+// on the bulk tag we always emit.
+func (e *Encoder) writeStringColumnStateless(strs []string) {
+	if e.tryWriteStringColumnDict(strs) {
+		return
+	}
+	e.writeStringColumnRawForced(strs)
+}
+
 // encodeSparseColumn writes nChanged, the gap-encoded ascending row indices, and
 // the changed cells as a length-nChanged subcolumn via the column codec. Only
 // int/uint/bool reach this via sparse mode for some kinds; float/float32/string/
@@ -342,21 +370,16 @@ func encodeSparseColumn(enc *Encoder, col *colColumn,
 		st.colScratchBool = s
 		return encodeSliceBool(enc, unsafe.Pointer(&s))
 	case colKindString:
-		if col.isByte {
-			// Producer/decoder contract: per-cell WriteBytes, decoded per-cell via
-			// readStringBytes() in applySparseColumn (NOT readStringColumn).
-			for _, r := range rows {
-				p := unsafe.Add(newData, uintptr(r)*stride+col.offset)
-				enc.WriteBytes(*(*[]byte)(p))
-			}
-			return nil
-		}
+		// Both string and []byte columns gather the changed cells into a []string
+		// and emit a wire-stateless dict/raw body (never the intern fallback). A
+		// []byte field is viewed as a string via loadStringField (col.isByte), so
+		// the same codec handles both; the decoder copies back to owned bytes.
 		s := st.colScratchStr[:0]
 		for _, r := range rows {
 			s = append(s, loadStringField(newData, stride, col, r))
 		}
 		st.colScratchStr = s
-		enc.writeStringColumn(s)
+		enc.writeStringColumnStateless(s)
 		return nil
 	case colKindTime:
 		sec := st.colScratchI64[:0]
@@ -639,24 +662,22 @@ func applySparseColumn(dec *Decoder, plan *columnarPlan, col *colColumn, base un
 			*(*bool)(unsafe.Add(base, uintptr(r)*plan.stride+col.offset)) = s[j]
 		}
 	case colKindString:
+		// Producer emitted a wire-stateless dict/raw body (writeStringColumnStateless)
+		// for both string and []byte columns; readStringColumn dispatches on the
+		// bulk tag. dec.colMaxLen is already tightened to nc above.
+		strs, err := dec.readStringColumn(nc)
+		if err != nil {
+			return err
+		}
+		if len(strs) != nc {
+			return ErrTypeMismatch
+		}
 		if col.isByte {
-			// Producer wrote per-cell WriteBytes → decode per-cell readStringBytes.
-			for _, r := range rows {
-				sb, err := dec.readStringBytes()
-				if err != nil {
-					return err
-				}
+			for j, r := range rows {
 				dp := unsafe.Add(base, uintptr(r)*plan.stride+col.offset)
-				*(*[]byte)(dp) = append([]byte(nil), sb...)
+				*(*[]byte)(dp) = append([]byte(nil), strs[j]...)
 			}
 		} else {
-			strs, err := dec.readStringColumn(nc)
-			if err != nil {
-				return err
-			}
-			if len(strs) != nc {
-				return ErrTypeMismatch
-			}
 			for j, r := range rows {
 				*(*string)(unsafe.Add(base, uintptr(r)*plan.stride+col.offset)) = strs[j]
 			}

--- a/delta_columnar.go
+++ b/delta_columnar.go
@@ -98,7 +98,7 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 	// WHOLE slice only if it actually changed (an unchanged unsupported column
 	// emits nothing, so its presence is harmless). Decide before touching enc.buf.
 	st.deltaColBitmap = newChangedBitmap(st.deltaColBitmap, n)
-	markChangedRows(st.deltaColBitmap, plan, stride, oldData, newData, n)
+	markChangedRows(st.deltaColBitmap, plan, stride, oldData, newData, n, elem.pod)
 
 	// Build the positional body into enc.buf first (the comparison baseline).
 	posStart := len(enc.buf)
@@ -197,12 +197,30 @@ func newChangedBitmap(dst []uint64, n int) []uint64 {
 }
 
 // markChangedRows sets bit i for every row whose bytes differ between old and
-// new. Returns true if any row changed. The pure-columnar element may carry
-// strings ([]byte/string columns make it non-POD), so compare per column rather
-// than assuming a flat byte span.
+// new. Returns true if any row changed.
+//
+// For a pointer-free (POD) element a row changed iff its whole stride span
+// differs, so one SIMD bytes.Equal per row replaces a per-column-per-cell sweep
+// — the same block-memcmp fast path the positional differ uses (equalSliceEV).
+// A padding-only difference can spuriously flag a row, but then every column's
+// per-cell compare in colChangedRows finds no real change → the column is
+// skipped → no wrong data, only a wasted attribution pass (the documented POD
+// trade). A non-POD element (string/[]byte columns) must compare per column.
 func markChangedRows(bm []uint64, plan *columnarPlan, stride uintptr,
-	oldData, newData unsafe.Pointer, n int) bool {
+	oldData, newData unsafe.Pointer, n int, pod bool) bool {
 	any := false
+	if pod {
+		for i := range n {
+			off := uintptr(i) * stride
+			ob := unsafe.Slice((*byte)(unsafe.Add(oldData, off)), stride)
+			nb := unsafe.Slice((*byte)(unsafe.Add(newData, off)), stride)
+			if !bytes.Equal(ob, nb) {
+				bm[i>>6] |= 1 << (uint(i) & 63)
+				any = true
+			}
+		}
+		return any
+	}
 	for ci := range plan.cols {
 		col := &plan.cols[ci]
 		for i := range n {
@@ -407,19 +425,23 @@ func encodeDeltaColumn(enc *Encoder, col *colColumn,
 	st := enc.state
 	switch col.kind {
 	case colKindInt:
-		s := st.colScratchI64[:0]
-		for i := range n {
-			s = append(s, loadIntCell(col, stride, newData, i)-loadIntCell(col, stride, oldData, i))
+		// Gather new and old contiguously (each gather hoists the width switch
+		// once), then a vectorizable subtract — no per-element width branch.
+		cur := gatherColI64(st.colScratchI64, newData, stride, col, n)
+		prev := gatherColI64(st.deltaColAuxI64, oldData, stride, col, n)
+		st.colScratchI64, st.deltaColAuxI64 = cur, prev
+		for i := range cur {
+			cur[i] -= prev[i]
 		}
-		st.colScratchI64 = s
-		return encodeSliceInt64(enc, unsafe.Pointer(&s))
+		return encodeSliceInt64(enc, unsafe.Pointer(&cur))
 	case colKindUint:
-		s := st.colScratchU64[:0]
-		for i := range n {
-			s = append(s, loadUintCell(col, stride, newData, i)-loadUintCell(col, stride, oldData, i))
+		cur := gatherColU64(st.colScratchU64, newData, stride, col, n)
+		prev := gatherColU64(st.deltaColAuxU64, oldData, stride, col, n)
+		st.colScratchU64, st.deltaColAuxU64 = cur, prev
+		for i := range cur {
+			cur[i] -= prev[i]
 		}
-		st.colScratchU64 = s
-		return encodeSliceUint64(enc, unsafe.Pointer(&s))
+		return encodeSliceUint64(enc, unsafe.Pointer(&cur))
 	case colKindBool:
 		// changed-flag column: true where the cell flipped. Apply XORs base where set.
 		s := st.colScratchBool[:0]
@@ -434,61 +456,24 @@ func encodeDeltaColumn(enc *Encoder, col *colColumn,
 	return ErrInvalidPatch
 }
 
-// loadIntCell / loadUintCell read a width-normalized scalar from a column cell.
+// loadIntCell / loadUintCell / storeIntCell / storeUintCell read or write a
+// width-normalized scalar at column cell i. They reuse the loadI64At/loadU64At/
+// storeI64At/storeU64At width helpers (nullable_col.go) so the width switch
+// lives in one place.
 func loadIntCell(col *colColumn, stride uintptr, data unsafe.Pointer, i int) int64 {
-	p := unsafe.Add(data, uintptr(i)*stride+col.offset)
-	switch col.width {
-	case 1:
-		return int64(*(*int8)(p))
-	case 2:
-		return int64(*(*int16)(p))
-	case 4:
-		return int64(*(*int32)(p))
-	default:
-		return *(*int64)(p)
-	}
+	return loadI64At(unsafe.Add(data, uintptr(i)*stride+col.offset), col.width)
 }
 
 func loadUintCell(col *colColumn, stride uintptr, data unsafe.Pointer, i int) uint64 {
-	p := unsafe.Add(data, uintptr(i)*stride+col.offset)
-	switch col.width {
-	case 1:
-		return uint64(*(*uint8)(p))
-	case 2:
-		return uint64(*(*uint16)(p))
-	case 4:
-		return uint64(*(*uint32)(p))
-	default:
-		return *(*uint64)(p)
-	}
+	return loadU64At(unsafe.Add(data, uintptr(i)*stride+col.offset), col.width)
 }
 
 func storeIntCell(col *colColumn, stride uintptr, data unsafe.Pointer, i int, v int64) {
-	p := unsafe.Add(data, uintptr(i)*stride+col.offset)
-	switch col.width {
-	case 1:
-		*(*int8)(p) = int8(v)
-	case 2:
-		*(*int16)(p) = int16(v)
-	case 4:
-		*(*int32)(p) = int32(v)
-	default:
-		*(*int64)(p) = v
-	}
+	storeI64At(unsafe.Add(data, uintptr(i)*stride+col.offset), col.width, v)
 }
 
 func storeUintCell(col *colColumn, stride uintptr, data unsafe.Pointer, i int, v uint64) {
-	p := unsafe.Add(data, uintptr(i)*stride+col.offset)
-	switch col.width {
-	case 1:
-		*(*uint8)(p) = uint8(v)
-	case 2:
-		*(*uint16)(p) = uint16(v)
-	case 4:
-		*(*uint32)(p) = uint32(v)
-	default:
-		*(*uint64)(p) = v
-	}
+	storeU64At(unsafe.Add(data, uintptr(i)*stride+col.offset), col.width, v)
 }
 
 // applyColSlice applies a tagColSlicePatch onto the base slice at baseP. It does

--- a/delta_columnar_test.go
+++ b/delta_columnar_test.go
@@ -60,7 +60,7 @@ func TestColChangedAttribution(t *testing.T) {
 	nd := unsafe.Pointer(&neu[0])
 
 	bm := newChangedBitmap(nil, 64)
-	any := markChangedRows(bm, plan, stride, od, nd, 64)
+	any := markChangedRows(bm, plan, stride, od, nd, 64, false)
 	if !any {
 		t.Fatal("expected changes")
 	}

--- a/delta_columnar_test.go
+++ b/delta_columnar_test.go
@@ -511,3 +511,143 @@ func TestColDiffBytesColumn(t *testing.T) {
 		}
 	}
 }
+
+func TestColDiffApplyHostile(t *testing.T) {
+	old := make([]ccRow, 64)
+	for i := range old {
+		old[i] = ccRow{A: int64(i), B: uint32(i), F: float64(i)}
+	}
+	neu := append([]ccRow(nil), old...)
+	for i := 0; i < 64; i += 2 {
+		neu[i].A = int64(i) * 5
+	}
+	good, err := Diff(old, neu, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seeds := make([][]byte, 0, 3+len(good))
+	seeds = append(seeds, nil, []byte{}, []byte{0x00})
+	for i := range len(good) {
+		trunc := make([]byte, i)
+		copy(trunc, good[:i])
+		seeds = append(seeds, trunc)
+	}
+	for i, b := range seeds {
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					t.Fatalf("seed %d panicked: %v", i, rec)
+				}
+			}()
+			got := append([]ccRow(nil), old...)
+			_ = Apply(&got, b)
+		}()
+	}
+}
+
+func FuzzColDiffApply(f *testing.F) {
+	old := make([]ccRow, 32)
+	for i := range old {
+		old[i] = ccRow{A: int64(i), B: uint32(i), F: float64(i)}
+	}
+	neu := append([]ccRow(nil), old...)
+	neu[1].A = 5
+	if good, err := Diff(old, neu, OptBalanced); err == nil {
+		f.Add(good)
+	}
+	f.Add([]byte{})
+	f.Add([]byte("garbage"))
+	f.Fuzz(func(t *testing.T, patch []byte) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				t.Fatalf("panic on %x: %v", patch, rec)
+			}
+		}()
+		got := append([]ccRow(nil), old...)
+		_ = Apply(&got, patch)
+	})
+}
+
+func FuzzColDiffOracle(f *testing.F) {
+	f.Add(int64(1), uint8(3), uint8(5))
+	f.Fuzz(func(t *testing.T, seed int64, nMod, which uint8) {
+		const n = 80
+		old := make([]ccRow, n)
+		for i := range old {
+			old[i] = ccRow{A: int64(i) ^ seed, B: uint32(i), F: float64(i)}
+		}
+		neu := append([]ccRow(nil), old...)
+		r := seed
+		for k := 0; k < int(nMod)%n; k++ {
+			r = r*1103515245 + 12345
+			idx := int(uint64(r)>>33) % n
+			switch which % 3 {
+			case 0:
+				neu[idx].A += r
+			case 1:
+				neu[idx].B ^= uint32(r)
+			case 2:
+				neu[idx].F = float64(r)
+			}
+		}
+		patch, err := Diff(old, neu, OptBalanced)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := append([]ccRow(nil), old...)
+		if err := Apply(&got, patch); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, neu) {
+			t.Fatalf("oracle mismatch seed=%d", seed)
+		}
+	})
+}
+
+func TestColDiffLengthChange(t *testing.T) {
+	old := make([]ccRow, 64)
+	for i := range old {
+		old[i] = ccRow{A: int64(i)}
+	}
+	neu := append(append([]ccRow(nil), old...), ccRow{A: 999}) // grew by 1
+	patch, err := Diff(old, neu, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := append([]ccRow(nil), old...)
+	if err := Apply(&got, patch); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, neu) {
+		t.Fatal("length-change round-trip mismatch")
+	}
+}
+
+func TestColDiffHybridFallsBack(t *testing.T) {
+	type hybrid struct {
+		A int64
+		M map[string]int
+	}
+	n := 32
+	old := make([]hybrid, n)
+	neu := make([]hybrid, n)
+	for i := range old {
+		old[i] = hybrid{A: int64(i), M: map[string]int{"k": i}}
+		neu[i] = hybrid{A: int64(i), M: map[string]int{"k": i}}
+	}
+	neu[3].A = 100
+	patch, err := Diff(old, neu, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]hybrid, n)
+	for i := range old {
+		got[i] = hybrid{A: old[i].A, M: map[string]int{"k": i}}
+	}
+	if err := Apply(&got, patch); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, neu) {
+		t.Fatal("hybrid round-trip mismatch")
+	}
+}

--- a/delta_columnar_test.go
+++ b/delta_columnar_test.go
@@ -3,6 +3,7 @@ package qdf
 import (
 	"reflect"
 	"testing"
+	"time"
 	"unsafe"
 )
 
@@ -243,5 +244,96 @@ func BenchmarkColDiffApply(b *testing.B) {
 		if err := Apply(&got, patch); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+type ccAll struct {
+	I  int32
+	U  uint16
+	F  float64
+	F3 float32
+	Bo bool
+	S  string
+	By []byte
+	T  time.Time
+}
+
+func TestColDiffAllKinds(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	mk := func() []ccAll {
+		rows := make([]ccAll, 120)
+		for i := range rows {
+			rows[i] = ccAll{
+				I: int32(i), U: uint16(i), F: float64(i) * 1.5, F3: float32(i),
+				Bo: i%2 == 0, S: "v" + string(rune('a'+i%26)),
+				By: []byte{byte(i)}, T: base.Add(time.Duration(i) * time.Second),
+			}
+		}
+		return rows
+	}
+	mutators := map[string]func(*ccAll){
+		"int":     func(r *ccAll) { r.I += 1000 },
+		"uint":    func(r *ccAll) { r.U += 7 },
+		"float":   func(r *ccAll) { r.F += 0.25 },
+		"float32": func(r *ccAll) { r.F3 += 2 },
+		"bool":    func(r *ccAll) { r.Bo = !r.Bo },
+		"string":  func(r *ccAll) { r.S += "X" },
+		"bytes":   func(r *ccAll) { r.By = append(append([]byte(nil), r.By...), 0xFF) },
+		"time":    func(r *ccAll) { r.T = r.T.Add(time.Hour) },
+	}
+	for _, opt := range []Options{OptSpeed, OptBalanced, OptCompression} {
+		old := mk()
+		for name, mut := range mutators {
+			// sparse: mutate a few rows (ratio 20); dense/delta: mutate all (ratio 1).
+			for _, ratio := range []int{20, 1} {
+				neu := mk()
+				for i := range neu {
+					if ratio == 1 || i%ratio == 0 {
+						mut(&neu[i])
+					}
+				}
+				patch, err := Diff(old, neu, opt)
+				if err != nil {
+					t.Fatalf("%s/%v/ratio%d diff: %v", name, opt, ratio, err)
+				}
+				got := append([]ccAll(nil), old...)
+				if err := Apply(&got, patch); err != nil {
+					t.Fatalf("%s/%v/ratio%d apply: %v", name, opt, ratio, err)
+				}
+				if !reflect.DeepEqual(got, neu) {
+					t.Fatalf("%s/%v/ratio%d round-trip mismatch", name, opt, ratio)
+				}
+			}
+		}
+	}
+}
+
+func TestColDiffNullable(t *testing.T) {
+	type ccNull struct {
+		A int64
+		P *int32
+	}
+	n := 64
+	old := make([]ccNull, n)
+	neu := make([]ccNull, n)
+	for i := range old {
+		v := int32(i)
+		old[i] = ccNull{A: int64(i), P: &v}
+		w := int32(i)
+		neu[i] = ccNull{A: int64(i), P: &w}
+	}
+	x := int32(999)
+	neu[10].P = &x
+	neu[20].P = nil
+	patch, err := Diff(old, neu, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := append([]ccNull(nil), old...)
+	if err := Apply(&got, patch); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, neu) {
+		t.Fatal("nullable round-trip mismatch")
 	}
 }

--- a/delta_columnar_test.go
+++ b/delta_columnar_test.go
@@ -1,0 +1,243 @@
+package qdf
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+)
+
+type ccRow struct {
+	A int64
+	B uint32
+	F float64
+}
+
+func TestColDiffRoundTripPlaceholder(t *testing.T) {
+	old := make([]ccRow, 100)
+	neu := make([]ccRow, 100)
+	for i := range old {
+		old[i] = ccRow{A: int64(i), B: uint32(i), F: float64(i)}
+		neu[i] = old[i]
+	}
+	neu[5].A = 999
+	patch, err := Diff(old, neu, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]ccRow, 100)
+	copy(got, old)
+	if err := Apply(&got, patch); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, neu) {
+		t.Fatal("round-trip mismatch")
+	}
+}
+
+func TestColChangedAttribution(t *testing.T) {
+	old := make([]ccRow, 64)
+	neu := make([]ccRow, 64)
+	for i := range old {
+		old[i] = ccRow{A: int64(i), B: uint32(i), F: float64(i)}
+		neu[i] = old[i]
+	}
+	neu[3].A = 1  // col 0 (A) changed at row 3
+	neu[40].A = 2 // col 0 (A) changed at row 40
+	neu[7].F = 9  // col 2 (F) changed at row 7
+
+	td, err := descOf(reflect.TypeFor[ccRow]())
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := td.colPlan
+	stride := plan.stride
+	od := unsafe.Pointer(&old[0])
+	nd := unsafe.Pointer(&neu[0])
+
+	bm := newChangedBitmap(nil, 64)
+	any := markChangedRows(bm, plan, stride, od, nd, 64)
+	if !any {
+		t.Fatal("expected changes")
+	}
+	// Attribute column 0 (A): rows 3 and 40.
+	rows := colChangedRows(nil, bm, &plan.cols[0], stride, od, nd, 64)
+	if len(rows) != 2 || rows[0] != 3 || rows[1] != 40 {
+		t.Fatalf("col A changed rows = %v, want [3 40]", rows)
+	}
+	// Column 1 (B): unchanged.
+	rowsB := colChangedRows(nil, bm, &plan.cols[1], stride, od, nd, 64)
+	if len(rowsB) != 0 {
+		t.Fatalf("col B changed rows = %v, want []", rowsB)
+	}
+}
+
+func patchTag(patch []byte) (byte, bool) {
+	h, n, err := readPatchHeader(patch)
+	if err != nil {
+		return 0, false
+	}
+	body := patch[n:]
+	if h.flags&flagPatchRANS != 0 {
+		b, err := decompressPatchBody(body)
+		if err != nil {
+			return 0, false
+		}
+		body = b
+	}
+	// body = root op (opMerge) then the slice patch tag at body[1:].
+	if len(body) < 2 || body[0] != opMerge {
+		return 0, false
+	}
+	return body[1], true
+}
+
+func TestColDiffIntSparse(t *testing.T) {
+	old := make([]ccRow, 200)
+	neu := make([]ccRow, 200)
+	for i := range old {
+		old[i] = ccRow{A: int64(i * 7), B: uint32(i), F: float64(i)}
+		neu[i] = old[i]
+	}
+	neu[10].A = -1
+	neu[150].A = -2
+	patch, err := Diff(old, neu, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag, ok := patchTag(patch); !ok || tag != tagColSlicePatch {
+		t.Fatalf("expected tagColSlicePatch, got %#x ok=%v", tag, ok)
+	}
+	got := append([]ccRow(nil), old...)
+	if err := Apply(&got, patch); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, neu) {
+		t.Fatal("sparse int round-trip mismatch")
+	}
+}
+
+func TestColDiffIntDelta(t *testing.T) {
+	old := make([]ccRow, 200)
+	neu := make([]ccRow, 200)
+	for i := range old {
+		old[i] = ccRow{A: int64(i), B: uint32(i), F: float64(i)}
+		neu[i] = old[i]
+		neu[i].A = int64(i) + 1000 // every row's A changed → delta mode
+	}
+	patch, err := Diff(old, neu, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag, _ := patchTag(patch); tag != tagColSlicePatch {
+		t.Fatalf("expected tagColSlicePatch, got %#x", tag)
+	}
+	got := append([]ccRow(nil), old...)
+	if err := Apply(&got, patch); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, neu) {
+		t.Fatal("delta int round-trip mismatch")
+	}
+}
+
+func TestColDiffNeverLarger(t *testing.T) {
+	const n = 300
+	old := make([]ccRow, n)
+	neu := make([]ccRow, n)
+	for i := range old {
+		old[i] = ccRow{A: int64(i), B: uint32(i * 3), F: float64(i)}
+		neu[i] = old[i]
+	}
+	// Clustered: only column A changes, across many rows → columnar should win.
+	for i := 0; i < n; i += 2 {
+		neu[i].A = int64(i) * 11
+	}
+	cPatch, err := Diff(old, neu, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	full, err := Marshal(neu, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cPatch) >= len(full) {
+		t.Fatalf("columnar patch %d not smaller than full encode %d", len(cPatch), len(full))
+	}
+	if tag, _ := patchTag(cPatch); tag != tagColSlicePatch {
+		t.Fatalf("expected tagColSlicePatch on clustered batch, got %#x", tag)
+	}
+	// Round-trip holds.
+	got := append([]ccRow(nil), old...)
+	if err := Apply(&got, cPatch); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, neu) {
+		t.Fatal("round-trip mismatch")
+	}
+}
+
+func TestColDiffScatteredFallsBack(t *testing.T) {
+	const n = 64
+	old := make([]ccRow, n)
+	neu := make([]ccRow, n)
+	for i := range old {
+		old[i] = ccRow{A: int64(i), B: uint32(i), F: float64(i)}
+		neu[i] = old[i]
+	}
+	neu[1].A = 1
+	neu[2].B = 2
+	neu[3].F = 3 // three different columns, one row each
+	patch, err := Diff(old, neu, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := append([]ccRow(nil), old...)
+	if err := Apply(&got, patch); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, neu) {
+		t.Fatal("round-trip mismatch")
+	}
+	// Either tag is acceptable here, but the patch must be no larger than the
+	// positional-only encoding. (Correctness + never-larger is what matters.)
+}
+
+func benchColRows(n int) ([]ccRow, []ccRow) {
+	old := make([]ccRow, n)
+	neu := make([]ccRow, n)
+	for i := range old {
+		old[i] = ccRow{A: int64(i), B: uint32(i * 3), F: float64(i)}
+		neu[i] = old[i]
+	}
+	for i := 0; i < n; i += 3 {
+		neu[i].A = int64(i) * 7 // one column changes across ~1/3 of rows
+	}
+	return old, neu
+}
+
+func BenchmarkColDiffDiff(b *testing.B) {
+	old, neu := benchColRows(1000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := Diff(old, neu, OptBalanced); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkColDiffApply(b *testing.B) {
+	old, neu := benchColRows(1000)
+	patch, err := Diff(old, neu, OptBalanced)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		got := append([]ccRow(nil), old...)
+		if err := Apply(&got, patch); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/delta_columnar_test.go
+++ b/delta_columnar_test.go
@@ -45,11 +45,15 @@ func TestColChangedAttribution(t *testing.T) {
 	neu[40].A = 2 // col 0 (A) changed at row 40
 	neu[7].F = 9  // col 2 (F) changed at row 7
 
-	td, err := descOf(reflect.TypeFor[ccRow]())
+	// The columnar plan is built on the slice descriptor, not the element struct.
+	td, err := descOf(reflect.TypeFor[[]ccRow]())
 	if err != nil {
 		t.Fatal(err)
 	}
 	plan := td.colPlan
+	if plan == nil {
+		t.Fatal("expected columnar plan on []ccRow")
+	}
 	stride := plan.stride
 	od := unsafe.Pointer(&old[0])
 	nd := unsafe.Pointer(&neu[0])

--- a/delta_columnar_test.go
+++ b/delta_columnar_test.go
@@ -337,3 +337,177 @@ func TestColDiffNullable(t *testing.T) {
 		t.Fatal("nullable round-trip mismatch")
 	}
 }
+
+type ccStr struct {
+	A int64
+	S string
+}
+
+// TestColDiffStringLowCardDict exercises the dict codec on the column-diff path:
+// a low-cardinality string column with many changed cells. Under OptBalanced
+// (Dense mode) the column patch must WIN over positional AND Apply must succeed
+// — this is the exact bug the stateless routing fixes (a stateful intern body
+// would emit a state-table ref the decoder never built → "unknown state-table
+// id" on Apply). Run under both Dense (OptBalanced) and Speed.
+func TestColDiffStringLowCardDict(t *testing.T) {
+	const n = 200
+	vals := []string{"alpha", "beta", "gamma", "delta", "epsilon"}
+	for _, opt := range []Options{OptBalanced, OptSpeed} {
+		old := make([]ccStr, n)
+		neu := make([]ccStr, n)
+		for i := range old {
+			old[i] = ccStr{A: int64(i), S: vals[i%len(vals)]}
+			neu[i] = old[i]
+		}
+		// Change many cells (~half) to a different value from the small set.
+		for i := 0; i < n; i += 2 {
+			neu[i].S = vals[(i+1)%len(vals)]
+		}
+		patch, err := Diff(old, neu, opt)
+		if err != nil {
+			t.Fatalf("%v diff: %v", opt, err)
+		}
+		if tag, ok := patchTag(patch); !ok || tag != tagColSlicePatch {
+			t.Fatalf("%v: expected tagColSlicePatch (column body must win), got %#x ok=%v", opt, tag, ok)
+		}
+		got := append([]ccStr(nil), old...)
+		if err := Apply(&got, patch); err != nil {
+			t.Fatalf("%v apply: %v", opt, err)
+		}
+		if !reflect.DeepEqual(got, neu) {
+			t.Fatalf("%v low-card string round-trip mismatch", opt)
+		}
+	}
+}
+
+// TestColDiffStringHighCard exercises the raw codec: an all-distinct string
+// column. Round-trip + Apply success under Dense (OptBalanced) and Speed.
+func TestColDiffStringHighCard(t *testing.T) {
+	const n = 200
+	for _, opt := range []Options{OptBalanced, OptSpeed} {
+		old := make([]ccStr, n)
+		neu := make([]ccStr, n)
+		for i := range old {
+			old[i] = ccStr{A: int64(i), S: "id-" + string(rune('A'+i%26)) + "-" + itoaTest(i)}
+			neu[i] = old[i]
+		}
+		// Mutate enough cells that the whole column re-ships (dense-whole → raw).
+		for i := range neu {
+			neu[i].S += "-mut"
+		}
+		patch, err := Diff(old, neu, opt)
+		if err != nil {
+			t.Fatalf("%v diff: %v", opt, err)
+		}
+		got := append([]ccStr(nil), old...)
+		if err := Apply(&got, patch); err != nil {
+			t.Fatalf("%v apply: %v", opt, err)
+		}
+		if !reflect.DeepEqual(got, neu) {
+			t.Fatalf("%v high-card string round-trip mismatch", opt)
+		}
+	}
+}
+
+func itoaTest(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [20]byte
+	p := len(b)
+	for i > 0 {
+		p--
+		b[p] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[p:])
+}
+
+// FuzzColDiffStringOracle mutates a string column with random per-row choices
+// (drawn from a mix of low-cardinality and high-cardinality candidates) and
+// asserts Diff then Apply round-trips DeepEqual across all modes — directly
+// stressing the stateless dict/raw column-diff path.
+func FuzzColDiffStringOracle(f *testing.F) {
+	f.Add(uint64(1), uint64(2), 64)
+	f.Add(uint64(7), uint64(7), 13)
+	f.Add(uint64(0xdead), uint64(0xbeef), 200)
+	pool := []string{"", "a", "alpha", "beta", "gamma", "x", "id-12345", "long-distinct-value-"}
+	mkVal := func(r uint64, i int) string {
+		choice := (r ^ uint64(i*2654435761)) % uint64(len(pool)+2)
+		switch {
+		case choice < uint64(len(pool)):
+			return pool[choice]
+		case choice == uint64(len(pool)):
+			return "u-" + itoaTest(int(r%97)) + "-" + itoaTest(i) // semi-distinct
+		default:
+			return "d-" + itoaTest(i) + "-" + itoaTest(int(r&0xffff)) // distinct-ish
+		}
+	}
+	f.Fuzz(func(t *testing.T, so, sn uint64, nRaw int) {
+		n := nRaw % 257
+		if n < 0 {
+			n = -n
+		}
+		// n >= 1: an empty slice exercises the framework's nil-vs-empty base
+		// fingerprint distinction (append([]T(nil), empty...) yields nil), which is
+		// orthogonal to the string-column codec under test and covered elsewhere.
+		n++
+		old := make([]ccStr, n)
+		neu := make([]ccStr, n)
+		for i := range old {
+			old[i] = ccStr{A: int64(i), S: mkVal(so, i)}
+			neu[i] = ccStr{A: int64(i), S: mkVal(sn, i)}
+		}
+		for _, opt := range []Options{OptSpeed, OptBalanced, OptCompression} {
+			patch, err := Diff(old, neu, opt)
+			if err != nil {
+				t.Fatalf("opt=%v diff: %v", opt, err)
+			}
+			got := append([]ccStr(nil), old...)
+			if err := Apply(&got, patch); err != nil {
+				t.Fatalf("opt=%v apply: %v", opt, err)
+			}
+			if !reflect.DeepEqual(got, neu) {
+				t.Fatalf("opt=%v mismatch\n old=%+v\n new=%+v\n got=%+v", opt, old, neu, got)
+			}
+		}
+	})
+}
+
+type ccBytes struct {
+	A int64
+	B []byte
+}
+
+// TestColDiffBytesColumn exercises a []byte column (classified colKindString
+// with isByte) on the column-diff path, both sparse (few changed) and
+// dense-whole (all changed), under Dense (OptBalanced) and Speed.
+func TestColDiffBytesColumn(t *testing.T) {
+	const n = 200
+	for _, opt := range []Options{OptBalanced, OptSpeed} {
+		for _, ratio := range []int{20, 1} { // sparse, then dense-whole
+			old := make([]ccBytes, n)
+			neu := make([]ccBytes, n)
+			for i := range old {
+				old[i] = ccBytes{A: int64(i), B: []byte("payload-" + itoaTest(i%7))}
+				neu[i] = ccBytes{A: int64(i), B: append([]byte(nil), old[i].B...)}
+			}
+			for i := range neu {
+				if ratio == 1 || i%ratio == 0 {
+					neu[i].B = append(append([]byte(nil), neu[i].B...), 0xAB)
+				}
+			}
+			patch, err := Diff(old, neu, opt)
+			if err != nil {
+				t.Fatalf("%v/ratio%d diff: %v", opt, ratio, err)
+			}
+			got := append([]ccBytes(nil), old...)
+			if err := Apply(&got, patch); err != nil {
+				t.Fatalf("%v/ratio%d apply: %v", opt, ratio, err)
+			}
+			if !reflect.DeepEqual(got, neu) {
+				t.Fatalf("%v/ratio%d bytes round-trip mismatch", opt, ratio)
+			}
+		}
+	}
+}

--- a/delta_diff.go
+++ b/delta_diff.go
@@ -44,6 +44,14 @@ func diffValue(enc *Encoder, td *typeDesc, oldP, newP unsafe.Pointer, depth int)
 		if ((*sliceHeader)(oldP).Data == nil) != ((*sliceHeader)(newP).Data == nil) {
 			return writeReplace(enc, td, newP)
 		}
+		elem := td.elem
+		if elem == nil {
+			elem, _ = descOf(td.rType.Elem())
+		}
+		if elem != nil && elem.keyed && keyTokenable(elem.keyDesc) {
+			enc.buf = append(enc.buf, opMerge)
+			return diffKeyedSlice(enc, td, elem, oldP, newP, depth)
+		}
 		enc.buf = append(enc.buf, opMerge)
 		return diffSlice(enc, td, oldP, newP, depth)
 	case reflect.Array:

--- a/delta_diff.go
+++ b/delta_diff.go
@@ -86,7 +86,10 @@ func diffSlice(enc *Encoder, td *typeDesc, oldP, newP unsafe.Pointer, depth int)
 	if elem == nil {
 		elem, _ = descOf(td.rType.Elem())
 	}
-	return diffElems(enc, elem, stride, oh.Data, oh.Len, nh.Data, nh.Len, depth)
+	// td.colPlan (the slice element's columnar plan, built on the slice
+	// descriptor) is threaded in so diffColumnar routes off a parameter rather
+	// than a field on the shared element typeDesc — no write to a published desc.
+	return diffElems(enc, elem, td.colPlan, stride, oh.Data, oh.Len, nh.Data, nh.Len, depth)
 }
 
 func diffArray(enc *Encoder, td *typeDesc, oldP, newP unsafe.Pointer, depth int) error {
@@ -200,10 +203,10 @@ func diffMap(enc *Encoder, td *typeDesc, oldP, newP unsafe.Pointer, depth int) e
 // patch, never-larger picker); every other case falls through to the positional
 // differ. Arrays never reach diffColumnar (they call diffElemsPositional
 // directly via diffArray).
-func diffElems(enc *Encoder, elem *typeDesc, stride uintptr,
+func diffElems(enc *Encoder, elem *typeDesc, colPlan *columnarPlan, stride uintptr,
 	oldData unsafe.Pointer, oldLen int, newData unsafe.Pointer, newLen int, depth int) error {
-	if oldLen == newLen && oldLen >= columnarMinElems && diffColumnarEligible(elem) {
-		handled, err := diffColumnar(enc, elem, stride, oldData, newData, oldLen, depth)
+	if oldLen == newLen && oldLen >= columnarMinElems && diffColumnarEligible(colPlan) {
+		handled, err := diffColumnar(enc, elem, colPlan, stride, oldData, newData, oldLen, depth)
 		if err != nil {
 			return err
 		}

--- a/delta_diff.go
+++ b/delta_diff.go
@@ -3,6 +3,7 @@ package qdf
 import (
 	"bytes"
 	"reflect"
+	"time"
 	"unsafe"
 )
 
@@ -338,6 +339,14 @@ func equalValue(td *typeDesc, aP, bP unsafe.Pointer, depth int) bool {
 		// holds a non-comparable field (slice/map/func) — a real crash for a
 		// Marshaler type with e.g. a []int field. Rare path; correctness over speed.
 		if len(td.fields) == 0 {
+			if td.rType == timeType {
+				// time.Time is the common fields-less struct. Compare the instant the
+				// codec actually round-trips (absolute sec + nsec) — no reflect, and it
+				// avoids a spurious change when only the monotonic-clock reading or the
+				// *Location differs (which the UTC sec+nsec wire form drops anyway).
+				at, bt := (*time.Time)(aP), (*time.Time)(bP)
+				return at.Unix() == bt.Unix() && at.Nanosecond() == bt.Nanosecond()
+			}
 			av := reflect.NewAt(td.rType, aP).Elem()
 			bv := reflect.NewAt(td.rType, bP).Elem()
 			// Fast path: a comparable fields-less struct (time.Time — common, on the

--- a/delta_diff.go
+++ b/delta_diff.go
@@ -96,7 +96,9 @@ func diffArray(enc *Encoder, td *typeDesc, oldP, newP unsafe.Pointer, depth int)
 	if elem == nil {
 		elem, _ = descOf(td.rType.Elem())
 	}
-	return diffElems(enc, elem, stride, oldP, n, newP, n, depth)
+	// Arrays are never columnar-eligible here (colPlan lives on slice element
+	// descriptors), so route straight to the positional differ.
+	return diffElemsPositional(enc, elem, stride, oldP, n, newP, n, depth)
 }
 
 // diffMap writes a tagMapPatch: updated/added keys (each with a recursive op),
@@ -193,8 +195,28 @@ func diffMap(enc *Encoder, td *typeDesc, oldP, newP unsafe.Pointer, depth int) e
 	return nil
 }
 
-// diffElems is the shared positional element differ for slices and arrays.
+// diffElems is the shared element differ for slices and arrays. For an
+// equal-length pure-columnar slice it routes through diffColumnar (column-level
+// patch, never-larger picker); every other case falls through to the positional
+// differ. Arrays never reach diffColumnar (they call diffElemsPositional
+// directly via diffArray).
 func diffElems(enc *Encoder, elem *typeDesc, stride uintptr,
+	oldData unsafe.Pointer, oldLen int, newData unsafe.Pointer, newLen int, depth int) error {
+	if oldLen == newLen && oldLen >= columnarMinElems && diffColumnarEligible(elem) {
+		handled, err := diffColumnar(enc, elem, stride, oldData, newData, oldLen, depth)
+		if err != nil {
+			return err
+		}
+		if handled {
+			return nil
+		}
+	}
+	return diffElemsPositional(enc, elem, stride, oldData, oldLen, newData, newLen, depth)
+}
+
+// diffElemsPositional is the positional element differ: one tagSlicePatch body
+// listing each changed/appended element index with its recursive op.
+func diffElemsPositional(enc *Encoder, elem *typeDesc, stride uintptr,
 	oldData unsafe.Pointer, oldLen int, newData unsafe.Pointer, newLen int, depth int) error {
 	minLen := min(newLen, oldLen)
 	// elem.pod was precomputed at build (noPointersWalk of the element type) —

--- a/delta_keyed.go
+++ b/delta_keyed.go
@@ -1,0 +1,49 @@
+package qdf
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// keyToken returns a string usable as a Go map key that uniquely identifies the
+// element's key field value WITHOUT allocating. elemP points at an element of a
+// keyed struct type td; td.keyOff/td.keyDesc locate the key field. Delegates to
+// keyTokenAt over the key field pointer.
+func keyToken(td *typeDesc, elemP unsafe.Pointer) string {
+	return keyTokenAt(td.keyDesc, unsafe.Add(elemP, td.keyOff))
+}
+
+// keyTokenAt returns the token for a key value of descriptor kd located at kp.
+//   - string key: the key string itself (its content is the identity).
+//   - scalar / [N]byte key: unsafe.String over the key's raw bytes. Valid only
+//     while the backing value is alive — true for the duration of a single
+//     Diff/Apply call. Safe because these kinds are gap-free (no padding within
+//     the key value), so the bytes ARE the whole value.
+//   - exotic comparable key (a comparable struct): the allocating reflect
+//     fallback (rare; the keyed path is gated to the kinds above elsewhere, so
+//     this branch is defensive).
+func keyTokenAt(kd *typeDesc, kp unsafe.Pointer) string {
+	switch kd.kind {
+	case reflect.String:
+		return *(*string)(kp)
+	case reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
+		reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32,
+		reflect.Uint64, reflect.Uintptr, reflect.Float32, reflect.Float64:
+		return unsafe.String((*byte)(kp), int(kd.rType.Size()))
+	case reflect.Array:
+		if kd.rType.Elem().Kind() == reflect.Uint8 {
+			return unsafe.String((*byte)(kp), kd.rType.Len())
+		}
+		return keyTokenReflect(kd, kp)
+	default:
+		return keyTokenReflect(kd, kp)
+	}
+}
+
+// keyTokenReflect is the allocating fallback for exotic comparable key types
+// (a comparable struct). Rare and off the hot path; the keyed diff/apply path is
+// gated (keyTokenable, a later task) to the non-fallback kinds, so a struct key
+// falls back to positional diff rather than relying on this token.
+func keyTokenReflect(kd *typeDesc, kp unsafe.Pointer) string {
+	return reflect.NewAt(kd.rType, kp).Elem().String()
+}

--- a/delta_keyed.go
+++ b/delta_keyed.go
@@ -40,6 +40,171 @@ func keyTokenAt(kd *typeDesc, kp unsafe.Pointer) string {
 	}
 }
 
+// keyedLinearMax is the element count below which keyed matching uses a linear
+// scan (no map allocation). O(n^2) but n small; cheaper than a map's hashing
+// plus warm-up allocation, and fully alloc-free.
+const keyedLinearMax = 32
+
+// keyTokenable reports whether the key kind is one keyTokenAt handles without
+// the allocating reflect fallback (so the keyed path is worth taking).
+func keyTokenable(kd *typeDesc) bool {
+	switch kd.kind {
+	case reflect.String, reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16,
+		reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16,
+		reflect.Uint32, reflect.Uint64, reflect.Uintptr, reflect.Float32, reflect.Float64:
+		return true
+	case reflect.Array:
+		return kd.rType.Elem().Kind() == reflect.Uint8
+	default:
+		return false
+	}
+}
+
+func diffKeyedSlice(enc *Encoder, td, elem *typeDesc, oldP, newP unsafe.Pointer, depth int) error {
+	oh := (*sliceHeader)(oldP)
+	nh := (*sliceHeader)(newP)
+	stride := td.rType.Elem().Size()
+	oldKeyAt := func(i int) string { return keyToken(elem, unsafe.Add(oh.Data, uintptr(i)*stride)) }
+	newKeyAt := func(i int) string { return keyToken(elem, unsafe.Add(nh.Data, uintptr(i)*stride)) }
+
+	lookup, dup := buildKeyLookup(&enc.keyIdx, oldKeyAt, oh.Len)
+	if dup || hasDupNewKeys(newKeyAt, nh.Len) {
+		// Ambiguous identity → positional fallback. diffValue already wrote opMerge;
+		// diffSlice writes its own tagSlicePatch body, so apply dispatches correctly.
+		return diffSlice(enc, td, oldP, newP, depth)
+	}
+
+	orderChanged := oh.Len != nh.Len
+	if !orderChanged {
+		for i := range nh.Len {
+			if oldKeyAt(i) != newKeyAt(i) {
+				orderChanged = true
+				break
+			}
+		}
+	}
+
+	enc.buf = append(enc.buf, tagKeyedSlicePatch)
+	flags := byte(0)
+	if orderChanged {
+		flags |= flagKeyedOrderChanged
+	}
+	enc.buf = append(enc.buf, flags)
+
+	if orderChanged {
+		enc.buf = appendUvarint(enc.buf, uint64(nh.Len))
+		for i := range nh.Len {
+			nP := unsafe.Add(nh.Data, uintptr(i)*stride)
+			if err := elem.keyDesc.encode(enc, unsafe.Add(nP, elem.keyOff)); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Count ops, then emit (so nOps is known before the entries).
+	nOps := 0
+	for i := range nh.Len {
+		nP := unsafe.Add(nh.Data, uintptr(i)*stride)
+		oi, ok := lookupGet(lookup, &enc.keyIdx, oldKeyAt, oh.Len, newKeyAt(i))
+		if ok && equalValue(elem, unsafe.Add(oh.Data, uintptr(oi)*stride), nP, depth) {
+			continue
+		}
+		nOps++
+	}
+	enc.buf = appendUvarint(enc.buf, uint64(nOps))
+	for i := range nh.Len {
+		nP := unsafe.Add(nh.Data, uintptr(i)*stride)
+		k := newKeyAt(i)
+		oi, ok := lookupGet(lookup, &enc.keyIdx, oldKeyAt, oh.Len, k)
+		if ok {
+			oP := unsafe.Add(oh.Data, uintptr(oi)*stride)
+			if equalValue(elem, oP, nP, depth) {
+				continue
+			}
+			if err := elem.keyDesc.encode(enc, unsafe.Add(nP, elem.keyOff)); err != nil {
+				return err
+			}
+			if err := diffValue(enc, elem, oP, nP, depth+1); err != nil {
+				return err
+			}
+		} else {
+			if err := elem.keyDesc.encode(enc, unsafe.Add(nP, elem.keyOff)); err != nil {
+				return err
+			}
+			if err := writeReplace(enc, elem, nP); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// keyLookup chooses linear (small n, no map) vs a reused cleared map.
+type keyLookup struct{ useMap bool }
+
+func buildKeyLookup(m *map[string]int, keyAt func(int) string, n int) (keyLookup, bool) {
+	if n <= keyedLinearMax {
+		for i := range n {
+			ki := keyAt(i)
+			for j := range i {
+				if keyAt(j) == ki {
+					return keyLookup{}, true
+				}
+			}
+		}
+		return keyLookup{useMap: false}, false
+	}
+	if *m == nil {
+		*m = make(map[string]int, n)
+	} else {
+		clear(*m)
+	}
+	for i := range n {
+		ki := keyAt(i)
+		if _, exists := (*m)[ki]; exists {
+			return keyLookup{useMap: true}, true
+		}
+		(*m)[ki] = i
+	}
+	return keyLookup{useMap: true}, false
+}
+
+func lookupGet(l keyLookup, m *map[string]int, keyAt func(int) string, n int, key string) (int, bool) {
+	if l.useMap {
+		i, ok := (*m)[key]
+		return i, ok
+	}
+	for i := range n {
+		if keyAt(i) == key {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func hasDupNewKeys(keyAt func(int) string, n int) bool {
+	if n <= keyedLinearMax {
+		for i := range n {
+			ki := keyAt(i)
+			for j := range i {
+				if keyAt(j) == ki {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	seen := make(map[string]struct{}, n)
+	for i := range n {
+		k := keyAt(i)
+		if _, ok := seen[k]; ok {
+			return true
+		}
+		seen[k] = struct{}{}
+	}
+	return false
+}
+
 // keyTokenReflect is the allocating fallback for exotic comparable key types
 // (a comparable struct). Rare and off the hot path; the keyed diff/apply path is
 // gated (keyTokenable, a later task) to the non-fallback kinds, so a struct key

--- a/delta_keyed.go
+++ b/delta_keyed.go
@@ -139,6 +139,131 @@ func diffKeyedSlice(enc *Encoder, td, elem *typeDesc, oldP, newP unsafe.Pointer,
 	return nil
 }
 
+// applyKeyedSlice reads a tagKeyedSlicePatch body and reconciles the base slice
+// by element identity (the key field), mirroring diffKeyedSlice on the encode
+// side. Element copies use typed reflect Set so the compiler emits GC write
+// barriers (raw memmove would not); the new slice is built with reflect.MakeSlice.
+func applyKeyedSlice(dec *Decoder, td *typeDesc, baseP unsafe.Pointer, depth int) error {
+	if depth > maxDeltaDepth {
+		return ErrInvalidPatch
+	}
+	if dec.i >= len(dec.buf) || dec.buf[dec.i] != tagKeyedSlicePatch {
+		return ErrInvalidPatch
+	}
+	dec.i++
+	if dec.i >= len(dec.buf) {
+		return ErrInvalidPatch
+	}
+	flags := dec.buf[dec.i]
+	dec.i++
+
+	elem := td.elem
+	if elem == nil {
+		elem, _ = descOf(td.rType.Elem())
+	}
+	if elem == nil || !elem.keyed || elem.keyDesc == nil {
+		return ErrInvalidPatch
+	}
+	elemType := td.rType.Elem()
+	stride := elemType.Size()
+	bh := (*sliceHeader)(baseP)
+	baseKeyAt := func(i int) string { return keyToken(elem, unsafe.Add(bh.Data, uintptr(i)*stride)) }
+
+	if flags&flagKeyedOrderChanged == 0 {
+		// Value-only updates on the same key sequence; apply each op in place.
+		lookup, _ := buildKeyLookup(&dec.keyIdx, baseKeyAt, bh.Len)
+		nOps, k := readUvarint(dec.buf[dec.i:])
+		if k <= 0 || nOps > uint64(len(dec.buf)-dec.i) {
+			return ErrInvalidPatch
+		}
+		dec.i += k
+		keyHold := reflect.New(elem.keyDesc.rType).Elem()
+		for range nOps {
+			if err := elem.keyDesc.decode(dec, keyHold.Addr().UnsafePointer()); err != nil {
+				return err
+			}
+			tok := keyTokenAt(elem.keyDesc, keyHold.Addr().UnsafePointer())
+			oi, ok := lookupGet(lookup, &dec.keyIdx, baseKeyAt, bh.Len, tok)
+			if !ok {
+				return ErrInvalidPatch // op for a key not in base (divergent base)
+			}
+			if err := applyValue(dec, elem, unsafe.Add(bh.Data, uintptr(oi)*stride), depth+1); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// orderChanged: read new key order, build base lookup, construct the new slice.
+	newLen64, k := readUvarint(dec.buf[dec.i:])
+	if k <= 0 {
+		return ErrInvalidPatch
+	}
+	dec.i += k
+	newLen := int(newLen64)
+	if newLen < 0 || uint64(newLen) > uint64(len(dec.buf)-dec.i) {
+		return ErrInvalidPatch
+	}
+	order := make([]string, newLen)
+	keyHold := reflect.New(elem.keyDesc.rType).Elem()
+	for i := range newLen {
+		if err := elem.keyDesc.decode(dec, keyHold.Addr().UnsafePointer()); err != nil {
+			return err
+		}
+		// token must outlive the decode loop → copy the content.
+		order[i] = string([]byte(keyTokenAt(elem.keyDesc, keyHold.Addr().UnsafePointer())))
+	}
+
+	lookup, _ := buildKeyLookup(&dec.keyIdx, baseKeyAt, bh.Len)
+
+	nv := reflect.MakeSlice(td.rType, newLen, newLen)
+	nb := nv.UnsafePointer()
+	orderIdx := make(map[string]int, newLen)
+	for i, tok := range order {
+		orderIdx[tok] = i
+	}
+	filled := make([]bool, newLen)
+	// Copy unchanged base elements into their new slots (GC-safe typed Set).
+	for i := range newLen {
+		oi, ok := lookupGet(lookup, &dec.keyIdx, baseKeyAt, bh.Len, order[i])
+		if ok {
+			dst := reflect.NewAt(elemType, unsafe.Add(nb, uintptr(i)*stride)).Elem()
+			src := reflect.NewAt(elemType, unsafe.Add(bh.Data, uintptr(oi)*stride)).Elem()
+			dst.Set(src)
+			filled[i] = true
+		}
+	}
+	// Apply ops into their slots by key.
+	nOps, k2 := readUvarint(dec.buf[dec.i:])
+	if k2 <= 0 || nOps > uint64(len(dec.buf)-dec.i) {
+		return ErrInvalidPatch
+	}
+	dec.i += k2
+	keyHold2 := reflect.New(elem.keyDesc.rType).Elem()
+	for range nOps {
+		if err := elem.keyDesc.decode(dec, keyHold2.Addr().UnsafePointer()); err != nil {
+			return err
+		}
+		tok := keyTokenAt(elem.keyDesc, keyHold2.Addr().UnsafePointer())
+		ni, ok := orderIdx[tok]
+		if !ok {
+			return ErrInvalidPatch
+		}
+		slot := unsafe.Add(nb, uintptr(ni)*stride)
+		if err := applyValue(dec, elem, slot, depth+1); err != nil {
+			return err
+		}
+		filled[ni] = true
+	}
+	for i := range newLen {
+		if !filled[i] {
+			return ErrInvalidPatch // a key with neither a base match nor an op
+		}
+	}
+	reflect.NewAt(td.rType, baseP).Elem().Set(nv)
+	return nil
+}
+
 // keyLookup chooses linear (small n, no map) vs a reused cleared map.
 type keyLookup struct{ useMap bool }
 

--- a/delta_keyed.go
+++ b/delta_keyed.go
@@ -204,14 +204,19 @@ func applyKeyedSlice(dec *Decoder, td *typeDesc, baseP unsafe.Pointer, depth int
 	if newLen < 0 || uint64(newLen) > uint64(len(dec.buf)-dec.i) {
 		return ErrInvalidPatch
 	}
+	// Decode all order keys into ONE contiguous typed buffer so each token can
+	// alias its stable element (no per-key string copy). keysV stays live for the
+	// function, keeping the key bytes (and any string-key heap content) reachable.
 	order := make([]string, newLen)
-	keyHold := reflect.New(elem.keyDesc.rType).Elem()
+	keysV := reflect.MakeSlice(reflect.SliceOf(elem.keyDesc.rType), newLen, newLen)
+	keysBase := keysV.UnsafePointer()
+	ksize := elem.keyDesc.rType.Size()
 	for i := range newLen {
-		if err := elem.keyDesc.decode(dec, keyHold.Addr().UnsafePointer()); err != nil {
+		kp := unsafe.Add(keysBase, uintptr(i)*ksize)
+		if err := elem.keyDesc.decode(dec, kp); err != nil {
 			return err
 		}
-		// token must outlive the decode loop → copy the content.
-		order[i] = string([]byte(keyTokenAt(elem.keyDesc, keyHold.Addr().UnsafePointer())))
+		order[i] = keyTokenAt(elem.keyDesc, kp) // aliases keysV (stable) — no copy
 	}
 
 	lookup, _ := buildKeyLookup(&dec.keyIdx, baseKeyAt, bh.Len)

--- a/delta_keyed_more_test.go
+++ b/delta_keyed_more_test.go
@@ -1,0 +1,221 @@
+package qdf
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+// --- Task 6: duplicate-key positional fallback ---
+
+func TestKeyedDuplicateKeysFallBackPositional(t *testing.T) {
+	type E struct {
+		ID  string `qdf:"id,key"`
+		Val int
+	}
+	old := []E{{"a", 1}, {"a", 2}, {"b", 3}} // duplicate key "a"
+	neu := []E{{"a", 9}, {"a", 2}, {"b", 3}}
+	patch, err := Diff(old, neu, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// dup keys → positional patch, not keyed
+	if !containsByte(patch, tagSlicePatch) {
+		t.Fatal("duplicate keys must fall back to the positional tagSlicePatch")
+	}
+	base := append([]E(nil), old...)
+	if err := Apply(&base, patch); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(base, neu) {
+		t.Fatalf("got %+v want %+v", base, neu)
+	}
+}
+
+// --- Task 7: nil / empty / presence + nested keyed slices ---
+
+func TestKeyedNilAndEmpty(t *testing.T) {
+	type E struct {
+		ID string `qdf:"id,key"`
+		V  int
+	}
+	type Rec struct{ Items []E }
+	cases := []struct {
+		name     string
+		old, neu Rec
+	}{
+		{"nil->filled", Rec{nil}, Rec{[]E{{"a", 1}}}},
+		{"filled->nil", Rec{[]E{{"a", 1}}}, Rec{nil}},
+		{"empty->filled", Rec{[]E{}}, Rec{[]E{{"a", 1}}}},
+		{"filled->empty", Rec{[]E{{"a", 1}}}, Rec{[]E{}}},
+		{"nil->empty", Rec{nil}, Rec{[]E{}}},
+		{"empty->nil", Rec{[]E{}}, Rec{nil}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			patch, err := Diff(tc.old, tc.neu, OptBalanced)
+			if err != nil {
+				t.Fatal(err)
+			}
+			base := Rec{}
+			if tc.old.Items != nil {
+				// Faithfully mirror old's nilness: make() keeps an empty slice
+				// non-nil (append-from-nil would collapse empty->nil and trip baseFP).
+				base.Items = make([]E, len(tc.old.Items))
+				copy(base.Items, tc.old.Items)
+			}
+			if err := Apply(&base, patch); err != nil {
+				t.Fatal(err)
+			}
+			if (base.Items == nil) != (tc.neu.Items == nil) {
+				t.Fatalf("nilness wrong: got nil=%v want nil=%v", base.Items == nil, tc.neu.Items == nil)
+			}
+			if !reflect.DeepEqual(base, tc.neu) {
+				t.Fatalf("got %+v want %+v", base, tc.neu)
+			}
+		})
+	}
+}
+
+func TestKeyedNested(t *testing.T) {
+	type Inner struct {
+		ID  string `qdf:"id,key"`
+		Sub []int
+	}
+	type Outer struct {
+		Rows []Inner
+		Map  map[string][]Inner
+	}
+	old := Outer{
+		Rows: []Inner{{"a", []int{1}}, {"b", []int{2}}},
+		Map:  map[string][]Inner{"g": {{"x", []int{9}}}},
+	}
+	neu := Outer{
+		Rows: []Inner{{"b", []int{2}}, {"a", []int{1, 1}}}, // reorder + change a.Sub
+		Map:  map[string][]Inner{"g": {{"y", []int{8}}, {"x", []int{9}}}},
+	}
+	patch, err := Diff(old, neu, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := Outer{
+		Rows: []Inner{{"a", []int{1}}, {"b", []int{2}}},
+		Map:  map[string][]Inner{"g": {{"x", []int{9}}}},
+	}
+	if err := Apply(&base, patch); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(base, neu) {
+		t.Fatalf("got %+v want %+v", base, neu)
+	}
+}
+
+// --- Task 8: never-larger on reorder + generative oracle + hostile fuzz ---
+
+func TestKeyedReorderBeatsPositional(t *testing.T) {
+	type E struct {
+		ID  int64 `qdf:"id,key"`
+		Big string
+	}
+	n := 200
+	old := make([]E, n)
+	for i := range old {
+		old[i] = E{ID: int64(i), Big: "payload-" + string(rune('a'+i%26))}
+	}
+	neu := make([]E, n)
+	for i := range neu {
+		neu[i] = old[n-1-i] // reverse reorder, no value change
+	}
+	keyed, _ := Diff(old, neu, OptBalanced)
+	full, _ := Marshal(neu, OptBalanced)
+	if len(keyed) >= len(full) {
+		t.Fatalf("keyed reorder patch (%d) must be below a full marshal (%d)", len(keyed), len(full))
+	}
+	t.Logf("reverse-reorder n=%d: keyed=%d bytes, full=%d bytes", n, len(keyed), len(full))
+}
+
+type kEnt struct {
+	ID   int64 `qdf:"id,key"`
+	A    string
+	B    []int64
+	Flag bool
+}
+
+func randKeyed(r *rand.Rand) []kEnt {
+	n := r.Intn(8)
+	seen := map[int64]bool{}
+	var out []kEnt
+	for range n {
+		id := int64(r.Intn(10))
+		if seen[id] {
+			continue // unique keys → exercise the keyed path, not the fallback
+		}
+		seen[id] = true
+		var b []int64
+		switch r.Intn(3) {
+		case 1:
+			b = []int64{}
+		case 2:
+			b = make([]int64, r.Intn(3))
+			for i := range b {
+				b[i] = int64(r.Intn(100))
+			}
+		}
+		out = append(out, kEnt{ID: id, A: []string{"x", "y", ""}[r.Intn(3)], B: b, Flag: r.Intn(2) == 0})
+	}
+	r.Shuffle(len(out), func(i, j int) { out[i], out[j] = out[j], out[i] })
+	return out
+}
+
+func cloneKeyed(s []kEnt) []kEnt {
+	if s == nil {
+		return nil
+	}
+	c := make([]kEnt, len(s))
+	copy(c, s)
+	for i := range c {
+		if s[i].B != nil { // preserve empty-non-nil (append-from-nil would collapse it)
+			c[i].B = make([]int64, len(s[i].B))
+			copy(c[i].B, s[i].B)
+		}
+	}
+	return c
+}
+
+func FuzzKeyedSliceOracle(f *testing.F) {
+	f.Add(int64(1), int64(2))
+	f.Add(int64(5), int64(5))
+	f.Add(int64(7), int64(99))
+	f.Fuzz(func(t *testing.T, so, sn int64) {
+		old := randKeyed(rand.New(rand.NewSource(so)))
+		neu := randKeyed(rand.New(rand.NewSource(sn)))
+		for _, opts := range []Options{OptBalanced, OptCompression, OptSpeed} {
+			patch, err := Diff(old, neu, opts)
+			if err != nil {
+				t.Fatalf("opts=%v Diff: %v", opts, err)
+			}
+			base := cloneKeyed(old)
+			if err := Apply(&base, patch); err != nil {
+				t.Fatalf("opts=%v Apply: %v", opts, err)
+			}
+			if !reflect.DeepEqual(base, neu) {
+				t.Fatalf("opts=%v mismatch\n old=%+v\n new=%+v\n got=%+v", opts, old, neu, base)
+			}
+		}
+	})
+}
+
+func FuzzApplyKeyedHostile(f *testing.F) {
+	good, _ := Diff([]kEnt{{ID: 1}}, []kEnt{{ID: 1, A: "x"}, {ID: 2}}, OptBalanced)
+	f.Add(good)
+	f.Add([]byte{})
+	f.Fuzz(func(t *testing.T, patch []byte) {
+		var base []kEnt
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("panic on hostile keyed patch: %v", r)
+			}
+		}()
+		_ = Apply(&base, patch) // error or nil, never panic/OOM
+	})
+}

--- a/delta_keyed_test.go
+++ b/delta_keyed_test.go
@@ -3,6 +3,7 @@ package qdf
 import (
 	"reflect"
 	"testing"
+	"unsafe"
 )
 
 func TestKeyTagParsed(t *testing.T) {
@@ -52,5 +53,73 @@ func TestKeyTagDoubleRejected(t *testing.T) {
 	}
 	if _, err := descOf(reflect.TypeFor[Two]()); err == nil {
 		t.Fatal("two ,key fields must be a build error")
+	}
+}
+
+func TestKeyToken(t *testing.T) {
+	type E struct {
+		ID string `qdf:"id,key"`
+		N  int
+	}
+	td, _ := descOf(reflect.TypeFor[E]())
+	a := E{ID: "alpha", N: 1}
+	b := E{ID: "alpha", N: 2}
+	c := E{ID: "beta", N: 1}
+	ta := keyToken(td, unsafe.Pointer(&a))
+	tb := keyToken(td, unsafe.Pointer(&b))
+	tc := keyToken(td, unsafe.Pointer(&c))
+	if ta != tb {
+		t.Fatal("same key content must yield equal tokens")
+	}
+	if ta == tc {
+		t.Fatal("different keys must yield different tokens")
+	}
+
+	type EI struct {
+		ID int64 `qdf:"id,key"`
+		N  int
+	}
+	tdi, _ := descOf(reflect.TypeFor[EI]())
+	x := EI{ID: 7}
+	y := EI{ID: 7}
+	z := EI{ID: 8}
+	if keyToken(tdi, unsafe.Pointer(&x)) != keyToken(tdi, unsafe.Pointer(&y)) {
+		t.Fatal("int64 key 7==7 token")
+	}
+	if keyToken(tdi, unsafe.Pointer(&x)) == keyToken(tdi, unsafe.Pointer(&z)) {
+		t.Fatal("int64 key 7!=8 token")
+	}
+}
+
+func TestKeyTokenByteArray(t *testing.T) {
+	type E struct {
+		ID [4]byte `qdf:"id,key"`
+		N  int
+	}
+	td, _ := descOf(reflect.TypeFor[E]())
+	a := E{ID: [4]byte{1, 2, 3, 4}}
+	b := E{ID: [4]byte{1, 2, 3, 4}}
+	c := E{ID: [4]byte{1, 2, 3, 5}}
+	if keyToken(td, unsafe.Pointer(&a)) != keyToken(td, unsafe.Pointer(&b)) {
+		t.Fatal("[4]byte key equal")
+	}
+	if keyToken(td, unsafe.Pointer(&a)) == keyToken(td, unsafe.Pointer(&c)) {
+		t.Fatal("[4]byte key differ")
+	}
+}
+
+func TestKeyTokenAtMatchesKeyToken(t *testing.T) {
+	// keyTokenAt over the key value alone must equal keyToken over the element.
+	type E struct {
+		Pad int
+		ID  string `qdf:"id,key"`
+	}
+	td, _ := descOf(reflect.TypeFor[E]())
+	e := E{Pad: 9, ID: "k"}
+	full := keyToken(td, unsafe.Pointer(&e))
+	kp := unsafe.Add(unsafe.Pointer(&e), td.keyOff)
+	at := keyTokenAt(td.keyDesc, kp)
+	if full != at {
+		t.Fatalf("keyTokenAt %q != keyToken %q", at, full)
 	}
 }

--- a/delta_keyed_test.go
+++ b/delta_keyed_test.go
@@ -1,0 +1,56 @@
+package qdf
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestKeyTagParsed(t *testing.T) {
+	type Entity struct {
+		ID string `qdf:"id,key"`
+		X  float64
+	}
+	td, err := descOf(reflect.TypeFor[Entity]())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !td.keyed {
+		t.Fatal("Entity should be keyed (ID has ,key)")
+	}
+	if td.keyOff != reflect.TypeFor[Entity]().Field(0).Offset {
+		t.Fatalf("keyOff=%d want %d", td.keyOff, reflect.TypeFor[Entity]().Field(0).Offset)
+	}
+	if td.keyDesc == nil || td.keyDesc.kind != reflect.String {
+		t.Fatalf("keyDesc wrong: %+v", td.keyDesc)
+	}
+}
+
+func TestKeyTagUntaggedNotKeyed(t *testing.T) {
+	type Plain struct {
+		ID string
+		X  float64
+	}
+	td, _ := descOf(reflect.TypeFor[Plain]())
+	if td.keyed {
+		t.Fatal("Plain has no ,key — must not be keyed")
+	}
+}
+
+func TestKeyTagNonComparableRejected(t *testing.T) {
+	type Bad struct {
+		K []int `qdf:"k,key"` // slice key is not comparable
+	}
+	if _, err := descOf(reflect.TypeFor[Bad]()); err == nil {
+		t.Fatal("a non-comparable key field must be a build error")
+	}
+}
+
+func TestKeyTagDoubleRejected(t *testing.T) {
+	type Two struct {
+		A int `qdf:"a,key"`
+		B int `qdf:"b,key"`
+	}
+	if _, err := descOf(reflect.TypeFor[Two]()); err == nil {
+		t.Fatal("two ,key fields must be a build error")
+	}
+}

--- a/delta_keyed_test.go
+++ b/delta_keyed_test.go
@@ -136,3 +136,60 @@ func TestKeyTokenAtMatchesKeyToken(t *testing.T) {
 		t.Fatalf("keyTokenAt %q != keyToken %q", at, full)
 	}
 }
+
+func TestDiffApplyKeyedReorderAndChange(t *testing.T) {
+	type E struct {
+		ID   string `qdf:"id,key"`
+		Val  int
+		Note string
+	}
+	old := []E{{"a", 1, "x"}, {"b", 2, "y"}, {"c", 3, "z"}}
+	neu := []E{{"c", 3, "z"}, {"a", 10, "x"}, {"b", 2, "y"}, {"d", 4, "w"}}
+	for _, opts := range []Options{OptBalanced, OptCompression, OptSpeed} {
+		patch, err := Diff(old, neu, opts)
+		if err != nil {
+			t.Fatalf("opts=%v Diff: %v", opts, err)
+		}
+		base := append([]E(nil), old...)
+		if err := Apply(&base, patch); err != nil {
+			t.Fatalf("opts=%v Apply: %v", opts, err)
+		}
+		if !reflect.DeepEqual(base, neu) {
+			t.Fatalf("opts=%v: got %+v want %+v", opts, base, neu)
+		}
+	}
+}
+
+func TestDiffApplyKeyedValueOnlyNoOrder(t *testing.T) {
+	type E struct {
+		ID  int64 `qdf:"id,key"`
+		Val int
+	}
+	old := []E{{1, 10}, {2, 20}, {3, 30}}
+	neu := []E{{1, 10}, {2, 99}, {3, 30}} // same order, one value changed
+	patch, _ := Diff(old, neu, OptBalanced)
+	base := append([]E(nil), old...)
+	if err := Apply(&base, patch); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(base, neu) {
+		t.Fatalf("got %+v want %+v", base, neu)
+	}
+}
+
+func TestDiffApplyKeyedDeleteInsert(t *testing.T) {
+	type E struct {
+		ID  int64 `qdf:"id,key"`
+		Val int
+	}
+	old := []E{{1, 1}, {2, 2}, {3, 3}, {4, 4}}
+	neu := []E{{1, 1}, {3, 30}, {5, 5}} // delete 2&4, change 3, add 5, reorder
+	patch, _ := Diff(old, neu, OptBalanced)
+	base := append([]E(nil), old...)
+	if err := Apply(&base, patch); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(base, neu) {
+		t.Fatalf("got %+v want %+v", base, neu)
+	}
+}

--- a/delta_keyed_test.go
+++ b/delta_keyed_test.go
@@ -108,6 +108,19 @@ func TestKeyTokenByteArray(t *testing.T) {
 	}
 }
 
+func TestKeyedPatchUsesKeyedTag(t *testing.T) {
+	type E struct {
+		ID  string `qdf:"id,key"`
+		Val int
+	}
+	old := []E{{"a", 1}}
+	neu := []E{{"a", 2}}
+	patch, _ := Diff(old, neu, OptBalanced)
+	if !containsByte(patch, tagKeyedSlicePatch) {
+		t.Fatal("keyed type must emit tagKeyedSlicePatch")
+	}
+}
+
 func TestKeyTokenAtMatchesKeyToken(t *testing.T) {
 	// keyTokenAt over the key value alone must equal keyToken over the element.
 	type E struct {

--- a/delta_wire.go
+++ b/delta_wire.go
@@ -32,6 +32,7 @@ const (
 	tagSlicePatch      = 0x02 // varuint(newLen), varuint(nEntries), nEntries×(varuint(idx), op)
 	tagMapPatch        = 0x03 // varuint(nUpdate), nUpdate×(key-value, op), varuint(nDelete), nDelete×(key-value)
 	tagKeyedSlicePatch = 0x04 // flags byte, [if orderChanged: varuint(newLen)+newLen×key], varuint(nOps), nOps×(key, op)
+	tagColSlicePatch   = 0x05 // varuint(n), varuint(nChangedCols), per col: varuint(colIdx), mode byte, body
 )
 
 // Keyed-slice-patch flag bits (the flags byte after tagKeyedSlicePatch).

--- a/delta_wire.go
+++ b/delta_wire.go
@@ -28,9 +28,15 @@ const (
 // Patch body tags. Disjoint numbering from the value tag space (wire.go) — a
 // patch body is parsed by the delta reader, never by the value tag dispatcher.
 const (
-	tagStructPatch = 0x01 // varuint(nChanged), nChanged×(varuint(fieldIdx), op)
-	tagSlicePatch  = 0x02 // varuint(newLen), varuint(nEntries), nEntries×(varuint(idx), op)
-	tagMapPatch    = 0x03 // varuint(nUpdate), nUpdate×(key-value, op), varuint(nDelete), nDelete×(key-value)
+	tagStructPatch     = 0x01 // varuint(nChanged), nChanged×(varuint(fieldIdx), op)
+	tagSlicePatch      = 0x02 // varuint(newLen), varuint(nEntries), nEntries×(varuint(idx), op)
+	tagMapPatch        = 0x03 // varuint(nUpdate), nUpdate×(key-value, op), varuint(nDelete), nDelete×(key-value)
+	tagKeyedSlicePatch = 0x04 // flags byte, [if orderChanged: varuint(newLen)+newLen×key], varuint(nOps), nOps×(key, op)
+)
+
+// Keyed-slice-patch flag bits (the flags byte after tagKeyedSlicePatch).
+const (
+	flagKeyedOrderChanged = 1 << 0 // keys were added/removed/reordered; the new key order follows
 )
 
 // Op bytes. Every changed location is one op byte + payload.

--- a/docs/DELTA.md
+++ b/docs/DELTA.md
@@ -70,6 +70,72 @@ and never has to be told which `Options` the producer used.
 
 ---
 
+## When to use what
+
+Most of the delta is **automatic** — you call `Diff` / `Apply` and the format
+picks the smallest representation per location, never larger than the
+alternative. The only things you actively choose are the `Options` tier, a few
+opt-ins for specific workloads, and whether to tag identity fields. This section
+is the decision guide; the rest of the document is the reference.
+
+### Which `Options` tier?
+
+The tier is the same bit-mask `Marshal` takes, and it only affects how *replaced
+values* inside the patch are codec-encoded (plus whether the optional rANS pass
+runs). The op-level structure is identical across tiers, and a patch is
+self-describing — **the consumer never needs to match the producer's tier.**
+
+| Tier | Use when | Cost |
+| ---- | -------- | ---- |
+| `OptSpeed` | Lowest latency matters more than bytes — a single-process cache, a LAN sync, a high-frequency tick where CPU is the budget. | Largest patches (no entropy pass, lightest codecs). |
+| `OptBalanced` *(default)* | The general choice. Good wire size, low CPU. Start here. | — |
+| `OptCompression` | Bytes are scarce — WAN replication, cross-region CDC, anything you pay egress for or persist at volume. Adds a never-larger order-0 rANS pass over the patch body. | More producer CPU; decode is cheap. |
+
+Rule of thumb: **`OptBalanced` unless you are measurably bottlenecked** on
+latency (→ `OptSpeed`) or on bytes over an expensive link (→ `OptCompression`).
+
+### Opt-ins, by workload
+
+| You have… | Do this | Why |
+| --------- | ------- | --- |
+| A **`[]struct` that reorders / inserts / deletes** in the middle (entity lists, ECS components, ordered records with a stable id) | Tag the identity field: `` `qdf:"id,key"` `` | Matches elements by key, not position — a reorder ships only the key order, an insert/delete touches one element instead of reshipping the tail. See [Keyed slices](#keyed-slices). |
+| A **consumer applying a stream of patches** (server pushes deltas of an evolving value) and you don't want to thread the previous value by hand | Use a `BaselineRegistry[T]` | Resolves each patch's base from a small weak-pointer cache; GC-reclaims dropped baselines. See [Baseline registry](#baseline-registry). |
+| A **large base, tiny patch, fully trusted pipeline** (single-writer cache, end-to-end-controlled CDC) where `Apply` latency matters | `Diff(old, new, tier \| OptDeltaNoBaseFingerprint)` | Skips the base-fingerprint walk — ~10× faster `Apply` on a large base. **Drops the wrong-base safety net** — only in trusted pipelines. See [Skipping the base fingerprint](#skipping-the-base-fingerprint). |
+| A patch that **replaces many strings** (a large changed `[]string`, a map of changed string values) and you apply at volume | `ApplyArena(&base, patch, arena)` | Batches the replaced-string copies into one arena instead of one heap alloc each — ~−99% allocs on string-heavy patches. See [Batching replaced strings](#batching-replaced-strings-with-an-arena). |
+| `Apply` that **creates maps / grows slices** on the hot path | Build with `-tags qdf_reflect2` | Faster destination allocation; default build unchanged. See [the build tag](#the-qdf_reflect2-build-tag). |
+| A **batch of flat all-scalar rows** (telemetry, metrics, time-series) where a few *columns* move across many rows | Nothing — it's **automatic** | An equal-length diff of a pure-columnar `[]struct` groups changes by column when that is smaller. See [Columnar column-level diff](#columnar-column-level-diff). |
+
+### What you never have to do
+
+- **Match the producer's tier on the consumer.** Patches are self-describing.
+- **Write per-type diff code, an IDL, or a `FieldMask`.** `Diff` works straight
+  from the two typed values.
+- **Choose between positional / keyed / columnar.** The format picks per case and
+  guarantees the result is never larger than the alternative; you only *enable*
+  keyed matching by tagging the id field.
+
+### Worked recipes
+
+```go
+// 1. Config hot-reload over a control plane — bytes matter, base is trusted.
+patch, _ := qdf.Diff(oldCfg, newCfg, qdf.OptCompression|qdf.OptDeltaNoBaseFingerprint)
+
+// 2. Game/realtime entity sync — latency matters, entities reorder by id.
+//    type Entity struct { ID uint64 `qdf:"id,key"`; X, Y float32 }
+patch, _ := qdf.Diff(prevWorld, curWorld, qdf.OptSpeed)
+
+// 3. Streaming consumer applying a chain — no manual base bookkeeping.
+reg := qdf.NewBaselineRegistry[State]()
+reg.Register(&s0)            // bootstrap from a decoded full value, keep it alive
+s1, _ := reg.Apply(patch1)   // resolves s0, returns *s1
+s2, _ := reg.Apply(patch2)   // resolves s1 (auto-registered), returns *s2
+
+// 4. CDC of a large row set, one field changes — default is already optimal.
+patch, _ := qdf.Diff(oldRows, newRows, qdf.OptBalanced)
+```
+
+---
+
 ## API
 
 ```go
@@ -389,9 +455,9 @@ without threading `old` by hand.
 	func (r *BaselineRegistry[T]) Len() int
 
 **No wire change.** A patch already carries `baseFP`, an 8-byte content hash of
-`old` (on by default; see *Skipping the base fingerprint*). Phase 1 uses it only
-to *reject* a mismatched base; the registry reuses the very same `baseFP` as a
-*lookup key*. The producer ships an ordinary `Diff` — there is no new tag, flag,
+`old` (on by default; see *Skipping the base fingerprint*). Plain `Apply` uses it
+only to *reject* a mismatched base; the registry reuses the very same `baseFP` as
+a *lookup key*. The producer ships an ordinary `Diff` — there is no new tag, flag,
 or field. The registry is a consumer-side construct layered on the existing
 format.
 
@@ -417,7 +483,7 @@ step). Resolving a baseline the caller has dropped is a clean miss
 `Apply` **deep-clones** the resolved baseline before applying — the registry
 keeps the original intact, since another patch may branch off it — and
 auto-registers the result so it can base the next patch. The clone preserves
-nil-vs-empty exactly, so its fingerprint matches the original's; the Phase 1
+nil-vs-empty exactly, so its fingerprint matches the original's; `Apply`'s
 `baseFP` check is the backstop that turns any clone discrepancy into an error,
 never silent corruption.
 
@@ -431,15 +497,19 @@ The registry is safe for concurrent `Register` / `Apply` / `Len`.
 
 ## Limitations
 
-A few things are not currently supported and may come later:
+Known boundaries of the current implementation:
 
-- **Column-level diff for `[]struct`** — when a slice of flat structs is stored
-  columnar, shipping only the columns that changed instead of per-element ops.
-
-A few things are not currently supported and may come later:
-
-- **Column-level diff for `[]struct`** — when a slice of flat structs is stored
-  columnar, shipping only the columns that changed instead of per-element ops.
-- **Content-addressed baselines** — addressing the base by a content hash so a
-  patch can be applied against a baseline fetched from a store, rather than the
-  caller holding `old`.
+- **Unkeyed slice middle edits.** A slice without a `,key` tag is matched
+  positionally, so inserting or deleting in the *middle* reships the shifted
+  tail. Tag the element's identity field (see [Keyed slices](#keyed-slices)) to
+  avoid this; end appends/truncates are already cheap.
+- **Columnar column-diff scope.** The by-column path covers equal-length diffs of
+  **pure-columnar** elements only. A **hybrid** element (one with a `map`,
+  non-`[]byte` slice, or nested-struct field) and a **nullable-string**
+  (`*string`) column fall back to the positional path (still correct, just not
+  column-grouped). A length change also uses the positional/keyed path.
+- **Codec coercions on replaced values.** A whole-value replace round-trips
+  through the normal qdf value codec, which (as elsewhere in qdf) normalizes
+  `time.Time` to UTC seconds + nanoseconds (dropping the monotonic-clock reading
+  and `*Location`) and widens an `int` boxed in an `interface{}` to its 64-bit
+  form. These are inherent to the wire format, not delta-specific.

--- a/docs/DELTA.md
+++ b/docs/DELTA.md
@@ -327,6 +327,44 @@ The key field must be comparable — a scalar, string, or `[N]byte`. If keys are
 not unique, the diff transparently falls back to the positional path (still
 correct). One `,key` field per element type.
 
+## Columnar column-level diff
+
+The positional diff walks a `[]struct` element by element: a changed row ships
+the whole element's per-field patch. For a large batch where only a few
+*columns* move — telemetry, metrics, event rows — that scatters the changes
+across every touched element. When the diff is **equal-length** (same number of
+elements old and new) and the element is **pure-columnar** (every field is a
+column the columnar encoder understands, with no map/slice/nested residual), at
+least `16` elements, the diff instead groups the changes **by column** and emits
+a compact column patch.
+
+Each changed column is encoded independently, in whichever of three modes is
+smallest for that column:
+
+- **sparse** — the changed row indices (gap-encoded, ascending) plus the new
+  values of just those cells, for a column touched in few rows;
+- **arithmetic-delta** — a full-length per-row delta added back on apply, for a
+  numeric (or bool) column that moved in most rows but by small amounts;
+- **dense-whole** — the entire new column re-shipped, when neither of the above
+  is cheaper.
+
+The per-column bodies reuse the existing column codecs — FOR / delta / RLE /
+dictionary for numerics, the dictionary-or-raw bulk path for strings, the
+sec/nsec sub-columns for `time.Time` — so each column is packed as tightly as a
+fresh columnar encode would pack it.
+
+This needs **no flag**: it is chosen automatically, and only when the resulting
+column patch is **smaller** than the positional patch for the same change
+(never-larger — if the changes are scattered across many columns, the positional
+patch wins and is used). Apply mirrors it, scattering each decoded column back
+into its rows.
+
+v1 covers pure-columnar elements only — a **hybrid** element (one carrying a
+`map` or non-columnar field) always uses the positional path — and every column
+kind except **nullable string** (`*string`), which also falls back to
+positional. Float columns never use arithmetic delta (floating-point subtraction
+does not round-trip exactly), so they pick sparse or dense-whole.
+
 ## Baseline registry
 
 `Apply[T](base *T, patch)` requires the caller to hold the exact `old` value the

--- a/docs/DELTA.md
+++ b/docs/DELTA.md
@@ -327,7 +327,76 @@ The key field must be comparable — a scalar, string, or `[N]byte`. If keys are
 not unique, the diff transparently falls back to the positional path (still
 correct). One `,key` field per element type.
 
+## Baseline registry
+
+`Apply[T](base *T, patch)` requires the caller to hold the exact `old` value the
+patch was diffed against. In a state-sync stream — a server pushing successive
+deltas of an evolving value to clients — the consumer would have to remember the
+previous state to apply the next patch. `BaselineRegistry[T]` does that
+bookkeeping: it keeps a small content-addressed cache of recent baselines and
+resolves a patch's base from it, so the consumer applies a chain of patches
+without threading `old` by hand.
+
+	// NewBaselineRegistry returns an empty registry for baselines of type T.
+	func NewBaselineRegistry[T any]() *BaselineRegistry[T]
+
+	// Register stores *v as a resolvable baseline and returns its content id.
+	func (r *BaselineRegistry[T]) Register(v *T) uint64
+
+	// Apply resolves the patch's baseline by its embedded fingerprint, applies
+	// the patch onto a fresh deep copy, registers the result, and returns it.
+	func (r *BaselineRegistry[T]) Apply(patch []byte) (*T, error)
+
+	// Len reports the number of live baselines (prunes dead entries).
+	func (r *BaselineRegistry[T]) Len() int
+
+**No wire change.** A patch already carries `baseFP`, an 8-byte content hash of
+`old` (on by default; see *Skipping the base fingerprint*). Phase 1 uses it only
+to *reject* a mismatched base; the registry reuses the very same `baseFP` as a
+*lookup key*. The producer ships an ordinary `Diff` — there is no new tag, flag,
+or field. The registry is a consumer-side construct layered on the existing
+format.
+
+	// producer holds prev; ships an ordinary diff (baseFP embedded by default)
+	patch, _ := qdf.Diff(prev, cur, qdf.OptBalanced)
+
+	// consumer
+	reg := qdf.NewBaselineRegistry[State]()
+	s0 := &decodedFullState        // a *State the consumer decoded and keeps alive
+	reg.Register(s0)               // bootstrap from a full value
+	s1, err := reg.Apply(patch)    // resolves s0 by baseFP, applies, returns *s1
+	// keep s1 to apply the next patch in the chain; drop it to let the GC reclaim it.
+
+**Non-pinning lifetime.** The registry holds each baseline through a
+`weak.Pointer`, never a strong reference, so the GC reclaims any baseline the
+**caller** has dropped — zero leak, automatic reclamation. The flip side is the
+caller's contract: a baseline stays resolvable only while the caller keeps a
+strong reference to it. In a chain, keep the previous `*T` reachable across the
+`Apply` that consumes it (the returned pointer is the natural anchor for the next
+step). Resolving a baseline the caller has dropped is a clean miss
+(`ErrBaselineEvicted`); recover by re-syncing a full value.
+
+`Apply` **deep-clones** the resolved baseline before applying — the registry
+keeps the original intact, since another patch may branch off it — and
+auto-registers the result so it can base the next patch. The clone preserves
+nil-vs-empty exactly, so its fingerprint matches the original's; the Phase 1
+`baseFP` check is the backstop that turns any clone discrepancy into an error,
+never silent corruption.
+
+`OptDeltaNoBaseFingerprint` is incompatible with the registry: such a patch
+carries no id, so `Apply` returns `ErrBaselineRequired`. Baselines are addressed
+by a 64-bit fingerprint; two distinct values sharing one (probability ~N²/2⁶⁴,
+negligible for thousands of live baselines) collide on the same key, the later
+registration wins, and the earlier baseline then reads as `ErrBaselineEvicted`.
+
+The registry is safe for concurrent `Register` / `Apply` / `Len`.
+
 ## Limitations
+
+A few things are not currently supported and may come later:
+
+- **Column-level diff for `[]struct`** — when a slice of flat structs is stored
+  columnar, shipping only the columns that changed instead of per-element ops.
 
 A few things are not currently supported and may come later:
 

--- a/docs/DELTA.md
+++ b/docs/DELTA.md
@@ -304,24 +304,35 @@ negligible.
 
 ---
 
-## Limitations
+## Keyed slices
 
-**Slices are matched positionally.** There is no keyed or identity-based
-matching, so reordering a slice, or inserting/deleting in the middle, reships
-the shifted tail (see [Deletion](#deletion)). If your slices are append-mostly
-or you mutate elements in place this is a non-issue; if you reorder a large
-slice often, a full `Marshal` of that slice may beat a positional diff.
+By default slices are matched **positionally**: reordering a slice, or inserting
+or deleting in the middle, reships the shifted tail. For slices whose elements
+have a stable identity, tag the identity field with `,key` on its `qdf` tag and
+the slice is matched by that key instead:
+
+	type Entity struct {
+	    ID   string `qdf:"id,key"`
+	    X, Y float64
+	}
+
+Now a `[]Entity` patch matches elements by `ID`. Reordering the slice ships only
+the new key order (no element values); inserting, deleting, or moving an element
+touches just that element — where the positional diff would reship everything
+after the change. Value-only edits that keep the same order ship no order list at
+all. In a benchmark, a full reverse of a 200-element slice produced a keyed patch
+~30% smaller than a full re-encode (and far smaller than a positional diff).
+
+The key field must be comparable — a scalar, string, or `[N]byte`. If keys are
+not unique, the diff transparently falls back to the positional path (still
+correct). One `,key` field per element type.
+
+## Limitations
 
 A few things are not currently supported and may come later:
 
-- **Keyed slice diff** — matching elements by a declared key field, so a reorder
-  or a middle insert/delete updates only the affected elements instead of
-  reshipping the positional tail.
 - **Column-level diff for `[]struct`** — when a slice of flat structs is stored
   columnar, shipping only the columns that changed instead of per-element ops.
 - **Content-addressed baselines** — addressing the base by a content hash so a
   patch can be applied against a baseline fetched from a store, rather than the
   caller holding `old`.
-
-None of these is wired up today; the positional diff above is the whole feature
-as it stands.

--- a/encoder.go
+++ b/encoder.go
@@ -174,6 +174,11 @@ type Encoder struct {
 	// zero. Bounded on return to the encoder pool (putEnc).
 	wideI64 []int64
 	wideU64 []uint64
+
+	// keyIdx is a reused (clear-not-realloc) old-key→index map for keyed slice
+	// diff. Lives on the Encoder so a many-element keyed slice builds its match
+	// table once per pool acquire; dropped past a spike cap in Reset().
+	keyIdx map[string]int
 }
 
 // applyOpts mirrors the options bitmask onto the cached mode / qpack
@@ -282,6 +287,11 @@ func (e *Encoder) Reset() {
 	// Pure []uint64 (no pointers) so no clear is needed.
 	if cap(e.alpScratch) > maxRetainedColScratch {
 		e.alpScratch = nil
+	}
+	// Drop a spike-sized keyed-diff match map before reuse; clearing happens
+	// lazily at build time (mirror the alpScratch cap-drop above).
+	if len(e.keyIdx) > 1<<16 {
+		e.keyIdx = nil
 	}
 	e.headerOut = false
 	if e.state != nil {

--- a/qpack_strraw.go
+++ b/qpack_strraw.go
@@ -85,6 +85,30 @@ func (e *Encoder) tryWriteStringColumnRaw(strs []string) bool {
 	return true
 }
 
+// writeStringColumnRawForced ALWAYS emits strs as a tagColStrRaw block, with no
+// size/cardinality decline. It is the unconditional emit half of
+// tryWriteStringColumnRaw (same wire shape, decoded by readStringColumnRaw for
+// any n >= 0). Used by the column-diff path, which needs a wire-stateless string
+// codec (raw is fully self-contained) it can build on a shared encoder state
+// without polluting the intern state table.
+func (e *Encoder) writeStringColumnRawForced(strs []string) {
+	n := len(strs)
+	total := 0
+	for _, s := range strs {
+		total += len(s)
+	}
+	e.writeHeader()
+	out := e.buf
+	out = append(out, tagColStrRaw)
+	out = appendUvarint(out, uint64(n))
+	out = appendUvarint(out, uint64(total))
+	for _, s := range strs {
+		out = appendUvarint(out, uint64(len(s)))
+		out = append(out, s...)
+	}
+	e.buf = out
+}
+
 // readStringColumnRaw decodes a tagColStrRaw block (tag at d.i) into n strings.
 // Under noCopy each row aliases the input buffer directly (zero allocation past
 // the result slice); otherwise every row is a sub-slice of one owned slab pre-

--- a/reflect_desc.go
+++ b/reflect_desc.go
@@ -251,13 +251,6 @@ func fillDesc(td *typeDesc, t reflect.Type, ctx *buildCtx) error {
 			td.elem = elem
 			if elem.kind == reflect.Struct {
 				td.colPlan = buildColumnarPlan(elem)
-				// Mirror the plan onto the element struct descriptor so the
-				// columnar column-level diff (delta_columnar.go) can route off the
-				// element desc it is handed (diffColumnarEligible). Additive: a
-				// struct desc's colPlan is otherwise unused.
-				if elem.colPlan == nil {
-					elem.colPlan = td.colPlan
-				}
 			}
 			td.encode = encodeSlice(elem, t.Elem().Size(), td.colPlan)
 			td.decode = decodeSlice(t, elem, t.Elem().Size(), td.colPlan)

--- a/reflect_desc.go
+++ b/reflect_desc.go
@@ -30,6 +30,12 @@ type typeDesc struct {
 	// typeCache via LoadOrStore (same happens-before as encode/decode).
 	schemaFP uint64
 
+	// keyed/keyOff/keyDesc describe a struct element's identity key (the field
+	// tagged `qdf:"...,key"`), used by keyed slice diff. keyed is false for
+	// types without a key tag. Set once at build.
+	keyOff  uintptr   // byte offset of the key field within the struct
+	keyDesc *typeDesc // descriptor of the key field's type
+
 	// kind / marshalerKind / pod are 1-byte (or kind-sized) tails kept last so
 	// they share one word instead of forcing padding ahead of the 8-byte fields
 	// above.
@@ -49,6 +55,8 @@ type typeDesc struct {
 	// descBuild (single-threaded, published with the descriptor). Shares the
 	// 1-byte tail with kind/marshalerKind/pod (no new padding).
 	tightPOD bool
+	// keyed reports whether a ,key-tagged field is present (keyOff/keyDesc valid).
+	keyed bool
 }
 
 type fieldDesc struct {
@@ -63,6 +71,7 @@ type fieldDesc struct {
 	// the first time (intern record) and rely on the encoder's state table
 	// to switch to refs on subsequent encodes.
 	preInternStr []byte
+	isKey        bool // this field carried the ,key tag option
 }
 
 var typeCache sync.Map // map[reflect.Type]*typeDesc — only fully-built entries
@@ -302,6 +311,19 @@ func fillDesc(td *typeDesc, t reflect.Type, ctx *buildCtx) error {
 			return err
 		}
 		td.fields = fields
+		// Record the identity key (the ,key-tagged field), if any. Reject more
+		// than one ,key field per type.
+		for i := range td.fields {
+			if !td.fields[i].isKey {
+				continue
+			}
+			if td.keyed {
+				return ErrUnsupported // at most one ,key field per type
+			}
+			td.keyed = true
+			td.keyOff = td.fields[i].offset
+			td.keyDesc = td.fields[i].desc
+		}
 		td.encode = encodeStruct(td)
 		td.decode = decodeStruct(td)
 	default:
@@ -360,6 +382,7 @@ func appendStructFields(out []fieldDesc, t reflect.Type, base uintptr, ctx *buil
 			continue
 		}
 		name := sf.Name
+		isKey := false
 		if tag, ok := sf.Tag.Lookup("qdf"); ok {
 			if tag == "-" {
 				continue
@@ -367,6 +390,14 @@ func appendStructFields(out []fieldDesc, t reflect.Type, base uintptr, ctx *buil
 			parts := strings.Split(tag, ",")
 			if parts[0] != "" {
 				name = parts[0]
+			}
+			for _, opt := range parts[1:] {
+				if opt == "key" {
+					if !sf.Type.Comparable() {
+						return nil, ErrUnsupported // a key field must be comparable
+					}
+					isKey = true
+				}
 			}
 		} else if tag, ok := sf.Tag.Lookup("json"); ok {
 			parts := strings.Split(tag, ",")
@@ -387,6 +418,7 @@ func appendStructFields(out []fieldDesc, t reflect.Type, base uintptr, ctx *buil
 			desc:         fd,
 			preFast:      precomputeFixstrHeader(name),
 			preInternStr: precomputeInternStrHeader(name),
+			isKey:        isKey,
 		})
 	}
 	// stable order = source order (no sort) — matches encoding/json behavior

--- a/reflect_desc.go
+++ b/reflect_desc.go
@@ -251,6 +251,13 @@ func fillDesc(td *typeDesc, t reflect.Type, ctx *buildCtx) error {
 			td.elem = elem
 			if elem.kind == reflect.Struct {
 				td.colPlan = buildColumnarPlan(elem)
+				// Mirror the plan onto the element struct descriptor so the
+				// columnar column-level diff (delta_columnar.go) can route off the
+				// element desc it is handed (diffColumnarEligible). Additive: a
+				// struct desc's colPlan is otherwise unused.
+				if elem.colPlan == nil {
+					elem.colPlan = td.colPlan
+				}
 			}
 			td.encode = encodeSlice(elem, t.Elem().Size(), td.colPlan)
 			td.decode = decodeSlice(t, elem, t.Elem().Size(), td.colPlan)

--- a/state.go
+++ b/state.go
@@ -195,6 +195,11 @@ type encState struct {
 	deltaColBitmap []uint64
 	deltaColRows   []int
 	deltaColBuf    []byte
+	// deltaColAux* hold the OLD column gathered contiguously for the arithmetic
+	// delta encode (new − old), so both operands are width-hoisted gathers fed to
+	// a vectorizable subtract instead of two per-element width switches.
+	deltaColAuxI64 []int64
+	deltaColAuxU64 []uint64
 	colDictTable   []string // distinct table for the string-dict codec
 	colMaskScratch []byte   // presence bitmap for nullable columns
 	// FSST codec scratch, reused across columns (same lifetime as colDictTable).

--- a/state.go
+++ b/state.go
@@ -188,6 +188,13 @@ type encState struct {
 	colScratchF64  []float64
 	colScratchBool []bool
 	colScratchStr  []string // gathered string column values
+	// Columnar column-level diff scratch (delta_columnar.go). deltaColBitmap is
+	// the per-row changed bitmap; deltaColRows the changed-row indices for one
+	// column; deltaColBuf the built tagColSlicePatch body for the never-larger
+	// compare. Row-scaled, retained/dropped like the colScratch* above.
+	deltaColBitmap []uint64
+	deltaColRows   []int
+	deltaColBuf    []byte
 	colDictTable   []string // distinct table for the string-dict codec
 	colMaskScratch []byte   // presence bitmap for nullable columns
 	// FSST codec scratch, reused across columns (same lifetime as colDictTable).
@@ -420,6 +427,17 @@ func (e *encState) reset() {
 	// memory. sync.Pool's GC eviction reclaims it when the encoder goes idle.
 	if cap(e.colScratchI64) > maxRetainedColScratch {
 		e.colScratchI64, e.colScratchU64, e.colScratchF64, e.colScratchBool = nil, nil, nil, nil
+	}
+	// Column-diff scratch (delta_columnar.go): same row-scaled hard-ceiling
+	// retention as colScratch* (pointer-free, no clear needed).
+	if cap(e.deltaColBitmap) > maxRetainedColScratch {
+		e.deltaColBitmap = nil
+	}
+	if cap(e.deltaColRows) > maxRetainedColScratch {
+		e.deltaColRows = nil
+	}
+	if cap(e.deltaColBuf) > maxRetainedColScratch {
+		e.deltaColBuf = nil
 	}
 	if cap(e.fsstScratch) > maxRetainedColScratch {
 		e.fsstScratch = nil
@@ -875,6 +893,10 @@ type decState struct {
 	colScratchF64  []float64
 	colScratchBool []bool
 
+	// deltaColRows is reused storage for a sparse column's decoded ascending row
+	// indices during a tagColSlicePatch apply (delta_columnar.go).
+	deltaColRows []int
+
 	// colLenScratch is reused storage for the column-length index parsed from
 	// a FlagColIndex columnar payload (one uint32 byte-length per column).
 	colLenScratch []uint32
@@ -968,6 +990,10 @@ func (d *decState) reset() {
 	}
 	if cap(d.colLenScratch) > maxRetainedColScratch {
 		d.colLenScratch = nil
+	}
+	// Column-diff sparse-row scratch (delta_columnar.go): same ceiling policy.
+	if cap(d.deltaColRows) > maxRetainedColScratch {
+		d.deltaColRows = nil
 	}
 	for i := range d.mruRing {
 		d.mruRing[i] = mruEmpty


### PR DESCRIPTION
## Summary

Adds a type-generic **structural delta** to qdf: `Diff(old, new)` produces a
patch carrying only what changed, `Apply(base, patch)` merges it back in place.
This is the primitive behind state-sync workloads — config hot-reload, CDC /
event sourcing, k8s-style reconciliation, game/realtime netcode, live dashboards
— with no IDL, no hand-maintained `FieldMask`, no per-type diff code.

On top of the core walk the PR layers three advanced capabilities, each adaptive
(no flags) and **never larger than the alternative** by construction:

1. **Keyed slices** — match `[]struct` elements by an identity field (`qdf:"id,key"`)
   instead of by position, so a reorder/insert/delete ships only the moved keys.
2. **Content-addressed baseline registry** — a consumer applies a chain of
   patches without threading `old` by hand; baselines are held weakly and
   GC-reclaimed.
3. **Columnar column-level diff** — for an equal-length diff of a pure-columnar
   `[]struct`, group changes *by column* (sparse / arithmetic-delta / dense),
   riding the existing FOR/RLE/dict/bitpack column codecs.

The patch is self-describing (its own `QDP` magic + schema/base fingerprints);
the receiver hands the bytes straight to `Apply` and never has to know which
`Options` the producer used.

## Public API

```go
func Diff[T any](old, new T, opts Options) ([]byte, error)
func AppendDiff[T any](dst []byte, old, new T, opts Options) ([]byte, error)
func Apply[T any](base *T, patch []byte) error
func ApplyArena[T any](base *T, patch []byte, arena *Arena) error

// content-addressed baseline registry (consumer-side, weak-pointer cache)
func NewBaselineRegistry[T any]() *BaselineRegistry[T]
func (r *BaselineRegistry[T]) Register(v *T) uint64
func (r *BaselineRegistry[T]) Apply(patch []byte) (*T, error)
func (r *BaselineRegistry[T]) Len() int

// errors
ErrInvalidPatch, ErrPatchSchemaMismatch, ErrPatchBaseMismatch, ErrCycleDetected
ErrBaselineRequired, ErrBaselineEvicted

// opt-out: drop the 8-byte base fingerprint
OptDeltaNoBaseFingerprint
```

Keyed slices need no API — tag the identity field `qdf:"id,key"`.

## What changed

### Core diff/apply (`delta.go`, `delta_wire.go`, `delta_diff.go`, `delta_apply.go`)
- `QDP` patch container: 3-byte magic + version + flags + 8-byte schemaFP +
  optional 8-byte baseFP, then op-level body. Ops: `opReplace` (whole value via
  the normal qdf codec) / `opMerge` (recursive sub-patch). Container sub-patches:
  struct (changed fields), slice (positional), map (per-key + tombstones).
- `equalValue` unchanged-fast-path: typed per-width scalar compares, `bytes.Equal`
  (SIMD) for strings/`[]byte`, **block-memcmp** over POD slice/array backing.
- nil-vs-empty preserved (a `nil` ↔ empty-non-nil slice/map/`[]byte` transition is
  a real change, never silently collapsed).
- Depth-guarded against cyclic / pathologically deep values (`ErrCycleDetected`).
- `valueFingerprint` (baseFP): unsafe bulk-POD hash for tight types, structural
  recurse otherwise; order-independent for maps.

### Keyed slices (`delta_keyed.go`)
- `qdf:"id,key"` tags the element's identity field (comparable: scalar / string /
  `[N]byte`), cached on the element `typeDesc`.
- `tagKeyedSlicePatch` + `flagKeyedOrderChanged`. Zero-alloc byte-token keys;
  small-N linear scan, larger uses a `clear()`-reused `map[string]int` on the
  pooled encoder. Duplicate keys transparently fall back to the positional diff.

### Baseline registry (`delta_baseline.go`)
- `map[uint64]weak.Pointer[T]` + `sync.Mutex`; reuses the patch's existing `baseFP`
  as the content id — **no wire change**. The caller owns the strong ref; the GC
  reclaims dropped baselines (`ErrBaselineEvicted` on a miss).
- `Apply` deep-clones the resolved baseline (keeping it intact for branching),
  applies, and auto-registers the result to chain the next patch.
- `deepClone` walks the `typeDesc`/`unsafe` representation (honors the
  `qdf_reflect2` build tag for slice/map allocation), preserves nil-vs-empty, and
  value-copies fields-less structs (`time.Time` etc.) so the clone fingerprints
  identically.

### Columnar column-level diff (`delta_columnar.go`)
- For `len(old)==len(new)`, a pure-columnar element (`<128` columns, `≥16` rows),
  emit `tagColSlicePatch` grouping changes by column. Per-column mode: **sparse**
  (gap-encoded changed-row indices + cells), **delta** (per-row arithmetic
  `new−old` for int/uint, XOR-flag for bool — zero runs crushed by FOR/RLE),
  **dense-whole** (re-ship). String/`[]byte` use a wire-stateless dict/raw codec.
- **Build-and-compare picker**: the column body is emitted only if strictly
  smaller than the positional body → hard never-larger guarantee. Hybrid elements
  and nullable-string columns fall back to the positional path.

### Docs
`docs/DELTA.md` covers the API, wire format, deletion semantics, safety,
performance, keyed slices, the baseline registry, and the columnar column-diff.

## Performance

Measure-first throughout (prototype → benchstat → keep/revert; never-larger by
construction). Intel i7-9750H, Go 1.26, `OptBalanced`.

| Path | Result |
|------|--------|
| Diff vs full re-encode | patch carries only the delta; orders of magnitude smaller on a one-field change in a 1000-record set |
| Keyed slice reorder (200 elems, reversed) | keyed patch ~30% smaller than a full re-encode, far smaller than positional |
| Columnar column-diff (clustered 1000-row batch) | column patch **1007 B vs 3276 B positional — 3.25× smaller**; apply 3 allocs |
| Columnar diff CPU | POD row-memequal detection **−12%**; arithmetic-delta via width-hoisted gather + vector subtract |
| `time.Time` diff fast path | absolute sec+nsec compare vs `reflect.Value.Equal` — **−14%** on timestamped structs, fewer spurious replaces |
| Baseline registry | reuses `baseFP`, non-pinning weak cache (no leak; `Len()` → 0 after release + GC) |

Notable that **didn't** ship (measure-first kills, documented): pooling the
`changed`/`entries` index slices (Go 1.25/1.26 escape analysis + the 32-byte
speculative stack buffer already keep them off the heap); snapshot/restore of the
encoder intern state for stateful string columns (replaced by a wire-stateless
string codec); SIMD gather for the sparse index scatter (VPGATHER measured 5×
slower on this hardware). The core diff/apply is at the SIMD/codec floor —
detection is typed compares + memcmp, encode/decode delegates to the hand-written
AVX2/NEON column codecs, maps are reflect-bound (Go floor).

## Safety

- **Never-larger by construction.** Keyed slices, the columnar column-diff, and
  the optional rANS patch pass all fall back to / decline in favor of the smaller
  encoding; a patch is never larger than the alternative it replaces.
- **Hostile input.** Every decode allocation is bounded by the input (or by the
  declared column count, tightened per sub-column); truncated / corrupt / bad-tag
  patches return an error, never panic or OOM. Covered by per-feature hostile-byte
  tests and fuzzers (oracle round-trip + apply-never-panics), millions of execs.
- **baseFP backstop.** A patch carries an 8-byte content hash of `old`; `Apply`
  rejects a mismatched base (`ErrPatchBaseMismatch`) rather than corrupting it.
  The baseline registry's deep clone fingerprints identically to the original, so
  this check also backstops any clone bug as an error, never silent corruption.
- **Concurrency.** The baseline registry is safe for concurrent
  `Register`/`Apply`/`Len`; the clone + apply happen outside the lock.
- **nil-vs-empty** preserved end to end.

## Validation

- `go test -tags 'qdf_reflect2 qdf_simd' -race -count=1 ./...` — green.
- `golangci-lint run ./` — 0 issues; `modernize` diagnostic clean.
- Generative deep-nesting round-trip oracle (arbitrary nested values, all tiers)
  + per-feature oracle and hostile fuzzers (keyed, baseline, columnar) — millions
  of executions, no mismatch / panic / OOM.
- Multiple adversarial review passes (incl. isolated-worktree final reviews) with
  every finding re-verified RED from a clean tree before fixing.
