### PR TITLE
feat(qdfgen): smart-encoding for codegen — shape-interning + threaded nested codec

### DIFF
--- a/bench/bench_qdf.go
+++ b/bench/bench_qdf.go
@@ -11,16 +11,16 @@ import (
 // emit a name with a single append, no per-call sizing.
 var (
 	qdfFieldHdr_entries_1   = []byte{0x87, 0x65, 0x6e, 0x74, 0x72, 0x69, 0x65, 0x73}
-	qdfFieldHdr_time_6      = []byte{0x84, 0x74, 0x69, 0x6d, 0x65}
-	qdfFieldHdr_level_7     = []byte{0x85, 0x6c, 0x65, 0x76, 0x65, 0x6c}
-	qdfFieldHdr_service_8   = []byte{0x87, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65}
-	qdfFieldHdr_host_9      = []byte{0x84, 0x68, 0x6f, 0x73, 0x74}
-	qdfFieldHdr_region_10   = []byte{0x86, 0x72, 0x65, 0x67, 0x69, 0x6f, 0x6e}
-	qdfFieldHdr_trace_id_11 = []byte{0x88, 0x74, 0x72, 0x61, 0x63, 0x65, 0x5f, 0x69, 0x64}
-	qdfFieldHdr_span_id_12  = []byte{0x87, 0x73, 0x70, 0x61, 0x6e, 0x5f, 0x69, 0x64}
-	qdfFieldHdr_msg_13      = []byte{0x83, 0x6d, 0x73, 0x67}
-	qdfFieldHdr_duration_14 = []byte{0x88, 0x64, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e}
-	qdfFieldHdr_status_15   = []byte{0x86, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73}
+	qdfFieldHdr_time_5      = []byte{0x84, 0x74, 0x69, 0x6d, 0x65}
+	qdfFieldHdr_level_6     = []byte{0x85, 0x6c, 0x65, 0x76, 0x65, 0x6c}
+	qdfFieldHdr_service_7   = []byte{0x87, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65}
+	qdfFieldHdr_host_8      = []byte{0x84, 0x68, 0x6f, 0x73, 0x74}
+	qdfFieldHdr_region_9    = []byte{0x86, 0x72, 0x65, 0x67, 0x69, 0x6f, 0x6e}
+	qdfFieldHdr_trace_id_10 = []byte{0x88, 0x74, 0x72, 0x61, 0x63, 0x65, 0x5f, 0x69, 0x64}
+	qdfFieldHdr_span_id_11  = []byte{0x87, 0x73, 0x70, 0x61, 0x6e, 0x5f, 0x69, 0x64}
+	qdfFieldHdr_msg_12      = []byte{0x83, 0x6d, 0x73, 0x67}
+	qdfFieldHdr_duration_13 = []byte{0x88, 0x64, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e}
+	qdfFieldHdr_status_14   = []byte{0x86, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73}
 )
 
 // MarshalQDF appends a qdf-encoded representation of v to dst and returns
@@ -57,6 +57,52 @@ func (v *LogBatch) EncodeQDF(e *qdf.Encoder) error {
 	return nil
 }
 
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *LogBatch) DecodeQDF(d *qdf.Decoder) error {
+	n, err := d.ReadMapHeader()
+	if err != nil {
+		return err
+	}
+	for range n {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		switch string(kb) {
+		case "entries":
+			{
+				isNil, err := d.IsNil()
+				if err != nil {
+					return err
+				}
+				if isNil {
+					v.Entries = nil
+				} else {
+					n3, err := d.ReadArrayHeader()
+					if err != nil {
+						return err
+					}
+					if err := d.CheckLength(n3, 1); err != nil {
+						return err
+					}
+					v.Entries = make([]LogEntry, n3)
+					for i4 := range n3 {
+						if err := qdf.DecodeNested(d, &v.Entries[i4]); err != nil {
+							return err
+						}
+					}
+				}
+			}
+		default:
+			if err := d.Skip(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // UnmarshalQDF decodes a qdf payload into v and returns the number of
 // bytes consumed.
 func (v *LogBatch) UnmarshalQDF(src []byte) (int, error) {
@@ -81,52 +127,12 @@ func (v *LogBatch) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int
 	if a != nil {
 		d.SetArena(a)
 	}
-	if !(len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2) {
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
 		d.MarkHeaderRead()
 	}
-	n, err := d.ReadMapHeader()
-	if err != nil {
+	if err := v.DecodeQDF(d); err != nil {
 		return 0, err
-	}
-	for range n {
-		kb, err := d.ReadStringBytes()
-		if err != nil {
-			return 0, err
-		}
-		switch string(kb) {
-		case "entries":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return 0, err
-				}
-				if isNil {
-					v.Entries = nil
-				} else {
-					n3, err := d.ReadArrayHeader()
-					if err != nil {
-						return 0, err
-					}
-					if err := d.CheckLength(n3, 1); err != nil {
-						return 0, err
-					}
-					v.Entries = make([]LogEntry, n3)
-					for i4 := range n3 {
-						{
-							nn5, err := qdf.UnmarshalNestedArena(&v.Entries[i4], d.RemainingBytes(), noCopy, a)
-							if err != nil {
-								return 0, err
-							}
-							d.Advance(nn5)
-						}
-					}
-				}
-			}
-		default:
-			if err := d.Skip(); err != nil {
-				return 0, err
-			}
-		}
 	}
 	return d.Pos(), nil
 }
@@ -151,29 +157,131 @@ func (v *LogEntry) MarshalQDF(dst []byte) ([]byte, error) {
 // through nested values instead of allocating an encoder per value.
 func (v *LogEntry) EncodeQDF(e *qdf.Encoder) error {
 	e.WriteMapHeader(10)
-	e.AppendBytes(qdfFieldHdr_time_6)
+	e.AppendBytes(qdfFieldHdr_time_5)
 	{
 		_t := (v.Time).UTC()
 		e.WriteTimestamp(_t.Unix(), uint32(_t.Nanosecond()))
 	}
-	e.AppendBytes(qdfFieldHdr_level_7)
+	e.AppendBytes(qdfFieldHdr_level_6)
 	e.WriteString(string(v.Level))
-	e.AppendBytes(qdfFieldHdr_service_8)
+	e.AppendBytes(qdfFieldHdr_service_7)
 	e.WriteString(string(v.Service))
-	e.AppendBytes(qdfFieldHdr_host_9)
+	e.AppendBytes(qdfFieldHdr_host_8)
 	e.WriteString(string(v.Host))
-	e.AppendBytes(qdfFieldHdr_region_10)
+	e.AppendBytes(qdfFieldHdr_region_9)
 	e.WriteString(string(v.Region))
-	e.AppendBytes(qdfFieldHdr_trace_id_11)
+	e.AppendBytes(qdfFieldHdr_trace_id_10)
 	e.WriteString(string(v.TraceID))
-	e.AppendBytes(qdfFieldHdr_span_id_12)
+	e.AppendBytes(qdfFieldHdr_span_id_11)
 	e.WriteString(string(v.SpanID))
-	e.AppendBytes(qdfFieldHdr_msg_13)
+	e.AppendBytes(qdfFieldHdr_msg_12)
 	e.WriteString(string(v.Msg))
-	e.AppendBytes(qdfFieldHdr_duration_14)
+	e.AppendBytes(qdfFieldHdr_duration_13)
 	e.WriteFloat64(float64(v.Duration))
-	e.AppendBytes(qdfFieldHdr_status_15)
+	e.AppendBytes(qdfFieldHdr_status_14)
 	e.WriteInt(int64(v.Status))
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *LogEntry) DecodeQDF(d *qdf.Decoder) error {
+	n, err := d.ReadMapHeader()
+	if err != nil {
+		return err
+	}
+	for range n {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		switch string(kb) {
+		case "time":
+			{
+				sec15, nsec16, err := d.ReadTimestamp()
+				if err != nil {
+					return err
+				}
+				v.Time = time.Unix(sec15, int64(nsec16)).UTC()
+			}
+		case "level":
+			{
+				rv17, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.Level = rv17
+			}
+		case "service":
+			{
+				rv18, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.Service = rv18
+			}
+		case "host":
+			{
+				rv19, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.Host = rv19
+			}
+		case "region":
+			{
+				rv20, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.Region = rv20
+			}
+		case "trace_id":
+			{
+				rv21, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.TraceID = rv21
+			}
+		case "span_id":
+			{
+				rv22, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.SpanID = rv22
+			}
+		case "msg":
+			{
+				rv23, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.Msg = rv23
+			}
+		case "duration":
+			{
+				rv24, err := d.ReadFloat64()
+				if err != nil {
+					return err
+				}
+				v.Duration = rv24
+			}
+		case "status":
+			{
+				rv25, err := d.ReadInt()
+				if err != nil {
+					return err
+				}
+				v.Status = int(rv25)
+			}
+		default:
+			if err := d.Skip(); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
@@ -201,104 +309,12 @@ func (v *LogEntry) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int
 	if a != nil {
 		d.SetArena(a)
 	}
-	if !(len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2) {
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
 		d.MarkHeaderRead()
 	}
-	n, err := d.ReadMapHeader()
-	if err != nil {
+	if err := v.DecodeQDF(d); err != nil {
 		return 0, err
-	}
-	for range n {
-		kb, err := d.ReadStringBytes()
-		if err != nil {
-			return 0, err
-		}
-		switch string(kb) {
-		case "time":
-			{
-				sec16, nsec17, err := d.ReadTimestamp()
-				if err != nil {
-					return 0, err
-				}
-				v.Time = time.Unix(sec16, int64(nsec17)).UTC()
-			}
-		case "level":
-			{
-				rv18, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.Level = rv18
-			}
-		case "service":
-			{
-				rv19, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.Service = rv19
-			}
-		case "host":
-			{
-				rv20, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.Host = rv20
-			}
-		case "region":
-			{
-				rv21, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.Region = rv21
-			}
-		case "trace_id":
-			{
-				rv22, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.TraceID = rv22
-			}
-		case "span_id":
-			{
-				rv23, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.SpanID = rv23
-			}
-		case "msg":
-			{
-				rv24, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.Msg = rv24
-			}
-		case "duration":
-			{
-				rv25, err := d.ReadFloat64()
-				if err != nil {
-					return 0, err
-				}
-				v.Duration = rv25
-			}
-		case "status":
-			{
-				rv26, err := d.ReadInt()
-				if err != nil {
-					return 0, err
-				}
-				v.Status = int(rv26)
-			}
-		default:
-			if err := d.Skip(); err != nil {
-				return 0, err
-			}
-		}
 	}
 	return d.Pos(), nil
 }

--- a/bench/bench_qdf.go
+++ b/bench/bench_qdf.go
@@ -39,11 +39,13 @@ func (v *LogBatch) MarshalQDF(dst []byte) ([]byte, error) {
 	return e.Bytes(), nil
 }
 
+var qdfShapeTok_LogBatch byte
+var qdfFieldHdrs_LogBatch = [][]byte{qdfFieldHdr_entries_1}
+
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
 func (v *LogBatch) EncodeQDF(e *qdf.Encoder) error {
-	e.WriteMapHeader(1)
-	e.AppendBytes(qdfFieldHdr_entries_1)
+	e.StructShape(&qdfShapeTok_LogBatch, qdfFieldHdrs_LogBatch)
 	if v.Entries == nil {
 		e.WriteNil()
 	} else {
@@ -60,44 +62,59 @@ func (v *LogBatch) EncodeQDF(e *qdf.Encoder) error {
 // DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
 // a parent thread one decoder through nested values (see qdf.DecodeNested).
 func (v *LogBatch) DecodeQDF(d *qdf.Decoder) error {
-	n, err := d.ReadMapHeader()
+	names, plainN, shaped, err := d.ReadStructHeader()
 	if err != nil {
 		return err
 	}
-	for range n {
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
 		kb, err := d.ReadStringBytes()
 		if err != nil {
 			return err
 		}
-		switch string(kb) {
-		case "entries":
-			{
-				isNil, err := d.IsNil()
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *LogBatch) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "entries":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Entries = nil
+			} else {
+				n3, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if isNil {
-					v.Entries = nil
-				} else {
-					n3, err := d.ReadArrayHeader()
-					if err != nil {
+				if err := d.CheckLength(n3, 1); err != nil {
+					return err
+				}
+				v.Entries = make([]LogEntry, n3)
+				for i4 := range n3 {
+					if err := qdf.DecodeNested(d, &v.Entries[i4]); err != nil {
 						return err
-					}
-					if err := d.CheckLength(n3, 1); err != nil {
-						return err
-					}
-					v.Entries = make([]LogEntry, n3)
-					for i4 := range n3 {
-						if err := qdf.DecodeNested(d, &v.Entries[i4]); err != nil {
-							return err
-						}
 					}
 				}
 			}
-		default:
-			if err := d.Skip(); err != nil {
-				return err
-			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -153,32 +170,25 @@ func (v *LogEntry) MarshalQDF(dst []byte) ([]byte, error) {
 	return e.Bytes(), nil
 }
 
+var qdfShapeTok_LogEntry byte
+var qdfFieldHdrs_LogEntry = [][]byte{qdfFieldHdr_time_5, qdfFieldHdr_level_6, qdfFieldHdr_service_7, qdfFieldHdr_host_8, qdfFieldHdr_region_9, qdfFieldHdr_trace_id_10, qdfFieldHdr_span_id_11, qdfFieldHdr_msg_12, qdfFieldHdr_duration_13, qdfFieldHdr_status_14}
+
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
 func (v *LogEntry) EncodeQDF(e *qdf.Encoder) error {
-	e.WriteMapHeader(10)
-	e.AppendBytes(qdfFieldHdr_time_5)
+	e.StructShape(&qdfShapeTok_LogEntry, qdfFieldHdrs_LogEntry)
 	{
 		_t := (v.Time).UTC()
 		e.WriteTimestamp(_t.Unix(), uint32(_t.Nanosecond()))
 	}
-	e.AppendBytes(qdfFieldHdr_level_6)
 	e.WriteString(string(v.Level))
-	e.AppendBytes(qdfFieldHdr_service_7)
 	e.WriteString(string(v.Service))
-	e.AppendBytes(qdfFieldHdr_host_8)
 	e.WriteString(string(v.Host))
-	e.AppendBytes(qdfFieldHdr_region_9)
 	e.WriteString(string(v.Region))
-	e.AppendBytes(qdfFieldHdr_trace_id_10)
 	e.WriteString(string(v.TraceID))
-	e.AppendBytes(qdfFieldHdr_span_id_11)
 	e.WriteString(string(v.SpanID))
-	e.AppendBytes(qdfFieldHdr_msg_12)
 	e.WriteString(string(v.Msg))
-	e.AppendBytes(qdfFieldHdr_duration_13)
 	e.WriteFloat64(float64(v.Duration))
-	e.AppendBytes(qdfFieldHdr_status_14)
 	e.WriteInt(int64(v.Status))
 	return nil
 }
@@ -186,100 +196,115 @@ func (v *LogEntry) EncodeQDF(e *qdf.Encoder) error {
 // DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
 // a parent thread one decoder through nested values (see qdf.DecodeNested).
 func (v *LogEntry) DecodeQDF(d *qdf.Decoder) error {
-	n, err := d.ReadMapHeader()
+	names, plainN, shaped, err := d.ReadStructHeader()
 	if err != nil {
 		return err
 	}
-	for range n {
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
 		kb, err := d.ReadStringBytes()
 		if err != nil {
 			return err
 		}
-		switch string(kb) {
-		case "time":
-			{
-				sec15, nsec16, err := d.ReadTimestamp()
-				if err != nil {
-					return err
-				}
-				v.Time = time.Unix(sec15, int64(nsec16)).UTC()
-			}
-		case "level":
-			{
-				rv17, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.Level = rv17
-			}
-		case "service":
-			{
-				rv18, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.Service = rv18
-			}
-		case "host":
-			{
-				rv19, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.Host = rv19
-			}
-		case "region":
-			{
-				rv20, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.Region = rv20
-			}
-		case "trace_id":
-			{
-				rv21, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.TraceID = rv21
-			}
-		case "span_id":
-			{
-				rv22, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.SpanID = rv22
-			}
-		case "msg":
-			{
-				rv23, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.Msg = rv23
-			}
-		case "duration":
-			{
-				rv24, err := d.ReadFloat64()
-				if err != nil {
-					return err
-				}
-				v.Duration = rv24
-			}
-		case "status":
-			{
-				rv25, err := d.ReadInt()
-				if err != nil {
-					return err
-				}
-				v.Status = int(rv25)
-			}
-		default:
-			if err := d.Skip(); err != nil {
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *LogEntry) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "time":
+		{
+			sec15, nsec16, err := d.ReadTimestamp()
+			if err != nil {
 				return err
 			}
+			v.Time = time.Unix(sec15, int64(nsec16)).UTC()
+		}
+	case "level":
+		{
+			rv17, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Level = rv17
+		}
+	case "service":
+		{
+			rv18, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Service = rv18
+		}
+	case "host":
+		{
+			rv19, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Host = rv19
+		}
+	case "region":
+		{
+			rv20, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Region = rv20
+		}
+	case "trace_id":
+		{
+			rv21, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.TraceID = rv21
+		}
+	case "span_id":
+		{
+			rv22, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.SpanID = rv22
+		}
+	case "msg":
+		{
+			rv23, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Msg = rv23
+		}
+	case "duration":
+		{
+			rv24, err := d.ReadFloat64()
+			if err != nil {
+				return err
+			}
+			v.Duration = rv24
+		}
+	case "status":
+		{
+			rv25, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v.Status = int(rv25)
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/cmd/qdf-bench/codegen.go
+++ b/cmd/qdf-bench/codegen.go
@@ -83,6 +83,21 @@ func printCodegen(iters int, typed []*Info) {
 			return qdf.Unmarshal(b, &out) == nil && reflect.DeepEqual(genTasks, out)
 		},
 		iters)
+
+	// GenHost{Services,Tasks}: the THREADED codegen path — host.MarshalQDF threads
+	// one encoder through every element, so struct field-name shape-interning fires
+	// (names written once per type, not per record). Compare its wire_B to the sum
+	// of the per-record []Service + []Task codegen rows above to see the win; the
+	// bare-slice codegen rows open a fresh encoder per element and can't intern.
+	host := GenHost{Services: genServices, Tasks: genTasks}
+	printCodegenRow(w, "GenHost", "codegen-threaded",
+		func() ([]byte, error) { return qdf.Marshal(host, opts) },
+		func(b []byte) error { var out GenHost; return qdf.Unmarshal(b, &out) },
+		func(b []byte) bool {
+			var out GenHost
+			return qdf.Unmarshal(b, &out) == nil && reflect.DeepEqual(host, out)
+		},
+		iters)
 	w.Flush()
 }
 

--- a/cmd/qdf-bench/types.go
+++ b/cmd/qdf-bench/types.go
@@ -164,8 +164,20 @@ type Privilege struct {
 // data — proving code generation handles arbitrary values, not only static
 // schema. They are zero-cost conversions of the real types (identical layout).
 //
-//go:generate go run github.com/alex60217101990/qdf/cmd/qdfgen -type GenService,GenTask -output types_qdf_gen.go .
+//go:generate go run github.com/alex60217101990/qdf/cmd/qdfgen -type GenService,GenTask,GenHost -output types_qdf_gen.go .
 type (
 	GenService Service
 	GenTask    Task
 )
+
+// GenHost is a code-generated wrapper holding slices of GenService / GenTask, so
+// the bench can exercise the THREADED encode/decode path: host.MarshalQDF()
+// threads one encoder through every element (qdf.EncodeNested), which is where
+// struct field-name shape-interning pays off — the field names are written once
+// per type instead of per record. The bare []GenService path (reflect-Marshal of
+// a slice) opens a fresh encoder per element and cannot intern, so it does not
+// show the win; GenHost does.
+type GenHost struct {
+	Services []GenService `json:"services"`
+	Tasks    []GenTask    `json:"tasks"`
+}

--- a/cmd/qdf-bench/types_qdf_gen.go
+++ b/cmd/qdf-bench/types_qdf_gen.go
@@ -9,27 +9,194 @@ import (
 // Pre-encoded field-name headers (fixstr / strN). Lets the hot path
 // emit a name with a single append, no per-call sizing.
 var (
-	qdfFieldHdr_RegistryOwner_1        = []byte{0x8d, 0x52, 0x65, 0x67, 0x69, 0x73, 0x74, 0x72, 0x79, 0x4f, 0x77, 0x6e, 0x65, 0x72}
-	qdfFieldHdr_RegistryDACL_2         = []byte{0x8c, 0x52, 0x65, 0x67, 0x69, 0x73, 0x74, 0x72, 0x79, 0x44, 0x41, 0x43, 0x4c}
-	qdfFieldHdr_Name_3                 = []byte{0x84, 0x4e, 0x61, 0x6d, 0x65}
-	qdfFieldHdr_DisplayName_4          = []byte{0x8b, 0x44, 0x69, 0x73, 0x70, 0x6c, 0x61, 0x79, 0x4e, 0x61, 0x6d, 0x65}
-	qdfFieldHdr_Description_5          = []byte{0x8b, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e}
-	qdfFieldHdr_ImagePath_6            = []byte{0x89, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x50, 0x61, 0x74, 0x68}
-	qdfFieldHdr_ImageExecutable_7      = []byte{0x8f, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65}
-	qdfFieldHdr_ImageExecutableOwner_8 = []byte{0x94, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x4f, 0x77, 0x6e, 0x65, 0x72}
-	qdfFieldHdr_ImageExecutableDACL_9  = []byte{0x93, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x44, 0x41, 0x43, 0x4c}
-	qdfFieldHdr_Start_10               = []byte{0x85, 0x53, 0x74, 0x61, 0x72, 0x74}
-	qdfFieldHdr_Type_11                = []byte{0x84, 0x54, 0x79, 0x70, 0x65}
-	qdfFieldHdr_Account_12             = []byte{0x87, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74}
-	qdfFieldHdr_RequiredPrivileges_13  = []byte{0x92, 0x52, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x50, 0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73}
-	qdfFieldHdr_Path_30                = []byte{0x84, 0x50, 0x61, 0x74, 0x68}
-	qdfFieldHdr_Definition_31          = []byte{0x8a, 0x44, 0x65, 0x66, 0x69, 0x6e, 0x69, 0x74, 0x69, 0x6f, 0x6e}
-	qdfFieldHdr_Enabled_32             = []byte{0x87, 0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64}
-	qdfFieldHdr_State_33               = []byte{0x85, 0x53, 0x74, 0x61, 0x74, 0x65}
-	qdfFieldHdr_MissedRuns_34          = []byte{0x8a, 0x4d, 0x69, 0x73, 0x73, 0x65, 0x64, 0x52, 0x75, 0x6e, 0x73}
-	qdfFieldHdr_NextRunTime_35         = []byte{0x8b, 0x4e, 0x65, 0x78, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
-	qdfFieldHdr_LastRunTime_36         = []byte{0x8b, 0x4c, 0x61, 0x73, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
+	qdfFieldHdr_services_1              = []byte{0x88, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73}
+	qdfFieldHdr_tasks_2                 = []byte{0x85, 0x74, 0x61, 0x73, 0x6b, 0x73}
+	qdfFieldHdr_RegistryOwner_9         = []byte{0x8d, 0x52, 0x65, 0x67, 0x69, 0x73, 0x74, 0x72, 0x79, 0x4f, 0x77, 0x6e, 0x65, 0x72}
+	qdfFieldHdr_RegistryDACL_10         = []byte{0x8c, 0x52, 0x65, 0x67, 0x69, 0x73, 0x74, 0x72, 0x79, 0x44, 0x41, 0x43, 0x4c}
+	qdfFieldHdr_Name_11                 = []byte{0x84, 0x4e, 0x61, 0x6d, 0x65}
+	qdfFieldHdr_DisplayName_12          = []byte{0x8b, 0x44, 0x69, 0x73, 0x70, 0x6c, 0x61, 0x79, 0x4e, 0x61, 0x6d, 0x65}
+	qdfFieldHdr_Description_13          = []byte{0x8b, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e}
+	qdfFieldHdr_ImagePath_14            = []byte{0x89, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x50, 0x61, 0x74, 0x68}
+	qdfFieldHdr_ImageExecutable_15      = []byte{0x8f, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65}
+	qdfFieldHdr_ImageExecutableOwner_16 = []byte{0x94, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x4f, 0x77, 0x6e, 0x65, 0x72}
+	qdfFieldHdr_ImageExecutableDACL_17  = []byte{0x93, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x44, 0x41, 0x43, 0x4c}
+	qdfFieldHdr_Start_18                = []byte{0x85, 0x53, 0x74, 0x61, 0x72, 0x74}
+	qdfFieldHdr_Type_19                 = []byte{0x84, 0x54, 0x79, 0x70, 0x65}
+	qdfFieldHdr_Account_20              = []byte{0x87, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74}
+	qdfFieldHdr_RequiredPrivileges_21   = []byte{0x92, 0x52, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x50, 0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73}
+	qdfFieldHdr_Path_38                 = []byte{0x84, 0x50, 0x61, 0x74, 0x68}
+	qdfFieldHdr_Definition_39           = []byte{0x8a, 0x44, 0x65, 0x66, 0x69, 0x6e, 0x69, 0x74, 0x69, 0x6f, 0x6e}
+	qdfFieldHdr_Enabled_40              = []byte{0x87, 0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64}
+	qdfFieldHdr_State_41                = []byte{0x85, 0x53, 0x74, 0x61, 0x74, 0x65}
+	qdfFieldHdr_MissedRuns_42           = []byte{0x8a, 0x4d, 0x69, 0x73, 0x73, 0x65, 0x64, 0x52, 0x75, 0x6e, 0x73}
+	qdfFieldHdr_NextRunTime_43          = []byte{0x8b, 0x4e, 0x65, 0x78, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
+	qdfFieldHdr_LastRunTime_44          = []byte{0x8b, 0x4c, 0x61, 0x73, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
 )
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
+func (v *GenHost) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenHost byte
+var qdfFieldHdrs_GenHost = [][]byte{qdfFieldHdr_services_1, qdfFieldHdr_tasks_2}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenHost) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenHost, qdfFieldHdrs_GenHost)
+	if v.Services == nil {
+		e.WriteNil()
+	} else {
+		e.WriteArrayHeader(len(v.Services))
+		for i3 := range v.Services {
+			if err := qdf.EncodeNested(e, &v.Services[i3]); err != nil {
+				return err
+			}
+		}
+	}
+	if v.Tasks == nil {
+		e.WriteNil()
+	} else {
+		e.WriteArrayHeader(len(v.Tasks))
+		for i4 := range v.Tasks {
+			if err := qdf.EncodeNested(e, &v.Tasks[i4]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenHost) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenHost) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "services":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Services = nil
+			} else {
+				n5, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n5, 1); err != nil {
+					return err
+				}
+				v.Services = make([]GenService, n5)
+				for i6 := range n5 {
+					if err := qdf.DecodeNested(d, &v.Services[i6]); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	case "tasks":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Tasks = nil
+			} else {
+				n7, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n7, 1); err != nil {
+					return err
+				}
+				v.Tasks = make([]GenTask, n7)
+				for i8 := range n7 {
+					if err := qdf.DecodeNested(d, &v.Tasks[i8]); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenHost) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenHost) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenHost) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
 
 // MarshalQDF appends a qdf-encoded representation of v to dst and returns
 // the extended slice.
@@ -48,7 +215,7 @@ func (v *GenService) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenService byte
-var qdfFieldHdrs_GenService = [][]byte{qdfFieldHdr_RegistryOwner_1, qdfFieldHdr_RegistryDACL_2, qdfFieldHdr_Name_3, qdfFieldHdr_DisplayName_4, qdfFieldHdr_Description_5, qdfFieldHdr_ImagePath_6, qdfFieldHdr_ImageExecutable_7, qdfFieldHdr_ImageExecutableOwner_8, qdfFieldHdr_ImageExecutableDACL_9, qdfFieldHdr_Start_10, qdfFieldHdr_Type_11, qdfFieldHdr_Account_12, qdfFieldHdr_RequiredPrivileges_13}
+var qdfFieldHdrs_GenService = [][]byte{qdfFieldHdr_RegistryOwner_9, qdfFieldHdr_RegistryDACL_10, qdfFieldHdr_Name_11, qdfFieldHdr_DisplayName_12, qdfFieldHdr_Description_13, qdfFieldHdr_ImagePath_14, qdfFieldHdr_ImageExecutable_15, qdfFieldHdr_ImageExecutableOwner_16, qdfFieldHdr_ImageExecutableDACL_17, qdfFieldHdr_Start_18, qdfFieldHdr_Type_19, qdfFieldHdr_Account_20, qdfFieldHdr_RequiredPrivileges_21}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -70,8 +237,8 @@ func (v *GenService) EncodeQDF(e *qdf.Encoder) error {
 		e.WriteNil()
 	} else {
 		e.WriteArrayHeader(len(v.RequiredPrivileges))
-		for i14 := range v.RequiredPrivileges {
-			e.WriteString(string(v.RequiredPrivileges[i14]))
+		for i22 := range v.RequiredPrivileges {
+			e.WriteString(string(v.RequiredPrivileges[i22]))
 		}
 	}
 	return nil
@@ -108,99 +275,99 @@ func (v *GenService) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "RegistryOwner":
 		{
-			rv15, err := d.ReadString()
-			if err != nil {
-				return err
-			}
-			v.RegistryOwner = rv15
-		}
-	case "RegistryDACL":
-		{
-			rv16, err := d.ReadString()
-			if err != nil {
-				return err
-			}
-			v.RegistryDACL = rv16
-		}
-	case "Name":
-		{
-			rv17, err := d.ReadString()
-			if err != nil {
-				return err
-			}
-			v.Name = rv17
-		}
-	case "DisplayName":
-		{
-			rv18, err := d.ReadString()
-			if err != nil {
-				return err
-			}
-			v.DisplayName = rv18
-		}
-	case "Description":
-		{
-			rv19, err := d.ReadString()
-			if err != nil {
-				return err
-			}
-			v.Description = rv19
-		}
-	case "ImagePath":
-		{
-			rv20, err := d.ReadString()
-			if err != nil {
-				return err
-			}
-			v.ImagePath = rv20
-		}
-	case "ImageExecutable":
-		{
-			rv21, err := d.ReadString()
-			if err != nil {
-				return err
-			}
-			v.ImageExecutable = rv21
-		}
-	case "ImageExecutableOwner":
-		{
-			rv22, err := d.ReadString()
-			if err != nil {
-				return err
-			}
-			v.ImageExecutableOwner = rv22
-		}
-	case "ImageExecutableDACL":
-		{
 			rv23, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.ImageExecutableDACL = rv23
+			v.RegistryOwner = rv23
 		}
-	case "Start":
+	case "RegistryDACL":
 		{
-			rv24, err := d.ReadInt()
+			rv24, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Start = int(rv24)
+			v.RegistryDACL = rv24
 		}
-	case "Type":
+	case "Name":
 		{
-			rv25, err := d.ReadInt()
+			rv25, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Type = int(rv25)
+			v.Name = rv25
 		}
-	case "Account":
+	case "DisplayName":
 		{
 			rv26, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Account = rv26
+			v.DisplayName = rv26
+		}
+	case "Description":
+		{
+			rv27, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Description = rv27
+		}
+	case "ImagePath":
+		{
+			rv28, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.ImagePath = rv28
+		}
+	case "ImageExecutable":
+		{
+			rv29, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.ImageExecutable = rv29
+		}
+	case "ImageExecutableOwner":
+		{
+			rv30, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.ImageExecutableOwner = rv30
+		}
+	case "ImageExecutableDACL":
+		{
+			rv31, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.ImageExecutableDACL = rv31
+		}
+	case "Start":
+		{
+			rv32, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v.Start = int(rv32)
+		}
+	case "Type":
+		{
+			rv33, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v.Type = int(rv33)
+		}
+	case "Account":
+		{
+			rv34, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Account = rv34
 		}
 	case "RequiredPrivileges":
 		{
@@ -211,21 +378,21 @@ func (v *GenService) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.RequiredPrivileges = nil
 			} else {
-				n27, err := d.ReadArrayHeader()
+				n35, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n27, 1); err != nil {
+				if err := d.CheckLength(n35, 1); err != nil {
 					return err
 				}
-				v.RequiredPrivileges = make([]string, n27)
-				for i28 := range n27 {
+				v.RequiredPrivileges = make([]string, n35)
+				for i36 := range n35 {
 					{
-						rv29, err := d.ReadString()
+						rv37, err := d.ReadString()
 						if err != nil {
 							return err
 						}
-						v.RequiredPrivileges[i28] = rv29
+						v.RequiredPrivileges[i36] = rv37
 					}
 				}
 			}
@@ -289,7 +456,7 @@ func (v *GenTask) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenTask byte
-var qdfFieldHdrs_GenTask = [][]byte{qdfFieldHdr_Name_3, qdfFieldHdr_Path_30, qdfFieldHdr_Definition_31, qdfFieldHdr_Enabled_32, qdfFieldHdr_State_33, qdfFieldHdr_MissedRuns_34, qdfFieldHdr_NextRunTime_35, qdfFieldHdr_LastRunTime_36}
+var qdfFieldHdrs_GenTask = [][]byte{qdfFieldHdr_Name_11, qdfFieldHdr_Path_38, qdfFieldHdr_Definition_39, qdfFieldHdr_Enabled_40, qdfFieldHdr_State_41, qdfFieldHdr_MissedRuns_42, qdfFieldHdr_NextRunTime_43, qdfFieldHdr_LastRunTime_44}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -301,9 +468,9 @@ func (v *GenTask) EncodeQDF(e *qdf.Encoder) error {
 		e.WriteNil()
 	} else {
 		e.WriteMapHeader(len(v.Definition))
-		for k37, vv38 := range v.Definition {
-			e.WriteString(string(k37))
-			if err := e.EncodeValue(vv38); err != nil {
+		for k45, vv46 := range v.Definition {
+			e.WriteString(string(k45))
+			if err := e.EncodeValue(vv46); err != nil {
 				return err
 			}
 		}
@@ -347,19 +514,19 @@ func (v *GenTask) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "Name":
 		{
-			rv39, err := d.ReadString()
+			rv47, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv39
+			v.Name = rv47
 		}
 	case "Path":
 		{
-			rv40, err := d.ReadString()
+			rv48, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Path = rv40
+			v.Path = rv48
 		}
 	case "Definition":
 		{
@@ -370,68 +537,68 @@ func (v *GenTask) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Definition = nil
 			} else {
-				n41, err := d.ReadMapHeader()
+				n49, err := d.ReadMapHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n41, 1); err != nil {
+				if err := d.CheckLength(n49, 1); err != nil {
 					return err
 				}
-				v.Definition = make(map[string]any, n41)
-				for range n41 {
-					var k42 string
-					var vv43 any
-					kb44, err := d.ReadStringBytes()
+				v.Definition = make(map[string]any, n49)
+				for range n49 {
+					var k50 string
+					var vv51 any
+					kb52, err := d.ReadStringBytes()
 					if err != nil {
 						return err
 					}
-					k42 = string(d.InternKey(kb44))
-					if err := d.DecodeValue(&vv43); err != nil {
+					k50 = string(d.InternKey(kb52))
+					if err := d.DecodeValue(&vv51); err != nil {
 						return err
 					}
-					v.Definition[k42] = vv43
+					v.Definition[k50] = vv51
 				}
 			}
 		}
 	case "Enabled":
 		{
-			rv45, err := d.ReadBool()
+			rv53, err := d.ReadBool()
 			if err != nil {
 				return err
 			}
-			v.Enabled = rv45
+			v.Enabled = rv53
 		}
 	case "State":
 		{
-			rv46, err := d.ReadString()
+			rv54, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.State = rv46
+			v.State = rv54
 		}
 	case "MissedRuns":
 		{
-			rv47, err := d.ReadInt()
+			rv55, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.MissedRuns = int(rv47)
+			v.MissedRuns = int(rv55)
 		}
 	case "NextRunTime":
 		{
-			rv48, err := d.ReadString()
+			rv56, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.NextRunTime = rv48
+			v.NextRunTime = rv56
 		}
 	case "LastRunTime":
 		{
-			rv49, err := d.ReadString()
+			rv57, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.LastRunTime = rv49
+			v.LastRunTime = rv57
 		}
 	default:
 		if err := d.Skip(); err != nil {

--- a/cmd/qdf-bench/types_qdf_gen.go
+++ b/cmd/qdf-bench/types_qdf_gen.go
@@ -87,6 +87,152 @@ func (v *GenService) EncodeQDF(e *qdf.Encoder) error {
 	return nil
 }
 
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenService) DecodeQDF(d *qdf.Decoder) error {
+	n, err := d.ReadMapHeader()
+	if err != nil {
+		return err
+	}
+	for range n {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		switch string(kb) {
+		case "RegistryOwner":
+			{
+				rv15, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.RegistryOwner = rv15
+			}
+		case "RegistryDACL":
+			{
+				rv16, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.RegistryDACL = rv16
+			}
+		case "Name":
+			{
+				rv17, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.Name = rv17
+			}
+		case "DisplayName":
+			{
+				rv18, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.DisplayName = rv18
+			}
+		case "Description":
+			{
+				rv19, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.Description = rv19
+			}
+		case "ImagePath":
+			{
+				rv20, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.ImagePath = rv20
+			}
+		case "ImageExecutable":
+			{
+				rv21, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.ImageExecutable = rv21
+			}
+		case "ImageExecutableOwner":
+			{
+				rv22, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.ImageExecutableOwner = rv22
+			}
+		case "ImageExecutableDACL":
+			{
+				rv23, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.ImageExecutableDACL = rv23
+			}
+		case "Start":
+			{
+				rv24, err := d.ReadInt()
+				if err != nil {
+					return err
+				}
+				v.Start = int(rv24)
+			}
+		case "Type":
+			{
+				rv25, err := d.ReadInt()
+				if err != nil {
+					return err
+				}
+				v.Type = int(rv25)
+			}
+		case "Account":
+			{
+				rv26, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.Account = rv26
+			}
+		case "RequiredPrivileges":
+			{
+				isNil, err := d.IsNil()
+				if err != nil {
+					return err
+				}
+				if isNil {
+					v.RequiredPrivileges = nil
+				} else {
+					n27, err := d.ReadArrayHeader()
+					if err != nil {
+						return err
+					}
+					if err := d.CheckLength(n27, 1); err != nil {
+						return err
+					}
+					v.RequiredPrivileges = make([]string, n27)
+					for i28 := range n27 {
+						{
+							rv29, err := d.ReadString()
+							if err != nil {
+								return err
+							}
+							v.RequiredPrivileges[i28] = rv29
+						}
+					}
+				}
+			}
+		default:
+			if err := d.Skip(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // UnmarshalQDF decodes a qdf payload into v and returns the number of
 // bytes consumed.
 func (v *GenService) UnmarshalQDF(src []byte) (int, error) {
@@ -111,148 +257,12 @@ func (v *GenService) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (i
 	if a != nil {
 		d.SetArena(a)
 	}
-	if !(len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2) {
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
 		d.MarkHeaderRead()
 	}
-	n, err := d.ReadMapHeader()
-	if err != nil {
+	if err := v.DecodeQDF(d); err != nil {
 		return 0, err
-	}
-	for range n {
-		kb, err := d.ReadStringBytes()
-		if err != nil {
-			return 0, err
-		}
-		switch string(kb) {
-		case "RegistryOwner":
-			{
-				rv15, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.RegistryOwner = rv15
-			}
-		case "RegistryDACL":
-			{
-				rv16, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.RegistryDACL = rv16
-			}
-		case "Name":
-			{
-				rv17, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.Name = rv17
-			}
-		case "DisplayName":
-			{
-				rv18, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.DisplayName = rv18
-			}
-		case "Description":
-			{
-				rv19, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.Description = rv19
-			}
-		case "ImagePath":
-			{
-				rv20, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.ImagePath = rv20
-			}
-		case "ImageExecutable":
-			{
-				rv21, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.ImageExecutable = rv21
-			}
-		case "ImageExecutableOwner":
-			{
-				rv22, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.ImageExecutableOwner = rv22
-			}
-		case "ImageExecutableDACL":
-			{
-				rv23, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.ImageExecutableDACL = rv23
-			}
-		case "Start":
-			{
-				rv24, err := d.ReadInt()
-				if err != nil {
-					return 0, err
-				}
-				v.Start = int(rv24)
-			}
-		case "Type":
-			{
-				rv25, err := d.ReadInt()
-				if err != nil {
-					return 0, err
-				}
-				v.Type = int(rv25)
-			}
-		case "Account":
-			{
-				rv26, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.Account = rv26
-			}
-		case "RequiredPrivileges":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return 0, err
-				}
-				if isNil {
-					v.RequiredPrivileges = nil
-				} else {
-					n27, err := d.ReadArrayHeader()
-					if err != nil {
-						return 0, err
-					}
-					if err := d.CheckLength(n27, 1); err != nil {
-						return 0, err
-					}
-					v.RequiredPrivileges = make([]string, n27)
-					for i28 := range n27 {
-						{
-							rv29, err := d.ReadString()
-							if err != nil {
-								return 0, err
-							}
-							v.RequiredPrivileges[i28] = rv29
-						}
-					}
-				}
-			}
-		default:
-			if err := d.Skip(); err != nil {
-				return 0, err
-			}
-		}
 	}
 	return d.Pos(), nil
 }
@@ -306,6 +316,116 @@ func (v *GenTask) EncodeQDF(e *qdf.Encoder) error {
 	return nil
 }
 
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenTask) DecodeQDF(d *qdf.Decoder) error {
+	n, err := d.ReadMapHeader()
+	if err != nil {
+		return err
+	}
+	for range n {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		switch string(kb) {
+		case "Name":
+			{
+				rv39, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.Name = rv39
+			}
+		case "Path":
+			{
+				rv40, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.Path = rv40
+			}
+		case "Definition":
+			{
+				isNil, err := d.IsNil()
+				if err != nil {
+					return err
+				}
+				if isNil {
+					v.Definition = nil
+				} else {
+					n41, err := d.ReadMapHeader()
+					if err != nil {
+						return err
+					}
+					if err := d.CheckLength(n41, 1); err != nil {
+						return err
+					}
+					v.Definition = make(map[string]any, n41)
+					for range n41 {
+						var k42 string
+						var vv43 any
+						kb44, err := d.ReadStringBytes()
+						if err != nil {
+							return err
+						}
+						k42 = string(d.InternKey(kb44))
+						if err := d.DecodeValue(&vv43); err != nil {
+							return err
+						}
+						v.Definition[k42] = vv43
+					}
+				}
+			}
+		case "Enabled":
+			{
+				rv45, err := d.ReadBool()
+				if err != nil {
+					return err
+				}
+				v.Enabled = rv45
+			}
+		case "State":
+			{
+				rv46, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.State = rv46
+			}
+		case "MissedRuns":
+			{
+				rv47, err := d.ReadInt()
+				if err != nil {
+					return err
+				}
+				v.MissedRuns = int(rv47)
+			}
+		case "NextRunTime":
+			{
+				rv48, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.NextRunTime = rv48
+			}
+		case "LastRunTime":
+			{
+				rv49, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.LastRunTime = rv49
+			}
+		default:
+			if err := d.Skip(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // UnmarshalQDF decodes a qdf payload into v and returns the number of
 // bytes consumed.
 func (v *GenTask) UnmarshalQDF(src []byte) (int, error) {
@@ -330,112 +450,12 @@ func (v *GenTask) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int,
 	if a != nil {
 		d.SetArena(a)
 	}
-	if !(len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2) {
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
 		d.MarkHeaderRead()
 	}
-	n, err := d.ReadMapHeader()
-	if err != nil {
+	if err := v.DecodeQDF(d); err != nil {
 		return 0, err
-	}
-	for range n {
-		kb, err := d.ReadStringBytes()
-		if err != nil {
-			return 0, err
-		}
-		switch string(kb) {
-		case "Name":
-			{
-				rv39, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.Name = rv39
-			}
-		case "Path":
-			{
-				rv40, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.Path = rv40
-			}
-		case "Definition":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return 0, err
-				}
-				if isNil {
-					v.Definition = nil
-				} else {
-					n41, err := d.ReadMapHeader()
-					if err != nil {
-						return 0, err
-					}
-					if err := d.CheckLength(n41, 1); err != nil {
-						return 0, err
-					}
-					v.Definition = make(map[string]any, n41)
-					for range n41 {
-						var k42 string
-						var vv43 any
-						kb44, err := d.ReadStringBytes()
-						if err != nil {
-							return 0, err
-						}
-						k42 = string(d.InternKey(kb44))
-						if err := d.DecodeValue(&vv43); err != nil {
-							return 0, err
-						}
-						v.Definition[k42] = vv43
-					}
-				}
-			}
-		case "Enabled":
-			{
-				rv45, err := d.ReadBool()
-				if err != nil {
-					return 0, err
-				}
-				v.Enabled = rv45
-			}
-		case "State":
-			{
-				rv46, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.State = rv46
-			}
-		case "MissedRuns":
-			{
-				rv47, err := d.ReadInt()
-				if err != nil {
-					return 0, err
-				}
-				v.MissedRuns = int(rv47)
-			}
-		case "NextRunTime":
-			{
-				rv48, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.NextRunTime = rv48
-			}
-		case "LastRunTime":
-			{
-				rv49, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.LastRunTime = rv49
-			}
-		default:
-			if err := d.Skip(); err != nil {
-				return 0, err
-			}
-		}
 	}
 	return d.Pos(), nil
 }

--- a/cmd/qdf-bench/types_qdf_gen.go
+++ b/cmd/qdf-bench/types_qdf_gen.go
@@ -24,11 +24,11 @@ var (
 	qdfFieldHdr_RequiredPrivileges_13  = []byte{0x92, 0x52, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x50, 0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73}
 	qdfFieldHdr_Path_30                = []byte{0x84, 0x50, 0x61, 0x74, 0x68}
 	qdfFieldHdr_Definition_31          = []byte{0x8a, 0x44, 0x65, 0x66, 0x69, 0x6e, 0x69, 0x74, 0x69, 0x6f, 0x6e}
-	qdfFieldHdr_Enabled_34             = []byte{0x87, 0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64}
-	qdfFieldHdr_State_35               = []byte{0x85, 0x53, 0x74, 0x61, 0x74, 0x65}
-	qdfFieldHdr_MissedRuns_36          = []byte{0x8a, 0x4d, 0x69, 0x73, 0x73, 0x65, 0x64, 0x52, 0x75, 0x6e, 0x73}
-	qdfFieldHdr_NextRunTime_37         = []byte{0x8b, 0x4e, 0x65, 0x78, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
-	qdfFieldHdr_LastRunTime_38         = []byte{0x8b, 0x4c, 0x61, 0x73, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
+	qdfFieldHdr_Enabled_32             = []byte{0x87, 0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64}
+	qdfFieldHdr_State_33               = []byte{0x85, 0x53, 0x74, 0x61, 0x74, 0x65}
+	qdfFieldHdr_MissedRuns_34          = []byte{0x8a, 0x4d, 0x69, 0x73, 0x73, 0x65, 0x64, 0x52, 0x75, 0x6e, 0x73}
+	qdfFieldHdr_NextRunTime_35         = []byte{0x8b, 0x4e, 0x65, 0x78, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
+	qdfFieldHdr_LastRunTime_36         = []byte{0x8b, 0x4c, 0x61, 0x73, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
 )
 
 // MarshalQDF appends a qdf-encoded representation of v to dst and returns
@@ -47,35 +47,25 @@ func (v *GenService) MarshalQDF(dst []byte) ([]byte, error) {
 	return e.Bytes(), nil
 }
 
+var qdfShapeTok_GenService byte
+var qdfFieldHdrs_GenService = [][]byte{qdfFieldHdr_RegistryOwner_1, qdfFieldHdr_RegistryDACL_2, qdfFieldHdr_Name_3, qdfFieldHdr_DisplayName_4, qdfFieldHdr_Description_5, qdfFieldHdr_ImagePath_6, qdfFieldHdr_ImageExecutable_7, qdfFieldHdr_ImageExecutableOwner_8, qdfFieldHdr_ImageExecutableDACL_9, qdfFieldHdr_Start_10, qdfFieldHdr_Type_11, qdfFieldHdr_Account_12, qdfFieldHdr_RequiredPrivileges_13}
+
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
 func (v *GenService) EncodeQDF(e *qdf.Encoder) error {
-	e.WriteMapHeader(13)
-	e.AppendBytes(qdfFieldHdr_RegistryOwner_1)
+	e.StructShape(&qdfShapeTok_GenService, qdfFieldHdrs_GenService)
 	e.WriteString(string(v.RegistryOwner))
-	e.AppendBytes(qdfFieldHdr_RegistryDACL_2)
 	e.WriteString(string(v.RegistryDACL))
-	e.AppendBytes(qdfFieldHdr_Name_3)
 	e.WriteString(string(v.Name))
-	e.AppendBytes(qdfFieldHdr_DisplayName_4)
 	e.WriteString(string(v.DisplayName))
-	e.AppendBytes(qdfFieldHdr_Description_5)
 	e.WriteString(string(v.Description))
-	e.AppendBytes(qdfFieldHdr_ImagePath_6)
 	e.WriteString(string(v.ImagePath))
-	e.AppendBytes(qdfFieldHdr_ImageExecutable_7)
 	e.WriteString(string(v.ImageExecutable))
-	e.AppendBytes(qdfFieldHdr_ImageExecutableOwner_8)
 	e.WriteString(string(v.ImageExecutableOwner))
-	e.AppendBytes(qdfFieldHdr_ImageExecutableDACL_9)
 	e.WriteString(string(v.ImageExecutableDACL))
-	e.AppendBytes(qdfFieldHdr_Start_10)
 	e.WriteInt(int64(v.Start))
-	e.AppendBytes(qdfFieldHdr_Type_11)
 	e.WriteInt(int64(v.Type))
-	e.AppendBytes(qdfFieldHdr_Account_12)
 	e.WriteString(string(v.Account))
-	e.AppendBytes(qdfFieldHdr_RequiredPrivileges_13)
 	if v.RequiredPrivileges == nil {
 		e.WriteNil()
 	} else {
@@ -90,144 +80,159 @@ func (v *GenService) EncodeQDF(e *qdf.Encoder) error {
 // DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
 // a parent thread one decoder through nested values (see qdf.DecodeNested).
 func (v *GenService) DecodeQDF(d *qdf.Decoder) error {
-	n, err := d.ReadMapHeader()
+	names, plainN, shaped, err := d.ReadStructHeader()
 	if err != nil {
 		return err
 	}
-	for range n {
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
 		kb, err := d.ReadStringBytes()
 		if err != nil {
 			return err
 		}
-		switch string(kb) {
-		case "RegistryOwner":
-			{
-				rv15, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.RegistryOwner = rv15
-			}
-		case "RegistryDACL":
-			{
-				rv16, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.RegistryDACL = rv16
-			}
-		case "Name":
-			{
-				rv17, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.Name = rv17
-			}
-		case "DisplayName":
-			{
-				rv18, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.DisplayName = rv18
-			}
-		case "Description":
-			{
-				rv19, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.Description = rv19
-			}
-		case "ImagePath":
-			{
-				rv20, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.ImagePath = rv20
-			}
-		case "ImageExecutable":
-			{
-				rv21, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.ImageExecutable = rv21
-			}
-		case "ImageExecutableOwner":
-			{
-				rv22, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.ImageExecutableOwner = rv22
-			}
-		case "ImageExecutableDACL":
-			{
-				rv23, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.ImageExecutableDACL = rv23
-			}
-		case "Start":
-			{
-				rv24, err := d.ReadInt()
-				if err != nil {
-					return err
-				}
-				v.Start = int(rv24)
-			}
-		case "Type":
-			{
-				rv25, err := d.ReadInt()
-				if err != nil {
-					return err
-				}
-				v.Type = int(rv25)
-			}
-		case "Account":
-			{
-				rv26, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.Account = rv26
-			}
-		case "RequiredPrivileges":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return err
-				}
-				if isNil {
-					v.RequiredPrivileges = nil
-				} else {
-					n27, err := d.ReadArrayHeader()
-					if err != nil {
-						return err
-					}
-					if err := d.CheckLength(n27, 1); err != nil {
-						return err
-					}
-					v.RequiredPrivileges = make([]string, n27)
-					for i28 := range n27 {
-						{
-							rv29, err := d.ReadString()
-							if err != nil {
-								return err
-							}
-							v.RequiredPrivileges[i28] = rv29
-						}
-					}
-				}
-			}
-		default:
-			if err := d.Skip(); err != nil {
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenService) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "RegistryOwner":
+		{
+			rv15, err := d.ReadString()
+			if err != nil {
 				return err
 			}
+			v.RegistryOwner = rv15
+		}
+	case "RegistryDACL":
+		{
+			rv16, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.RegistryDACL = rv16
+		}
+	case "Name":
+		{
+			rv17, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Name = rv17
+		}
+	case "DisplayName":
+		{
+			rv18, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.DisplayName = rv18
+		}
+	case "Description":
+		{
+			rv19, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Description = rv19
+		}
+	case "ImagePath":
+		{
+			rv20, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.ImagePath = rv20
+		}
+	case "ImageExecutable":
+		{
+			rv21, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.ImageExecutable = rv21
+		}
+	case "ImageExecutableOwner":
+		{
+			rv22, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.ImageExecutableOwner = rv22
+		}
+	case "ImageExecutableDACL":
+		{
+			rv23, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.ImageExecutableDACL = rv23
+		}
+	case "Start":
+		{
+			rv24, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v.Start = int(rv24)
+		}
+	case "Type":
+		{
+			rv25, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v.Type = int(rv25)
+		}
+	case "Account":
+		{
+			rv26, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Account = rv26
+		}
+	case "RequiredPrivileges":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.RequiredPrivileges = nil
+			} else {
+				n27, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n27, 1); err != nil {
+					return err
+				}
+				v.RequiredPrivileges = make([]string, n27)
+				for i28 := range n27 {
+					{
+						rv29, err := d.ReadString()
+						if err != nil {
+							return err
+						}
+						v.RequiredPrivileges[i28] = rv29
+					}
+				}
+			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -283,35 +288,30 @@ func (v *GenTask) MarshalQDF(dst []byte) ([]byte, error) {
 	return e.Bytes(), nil
 }
 
+var qdfShapeTok_GenTask byte
+var qdfFieldHdrs_GenTask = [][]byte{qdfFieldHdr_Name_3, qdfFieldHdr_Path_30, qdfFieldHdr_Definition_31, qdfFieldHdr_Enabled_32, qdfFieldHdr_State_33, qdfFieldHdr_MissedRuns_34, qdfFieldHdr_NextRunTime_35, qdfFieldHdr_LastRunTime_36}
+
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
 func (v *GenTask) EncodeQDF(e *qdf.Encoder) error {
-	e.WriteMapHeader(8)
-	e.AppendBytes(qdfFieldHdr_Name_3)
+	e.StructShape(&qdfShapeTok_GenTask, qdfFieldHdrs_GenTask)
 	e.WriteString(string(v.Name))
-	e.AppendBytes(qdfFieldHdr_Path_30)
 	e.WriteString(string(v.Path))
-	e.AppendBytes(qdfFieldHdr_Definition_31)
 	if v.Definition == nil {
 		e.WriteNil()
 	} else {
 		e.WriteMapHeader(len(v.Definition))
-		for k32, vv33 := range v.Definition {
-			e.WriteString(string(k32))
-			if err := e.EncodeValue(vv33); err != nil {
+		for k37, vv38 := range v.Definition {
+			e.WriteString(string(k37))
+			if err := e.EncodeValue(vv38); err != nil {
 				return err
 			}
 		}
 	}
-	e.AppendBytes(qdfFieldHdr_Enabled_34)
 	e.WriteBool(bool(v.Enabled))
-	e.AppendBytes(qdfFieldHdr_State_35)
 	e.WriteString(string(v.State))
-	e.AppendBytes(qdfFieldHdr_MissedRuns_36)
 	e.WriteInt(int64(v.MissedRuns))
-	e.AppendBytes(qdfFieldHdr_NextRunTime_37)
 	e.WriteString(string(v.NextRunTime))
-	e.AppendBytes(qdfFieldHdr_LastRunTime_38)
 	e.WriteString(string(v.LastRunTime))
 	return nil
 }
@@ -319,108 +319,123 @@ func (v *GenTask) EncodeQDF(e *qdf.Encoder) error {
 // DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
 // a parent thread one decoder through nested values (see qdf.DecodeNested).
 func (v *GenTask) DecodeQDF(d *qdf.Decoder) error {
-	n, err := d.ReadMapHeader()
+	names, plainN, shaped, err := d.ReadStructHeader()
 	if err != nil {
 		return err
 	}
-	for range n {
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
 		kb, err := d.ReadStringBytes()
 		if err != nil {
 			return err
 		}
-		switch string(kb) {
-		case "Name":
-			{
-				rv39, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.Name = rv39
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenTask) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "Name":
+		{
+			rv39, err := d.ReadString()
+			if err != nil {
+				return err
 			}
-		case "Path":
-			{
-				rv40, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.Path = rv40
+			v.Name = rv39
+		}
+	case "Path":
+		{
+			rv40, err := d.ReadString()
+			if err != nil {
+				return err
 			}
-		case "Definition":
-			{
-				isNil, err := d.IsNil()
+			v.Path = rv40
+		}
+	case "Definition":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Definition = nil
+			} else {
+				n41, err := d.ReadMapHeader()
 				if err != nil {
 					return err
 				}
-				if isNil {
-					v.Definition = nil
-				} else {
-					n41, err := d.ReadMapHeader()
+				if err := d.CheckLength(n41, 1); err != nil {
+					return err
+				}
+				v.Definition = make(map[string]any, n41)
+				for range n41 {
+					var k42 string
+					var vv43 any
+					kb44, err := d.ReadStringBytes()
 					if err != nil {
 						return err
 					}
-					if err := d.CheckLength(n41, 1); err != nil {
+					k42 = string(d.InternKey(kb44))
+					if err := d.DecodeValue(&vv43); err != nil {
 						return err
 					}
-					v.Definition = make(map[string]any, n41)
-					for range n41 {
-						var k42 string
-						var vv43 any
-						kb44, err := d.ReadStringBytes()
-						if err != nil {
-							return err
-						}
-						k42 = string(d.InternKey(kb44))
-						if err := d.DecodeValue(&vv43); err != nil {
-							return err
-						}
-						v.Definition[k42] = vv43
-					}
+					v.Definition[k42] = vv43
 				}
 			}
-		case "Enabled":
-			{
-				rv45, err := d.ReadBool()
-				if err != nil {
-					return err
-				}
-				v.Enabled = rv45
-			}
-		case "State":
-			{
-				rv46, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.State = rv46
-			}
-		case "MissedRuns":
-			{
-				rv47, err := d.ReadInt()
-				if err != nil {
-					return err
-				}
-				v.MissedRuns = int(rv47)
-			}
-		case "NextRunTime":
-			{
-				rv48, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.NextRunTime = rv48
-			}
-		case "LastRunTime":
-			{
-				rv49, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.LastRunTime = rv49
-			}
-		default:
-			if err := d.Skip(); err != nil {
+		}
+	case "Enabled":
+		{
+			rv45, err := d.ReadBool()
+			if err != nil {
 				return err
 			}
+			v.Enabled = rv45
+		}
+	case "State":
+		{
+			rv46, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.State = rv46
+		}
+	case "MissedRuns":
+		{
+			rv47, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v.MissedRuns = int(rv47)
+		}
+	case "NextRunTime":
+		{
+			rv48, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.NextRunTime = rv48
+		}
+	case "LastRunTime":
+		{
+			rv49, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.LastRunTime = rv49
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -1015,7 +1015,7 @@ func (g *gen) emitDecodeArray(w io.Writer, lhs string, a *types.Array, indent st
 		fmt.Fprintf(w, "%s{\n", indent)
 		fmt.Fprintf(w, "%s\t%s, err := d.ReadStringBytes()\n", indent, bv)
 		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
-		fmt.Fprintf(w, "%s\tif len(%s) != %d {\n%s\t\treturn 0, qdf.ErrTypeMismatch\n%s\t}\n", indent, bv, a.Len(), indent, indent)
+		fmt.Fprintf(w, "%s\tif len(%s) != %d {\n%s\t\treturn qdf.ErrTypeMismatch\n%s\t}\n", indent, bv, a.Len(), indent, indent)
 		fmt.Fprintf(w, "%s\tcopy(%s[:], %s)\n", indent, lhs, bv)
 		fmt.Fprintf(w, "%s}\n", indent)
 		return nil
@@ -1024,7 +1024,7 @@ func (g *gen) emitDecodeArray(w io.Writer, lhs string, a *types.Array, indent st
 	nVar := g.fresh("n")
 	fmt.Fprintf(w, "%s\t%s, err := d.ReadArrayHeader()\n", indent, nVar)
 	fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
-	fmt.Fprintf(w, "%s\tif %s != %d {\n%s\t\treturn 0, qdf.ErrTypeMismatch\n%s\t}\n", indent, nVar, a.Len(), indent, indent)
+	fmt.Fprintf(w, "%s\tif %s != %d {\n%s\t\treturn qdf.ErrTypeMismatch\n%s\t}\n", indent, nVar, a.Len(), indent, indent)
 	loopVar := g.fresh("i")
 	fmt.Fprintf(w, "%s\tfor %s := range %d {\n", indent, loopVar, a.Len())
 	if err := g.emitDecodeValue(w, lhs+"["+loopVar+"]", elem, indent+"\t\t"); err != nil {

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -574,6 +574,34 @@ func (g *gen) emitMarshal(typeName string, fields []fieldInfo) error {
 func (g *gen) emitUnmarshal(typeName string, fields []fieldInfo) error {
 	w := &g.body
 
+	// DecodeQDF holds the field-reading body and operates on a SHARED decoder,
+	// advancing it. It lets a parent thread one decoder through nested values
+	// (via qdf.DecodeNested) instead of opening a fresh decoder per nested value.
+	// noCopy / arena live on the shared decoder, so nested decodes inherit them.
+	fmt.Fprintf(w, "// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets\n")
+	fmt.Fprintf(w, "// a parent thread one decoder through nested values (see qdf.DecodeNested).\n")
+	fmt.Fprintf(w, "func (v *%s) DecodeQDF(d *qdf.Decoder) error {\n", typeName)
+	fmt.Fprintf(w, "\tn, err := d.ReadMapHeader()\n")
+	fmt.Fprintf(w, "\tif err != nil {\n\t\treturn err\n\t}\n")
+	fmt.Fprintf(w, "\tfor range n {\n")
+	fmt.Fprintf(w, "\t\tkb, err := d.ReadStringBytes()\n")
+	fmt.Fprintf(w, "\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n")
+	fmt.Fprintf(w, "\t\tswitch string(kb) {\n")
+	for _, f := range fields {
+		fmt.Fprintf(w, "\t\tcase %q:\n", f.WireKey)
+		if err := g.emitDecodeValue(w, "v."+f.Access, f.Field.Type(), "\t\t\t"); err != nil {
+			return fmt.Errorf("%s.%s: %w", typeName, f.GoName, err)
+		}
+	}
+	fmt.Fprintf(w, "\t\tdefault:\n")
+	fmt.Fprintf(w, "\t\t\tif err := d.Skip(); err != nil {\n\t\t\t\treturn err\n\t\t\t}\n")
+	fmt.Fprintf(w, "\t\t}\n")
+	fmt.Fprintf(w, "\t}\n")
+	fmt.Fprintf(w, "\treturn nil\n")
+	fmt.Fprintf(w, "}\n\n")
+
+	// Wrappers: open one decoder, set flags, consume the stream header, delegate
+	// the field reading to DecodeQDF, and report the bytes consumed.
 	fmt.Fprintf(w, "// UnmarshalQDF decodes a qdf payload into v and returns the number of\n")
 	fmt.Fprintf(w, "// bytes consumed.\n")
 	fmt.Fprintf(w, "func (v *%s) UnmarshalQDF(src []byte) (int, error) {\n", typeName)
@@ -592,28 +620,14 @@ func (g *gen) emitUnmarshal(typeName string, fields []fieldInfo) error {
 	fmt.Fprintf(w, "\td := qdf.NewDecoderOnBuf(src)\n")
 	fmt.Fprintf(w, "\tif noCopy {\n\t\td.SetNoCopy(true)\n\t}\n")
 	fmt.Fprintf(w, "\tif a != nil {\n\t\td.SetArena(a)\n\t}\n")
-	// If src starts with QDF magic this is a top-level decode; otherwise
-	// a nested call from a parent decoder that already consumed the
-	// header.
-	fmt.Fprintf(w, "\tif !(len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2) {\n")
+	// If src starts with QDF magic this is a top-level decode (the first read
+	// consumes the header); otherwise a nested call from a parent decoder that
+	// already consumed the header.
+	fmt.Fprintf(w, "\thasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2\n")
+	fmt.Fprintf(w, "\tif !hasHeader {\n")
 	fmt.Fprintf(w, "\t\td.MarkHeaderRead()\n")
 	fmt.Fprintf(w, "\t}\n")
-	fmt.Fprintf(w, "\tn, err := d.ReadMapHeader()\n")
-	fmt.Fprintf(w, "\tif err != nil {\n\t\treturn 0, err\n\t}\n")
-	fmt.Fprintf(w, "\tfor range n {\n")
-	fmt.Fprintf(w, "\t\tkb, err := d.ReadStringBytes()\n")
-	fmt.Fprintf(w, "\t\tif err != nil {\n\t\t\treturn 0, err\n\t\t}\n")
-	fmt.Fprintf(w, "\t\tswitch string(kb) {\n")
-	for _, f := range fields {
-		fmt.Fprintf(w, "\t\tcase %q:\n", f.WireKey)
-		if err := g.emitDecodeValue(w, "v."+f.Access, f.Field.Type(), "\t\t\t"); err != nil {
-			return fmt.Errorf("%s.%s: %w", typeName, f.GoName, err)
-		}
-	}
-	fmt.Fprintf(w, "\t\tdefault:\n")
-	fmt.Fprintf(w, "\t\t\tif err := d.Skip(); err != nil {\n\t\t\t\treturn 0, err\n\t\t\t}\n")
-	fmt.Fprintf(w, "\t\t}\n")
-	fmt.Fprintf(w, "\t}\n")
+	fmt.Fprintf(w, "\tif err := v.DecodeQDF(d); err != nil {\n\t\treturn 0, err\n\t}\n")
 	fmt.Fprintf(w, "\treturn d.Pos(), nil\n")
 	fmt.Fprintf(w, "}\n\n")
 	return nil
@@ -786,7 +800,7 @@ func (g *gen) emitDecodeValue(w io.Writer, lhs string, t types.Type, indent stri
 		nsecTmp := g.fresh("nsec")
 		fmt.Fprintf(w, "%s{\n", indent)
 		fmt.Fprintf(w, "%s\t%s, %s, err := d.ReadTimestamp()\n", indent, secTmp, nsecTmp)
-		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
 		g.imports["time"] = ""
 		fmt.Fprintf(w, "%s\t%s = time.Unix(%s, int64(%s)).UTC()\n", indent, lhs, secTmp, nsecTmp)
 		fmt.Fprintf(w, "%s}\n", indent)
@@ -810,7 +824,7 @@ func (g *gen) emitDecodeValue(w io.Writer, lhs string, t types.Type, indent stri
 		// Empty interface (any): decode the dynamic value via the runtime,
 		// mirroring the e.EncodeValue emitted on the encode side.
 		if tt.NumMethods() == 0 {
-			fmt.Fprintf(w, "%sif err := d.DecodeValue(&%s); err != nil {\n%s\treturn 0, err\n%s}\n", indent, lhs, indent, indent)
+			fmt.Fprintf(w, "%sif err := d.DecodeValue(&%s); err != nil {\n%s\treturn err\n%s}\n", indent, lhs, indent, indent)
 			return nil
 		}
 		return fmt.Errorf("non-empty interface fields are not supported by qdfgen")
@@ -824,7 +838,7 @@ func (g *gen) emitDecodeBasic(w io.Writer, lhs string, b *types.Basic, indent st
 	switch k := b.Kind(); k {
 	case types.Bool:
 		fmt.Fprintf(w, "%s{\n%s\t%s, err := d.ReadBool()\n", indent, indent, tmp)
-		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
 		fmt.Fprintf(w, "%s\t%s = %s\n%s}\n", indent, lhs, tmp, indent)
 	case types.Int:
 		g.emitDecodeIntoInt(w, lhs, "int", indent, tmp)
@@ -850,15 +864,15 @@ func (g *gen) emitDecodeBasic(w io.Writer, lhs string, b *types.Basic, indent st
 		g.emitDecodeIntoUint(w, lhs, "uintptr", indent, tmp)
 	case types.Float32:
 		fmt.Fprintf(w, "%s{\n%s\t%s, err := d.ReadFloat32()\n", indent, indent, tmp)
-		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
 		fmt.Fprintf(w, "%s\t%s = %s\n%s}\n", indent, lhs, tmp, indent)
 	case types.Float64:
 		fmt.Fprintf(w, "%s{\n%s\t%s, err := d.ReadFloat64()\n", indent, indent, tmp)
-		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
 		fmt.Fprintf(w, "%s\t%s = %s\n%s}\n", indent, lhs, tmp, indent)
 	case types.String:
 		fmt.Fprintf(w, "%s{\n%s\t%s, err := d.ReadString()\n", indent, indent, tmp)
-		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
 		fmt.Fprintf(w, "%s\t%s = %s\n%s}\n", indent, lhs, tmp, indent)
 	default:
 		return fmt.Errorf("unsupported basic kind %v", k)
@@ -868,13 +882,13 @@ func (g *gen) emitDecodeBasic(w io.Writer, lhs string, b *types.Basic, indent st
 
 func (g *gen) emitDecodeIntoInt(w io.Writer, lhs, target, indent, tmp string) {
 	fmt.Fprintf(w, "%s{\n%s\t%s, err := d.ReadInt()\n", indent, indent, tmp)
-	fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+	fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
 	fmt.Fprintf(w, "%s\t%s = %s(%s)\n%s}\n", indent, lhs, target, tmp, indent)
 }
 
 func (g *gen) emitDecodeIntoUint(w io.Writer, lhs, target, indent, tmp string) {
 	fmt.Fprintf(w, "%s{\n%s\t%s, err := d.ReadUint()\n", indent, indent, tmp)
-	fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+	fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
 	fmt.Fprintf(w, "%s\t%s = %s(%s)\n%s}\n", indent, lhs, target, tmp, indent)
 }
 
@@ -899,19 +913,14 @@ func (g *gen) emitDecodeNamed(w io.Writer, lhs string, n *types.Named, indent st
 		default:
 			return fmt.Errorf("unsupported named basic kind %v", k)
 		}
-		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
 		fmt.Fprintf(w, "%s\t%s = %s(%s)\n", indent, lhs, g.typeRef(n), tmp)
 		fmt.Fprintf(w, "%s}\n", indent)
 		return nil
 	case *types.Struct:
-		// Nested struct: dispatch on the remaining bytes, threading noCopy so
-		// nested string/[]byte fields alias the buffer too when requested.
-		tmp := g.fresh("nn")
-		fmt.Fprintf(w, "%s{\n", indent)
-		fmt.Fprintf(w, "%s\t%s, err := qdf.UnmarshalNestedArena(&%s, d.RemainingBytes(), noCopy, a)\n", indent, tmp, lhs)
-		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
-		fmt.Fprintf(w, "%s\td.Advance(%s)\n", indent, tmp)
-		fmt.Fprintf(w, "%s}\n", indent)
+		// Nested struct: thread the shared decoder (no new decoder; the nested
+		// DecodeQDF inherits d's noCopy / arena).
+		fmt.Fprintf(w, "%sif err := qdf.DecodeNested(d, &%s); err != nil {\n%s\treturn err\n%s}\n", indent, lhs, indent, indent)
 		return nil
 	case *types.Slice, *types.Array, *types.Map, *types.Pointer:
 		return g.emitDecodeValue(w, lhs, ut, indent)
@@ -923,7 +932,7 @@ func (g *gen) emitDecodeNamed(w io.Writer, lhs string, n *types.Named, indent st
 func (g *gen) emitDecodePointer(w io.Writer, lhs string, p *types.Pointer, indent string) error {
 	fmt.Fprintf(w, "%s{\n", indent)
 	fmt.Fprintf(w, "%s\tisNil, err := d.IsNil()\n", indent)
-	fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+	fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
 	fmt.Fprintf(w, "%s\tif isNil {\n%s\t\t%s = nil\n%s\t} else {\n", indent, indent, lhs, indent)
 
 	elem := p.Elem()
@@ -931,17 +940,14 @@ func (g *gen) emitDecodePointer(w io.Writer, lhs string, p *types.Pointer, inden
 		secTmp := g.fresh("sec")
 		nsecTmp := g.fresh("nsec")
 		fmt.Fprintf(w, "%s\t\t%s, %s, err := d.ReadTimestamp()\n", indent, secTmp, nsecTmp)
-		fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn 0, err\n%s\t\t}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn err\n%s\t\t}\n", indent, indent, indent)
 		g.imports["time"] = ""
 		fmt.Fprintf(w, "%s\t\tt := time.Unix(%s, int64(%s)).UTC()\n", indent, secTmp, nsecTmp)
 		fmt.Fprintf(w, "%s\t\t%s = &t\n", indent, lhs)
 	} else if named, ok := elem.(*types.Named); ok {
 		if _, isStruct := named.Underlying().(*types.Struct); isStruct {
-			tmp := g.fresh("nn")
 			fmt.Fprintf(w, "%s\t\t%s = new(%s)\n", indent, lhs, g.typeRef(named))
-			fmt.Fprintf(w, "%s\t\t%s, err := qdf.UnmarshalNestedArena(%s, d.RemainingBytes(), noCopy, a)\n", indent, tmp, lhs)
-			fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn 0, err\n%s\t\t}\n", indent, indent, indent)
-			fmt.Fprintf(w, "%s\t\td.Advance(%s)\n", indent, tmp)
+			fmt.Fprintf(w, "%s\t\tif err := qdf.DecodeNested(d, %s); err != nil {\n%s\t\t\treturn err\n%s\t\t}\n", indent, lhs, indent, indent)
 		} else {
 			// Named non-struct element (e.g. *Label where type Label string):
 			// route through emitDecodeNamed so it emits the Label(tmp) conversion.
@@ -968,10 +974,10 @@ func (g *gen) emitDecodeSlice(w io.Writer, lhs string, s *types.Slice, indent st
 	if b, ok := elem.(*types.Basic); ok && b.Kind() == types.Uint8 {
 		fmt.Fprintf(w, "%s{\n", indent)
 		fmt.Fprintf(w, "%s\tisNil, err := d.IsNil()\n", indent)
-		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
 		fmt.Fprintf(w, "%s\tif isNil {\n%s\t\t%s = nil\n%s\t} else {\n", indent, indent, lhs, indent)
 		fmt.Fprintf(w, "%s\t\t_v, err := d.ReadBytes()\n", indent)
-		fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn 0, err\n%s\t\t}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn err\n%s\t\t}\n", indent, indent, indent)
 		fmt.Fprintf(w, "%s\t\t%s = _v\n", indent, lhs)
 		fmt.Fprintf(w, "%s\t}\n", indent)
 		fmt.Fprintf(w, "%s}\n", indent)
@@ -979,15 +985,15 @@ func (g *gen) emitDecodeSlice(w io.Writer, lhs string, s *types.Slice, indent st
 	}
 	fmt.Fprintf(w, "%s{\n", indent)
 	fmt.Fprintf(w, "%s\tisNil, err := d.IsNil()\n", indent)
-	fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+	fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
 	fmt.Fprintf(w, "%s\tif isNil {\n%s\t\t%s = nil\n%s\t} else {\n", indent, indent, lhs, indent)
 	nVar := g.fresh("n")
 	fmt.Fprintf(w, "%s\t\t%s, err := d.ReadArrayHeader()\n", indent, nVar)
-	fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn 0, err\n%s\t\t}\n", indent, indent, indent)
+	fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn err\n%s\t\t}\n", indent, indent, indent)
 	// Bound the allocation by remaining input so a hostile length header
 	// can't trigger a multi-GB make before any element is read (matches the
 	// reflect decoder's CheckLength gate).
-	fmt.Fprintf(w, "%s\t\tif err := d.CheckLength(%s, 1); err != nil {\n%s\t\t\treturn 0, err\n%s\t\t}\n", indent, nVar, indent, indent)
+	fmt.Fprintf(w, "%s\t\tif err := d.CheckLength(%s, 1); err != nil {\n%s\t\t\treturn err\n%s\t\t}\n", indent, nVar, indent, indent)
 	fmt.Fprintf(w, "%s\t\t%s = make([]%s, %s)\n", indent, lhs, g.typeExprFromType(elem), nVar)
 	loopVar := g.fresh("i")
 	fmt.Fprintf(w, "%s\t\tfor %s := range %s {\n", indent, loopVar, nVar)
@@ -1008,7 +1014,7 @@ func (g *gen) emitDecodeArray(w io.Writer, lhs string, a *types.Array, indent st
 		bv := g.fresh("ab")
 		fmt.Fprintf(w, "%s{\n", indent)
 		fmt.Fprintf(w, "%s\t%s, err := d.ReadStringBytes()\n", indent, bv)
-		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
 		fmt.Fprintf(w, "%s\tif len(%s) != %d {\n%s\t\treturn 0, qdf.ErrTypeMismatch\n%s\t}\n", indent, bv, a.Len(), indent, indent)
 		fmt.Fprintf(w, "%s\tcopy(%s[:], %s)\n", indent, lhs, bv)
 		fmt.Fprintf(w, "%s}\n", indent)
@@ -1017,7 +1023,7 @@ func (g *gen) emitDecodeArray(w io.Writer, lhs string, a *types.Array, indent st
 	fmt.Fprintf(w, "%s{\n", indent)
 	nVar := g.fresh("n")
 	fmt.Fprintf(w, "%s\t%s, err := d.ReadArrayHeader()\n", indent, nVar)
-	fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+	fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
 	fmt.Fprintf(w, "%s\tif %s != %d {\n%s\t\treturn 0, qdf.ErrTypeMismatch\n%s\t}\n", indent, nVar, a.Len(), indent, indent)
 	loopVar := g.fresh("i")
 	fmt.Fprintf(w, "%s\tfor %s := range %d {\n", indent, loopVar, a.Len())
@@ -1032,16 +1038,16 @@ func (g *gen) emitDecodeArray(w io.Writer, lhs string, a *types.Array, indent st
 func (g *gen) emitDecodeMap(w io.Writer, lhs string, m *types.Map, indent string) error {
 	fmt.Fprintf(w, "%s{\n", indent)
 	fmt.Fprintf(w, "%s\tisNil, err := d.IsNil()\n", indent)
-	fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn 0, err\n%s\t}\n", indent, indent, indent)
+	fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
 	fmt.Fprintf(w, "%s\tif isNil {\n%s\t\t%s = nil\n%s\t} else {\n", indent, indent, lhs, indent)
 	nVar := g.fresh("n")
 	fmt.Fprintf(w, "%s\t\t%s, err := d.ReadMapHeader()\n", indent, nVar)
-	fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn 0, err\n%s\t\t}\n", indent, indent, indent)
+	fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn err\n%s\t\t}\n", indent, indent, indent)
 	keyExpr := g.typeExprFromType(m.Key())
 	valExpr := g.typeExprFromType(m.Elem())
 	// Each map entry is at least two wire bytes (key + value); CheckLength(n,1)
 	// conservatively bounds the alloc by remaining input against a hostile count.
-	fmt.Fprintf(w, "%s\t\tif err := d.CheckLength(%s, 1); err != nil {\n%s\t\t\treturn 0, err\n%s\t\t}\n", indent, nVar, indent, indent)
+	fmt.Fprintf(w, "%s\t\tif err := d.CheckLength(%s, 1); err != nil {\n%s\t\t\treturn err\n%s\t\t}\n", indent, nVar, indent, indent)
 	fmt.Fprintf(w, "%s\t\t%s = make(map[%s]%s, %s)\n", indent, lhs, keyExpr, valExpr, nVar)
 	fmt.Fprintf(w, "%s\t\tfor range %s {\n", indent, nVar)
 	kVar := g.fresh("k")
@@ -1053,7 +1059,7 @@ func (g *gen) emitDecodeMap(w io.Writer, lhs string, m *types.Map, indent string
 	if b, ok := m.Key().Underlying().(*types.Basic); ok && b.Kind() == types.String {
 		kbVar := g.fresh("kb")
 		fmt.Fprintf(w, "%s\t\t\t%s, err := d.ReadStringBytes()\n", indent, kbVar)
-		fmt.Fprintf(w, "%s\t\t\tif err != nil { return 0, err }\n", indent)
+		fmt.Fprintf(w, "%s\t\t\tif err != nil { return err }\n", indent)
 		// InternKey returns string; a defined string key type (e.g. type K string)
 		// needs an explicit conversion. keyExpr is "string" for a plain key, so
 		// the conversion is a harmless no-op there.

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -551,16 +551,27 @@ func (g *gen) emitMarshal(typeName string, fields []fieldInfo) error {
 	fmt.Fprintf(w, "\treturn e.Bytes(), nil\n")
 	fmt.Fprintf(w, "}\n\n")
 
+	// Shape-interning state for this type: a stable per-type token the encoder
+	// keys the field-name shape on, and the field-name headers in field order.
+	// EncodeQDF declares the shape once per encoder (StructShape) so a slice of
+	// this struct threaded through one encoder writes the names once.
+	shapeTok := fmt.Sprintf("qdfShapeTok_%s", typeName)
+	hdrsVar := fmt.Sprintf("qdfFieldHdrs_%s", typeName)
+	hdrNames := make([]string, len(fields))
+	for i, f := range fields {
+		hdrNames[i] = g.fieldNameVar(f.WireKey)
+	}
+	fmt.Fprintf(w, "var %s byte\n", shapeTok)
+	fmt.Fprintf(w, "var %s = [][]byte{%s}\n\n", hdrsVar, strings.Join(hdrNames, ", "))
+
 	// Encoder-based body — writes v's fields into a shared encoder. A parent
 	// threads one encoder through nested values via qdf.EncodeNested, avoiding
 	// the per-nested-value *Encoder allocation the buffer-based path costs.
 	fmt.Fprintf(w, "// EncodeQDF writes v's fields into e. It lets a parent thread one encoder\n")
 	fmt.Fprintf(w, "// through nested values instead of allocating an encoder per value.\n")
 	fmt.Fprintf(w, "func (v *%s) EncodeQDF(e *qdf.Encoder) error {\n", typeName)
-	fmt.Fprintf(w, "\te.WriteMapHeader(%d)\n", len(fields))
+	fmt.Fprintf(w, "\te.StructShape(&%s, %s)\n", shapeTok, hdrsVar)
 	for _, f := range fields {
-		hdrVar := g.fieldNameVar(f.WireKey)
-		fmt.Fprintf(w, "\te.AppendBytes(%s)\n", hdrVar)
 		expr := "v." + f.Access
 		if err := g.emitEncodeValue(w, expr, f.Field.Type(), "\t"); err != nil {
 			return fmt.Errorf("%s.%s: %w", typeName, f.GoName, err)
@@ -581,21 +592,35 @@ func (g *gen) emitUnmarshal(typeName string, fields []fieldInfo) error {
 	fmt.Fprintf(w, "// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets\n")
 	fmt.Fprintf(w, "// a parent thread one decoder through nested values (see qdf.DecodeNested).\n")
 	fmt.Fprintf(w, "func (v *%s) DecodeQDF(d *qdf.Decoder) error {\n", typeName)
-	fmt.Fprintf(w, "\tn, err := d.ReadMapHeader()\n")
+	fmt.Fprintf(w, "\tnames, plainN, shaped, err := d.ReadStructHeader()\n")
 	fmt.Fprintf(w, "\tif err != nil {\n\t\treturn err\n\t}\n")
-	fmt.Fprintf(w, "\tfor range n {\n")
+	fmt.Fprintf(w, "\tif shaped {\n")
+	fmt.Fprintf(w, "\t\tfor _, name := range names {\n")
+	fmt.Fprintf(w, "\t\t\tif err := v.decodeQDFField(d, name); err != nil {\n\t\t\t\treturn err\n\t\t\t}\n")
+	fmt.Fprintf(w, "\t\t}\n")
+	fmt.Fprintf(w, "\t\treturn nil\n")
+	fmt.Fprintf(w, "\t}\n")
+	fmt.Fprintf(w, "\tfor range plainN {\n")
 	fmt.Fprintf(w, "\t\tkb, err := d.ReadStringBytes()\n")
 	fmt.Fprintf(w, "\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n")
-	fmt.Fprintf(w, "\t\tswitch string(kb) {\n")
+	fmt.Fprintf(w, "\t\tif err := v.decodeQDFField(d, string(kb)); err != nil {\n\t\t\treturn err\n\t\t}\n")
+	fmt.Fprintf(w, "\t}\n")
+	fmt.Fprintf(w, "\treturn nil\n")
+	fmt.Fprintf(w, "}\n\n")
+
+	// decodeQDFField decodes one field by wire name from the shared decoder. The
+	// switch is shared by both DecodeQDF loops (shape-interned and plain-map), so
+	// the field-reading code is emitted once.
+	fmt.Fprintf(w, "func (v *%s) decodeQDFField(d *qdf.Decoder, name string) error {\n", typeName)
+	fmt.Fprintf(w, "\tswitch name {\n")
 	for _, f := range fields {
-		fmt.Fprintf(w, "\t\tcase %q:\n", f.WireKey)
-		if err := g.emitDecodeValue(w, "v."+f.Access, f.Field.Type(), "\t\t\t"); err != nil {
+		fmt.Fprintf(w, "\tcase %q:\n", f.WireKey)
+		if err := g.emitDecodeValue(w, "v."+f.Access, f.Field.Type(), "\t\t"); err != nil {
 			return fmt.Errorf("%s.%s: %w", typeName, f.GoName, err)
 		}
 	}
-	fmt.Fprintf(w, "\t\tdefault:\n")
-	fmt.Fprintf(w, "\t\t\tif err := d.Skip(); err != nil {\n\t\t\t\treturn err\n\t\t\t}\n")
-	fmt.Fprintf(w, "\t\t}\n")
+	fmt.Fprintf(w, "\tdefault:\n")
+	fmt.Fprintf(w, "\t\tif err := d.Skip(); err != nil {\n\t\t\treturn err\n\t\t}\n")
 	fmt.Fprintf(w, "\t}\n")
 	fmt.Fprintf(w, "\treturn nil\n")
 	fmt.Fprintf(w, "}\n\n")

--- a/decode_thread_reflect_test.go
+++ b/decode_thread_reflect_test.go
@@ -1,0 +1,37 @@
+package qdf
+
+import "testing"
+
+// TestThreadedSliceDecodeAllocs decodes a slice whose element type implements
+// DecoderUnmarshaler through the reflect path. With threading, the whole slice
+// shares one decoder instead of allocating a fresh decoder (plus its scratch
+// state) per element. Reuses threadProbe from marshaler_decodethread_test.go.
+func TestThreadedSliceDecodeAllocs(t *testing.T) {
+	const n = 200
+	in := make([]*threadProbe, n)
+	for i := range in {
+		in[i] = &threadProbe{V: int64(i)}
+	}
+	buf, err := Marshal(in, OptSpeed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []*threadProbe
+	if err := Unmarshal(buf, &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != n || out[n-1].V != int64(n-1) {
+		t.Fatalf("round-trip: len=%d", len(out))
+	}
+	allocs := testing.AllocsPerRun(50, func() {
+		var o []*threadProbe
+		_ = Unmarshal(buf, &o)
+	})
+	// Threaded: one shared decoder for the whole slice, so allocs are ~one result
+	// struct per element plus a small constant (~n). The fresh-decoder-per-element
+	// path adds a decoder per element (~2n). A ceiling below 2n fails if threading
+	// regresses; n + n/2 leaves headroom for the result structs + slice growth.
+	if allocs > float64(n+n/2) {
+		t.Fatalf("decode allocs=%.0f (>%d) — per-element decoder not eliminated (threading regressed)", allocs, n+n/2)
+	}
+}

--- a/decoder.go
+++ b/decoder.go
@@ -121,6 +121,31 @@ func (d *Decoder) ReadStringBytes() ([]byte, error) { return d.readStringBytes()
 // PeekTag returns the next tag byte without advancing the cursor.
 func (d *Decoder) PeekTag() (byte, error) { return d.peekTag() }
 
+// ReadStructHeader reads a struct/map header for code-generated DecodeQDF,
+// transparently handling both forms a struct takes on the wire:
+//   - a shape-interned header (tagMapShape, see Encoder.StructShape) → returns the
+//     field names in encoded order with shaped=true; the caller reads len(names)
+//     values in that order.
+//   - a plain map header (tagMap8/16/32) → returns the entry count as plainN with
+//     shaped=false; the caller reads plainN (name, value) pairs inline.
+//
+// This lets a generated decoder consume both qdfgen shape output and a plain qdf
+// map (e.g. from a non-shaped encoder, an older generated type, or the reflect
+// path under OptSpeed) without a wire-format negotiation. Exported for
+// cmd/qdfgen-generated code.
+func (d *Decoder) ReadStructHeader() (names []string, plainN int, shaped bool, err error) {
+	tag, err := d.peekTag()
+	if err != nil {
+		return nil, 0, false, err
+	}
+	if tag == tagMapShape {
+		names, err = decodeMapStringShapeHeader(d)
+		return names, 0, true, err
+	}
+	n, err := d.ReadMapHeader()
+	return nil, n, false, err
+}
+
 // DecodeValue decodes the next value as a dynamic any — the schemaless form
 // (string, bool, int64/uint64/float64, []any, map[string]any, …) that decoding
 // into an interface{} produces, mirroring encoding/json. It is the decode

--- a/decoder_skip.go
+++ b/decoder_skip.go
@@ -229,7 +229,6 @@ func (d *Decoder) Skip() error {
 			}
 			cnt = int(cnt64)
 			sh := d.state.shapeDeclare()
-			sh.keyIDs = make([]uint32, 0, cnt)
 			sh.names = make([]string, 0, cnt)
 			for i := 0; i < cnt; i++ {
 				kb, err := d.readStringBytes()
@@ -237,11 +236,6 @@ func (d *Decoder) Skip() error {
 					return err
 				}
 				sh.names = append(sh.names, string(kb))
-				if d.state.lastID != lruInvalidID {
-					sh.keyIDs = append(sh.keyIDs, d.state.lastID)
-				} else {
-					sh.keyIDs = append(sh.keyIDs, 0)
-				}
 			}
 		} else {
 			sh := d.state.shapeLookup(uint32(shapeID))

--- a/delta.go
+++ b/delta.go
@@ -241,7 +241,11 @@ func maybeApplyPatchRANS(enc *Encoder, start int) {
 	if len(cand) >= len(body) {
 		return
 	}
-	if uint64(len(body)) > uint64(hdr+len(cand))*64+(1<<20) {
+	// Decline rANS whenever decompressPatchBody would later reject the frame:
+	// it strips the QDP header first and bounds origLen by the post-header body
+	// length (len(cand)), not hdr+len(cand). Using the same measure here keeps
+	// the encoder from ever emitting a patch its own Apply rejects.
+	if uint64(len(body)) > uint64(len(cand))*64+(1<<20) {
 		return
 	}
 	enc.buf = append(enc.buf[:start+hdr], cand...)

--- a/encoder.go
+++ b/encoder.go
@@ -865,6 +865,39 @@ func (e *Encoder) WriteMapHeader(n int) {
 	}
 }
 
+// StructShape begins a shape-interned struct emission for a code-generated type
+// (the decode-time counterpart is Decoder.ReadStructHeader). token is a stable
+// per-type address — a package-level var the generated EncodeQDF passes;
+// fieldHdrs are the pre-encoded fixstr/strN field-name headers in field order.
+//
+// On the first emit for token on this encoder it DECLARES the shape — tagMapShape,
+// id 0, the field count, then the names — so the decoder registers it; every
+// later emit writes only tagMapShape + the shape ID. The caller then writes the
+// field VALUES in field order (no names). Across a slice of the same struct
+// threaded through one encoder, the field names are written once instead of per
+// record. Reuses the shared shape-ID space, so a generated buffer stays decodable
+// by the reflection path (tagMapShape is standard wire).
+func (e *Encoder) StructShape(token *byte, fieldHdrs [][]byte) {
+	e.writeHeader()
+	if e.state == nil {
+		e.state = newEncState()
+	}
+	st := e.state
+	if id := st.shapeForToken(token); id != 0 {
+		e.buf = append(e.buf, tagMapShape)
+		e.buf = appendUvarint(e.buf, uint64(id))
+		return
+	}
+	id := st.shapeDeclareEnc()
+	st.shapeBindToken(token, id)
+	e.buf = append(e.buf, tagMapShape)
+	e.buf = appendUvarint(e.buf, 0) // 0 ⇒ declaration follows
+	e.buf = appendUvarint(e.buf, uint64(len(fieldHdrs)))
+	for _, h := range fieldHdrs {
+		e.buf = append(e.buf, h...)
+	}
+}
+
 // WriteTimestamp writes a full-range timestamp as two uvarints:
 // sec (zigzag-encoded signed int64 seconds since Unix epoch) and
 // nsec (unsigned uint32 nanoseconds in [0, 999_999_999]).

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -546,7 +546,7 @@ func (v *Sample) DecodeQDF(d *qdf.Decoder) error {
 					return err
 				}
 				if n50 != 3 {
-					return 0, qdf.ErrTypeMismatch
+					return qdf.ErrTypeMismatch
 				}
 				for i51 := range 3 {
 					{

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -13,8 +13,8 @@ var (
 	qdfFieldHdr_base_a_1  = []byte{0x86, 0x62, 0x61, 0x73, 0x65, 0x5f, 0x61}
 	qdfFieldHdr_base_b_2  = []byte{0x86, 0x62, 0x61, 0x73, 0x65, 0x5f, 0x62}
 	qdfFieldHdr_labels_3  = []byte{0x86, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x73}
-	qdfFieldHdr_ptr_6     = []byte{0x83, 0x70, 0x74, 0x72}
-	qdfFieldHdr_tail_7    = []byte{0x84, 0x74, 0x61, 0x69, 0x6c}
+	qdfFieldHdr_ptr_4     = []byte{0x83, 0x70, 0x74, 0x72}
+	qdfFieldHdr_tail_5    = []byte{0x84, 0x74, 0x61, 0x69, 0x6c}
 	qdfFieldHdr_x_17      = []byte{0x81, 0x78}
 	qdfFieldHdr_y_18      = []byte{0x81, 0x79}
 	qdfFieldHdr_name_21   = []byte{0x84, 0x6e, 0x61, 0x6d, 0x65}
@@ -22,12 +22,12 @@ var (
 	qdfFieldHdr_active_23 = []byte{0x86, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65}
 	qdfFieldHdr_score_24  = []byte{0x85, 0x73, 0x63, 0x6f, 0x72, 0x65}
 	qdfFieldHdr_tags_25   = []byte{0x84, 0x74, 0x61, 0x67, 0x73}
-	qdfFieldHdr_meta_27   = []byte{0x84, 0x6d, 0x65, 0x74, 0x61}
-	qdfFieldHdr_inner_30  = []byte{0x85, 0x69, 0x6e, 0x6e, 0x65, 0x72}
-	qdfFieldHdr_when_31   = []byte{0x84, 0x77, 0x68, 0x65, 0x6e}
-	qdfFieldHdr_buf_32    = []byte{0x83, 0x62, 0x75, 0x66}
-	qdfFieldHdr_opt_33    = []byte{0x83, 0x6f, 0x70, 0x74}
-	qdfFieldHdr_counts_34 = []byte{0x86, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73}
+	qdfFieldHdr_meta_26   = []byte{0x84, 0x6d, 0x65, 0x74, 0x61}
+	qdfFieldHdr_inner_27  = []byte{0x85, 0x69, 0x6e, 0x6e, 0x65, 0x72}
+	qdfFieldHdr_when_28   = []byte{0x84, 0x77, 0x68, 0x65, 0x6e}
+	qdfFieldHdr_buf_29    = []byte{0x83, 0x62, 0x75, 0x66}
+	qdfFieldHdr_opt_30    = []byte{0x83, 0x6f, 0x70, 0x74}
+	qdfFieldHdr_counts_31 = []byte{0x86, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73}
 )
 
 // MarshalQDF appends a qdf-encoded representation of v to dst and returns
@@ -46,31 +46,29 @@ func (v *Edge) MarshalQDF(dst []byte) ([]byte, error) {
 	return e.Bytes(), nil
 }
 
+var qdfShapeTok_Edge byte
+var qdfFieldHdrs_Edge = [][]byte{qdfFieldHdr_base_a_1, qdfFieldHdr_base_b_2, qdfFieldHdr_labels_3, qdfFieldHdr_ptr_4, qdfFieldHdr_tail_5}
+
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
 func (v *Edge) EncodeQDF(e *qdf.Encoder) error {
-	e.WriteMapHeader(5)
-	e.AppendBytes(qdfFieldHdr_base_a_1)
+	e.StructShape(&qdfShapeTok_Edge, qdfFieldHdrs_Edge)
 	e.WriteInt(int64(v.EmbeddedBase.BaseA))
-	e.AppendBytes(qdfFieldHdr_base_b_2)
 	e.WriteString(string(v.EmbeddedBase.BaseB))
-	e.AppendBytes(qdfFieldHdr_labels_3)
 	if v.Labels == nil {
 		e.WriteNil()
 	} else {
 		e.WriteMapHeader(len(v.Labels))
-		for k4, vv5 := range v.Labels {
-			e.WriteString(string(k4))
-			e.WriteInt(int64(vv5))
+		for k6, vv7 := range v.Labels {
+			e.WriteString(string(k6))
+			e.WriteInt(int64(vv7))
 		}
 	}
-	e.AppendBytes(qdfFieldHdr_ptr_6)
 	if v.Ptr == nil {
 		e.WriteNil()
 	} else {
 		e.WriteString(string((*v.Ptr)))
 	}
-	e.AppendBytes(qdfFieldHdr_tail_7)
 	e.WriteInt(int64(v.Tail))
 	return nil
 }
@@ -78,99 +76,114 @@ func (v *Edge) EncodeQDF(e *qdf.Encoder) error {
 // DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
 // a parent thread one decoder through nested values (see qdf.DecodeNested).
 func (v *Edge) DecodeQDF(d *qdf.Decoder) error {
-	n, err := d.ReadMapHeader()
+	names, plainN, shaped, err := d.ReadStructHeader()
 	if err != nil {
 		return err
 	}
-	for range n {
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
 		kb, err := d.ReadStringBytes()
 		if err != nil {
 			return err
 		}
-		switch string(kb) {
-		case "base_a":
-			{
-				rv8, err := d.ReadInt()
-				if err != nil {
-					return err
-				}
-				v.EmbeddedBase.BaseA = int(rv8)
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *Edge) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "base_a":
+		{
+			rv8, err := d.ReadInt()
+			if err != nil {
+				return err
 			}
-		case "base_b":
-			{
-				rv9, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.EmbeddedBase.BaseB = rv9
+			v.EmbeddedBase.BaseA = int(rv8)
+		}
+	case "base_b":
+		{
+			rv9, err := d.ReadString()
+			if err != nil {
+				return err
 			}
-		case "labels":
-			{
-				isNil, err := d.IsNil()
+			v.EmbeddedBase.BaseB = rv9
+		}
+	case "labels":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Labels = nil
+			} else {
+				n10, err := d.ReadMapHeader()
 				if err != nil {
 					return err
 				}
-				if isNil {
-					v.Labels = nil
-				} else {
-					n10, err := d.ReadMapHeader()
+				if err := d.CheckLength(n10, 1); err != nil {
+					return err
+				}
+				v.Labels = make(map[Label]int, n10)
+				for range n10 {
+					var k11 Label
+					var vv12 int
+					kb13, err := d.ReadStringBytes()
 					if err != nil {
 						return err
 					}
-					if err := d.CheckLength(n10, 1); err != nil {
-						return err
-					}
-					v.Labels = make(map[Label]int, n10)
-					for range n10 {
-						var k11 Label
-						var vv12 int
-						kb13, err := d.ReadStringBytes()
-						if err != nil {
-							return err
-						}
-						k11 = Label(d.InternKey(kb13))
-						{
-							rv14, err := d.ReadInt()
-							if err != nil {
-								return err
-							}
-							vv12 = int(rv14)
-						}
-						v.Labels[k11] = vv12
-					}
-				}
-			}
-		case "ptr":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return err
-				}
-				if isNil {
-					v.Ptr = nil
-				} else {
-					v.Ptr = new(Label)
+					k11 = Label(d.InternKey(kb13))
 					{
-						nv15, err := d.ReadString()
+						rv14, err := d.ReadInt()
 						if err != nil {
 							return err
 						}
-						(*v.Ptr) = Label(nv15)
+						vv12 = int(rv14)
 					}
+					v.Labels[k11] = vv12
 				}
 			}
-		case "tail":
-			{
-				rv16, err := d.ReadInt()
-				if err != nil {
-					return err
-				}
-				v.Tail = int(rv16)
-			}
-		default:
-			if err := d.Skip(); err != nil {
+		}
+	case "ptr":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
 				return err
 			}
+			if isNil {
+				v.Ptr = nil
+			} else {
+				v.Ptr = new(Label)
+				{
+					nv15, err := d.ReadString()
+					if err != nil {
+						return err
+					}
+					(*v.Ptr) = Label(nv15)
+				}
+			}
+		}
+	case "tail":
+		{
+			rv16, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v.Tail = int(rv16)
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -226,13 +239,14 @@ func (v *Inner) MarshalQDF(dst []byte) ([]byte, error) {
 	return e.Bytes(), nil
 }
 
+var qdfShapeTok_Inner byte
+var qdfFieldHdrs_Inner = [][]byte{qdfFieldHdr_x_17, qdfFieldHdr_y_18}
+
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
 func (v *Inner) EncodeQDF(e *qdf.Encoder) error {
-	e.WriteMapHeader(2)
-	e.AppendBytes(qdfFieldHdr_x_17)
+	e.StructShape(&qdfShapeTok_Inner, qdfFieldHdrs_Inner)
 	e.WriteInt(int64(v.X))
-	e.AppendBytes(qdfFieldHdr_y_18)
 	e.WriteFloat64(float64(v.Y))
 	return nil
 }
@@ -240,36 +254,51 @@ func (v *Inner) EncodeQDF(e *qdf.Encoder) error {
 // DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
 // a parent thread one decoder through nested values (see qdf.DecodeNested).
 func (v *Inner) DecodeQDF(d *qdf.Decoder) error {
-	n, err := d.ReadMapHeader()
+	names, plainN, shaped, err := d.ReadStructHeader()
 	if err != nil {
 		return err
 	}
-	for range n {
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
 		kb, err := d.ReadStringBytes()
 		if err != nil {
 			return err
 		}
-		switch string(kb) {
-		case "x":
-			{
-				rv19, err := d.ReadInt()
-				if err != nil {
-					return err
-				}
-				v.X = int(rv19)
-			}
-		case "y":
-			{
-				rv20, err := d.ReadFloat64()
-				if err != nil {
-					return err
-				}
-				v.Y = rv20
-			}
-		default:
-			if err := d.Skip(); err != nil {
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *Inner) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "x":
+		{
+			rv19, err := d.ReadInt()
+			if err != nil {
 				return err
 			}
+			v.X = int(rv19)
+		}
+	case "y":
+		{
+			rv20, err := d.ReadFloat64()
+			if err != nil {
+				return err
+			}
+			v.Y = rv20
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -325,53 +354,46 @@ func (v *Sample) MarshalQDF(dst []byte) ([]byte, error) {
 	return e.Bytes(), nil
 }
 
+var qdfShapeTok_Sample byte
+var qdfFieldHdrs_Sample = [][]byte{qdfFieldHdr_name_21, qdfFieldHdr_age_22, qdfFieldHdr_active_23, qdfFieldHdr_score_24, qdfFieldHdr_tags_25, qdfFieldHdr_meta_26, qdfFieldHdr_inner_27, qdfFieldHdr_when_28, qdfFieldHdr_buf_29, qdfFieldHdr_opt_30, qdfFieldHdr_counts_31}
+
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
 func (v *Sample) EncodeQDF(e *qdf.Encoder) error {
-	e.WriteMapHeader(11)
-	e.AppendBytes(qdfFieldHdr_name_21)
+	e.StructShape(&qdfShapeTok_Sample, qdfFieldHdrs_Sample)
 	e.WriteString(string(v.Name))
-	e.AppendBytes(qdfFieldHdr_age_22)
 	e.WriteInt(int64(v.Age))
-	e.AppendBytes(qdfFieldHdr_active_23)
 	e.WriteBool(bool(v.Active))
-	e.AppendBytes(qdfFieldHdr_score_24)
 	e.WriteFloat64(float64(v.Score))
-	e.AppendBytes(qdfFieldHdr_tags_25)
 	if v.Tags == nil {
 		e.WriteNil()
 	} else {
 		e.WriteArrayHeader(len(v.Tags))
-		for i26 := range v.Tags {
-			e.WriteString(string(v.Tags[i26]))
+		for i32 := range v.Tags {
+			e.WriteString(string(v.Tags[i32]))
 		}
 	}
-	e.AppendBytes(qdfFieldHdr_meta_27)
 	if v.Meta == nil {
 		e.WriteNil()
 	} else {
 		e.WriteMapHeader(len(v.Meta))
-		for k28, vv29 := range v.Meta {
-			e.WriteString(string(k28))
-			e.WriteString(string(vv29))
+		for k33, vv34 := range v.Meta {
+			e.WriteString(string(k33))
+			e.WriteString(string(vv34))
 		}
 	}
-	e.AppendBytes(qdfFieldHdr_inner_30)
 	if err := qdf.EncodeNested(e, &v.Inner); err != nil {
 		return err
 	}
-	e.AppendBytes(qdfFieldHdr_when_31)
 	{
 		_t := (v.When).UTC()
 		e.WriteTimestamp(_t.Unix(), uint32(_t.Nanosecond()))
 	}
-	e.AppendBytes(qdfFieldHdr_buf_32)
 	if v.Buf == nil {
 		e.WriteNil()
 	} else {
 		e.WriteBytes([]byte(v.Buf))
 	}
-	e.AppendBytes(qdfFieldHdr_opt_33)
 	if v.OptPtr == nil {
 		e.WriteNil()
 	} else {
@@ -379,7 +401,6 @@ func (v *Sample) EncodeQDF(e *qdf.Encoder) error {
 			return err
 		}
 	}
-	e.AppendBytes(qdfFieldHdr_counts_34)
 	e.WriteArrayHeader(3)
 	for i35 := range v.Counts {
 		e.WriteInt(int64(v.Counts[i35]))
@@ -390,178 +411,193 @@ func (v *Sample) EncodeQDF(e *qdf.Encoder) error {
 // DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
 // a parent thread one decoder through nested values (see qdf.DecodeNested).
 func (v *Sample) DecodeQDF(d *qdf.Decoder) error {
-	n, err := d.ReadMapHeader()
+	names, plainN, shaped, err := d.ReadStructHeader()
 	if err != nil {
 		return err
 	}
-	for range n {
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
 		kb, err := d.ReadStringBytes()
 		if err != nil {
 			return err
 		}
-		switch string(kb) {
-		case "name":
-			{
-				rv36, err := d.ReadString()
-				if err != nil {
-					return err
-				}
-				v.Name = rv36
-			}
-		case "age":
-			{
-				rv37, err := d.ReadInt()
-				if err != nil {
-					return err
-				}
-				v.Age = int(rv37)
-			}
-		case "active":
-			{
-				rv38, err := d.ReadBool()
-				if err != nil {
-					return err
-				}
-				v.Active = rv38
-			}
-		case "score":
-			{
-				rv39, err := d.ReadFloat64()
-				if err != nil {
-					return err
-				}
-				v.Score = rv39
-			}
-		case "tags":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return err
-				}
-				if isNil {
-					v.Tags = nil
-				} else {
-					n40, err := d.ReadArrayHeader()
-					if err != nil {
-						return err
-					}
-					if err := d.CheckLength(n40, 1); err != nil {
-						return err
-					}
-					v.Tags = make([]string, n40)
-					for i41 := range n40 {
-						{
-							rv42, err := d.ReadString()
-							if err != nil {
-								return err
-							}
-							v.Tags[i41] = rv42
-						}
-					}
-				}
-			}
-		case "meta":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return err
-				}
-				if isNil {
-					v.Meta = nil
-				} else {
-					n43, err := d.ReadMapHeader()
-					if err != nil {
-						return err
-					}
-					if err := d.CheckLength(n43, 1); err != nil {
-						return err
-					}
-					v.Meta = make(map[string]string, n43)
-					for range n43 {
-						var k44 string
-						var vv45 string
-						kb46, err := d.ReadStringBytes()
-						if err != nil {
-							return err
-						}
-						k44 = string(d.InternKey(kb46))
-						{
-							rv47, err := d.ReadString()
-							if err != nil {
-								return err
-							}
-							vv45 = rv47
-						}
-						v.Meta[k44] = vv45
-					}
-				}
-			}
-		case "inner":
-			if err := qdf.DecodeNested(d, &v.Inner); err != nil {
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "name":
+		{
+			rv36, err := d.ReadString()
+			if err != nil {
 				return err
 			}
-		case "when":
-			{
-				sec48, nsec49, err := d.ReadTimestamp()
-				if err != nil {
-					return err
-				}
-				v.When = time.Unix(sec48, int64(nsec49)).UTC()
+			v.Name = rv36
+		}
+	case "age":
+		{
+			rv37, err := d.ReadInt()
+			if err != nil {
+				return err
 			}
-		case "buf":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return err
-				}
-				if isNil {
-					v.Buf = nil
-				} else {
-					_v, err := d.ReadBytes()
-					if err != nil {
-						return err
-					}
-					v.Buf = _v
-				}
+			v.Age = int(rv37)
+		}
+	case "active":
+		{
+			rv38, err := d.ReadBool()
+			if err != nil {
+				return err
 			}
-		case "opt":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return err
-				}
-				if isNil {
-					v.OptPtr = nil
-				} else {
-					v.OptPtr = new(Inner)
-					if err := qdf.DecodeNested(d, v.OptPtr); err != nil {
-						return err
-					}
-				}
+			v.Active = rv38
+		}
+	case "score":
+		{
+			rv39, err := d.ReadFloat64()
+			if err != nil {
+				return err
 			}
-		case "counts":
-			{
-				n50, err := d.ReadArrayHeader()
+			v.Score = rv39
+		}
+	case "tags":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Tags = nil
+			} else {
+				n40, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if n50 != 3 {
-					return qdf.ErrTypeMismatch
+				if err := d.CheckLength(n40, 1); err != nil {
+					return err
 				}
-				for i51 := range 3 {
+				v.Tags = make([]string, n40)
+				for i41 := range n40 {
 					{
-						rv52, err := d.ReadInt()
+						rv42, err := d.ReadString()
 						if err != nil {
 							return err
 						}
-						v.Counts[i51] = int32(rv52)
+						v.Tags[i41] = rv42
 					}
 				}
 			}
-		default:
-			if err := d.Skip(); err != nil {
+		}
+	case "meta":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
 				return err
 			}
+			if isNil {
+				v.Meta = nil
+			} else {
+				n43, err := d.ReadMapHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n43, 1); err != nil {
+					return err
+				}
+				v.Meta = make(map[string]string, n43)
+				for range n43 {
+					var k44 string
+					var vv45 string
+					kb46, err := d.ReadStringBytes()
+					if err != nil {
+						return err
+					}
+					k44 = string(d.InternKey(kb46))
+					{
+						rv47, err := d.ReadString()
+						if err != nil {
+							return err
+						}
+						vv45 = rv47
+					}
+					v.Meta[k44] = vv45
+				}
+			}
+		}
+	case "inner":
+		if err := qdf.DecodeNested(d, &v.Inner); err != nil {
+			return err
+		}
+	case "when":
+		{
+			sec48, nsec49, err := d.ReadTimestamp()
+			if err != nil {
+				return err
+			}
+			v.When = time.Unix(sec48, int64(nsec49)).UTC()
+		}
+	case "buf":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Buf = nil
+			} else {
+				_v, err := d.ReadBytes()
+				if err != nil {
+					return err
+				}
+				v.Buf = _v
+			}
+		}
+	case "opt":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.OptPtr = nil
+			} else {
+				v.OptPtr = new(Inner)
+				if err := qdf.DecodeNested(d, v.OptPtr); err != nil {
+					return err
+				}
+			}
+		}
+	case "counts":
+		{
+			n50, err := d.ReadArrayHeader()
+			if err != nil {
+				return err
+			}
+			if n50 != 3 {
+				return qdf.ErrTypeMismatch
+			}
+			for i51 := range 3 {
+				{
+					rv52, err := d.ReadInt()
+					if err != nil {
+						return err
+					}
+					v.Counts[i51] = int32(rv52)
+				}
+			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -75,6 +75,107 @@ func (v *Edge) EncodeQDF(e *qdf.Encoder) error {
 	return nil
 }
 
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *Edge) DecodeQDF(d *qdf.Decoder) error {
+	n, err := d.ReadMapHeader()
+	if err != nil {
+		return err
+	}
+	for range n {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		switch string(kb) {
+		case "base_a":
+			{
+				rv8, err := d.ReadInt()
+				if err != nil {
+					return err
+				}
+				v.EmbeddedBase.BaseA = int(rv8)
+			}
+		case "base_b":
+			{
+				rv9, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.EmbeddedBase.BaseB = rv9
+			}
+		case "labels":
+			{
+				isNil, err := d.IsNil()
+				if err != nil {
+					return err
+				}
+				if isNil {
+					v.Labels = nil
+				} else {
+					n10, err := d.ReadMapHeader()
+					if err != nil {
+						return err
+					}
+					if err := d.CheckLength(n10, 1); err != nil {
+						return err
+					}
+					v.Labels = make(map[Label]int, n10)
+					for range n10 {
+						var k11 Label
+						var vv12 int
+						kb13, err := d.ReadStringBytes()
+						if err != nil {
+							return err
+						}
+						k11 = Label(d.InternKey(kb13))
+						{
+							rv14, err := d.ReadInt()
+							if err != nil {
+								return err
+							}
+							vv12 = int(rv14)
+						}
+						v.Labels[k11] = vv12
+					}
+				}
+			}
+		case "ptr":
+			{
+				isNil, err := d.IsNil()
+				if err != nil {
+					return err
+				}
+				if isNil {
+					v.Ptr = nil
+				} else {
+					v.Ptr = new(Label)
+					{
+						nv15, err := d.ReadString()
+						if err != nil {
+							return err
+						}
+						(*v.Ptr) = Label(nv15)
+					}
+				}
+			}
+		case "tail":
+			{
+				rv16, err := d.ReadInt()
+				if err != nil {
+					return err
+				}
+				v.Tail = int(rv16)
+			}
+		default:
+			if err := d.Skip(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // UnmarshalQDF decodes a qdf payload into v and returns the number of
 // bytes consumed.
 func (v *Edge) UnmarshalQDF(src []byte) (int, error) {
@@ -99,103 +200,12 @@ func (v *Edge) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, er
 	if a != nil {
 		d.SetArena(a)
 	}
-	if !(len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2) {
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
 		d.MarkHeaderRead()
 	}
-	n, err := d.ReadMapHeader()
-	if err != nil {
+	if err := v.DecodeQDF(d); err != nil {
 		return 0, err
-	}
-	for range n {
-		kb, err := d.ReadStringBytes()
-		if err != nil {
-			return 0, err
-		}
-		switch string(kb) {
-		case "base_a":
-			{
-				rv8, err := d.ReadInt()
-				if err != nil {
-					return 0, err
-				}
-				v.EmbeddedBase.BaseA = int(rv8)
-			}
-		case "base_b":
-			{
-				rv9, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.EmbeddedBase.BaseB = rv9
-			}
-		case "labels":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return 0, err
-				}
-				if isNil {
-					v.Labels = nil
-				} else {
-					n10, err := d.ReadMapHeader()
-					if err != nil {
-						return 0, err
-					}
-					if err := d.CheckLength(n10, 1); err != nil {
-						return 0, err
-					}
-					v.Labels = make(map[Label]int, n10)
-					for range n10 {
-						var k11 Label
-						var vv12 int
-						kb13, err := d.ReadStringBytes()
-						if err != nil {
-							return 0, err
-						}
-						k11 = Label(d.InternKey(kb13))
-						{
-							rv14, err := d.ReadInt()
-							if err != nil {
-								return 0, err
-							}
-							vv12 = int(rv14)
-						}
-						v.Labels[k11] = vv12
-					}
-				}
-			}
-		case "ptr":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return 0, err
-				}
-				if isNil {
-					v.Ptr = nil
-				} else {
-					v.Ptr = new(Label)
-					{
-						nv15, err := d.ReadString()
-						if err != nil {
-							return 0, err
-						}
-						(*v.Ptr) = Label(nv15)
-					}
-				}
-			}
-		case "tail":
-			{
-				rv16, err := d.ReadInt()
-				if err != nil {
-					return 0, err
-				}
-				v.Tail = int(rv16)
-			}
-		default:
-			if err := d.Skip(); err != nil {
-				return 0, err
-			}
-		}
 	}
 	return d.Pos(), nil
 }
@@ -227,6 +237,44 @@ func (v *Inner) EncodeQDF(e *qdf.Encoder) error {
 	return nil
 }
 
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *Inner) DecodeQDF(d *qdf.Decoder) error {
+	n, err := d.ReadMapHeader()
+	if err != nil {
+		return err
+	}
+	for range n {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		switch string(kb) {
+		case "x":
+			{
+				rv19, err := d.ReadInt()
+				if err != nil {
+					return err
+				}
+				v.X = int(rv19)
+			}
+		case "y":
+			{
+				rv20, err := d.ReadFloat64()
+				if err != nil {
+					return err
+				}
+				v.Y = rv20
+			}
+		default:
+			if err := d.Skip(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // UnmarshalQDF decodes a qdf payload into v and returns the number of
 // bytes consumed.
 func (v *Inner) UnmarshalQDF(src []byte) (int, error) {
@@ -251,40 +299,12 @@ func (v *Inner) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, e
 	if a != nil {
 		d.SetArena(a)
 	}
-	if !(len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2) {
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
 		d.MarkHeaderRead()
 	}
-	n, err := d.ReadMapHeader()
-	if err != nil {
+	if err := v.DecodeQDF(d); err != nil {
 		return 0, err
-	}
-	for range n {
-		kb, err := d.ReadStringBytes()
-		if err != nil {
-			return 0, err
-		}
-		switch string(kb) {
-		case "x":
-			{
-				rv19, err := d.ReadInt()
-				if err != nil {
-					return 0, err
-				}
-				v.X = int(rv19)
-			}
-		case "y":
-			{
-				rv20, err := d.ReadFloat64()
-				if err != nil {
-					return 0, err
-				}
-				v.Y = rv20
-			}
-		default:
-			if err := d.Skip(); err != nil {
-				return 0, err
-			}
-		}
 	}
 	return d.Pos(), nil
 }
@@ -367,6 +387,186 @@ func (v *Sample) EncodeQDF(e *qdf.Encoder) error {
 	return nil
 }
 
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *Sample) DecodeQDF(d *qdf.Decoder) error {
+	n, err := d.ReadMapHeader()
+	if err != nil {
+		return err
+	}
+	for range n {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		switch string(kb) {
+		case "name":
+			{
+				rv36, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v.Name = rv36
+			}
+		case "age":
+			{
+				rv37, err := d.ReadInt()
+				if err != nil {
+					return err
+				}
+				v.Age = int(rv37)
+			}
+		case "active":
+			{
+				rv38, err := d.ReadBool()
+				if err != nil {
+					return err
+				}
+				v.Active = rv38
+			}
+		case "score":
+			{
+				rv39, err := d.ReadFloat64()
+				if err != nil {
+					return err
+				}
+				v.Score = rv39
+			}
+		case "tags":
+			{
+				isNil, err := d.IsNil()
+				if err != nil {
+					return err
+				}
+				if isNil {
+					v.Tags = nil
+				} else {
+					n40, err := d.ReadArrayHeader()
+					if err != nil {
+						return err
+					}
+					if err := d.CheckLength(n40, 1); err != nil {
+						return err
+					}
+					v.Tags = make([]string, n40)
+					for i41 := range n40 {
+						{
+							rv42, err := d.ReadString()
+							if err != nil {
+								return err
+							}
+							v.Tags[i41] = rv42
+						}
+					}
+				}
+			}
+		case "meta":
+			{
+				isNil, err := d.IsNil()
+				if err != nil {
+					return err
+				}
+				if isNil {
+					v.Meta = nil
+				} else {
+					n43, err := d.ReadMapHeader()
+					if err != nil {
+						return err
+					}
+					if err := d.CheckLength(n43, 1); err != nil {
+						return err
+					}
+					v.Meta = make(map[string]string, n43)
+					for range n43 {
+						var k44 string
+						var vv45 string
+						kb46, err := d.ReadStringBytes()
+						if err != nil {
+							return err
+						}
+						k44 = string(d.InternKey(kb46))
+						{
+							rv47, err := d.ReadString()
+							if err != nil {
+								return err
+							}
+							vv45 = rv47
+						}
+						v.Meta[k44] = vv45
+					}
+				}
+			}
+		case "inner":
+			if err := qdf.DecodeNested(d, &v.Inner); err != nil {
+				return err
+			}
+		case "when":
+			{
+				sec48, nsec49, err := d.ReadTimestamp()
+				if err != nil {
+					return err
+				}
+				v.When = time.Unix(sec48, int64(nsec49)).UTC()
+			}
+		case "buf":
+			{
+				isNil, err := d.IsNil()
+				if err != nil {
+					return err
+				}
+				if isNil {
+					v.Buf = nil
+				} else {
+					_v, err := d.ReadBytes()
+					if err != nil {
+						return err
+					}
+					v.Buf = _v
+				}
+			}
+		case "opt":
+			{
+				isNil, err := d.IsNil()
+				if err != nil {
+					return err
+				}
+				if isNil {
+					v.OptPtr = nil
+				} else {
+					v.OptPtr = new(Inner)
+					if err := qdf.DecodeNested(d, v.OptPtr); err != nil {
+						return err
+					}
+				}
+			}
+		case "counts":
+			{
+				n50, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if n50 != 3 {
+					return 0, qdf.ErrTypeMismatch
+				}
+				for i51 := range 3 {
+					{
+						rv52, err := d.ReadInt()
+						if err != nil {
+							return err
+						}
+						v.Counts[i51] = int32(rv52)
+					}
+				}
+			}
+		default:
+			if err := d.Skip(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // UnmarshalQDF decodes a qdf payload into v and returns the number of
 // bytes consumed.
 func (v *Sample) UnmarshalQDF(src []byte) (int, error) {
@@ -391,188 +591,12 @@ func (v *Sample) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, 
 	if a != nil {
 		d.SetArena(a)
 	}
-	if !(len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2) {
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
 		d.MarkHeaderRead()
 	}
-	n, err := d.ReadMapHeader()
-	if err != nil {
+	if err := v.DecodeQDF(d); err != nil {
 		return 0, err
-	}
-	for range n {
-		kb, err := d.ReadStringBytes()
-		if err != nil {
-			return 0, err
-		}
-		switch string(kb) {
-		case "name":
-			{
-				rv36, err := d.ReadString()
-				if err != nil {
-					return 0, err
-				}
-				v.Name = rv36
-			}
-		case "age":
-			{
-				rv37, err := d.ReadInt()
-				if err != nil {
-					return 0, err
-				}
-				v.Age = int(rv37)
-			}
-		case "active":
-			{
-				rv38, err := d.ReadBool()
-				if err != nil {
-					return 0, err
-				}
-				v.Active = rv38
-			}
-		case "score":
-			{
-				rv39, err := d.ReadFloat64()
-				if err != nil {
-					return 0, err
-				}
-				v.Score = rv39
-			}
-		case "tags":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return 0, err
-				}
-				if isNil {
-					v.Tags = nil
-				} else {
-					n40, err := d.ReadArrayHeader()
-					if err != nil {
-						return 0, err
-					}
-					if err := d.CheckLength(n40, 1); err != nil {
-						return 0, err
-					}
-					v.Tags = make([]string, n40)
-					for i41 := range n40 {
-						{
-							rv42, err := d.ReadString()
-							if err != nil {
-								return 0, err
-							}
-							v.Tags[i41] = rv42
-						}
-					}
-				}
-			}
-		case "meta":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return 0, err
-				}
-				if isNil {
-					v.Meta = nil
-				} else {
-					n43, err := d.ReadMapHeader()
-					if err != nil {
-						return 0, err
-					}
-					if err := d.CheckLength(n43, 1); err != nil {
-						return 0, err
-					}
-					v.Meta = make(map[string]string, n43)
-					for range n43 {
-						var k44 string
-						var vv45 string
-						kb46, err := d.ReadStringBytes()
-						if err != nil {
-							return 0, err
-						}
-						k44 = string(d.InternKey(kb46))
-						{
-							rv47, err := d.ReadString()
-							if err != nil {
-								return 0, err
-							}
-							vv45 = rv47
-						}
-						v.Meta[k44] = vv45
-					}
-				}
-			}
-		case "inner":
-			{
-				nn48, err := qdf.UnmarshalNestedArena(&v.Inner, d.RemainingBytes(), noCopy, a)
-				if err != nil {
-					return 0, err
-				}
-				d.Advance(nn48)
-			}
-		case "when":
-			{
-				sec49, nsec50, err := d.ReadTimestamp()
-				if err != nil {
-					return 0, err
-				}
-				v.When = time.Unix(sec49, int64(nsec50)).UTC()
-			}
-		case "buf":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return 0, err
-				}
-				if isNil {
-					v.Buf = nil
-				} else {
-					_v, err := d.ReadBytes()
-					if err != nil {
-						return 0, err
-					}
-					v.Buf = _v
-				}
-			}
-		case "opt":
-			{
-				isNil, err := d.IsNil()
-				if err != nil {
-					return 0, err
-				}
-				if isNil {
-					v.OptPtr = nil
-				} else {
-					v.OptPtr = new(Inner)
-					nn51, err := qdf.UnmarshalNestedArena(v.OptPtr, d.RemainingBytes(), noCopy, a)
-					if err != nil {
-						return 0, err
-					}
-					d.Advance(nn51)
-				}
-			}
-		case "counts":
-			{
-				n52, err := d.ReadArrayHeader()
-				if err != nil {
-					return 0, err
-				}
-				if n52 != 3 {
-					return 0, qdf.ErrTypeMismatch
-				}
-				for i53 := range 3 {
-					{
-						rv54, err := d.ReadInt()
-						if err != nil {
-							return 0, err
-						}
-						v.Counts[i53] = int32(rv54)
-					}
-				}
-			}
-		default:
-			if err := d.Skip(); err != nil {
-				return 0, err
-			}
-		}
 	}
 	return d.Pos(), nil
 }

--- a/map_shape.go
+++ b/map_shape.go
@@ -110,7 +110,6 @@ func decodeMapStringShapeHeader(d *Decoder) ([]string, error) {
 			return nil, err
 		}
 		sh := d.state.shapeDeclare()
-		sh.keyIDs = make([]uint32, 0, cnt)
 		keys := make([]string, 0, cnt)
 		for range cnt {
 			kb, err := d.readStringBytes()
@@ -118,11 +117,6 @@ func decodeMapStringShapeHeader(d *Decoder) ([]string, error) {
 				return nil, err
 			}
 			keys = append(keys, d.keyCache.Make(kb))
-			if d.state.lastID != lruInvalidID {
-				sh.keyIDs = append(sh.keyIDs, d.state.lastID)
-			} else {
-				sh.keyIDs = append(sh.keyIDs, 0)
-			}
 		}
 		sh.names = keys
 		return keys, nil

--- a/marshaler.go
+++ b/marshaler.go
@@ -34,6 +34,62 @@ func EncodeNested(e *Encoder, m Marshaler) error {
 	return nil
 }
 
+// DecoderUnmarshaler is the decode counterpart of EncoderMarshaler: it reads its
+// value from a SHARED Decoder, advancing it, so a parent can thread one decoder
+// through a whole value graph instead of opening one per nested value (one
+// *Decoder plus its scratch / intern state per nested value otherwise).
+// Generated code (cmd/qdfgen) implements it; DecodeNested prefers it. noCopy and
+// arena live on the shared decoder, so a threaded nested decode inherits them
+// with no extra arguments.
+type DecoderUnmarshaler interface {
+	Unmarshaler
+	DecodeQDF(d *Decoder) error
+}
+
+// DecodeNested decodes one nested value from the shared decoder d. When u
+// implements DecoderUnmarshaler it reads directly from d (no new decoder, and it
+// inherits d's noCopy / arena). Otherwise it falls back to the buffer-based
+// UnmarshalQDF over d's remaining bytes — honoring d's noCopy / arena via the
+// Opts / Arena extensions — and advances d by the bytes consumed. Exported for
+// cmd/qdfgen-generated code.
+func DecodeNested(d *Decoder, u Unmarshaler) error {
+	if du, ok := u.(DecoderUnmarshaler); ok {
+		return du.DecodeQDF(d)
+	}
+	src := d.RemainingBytes()
+	var n int
+	var err error
+	switch {
+	case d.arena != nil:
+		if ua, ok := u.(UnmarshalerArena); ok {
+			n, err = ua.UnmarshalQDFArena(src, d.noCopy, d.arena)
+			break
+		}
+		if uo, ok := u.(UnmarshalerOpts); ok && d.noCopy {
+			n, err = uo.UnmarshalQDFOpts(src, true)
+		} else {
+			n, err = u.UnmarshalQDF(src)
+		}
+	default:
+		if uo, ok := u.(UnmarshalerOpts); ok && d.noCopy {
+			n, err = uo.UnmarshalQDFOpts(src, true)
+		} else {
+			n, err = u.UnmarshalQDF(src)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	// Guard the shared cursor against a misbehaving Unmarshaler (mirrors
+	// UnmarshalNested): a count past the remaining bytes would push the cursor
+	// out of bounds and panic the next read.
+	if n < 0 || n > d.Remaining() {
+		return ErrShortBuffer
+	}
+	d.Advance(n)
+	return nil
+}
+
 // Unmarshaler is implemented by types that know how to deserialize themselves
 // from a QDF wire-format slice. Implementations should consume exactly one
 // value from src and return the number of bytes consumed.

--- a/marshaler_decodethread_test.go
+++ b/marshaler_decodethread_test.go
@@ -1,0 +1,162 @@
+package qdf
+
+import "testing"
+
+// threadProbe records the decoder identity DecodeQDF saw, to prove threading.
+type threadProbe struct {
+	V    int64
+	seen *Decoder
+}
+
+func (t *threadProbe) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == Magic0 && dst[1] == Magic1 && dst[2] == Magic2
+	e := NewEncoderOnBuf(dst, Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	e.WriteMapHeader(1)
+	e.WriteString("V")
+	e.WriteInt(t.V)
+	return e.Bytes(), nil
+}
+
+func (t *threadProbe) UnmarshalQDF(src []byte) (int, error) {
+	d := NewDecoderOnBuf(src)
+	hasMagic := len(src) >= 5 && src[0] == Magic0 && src[1] == Magic1 && src[2] == Magic2
+	if !hasMagic {
+		d.MarkHeaderRead()
+	}
+	if err := t.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+func (t *threadProbe) DecodeQDF(d *Decoder) error {
+	t.seen = d
+	n, err := d.ReadMapHeader()
+	if err != nil {
+		return err
+	}
+	for range n {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		switch string(kb) {
+		case "V":
+			v, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			t.V = v
+		default:
+			if err := d.Skip(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// TestDecodeNestedThreadsDecoder proves DecodeNested reads through the SAME
+// decoder it is handed (no fresh decoder per nested value) and decodes
+// back-to-back values correctly.
+func TestDecodeNestedThreadsDecoder(t *testing.T) {
+	e := NewEncoderOnBuf(nil, Fast)
+	e.EnsureHeader()
+	if err := EncodeNested(e, &threadProbe{V: 7}); err != nil {
+		t.Fatal(err)
+	}
+	if err := EncodeNested(e, &threadProbe{V: 9}); err != nil {
+		t.Fatal(err)
+	}
+	buf := e.Bytes()
+
+	d := NewDecoderOnBuf(buf) // buf has the stream header; first read consumes it
+	var a, b threadProbe
+	if err := DecodeNested(d, &a); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if err := DecodeNested(d, &b); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if a.V != 7 || b.V != 9 {
+		t.Fatalf("values: a=%d b=%d", a.V, b.V)
+	}
+	if a.seen != d || b.seen != d {
+		t.Fatal("DecodeNested did not thread the shared decoder")
+	}
+}
+
+// plainOnly implements only Unmarshaler (no DecodeQDF) → exercises the
+// buffer-based fallback path of DecodeNested.
+type plainOnly struct{ V int64 }
+
+func (p *plainOnly) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == Magic0 && dst[1] == Magic1 && dst[2] == Magic2
+	e := NewEncoderOnBuf(dst, Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	e.WriteMapHeader(1)
+	e.WriteString("V")
+	e.WriteInt(p.V)
+	return e.Bytes(), nil
+}
+
+func (p *plainOnly) UnmarshalQDF(src []byte) (int, error) {
+	d := NewDecoderOnBuf(src)
+	hasMagic := len(src) >= 5 && src[0] == Magic0 && src[1] == Magic1 && src[2] == Magic2
+	if !hasMagic {
+		d.MarkHeaderRead()
+	}
+	n, err := d.ReadMapHeader()
+	if err != nil {
+		return 0, err
+	}
+	for range n {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return 0, err
+		}
+		if string(kb) == "V" {
+			v, err := d.ReadInt()
+			if err != nil {
+				return 0, err
+			}
+			p.V = v
+		} else if err := d.Skip(); err != nil {
+			return 0, err
+		}
+	}
+	return d.Pos(), nil
+}
+
+func TestDecodeNestedFallback(t *testing.T) {
+	e := NewEncoderOnBuf(nil, Fast)
+	e.EnsureHeader()
+	if err := EncodeNested(e, &plainOnly{V: 5}); err != nil {
+		t.Fatal(err)
+	}
+	if err := EncodeNested(e, &plainOnly{V: 6}); err != nil {
+		t.Fatal(err)
+	}
+	buf := e.Bytes()
+
+	d := NewDecoderOnBuf(buf) // buf has the stream header; first read consumes it
+	var a, b plainOnly
+	if err := DecodeNested(d, &a); err != nil {
+		t.Fatal(err)
+	}
+	if err := DecodeNested(d, &b); err != nil {
+		t.Fatal(err)
+	}
+	if a.V != 5 || b.V != 6 {
+		t.Fatalf("fallback values a=%d b=%d", a.V, b.V)
+	}
+}

--- a/marshaler_decodethread_test.go
+++ b/marshaler_decodethread_test.go
@@ -34,6 +34,34 @@ func (t *threadProbe) UnmarshalQDF(src []byte) (int, error) {
 	return d.Pos(), nil
 }
 
+func (t *threadProbe) EncodeQDF(e *Encoder) error {
+	e.WriteMapHeader(1)
+	e.WriteString("V")
+	e.WriteInt(t.V)
+	return nil
+}
+
+// TestMarshalSliceThreadsEncoder: a []EncoderMarshaler encoded through the
+// reflect slice path must share ONE encoder (threaded via EncodeQDF), not open a
+// fresh encoder per element.
+func TestMarshalSliceThreadsEncoder(t *testing.T) {
+	const n = 200
+	in := make([]*threadProbe, n)
+	for i := range in {
+		in[i] = &threadProbe{V: int64(i)}
+	}
+	if _, err := Marshal(in, OptSpeed); err != nil { // warm
+		t.Fatal(err)
+	}
+	allocs := testing.AllocsPerRun(20, func() { _, _ = Marshal(in, OptSpeed) })
+	// Threaded: one encoder + output buffer (a small constant). The
+	// fresh-encoder-per-element path adds an encoder per element (~n). 50 fails
+	// hard on the unthreaded path while leaving headroom for buffer growth.
+	if allocs > 50 {
+		t.Fatalf("marshal allocs=%.0f (>50) — per-element encoder not eliminated (threading regressed)", allocs)
+	}
+}
+
 func (t *threadProbe) DecodeQDF(d *Decoder) error {
 	t.seen = d
 	n, err := d.ReadMapHeader()

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -1186,28 +1186,14 @@ func decodeStruct(td *typeDesc) func(*Decoder, unsafe.Pointer) error {
 					return err
 				}
 				sh := d.state.shapeDeclare()
-				sh.keyIDs = make([]uint32, 0, cnt)
 				keys := make([]string, 0, cnt)
 				for range cnt {
 					kb, err := d.readStringBytes()
 					if err != nil {
 						return err
 					}
-					// Cache the resolved name. The decoder state's
-					// lastID is updated by readStringBytes for state-ref
-					// variants, so we capture it as the key's intern ID
-					// when available (purely informational; we look up
-					// by name string anyway).
 					keys = append(keys, d.keyCache.Make(kb))
-					if d.state.lastID != lruInvalidID {
-						sh.keyIDs = append(sh.keyIDs, d.state.lastID)
-					} else {
-						sh.keyIDs = append(sh.keyIDs, 0)
-					}
 				}
-				// Attach the field name slice to the shape entry by
-				// stashing it after keyIDs: we reuse a small parallel
-				// slice (the names) keyed by index.
 				sh.names = keys
 				fieldNames = keys
 			} else {
@@ -1546,7 +1532,6 @@ func decodeAny(d *Decoder) (any, error) {
 				return nil, err
 			}
 			sh := d.state.shapeDeclare()
-			sh.keyIDs = make([]uint32, 0, cnt)
 			sh.names = make([]string, 0, cnt)
 			for range cnt {
 				kb, err := d.readStringBytes()
@@ -1554,11 +1539,6 @@ func decodeAny(d *Decoder) (any, error) {
 					return nil, err
 				}
 				sh.names = append(sh.names, d.keyCache.Make(kb))
-				if d.state.lastID != lruInvalidID {
-					sh.keyIDs = append(sh.keyIDs, d.state.lastID)
-				} else {
-					sh.keyIDs = append(sh.keyIDs, 0)
-				}
 			}
 			names = sh.names
 		} else {

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -1682,6 +1682,13 @@ func encodeMarshaler(t reflect.Type) func(*Encoder, unsafe.Pointer) error {
 			e.customFramed = true
 		}
 		m := reflect.NewAt(t, p).Interface().(Marshaler)
+		// Thread the shared encoder when the type supports it (generated code):
+		// no fresh encoder (and its state) per element, and shape/intern state is
+		// shared across a slice so it can be interned. The top-level framing above
+		// has already run; EncodeQDF writes the body into e directly.
+		if em, ok := m.(EncoderMarshaler); ok {
+			return em.EncodeQDF(e)
+		}
 		out, err := m.MarshalQDF(e.buf)
 		if err != nil {
 			return err

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -1702,6 +1702,12 @@ func decodeUnmarshaler(t reflect.Type) func(*Decoder, unsafe.Pointer) error {
 			return err
 		}
 		u := reflect.NewAt(t, p).Interface().(Unmarshaler)
+		// Thread the shared decoder when the type supports it (generated code):
+		// no fresh decoder per element, and it inherits d's noCopy / arena. This
+		// is what drops the per-element decoder on a []GeneratedStruct decode.
+		if du, ok := u.(DecoderUnmarshaler); ok {
+			return du.DecodeQDF(d)
+		}
 		var n int
 		var err error
 		if d.arena != nil {

--- a/shape_struct_test.go
+++ b/shape_struct_test.go
@@ -1,0 +1,128 @@
+package qdf
+
+import "testing"
+
+// shapeToken is a stable per-"type" address the encoder keys the struct shape on
+// (the generated code uses a package-level var per type).
+var shapeToken byte
+
+// TestStructShapeDeclareReuse drives Encoder.StructShape directly: the first
+// emit for a token declares the field-name shape (tagMapShape, id 0, count,
+// names); subsequent emits for the same token on the same encoder reuse it
+// (tagMapShape + id, no names). A decoder reading the stream sees the same field
+// names for every record.
+func TestStructShapeDeclareReuse(t *testing.T) {
+	// Two pre-encoded fixstr field-name headers, as qdfgen emits (qdfFieldHdr_*).
+	hdrA := append([]byte{tagFixstr | 1}, 'A')
+	hdrB := append([]byte{tagFixstr | 1}, 'B')
+	fieldHdrs := [][]byte{hdrA, hdrB}
+
+	e := NewEncoderOnBuf(nil, Fast)
+	e.EnsureHeader()
+	// Three "records" of the same shape, each: shape header + 2 int values.
+	for i := range 3 {
+		e.StructShape(&shapeToken, fieldHdrs)
+		e.WriteInt(int64(i * 10))
+		e.WriteInt(int64(i*10 + 1))
+	}
+	buf := e.Bytes()
+
+	// Decode: every record's shape must resolve to the same names ["A","B"].
+	d := NewDecoderOnBuf(buf)
+	if err := d.readHeader(); err != nil { // consume the 5-byte stream header
+		t.Fatal(err)
+	}
+	for i := range 3 {
+		names, err := decodeMapStringShapeHeader(d)
+		if err != nil {
+			t.Fatalf("record %d shape header: %v", i, err)
+		}
+		if len(names) != 2 || names[0] != "A" || names[1] != "B" {
+			t.Fatalf("record %d names = %v, want [A B]", i, names)
+		}
+		v0, err := d.ReadInt()
+		if err != nil {
+			t.Fatal(err)
+		}
+		v1, err := d.ReadInt()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v0 != int64(i*10) || v1 != int64(i*10+1) {
+			t.Fatalf("record %d values = %d,%d", i, v0, v1)
+		}
+	}
+
+	// The reuse records must be far smaller than the declaration: only the first
+	// carries the field names. A second encoder emitting the SAME single record
+	// must be larger per-record than the amortized reuse, proving the names are
+	// written once.
+	eDecl := NewEncoderOnBuf(nil, Fast)
+	eDecl.EnsureHeader()
+	eDecl.StructShape(&shapeToken2, fieldHdrs)
+	declLen := len(eDecl.Bytes())
+	eReuse := NewEncoderOnBuf(nil, Fast)
+	eReuse.EnsureHeader()
+	eReuse.StructShape(&shapeToken2, fieldHdrs) // declare
+	afterDecl := len(eReuse.Bytes())
+	eReuse.StructShape(&shapeToken2, fieldHdrs) // reuse
+	reuseDelta := len(eReuse.Bytes()) - afterDecl
+	if reuseDelta >= declLen {
+		t.Fatalf("reuse delta %d not smaller than declaration %d — names not interned", reuseDelta, declLen)
+	}
+}
+
+var shapeToken2 byte
+var shapeToken3 byte
+
+// TestReadStructHeader covers both forms ReadStructHeader must accept: a
+// shape-interned header (from StructShape) and a plain map header.
+func TestReadStructHeader(t *testing.T) {
+	hdrA := append([]byte{tagFixstr | 1}, 'A')
+	fieldHdrs := [][]byte{hdrA}
+
+	// Shaped form.
+	es := NewEncoderOnBuf(nil, Fast)
+	es.EnsureHeader()
+	es.StructShape(&shapeToken3, fieldHdrs)
+	es.WriteInt(42)
+	ds := NewDecoderOnBuf(es.Bytes())
+	if err := ds.readHeader(); err != nil {
+		t.Fatal(err)
+	}
+	names, plainN, shaped, err := ds.ReadStructHeader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !shaped || len(names) != 1 || names[0] != "A" || plainN != 0 {
+		t.Fatalf("shaped: names=%v plainN=%d shaped=%v", names, plainN, shaped)
+	}
+	if v, _ := ds.ReadInt(); v != 42 {
+		t.Fatalf("shaped value=%d", v)
+	}
+
+	// Plain map form (interop: a non-shaped producer).
+	ep := NewEncoderOnBuf(nil, Fast)
+	ep.EnsureHeader()
+	ep.WriteMapHeader(1)
+	ep.WriteString("A")
+	ep.WriteInt(7)
+	dp := NewDecoderOnBuf(ep.Bytes())
+	if err := dp.readHeader(); err != nil {
+		t.Fatal(err)
+	}
+	names, plainN, shaped, err = dp.ReadStructHeader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shaped || plainN != 1 || names != nil {
+		t.Fatalf("plain: names=%v plainN=%d shaped=%v", names, plainN, shaped)
+	}
+	kb, _ := dp.ReadStringBytes()
+	if string(kb) != "A" {
+		t.Fatalf("plain key=%q", kb)
+	}
+	if v, _ := dp.ReadInt(); v != 7 {
+		t.Fatalf("plain value=%d", v)
+	}
+}

--- a/state.go
+++ b/state.go
@@ -921,14 +921,11 @@ func (e *encState) internTableGrow() {
 	}
 }
 
-// decShape is the decoder-side mirror of an encShape. keyIDs holds
-// the intern IDs of the field names (informational; same ordering as
-// names). names is the resolved Go-string for each field in
-// declaration order — used to dispatch values to struct fields when
-// the shape is re-used.
+// decShape is the decoder-side mirror of an encShape. names is the
+// resolved Go-string for each field in declaration order — used to
+// dispatch values to struct fields when the shape is re-used.
 type decShape struct {
-	keyIDs []uint32
-	names  []string
+	names []string
 }
 
 // decColShape is the decoder-side descriptor for a columnar struct shape

--- a/state.go
+++ b/state.go
@@ -157,6 +157,13 @@ type encState struct {
 	shapeCount    uint32
 	shapeBindings []shapeBinding
 
+	// tokenShapes interns recurring struct shapes for code-generated types,
+	// which have no *typeDesc — keyed on a stable per-type token address the
+	// generated EncodeQDF passes (see Encoder.StructShape). Shares the shapeCount
+	// ID space with shapeBindings / mapShapes so the decoder's single shape table
+	// stays in lockstep.
+	tokenShapes []tokenShape
+
 	// mapShapes interns recurring map key-sets (OptMapShape), parallel to
 	// shapeBindings but keyed on the key-set rather than a *typeDesc. Shares
 	// the shapeCount ID space with struct shapes (shapeDeclareEnc) so the
@@ -250,6 +257,15 @@ type encState struct {
 type shapeBinding struct {
 	td *typeDesc
 	id uint32
+}
+
+// tokenShape is a (per-type token address → wire shape ID) pair, the
+// code-generated analogue of shapeBinding (which keys on *typeDesc). The token
+// is a stable package-level address the generated EncodeQDF passes; a linear
+// scan keeps the hot path map-free and allocation-free under -race.
+type tokenShape struct {
+	token *byte
+	id    uint32
 }
 
 // mapShapeBinding maps a recurring map key-set to a shared shape ID.
@@ -426,6 +442,11 @@ func (e *encState) reset() {
 	}
 	e.lastShapeTd = nil
 	e.lastShapeID = 0
+	if cap(e.tokenShapes) > maxRetainedShapeCap && release {
+		e.tokenShapes = nil
+	} else {
+		e.tokenShapes = e.tokenShapes[:0]
+	}
 	if cap(e.mapShapes) > maxRetainedShapeCap && release {
 		e.mapShapes = nil
 	} else {
@@ -558,6 +579,22 @@ func (e *encState) shapeBindType(t *typeDesc, id uint32) {
 	e.shapeBindings = append(e.shapeBindings, shapeBinding{td: t, id: id})
 	e.lastShapeTd = t
 	e.lastShapeID = id
+}
+
+// shapeForToken returns the wire shape ID bound to a code-generated type's token
+// address in this encoder's state, or 0 if none. Pair with shapeBindToken after
+// a declaration.
+func (e *encState) shapeForToken(token *byte) uint32 {
+	for i := range e.tokenShapes {
+		if e.tokenShapes[i].token == token {
+			return e.tokenShapes[i].id
+		}
+	}
+	return 0
+}
+
+func (e *encState) shapeBindToken(token *byte, id uint32) {
+	e.tokenShapes = append(e.tokenShapes, tokenShape{token: token, id: id})
 }
 
 // shapeDeclareEnc reserves the next sequential wire ID and returns

--- a/state.go
+++ b/state.go
@@ -161,8 +161,12 @@ type encState struct {
 	// which have no *typeDesc — keyed on a stable per-type token address the
 	// generated EncodeQDF passes (see Encoder.StructShape). Shares the shapeCount
 	// ID space with shapeBindings / mapShapes so the decoder's single shape table
-	// stays in lockstep.
-	tokenShapes []tokenShape
+	// stays in lockstep. lastTokenPtr/lastTokenID memoise the most recent lookup
+	// so a homogeneous slice (the common case: one token, N elements threaded
+	// through one encoder) hits a single pointer compare, mirroring lastShapeTd.
+	tokenShapes  []tokenShape
+	lastTokenPtr *byte
+	lastTokenID  uint32
 
 	// mapShapes interns recurring map key-sets (OptMapShape), parallel to
 	// shapeBindings but keyed on the key-set rather than a *typeDesc. Shares
@@ -447,6 +451,8 @@ func (e *encState) reset() {
 	} else {
 		e.tokenShapes = e.tokenShapes[:0]
 	}
+	e.lastTokenPtr = nil
+	e.lastTokenID = 0
 	if cap(e.mapShapes) > maxRetainedShapeCap && release {
 		e.mapShapes = nil
 	} else {
@@ -585,8 +591,13 @@ func (e *encState) shapeBindType(t *typeDesc, id uint32) {
 // address in this encoder's state, or 0 if none. Pair with shapeBindToken after
 // a declaration.
 func (e *encState) shapeForToken(token *byte) uint32 {
+	if e.lastTokenPtr == token && e.lastTokenID != 0 {
+		return e.lastTokenID
+	}
 	for i := range e.tokenShapes {
 		if e.tokenShapes[i].token == token {
+			e.lastTokenPtr = token
+			e.lastTokenID = e.tokenShapes[i].id
 			return e.tokenShapes[i].id
 		}
 	}
@@ -595,6 +606,8 @@ func (e *encState) shapeForToken(token *byte) uint32 {
 
 func (e *encState) shapeBindToken(token *byte, id uint32) {
 	e.tokenShapes = append(e.tokenShapes, tokenShape{token: token, id: id})
+	e.lastTokenPtr = token
+	e.lastTokenID = id
 }
 
 // shapeDeclareEnc reserves the next sequential wire ID and returns


### PR DESCRIPTION
Code-generated `MarshalQDF`/`UnmarshalQDF` now match the reflect+`Balanced` path on
wire size and decode allocations for homogeneous `[]struct`, while keeping the
encode-CPU win codegen already had. The headline gap the `qdf-bench` work surfaced —
codegen emitting a naive per-record self-describing format (no cross-record
interning, one fresh encoder/decoder per nested element) — is closed.

## Headline result (qdf-bench codegen section, adalanche `[]Service`, iters=200)

| metric        | reflect (Balanced) | codegen **before** | codegen **after** |
|---------------|--------------------|--------------------|-------------------|
| wire_B        | 85942              | ~1,240,000         | **85890** (= reflect) |
| ser_alloc     | 18                 | 4363               | **19**            |
| deser_alloc   | 1979               | 15533              | **1978** (= reflect) |
| deser_ns      | 832011             | —                  | **763581** (faster, no reflection) |

Codegen now ties reflect on string/row-major wire + decode-allocs **and** wins
decode CPU (no reflect dispatch). Field *names* are ~93% of the unshaped wire on AD
data (string values are mostly empty/short), so interning the names is the dominant
win.

## What changed

### Phase 0 — threaded nested decode (`9a44d52`, `66a5a2d`, `f201af8`)
Shape-interning needs **one** decoder threaded through the nested graph (the encoder
already threads via `EncodeNested`; decode opened a fresh `NewDecoderOnBuf` per nested
element → empty shape table → shape-reuse would `ErrUnknownStateID`). Added:
- `DecoderUnmarshaler{ Unmarshaler; DecodeQDF(d *Decoder) error }` + `DecodeNested(d, u)`
  (marshaler.go) — prefers `DecodeQDF` on the shared decoder (inherits `d.noCopy`/
  `d.arena`), falls back to a buffer-based `UnmarshalQDF` + `Advance` for external
  `Unmarshaler`s (with a cursor guard).
- qdfgen emits the field-reading body as `DecodeQDF(d)` + thin `UnmarshalQDF`/`Opts`/
  `Arena` wrappers; nested struct / struct-ptr fields decode via `DecodeNested` (no
  per-element decoder).
- reflect `decodeUnmarshaler` threads `DecodeQDF` so a reflect `[]GeneratedStruct`
  decode also shares one decoder.

### Phase 1 — struct field-name shape-interning (`bc49346`, `c53510c`, `3377ed4`)
- `Encoder.StructShape(token *byte, fieldHdrs [][]byte)` — declare-once / reuse keyed
  on a per-type token, sharing the `shapeCount` ID space with type/map shapes;
  `Decoder.ReadStructHeader() (names, plainN, shaped, err)` reads `tagMapShape` **or**
  a plain map header (reflect-interop preserved both ways).
- qdfgen `EncodeQDF` emits `e.StructShape(&qdfShapeTok_T, qdfFieldHdrs_T)` + values
  (no per-field names on reuse); `DecodeQDF` = `ReadStructHeader` + a shared
  `decodeQDFField` switch (dual shaped/plain path).
- **encode-reflect-threading** (`3377ed4`, the key): `encodeMarshaler` calls
  `EncodeQDF` on the shared encoder when an element implements `EncoderMarshaler`, so a
  bare `Marshal([]GenStruct)` interns the shape across the slice instead of
  re-declaring it per record (without it: shape re-declared + fresh `encState` per
  element = 4363-alloc regression).

### Perf + correctness follow-ups
- `b8a56ef perf(encode)`: memoize the last struct-shape token lookup in `encState`
  (`lastTokenPtr`/`lastTokenID`) — pointer-compare short-circuit for the homogeneous
  one-token-N-elements common case, mirroring `shapeForType`.
- `6b5dba0 fix(delta)`: `maybeApplyPatchRANS` kept a rANS patch by the bound
  `(hdr+len(cand))*64+1MiB` while `Apply` rejects by `len(cand)*64+1MiB` (it strips the
  QDP header first). Since `hdr` (13/21) > the uvarint prefix, a narrow window existed
  where the encoder emitted a patch its own `Apply` rejected with `ErrInvalidPatch`.
  Bound the encoder by the same post-header measure. (Latent — not reachable with a
  natural `Diff`, body size is quantized — but a hostile/unlucky patch could hit it.)
- `fc27d75 perf(state)`: drop the dead write-only `decShape.keyIDs` field — allocated
  (`make` + N appends) on every first-sight shape declaration across four sites but
  never read (dispatch keys on the `names` strings). Removes one heap alloc + N
  appends per distinct shape on the shape/Dense decode path.

## Interop & invariants

- Generated `tagMapShape` output is decoded by the reflect path and vice-versa (Phase 1
  kept full interop; same shared `shapeCount` ID space).
- `Marshaler` always-Fast-framing + opts-invariant-body contract intact
  (`TestMarshaler_AlwaysFastFraming`); nested Marshalers stay inline (header already
  out), only the top-level forces Fast framing / `customFramed`.
- No wire-format change beyond what shape-interning emits; decode of all prior wire is
  byte-compatible.

## Verification

- Full suite + `cmd/qdf-bench` + qdfgen (nested module) green; `-race` green (82s);
  golangci-lint **0 issues** on both modules.
- Delta/patch fuzz oracles (`FuzzDiffApplyOracle` 478k+ execs, hostile/baseline/col
  oracles) + `FuzzDecoder_NeverPanics` (2.7M execs) clean.
- TDD: `TestStructShape*`, `TestReadStructHeader`, `TestMarshalSliceThreadsEncoder`,
  `TestThreadedSliceDecodeAllocs` (203 allocs for 200 elements ≈ 1/elem threaded).
- **Adversarial multi-round agent sweep** (encode / decode / columnar+qpack /
  rANS-FSST-intern-delta / state-shape-maps-stream + regression / hostile-input /
  concurrency-pool vectors): the two follow-up commits proven safe, no regression,
  no reachable panic/OOM/race; the rest of the codec confirmed at floor.