### PR TITLE
perf(query): enumerate columnar result-mask matches via bits.TrailingZeros64 word-skip

### DIFF
--- a/query.go
+++ b/query.go
@@ -357,11 +357,29 @@ func popcount(b []uint64) int {
 	return n
 }
 
-// matchedIndices appends the set-bit indices (< n) of b to dst in order.
+// matchedIndices appends the set-bit indices (< n) of b to dst in order. It
+// enumerates per word via bits.TrailingZeros64, skipping whole zero words, so a
+// sparse (selective) result mask costs ~one append per match instead of n
+// per-bit tests — the common case for a selective columnar-query predicate.
+// Bit layout is LSB-first (see getBit), so the lowest set bit is the lowest
+// index and the emitted order is ascending, identical to the per-bit scan.
 func matchedIndices(b []uint64, n int, dst []int) []int {
-	for i := range n {
-		if getBit(b, i) {
-			dst = append(dst, i)
+	full := n >> 6 // count of words wholly in range [0, n)
+	for w := range full {
+		x := b[w]
+		base := w << 6
+		for x != 0 {
+			dst = append(dst, base+bits.TrailingZeros64(x))
+			x &= x - 1 // clear lowest set bit
+		}
+	}
+	// Tail word: keep only the bits below n.
+	if r := n & 63; r != 0 && full < len(b) {
+		x := b[full] & ((uint64(1) << uint(r)) - 1)
+		base := full << 6
+		for x != 0 {
+			dst = append(dst, base+bits.TrailingZeros64(x))
+			x &= x - 1
 		}
 	}
 	return dst

--- a/query_matched_test.go
+++ b/query_matched_test.go
@@ -1,0 +1,100 @@
+package qdf
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// matchedIndicesNaive is the pre-optimization per-bit reference.
+func matchedIndicesNaive(b []uint64, n int, dst []int) []int {
+	for i := range n {
+		if getBit(b, i) {
+			dst = append(dst, i)
+		}
+	}
+	return dst
+}
+
+func TestMatchedIndicesEquivalence(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	// Cover edges: 0, sub-word, exact word multiples, +1, large; densities 0..1.
+	ns := []int{0, 1, 7, 63, 64, 65, 127, 128, 129, 1000, 4096, 4097}
+	densities := []float64{0, 0.001, 0.01, 0.1, 0.5, 0.9, 1.0}
+	for _, n := range ns {
+		words := (n + 63) >> 6
+		for _, d := range densities {
+			b := make([]uint64, words)
+			for i := range n {
+				if r.Float64() < d {
+					setBit(b, i)
+				}
+			}
+			// Set some out-of-range bits in the tail word to prove they're ignored.
+			if words > 0 && n&63 != 0 {
+				b[words-1] |= ^uint64(0) << uint(n&63)
+			}
+			want := matchedIndicesNaive(b, n, nil)
+			got := matchedIndices(b, n, nil)
+			if len(want) != len(got) {
+				t.Fatalf("n=%d d=%g: len %d != %d", n, d, len(got), len(want))
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("n=%d d=%g: idx %d = %d, want %d", n, d, i, got[i], want[i])
+				}
+			}
+		}
+	}
+}
+
+func benchMask(n int, density float64) []uint64 {
+	r := rand.New(rand.NewSource(42))
+	b := make([]uint64, (n+63)>>6)
+	for i := range n {
+		if r.Float64() < density {
+			setBit(b, i)
+		}
+	}
+	return b
+}
+
+func BenchmarkMatchedIndices(b *testing.B) {
+	const n = 100_000
+	for _, d := range []float64{0.01, 0.1, 0.5, 0.9} {
+		mask := benchMask(n, d)
+		dst := make([]int, 0, n)
+		b.Run(densityName(d), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				_ = matchedIndices(mask, n, dst[:0])
+			}
+		})
+	}
+}
+
+func BenchmarkMatchedIndicesNaive(b *testing.B) {
+	const n = 100_000
+	for _, d := range []float64{0.01, 0.1, 0.5, 0.9} {
+		mask := benchMask(n, d)
+		dst := make([]int, 0, n)
+		b.Run(densityName(d), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				_ = matchedIndicesNaive(mask, n, dst[:0])
+			}
+		})
+	}
+}
+
+func densityName(d float64) string {
+	switch d {
+	case 0.01:
+		return "d1pct"
+	case 0.1:
+		return "d10pct"
+	case 0.5:
+		return "d50pct"
+	default:
+		return "d90pct"
+	}
+}


### PR DESCRIPTION
## Summary

`matchedIndices` turns a query's result bitmask into the list of matching row
indices. It did this with a per-row `getBit` loop — `n` bit tests regardless of
how many rows actually matched. This rewrites it as a per-word enumeration:
skip whole zero words, and for each non-zero word emit `base + TrailingZeros64`
then clear the lowest set bit. A selective (sparse) predicate now costs roughly
one append per match instead of one test per row.

It runs once per columnar query (`decodeColumnarQuery` / the `OptColumnIndex`
path), so the win scales with batch size and lands hardest on the common
low-selectivity predicate.

## What changed

`query.go`:

```go
func matchedIndices(b []uint64, n int, dst []int) []int {
	full := n >> 6 // words wholly in range [0, n)
	for w := 0; w < full; w++ {
		x := b[w]
		base := w << 6
		for x != 0 {
			dst = append(dst, base+bits.TrailingZeros64(x))
			x &= x - 1 // clear lowest set bit
		}
	}
	// tail word: keep only the bits below n
	if r := n & 63; r != 0 && full < len(b) {
		x := b[full] & ((uint64(1) << uint(r)) - 1)
		base := full << 6
		for x != 0 {
			dst = append(dst, base+bits.TrailingZeros64(x))
			x &= x - 1
		}
	}
	return dst
}
```

The bit layout is LSB-first (see `getBit`), so the lowest set bit is the lowest
index and the emitted order is ascending — byte-identical output to the per-bit
scan. No wire-format or semantics change; only the bit enumeration is faster.

## Correctness

- **Equivalence test** (`query_matched_test.go`, `TestMatchedIndicesEquivalence`):
  compared against a naive per-bit reference across `n ∈ {0,1,7,63,64,65,127,128,
  129,1000,4096,4097}` × densities `{0 … 1.0}`, with out-of-range tail bits
  deliberately set to prove they are ignored. Handles `n = 0`, `n` not a multiple
  of 64, and `n` exactly a multiple of 64; never reads past the mask slice (both
  callers size masks at `(n+63)>>6`).
- Full package suite (`-race`, `-tags 'qdf_reflect2 qdf_simd'`) green; lint 0.

## Measurements

`BenchmarkMatchedIndices`, 100 000-row mask, Intel i7-9750H, Go 1.26, 0 allocs at
every density — faster across the board:

| selectivity | naive (per-bit) | word-skip | speedup |
| ----------- | --------------: | --------: | ------: |
| 1 %         | ~86 µs          | ~4.4 µs   | **~19×** |
| 10 %        | ~160 µs         | ~18 µs    | **~9×**  |
| 50 %        | ~450 µs         | ~50 µs    | **~9×**  |
| 90 %        | ~207 µs         | ~78 µs    | **~2.6×** |

(The naive path is *slower* at 50 % than at 90 % — branch misprediction at half
density; the word-skip enumeration has no per-bit branch, so it avoids that.)

## Scope / safety

- One self-contained function in `query.go`; no API, wire, or behavior change.
- 0 allocations; `dst` is reused by the caller.
- `math/bits` is already imported in `query.go`. No new dependency, no build tag.
