### PR TITLE
feat(qdfgen): monomorphized columnar codegen for `[]struct` fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ docs/PAGES-SETUP.md
 docs/PERF-NEXT.md
 # Claude Code local session/worktree state (never commit)
 .claude/
+cmd/qdf-bench/qdf-bench

--- a/README.md
+++ b/README.md
@@ -193,11 +193,14 @@ Tag space is msgpack-inspired with a few additions:
 | `0xF4`               | QPack: ALP decimal-coded `[]float64` slice    |
 | `0xF5`               | QPack: dictionary-coded string column          |
 | `0xF6`               | QPack: FSST-coded string column (inside columnar) |
-| `0xF7..0xFF`         | reserved (rANS, n-gram graph, future)         |
+| `0xF7`               | QPack: hybrid columnar container (mixed `[]struct`) |
+| `0xF8`               | QPack: bulk-slab string column (inside columnar) |
+| `0xF9`               | QPack: constant string column (inside columnar) |
+| `0xFA..0xFF`         | reserved (n-gram graph, future)               |
 
 The 5th header byte holds two flag bits: `FlagDense` (`0x01`) for the
 intern dialect, and `FlagQPack` (`0x02`) as an early hint that the body
-may carry codec tags from the QPack codec range (`0xE3..0xEF`, `0xF4..0xF6`). A reader that does
+may carry codec tags from the QPack codec range (`0xE3..0xEF`, `0xF4..0xF9`). A reader that does
 not implement the QPack tags fails with `ErrBadTag` on first contact;
 it never decodes a packed payload as scalar by accident.
 

--- a/cmd/qdf-bench/codegen.go
+++ b/cmd/qdf-bench/codegen.go
@@ -98,6 +98,54 @@ func printCodegen(iters int, typed []*Info) {
 			return qdf.Unmarshal(b, &out) == nil && reflect.DeepEqual(host, out)
 		},
 		iters)
+
+	// Numeric metrics: the columnar lever Phase 2 recovers. The columnar path
+	// fires on a []scalar-struct FIELD; a bare []GenMetric (Marshaler element)
+	// would fall back to row-major, so the meaningful comparison is the wrapper
+	// MetricHost (reflect columnar) vs GenMetricHost (codegen columnar). Same
+	// all-scalar layout → wire should match (codegen ≈ reflect columnar) while
+	// codegen spends no reflection on the hot path. Synthetic data — real AD
+	// samples have no numeric metric slice.
+	const nMetric = 2000
+	metrics := make([]Metric, nMetric)
+	genMetrics := make([]GenMetric, nMetric)
+	for i := range metrics {
+		metrics[i] = Metric{
+			TS: int64(1_700_000_000 + i), CPU: float64(i%97) * 0.5,
+			Mem: uint64(i%512) << 20, Errors: uint32(i % 7), Up: i%3 != 0,
+		}
+		genMetrics[i] = GenMetric(metrics[i])
+	}
+	mhost := MetricHost{Host: "host1", Metrics: metrics}
+	genMHost := GenMetricHost{Host: "host1", Metrics: genMetrics}
+	printCodegenRow(w, "MetricHost", "reflect-columnar",
+		func() ([]byte, error) { return qdf.Marshal(mhost, opts) },
+		func(b []byte) error { var out MetricHost; return qdf.Unmarshal(b, &out) },
+		func(b []byte) bool {
+			var out MetricHost
+			return qdf.Unmarshal(b, &out) == nil && reflect.DeepEqual(mhost, out)
+		},
+		iters)
+	printCodegenRow(w, "GenMetricHost", "codegen-columnar",
+		func() ([]byte, error) { return qdf.Marshal(genMHost, opts) },
+		func(b []byte) error { var out GenMetricHost; return qdf.Unmarshal(b, &out) },
+		func(b []byte) bool {
+			var out GenMetricHost
+			return qdf.Unmarshal(b, &out) == nil && reflect.DeepEqual(genMHost, out)
+		},
+		iters)
+	// The loser case, for contrast: a bare []GenMetric falls back to row-major
+	// (Marshaler element disables reflect columnar) — shows why the wrapper win
+	// matters.
+	printCodegenRow(w, "[]GenMetric(bare)", "codegen-rowmajor",
+		func() ([]byte, error) { return qdf.Marshal(genMetrics, opts) },
+		func(b []byte) error { var out []GenMetric; return qdf.Unmarshal(b, &out) },
+		func(b []byte) bool {
+			var out []GenMetric
+			return qdf.Unmarshal(b, &out) == nil && reflect.DeepEqual(genMetrics, out)
+		},
+		iters)
+
 	w.Flush()
 }
 

--- a/cmd/qdf-bench/codegen_columnar_test.go
+++ b/cmd/qdf-bench/codegen_columnar_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/alex60217101990/qdf"
+)
+
+// GenService is a string-heavy struct; eligibility rejects its String fields, so
+// its codegen must stay row-major (no columnar frame). Guards against a
+// regression that would columnar-encode strings and bloat the wire.
+func TestGenService_StaysRowMajor(t *testing.T) {
+	svcs := make([]GenService, 32)
+	for i := range svcs {
+		svcs[i].Name = "service-name"
+	}
+	buf, err := qdf.Marshal(svcs, qdf.OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(buf, []byte{0xEF}) {
+		t.Fatal("GenService unexpectedly emitted a columnar frame; strings must stay row-major")
+	}
+}
+
+// A GenMetricHost wraps an all-scalar []GenMetric field, so its generated
+// encode MUST take the columnar transpose path (0xEF frame). A bare
+// []GenMetric, by contrast, is a Marshaler element and stays row-major — that
+// is exactly why the columnar lever lives on the wrapper field.
+func TestGenMetricHost_IsColumnar(t *testing.T) {
+	ms := make([]GenMetric, 32)
+	for i := range ms {
+		ms[i] = GenMetric{TS: int64(i), CPU: float64(i), Mem: uint64(i), Errors: uint32(i), Up: true}
+	}
+	h := GenMetricHost{Host: "h", Metrics: ms}
+	buf, err := qdf.Marshal(h, qdf.OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(buf, []byte{0xEF}) {
+		t.Fatal("GenMetricHost.Metrics should be columnar-encoded (0xEF frame)")
+	}
+}
+
+const benchMetricN = 2000
+
+func benchMetricHosts() (MetricHost, GenMetricHost) {
+	metrics := make([]Metric, benchMetricN)
+	gms := make([]GenMetric, benchMetricN)
+	for i := range metrics {
+		metrics[i] = Metric{
+			TS: int64(1_700_000_000 + i), CPU: float64(i%97) * 0.5,
+			Mem: uint64(i%512) << 20, Errors: uint32(i % 7), Up: i%3 != 0,
+		}
+		gms[i] = GenMetric(metrics[i])
+	}
+	return MetricHost{Host: "host1", Metrics: metrics}, GenMetricHost{Host: "host1", Metrics: gms}
+}
+
+// TestColumnarCodegen_WireMatchesReflect asserts the codegen columnar wire is
+// no larger than the reflect columnar baseline on the same numeric data — the
+// whole point of Phase 2 (recover the columnar win for a generated type).
+func TestColumnarCodegen_WireMatchesReflect(t *testing.T) {
+	mh, gmh := benchMetricHosts()
+	rb, err := qdf.Marshal(mh, qdf.OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cb, err := qdf.Marshal(gmh, qdf.OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wire: reflect-columnar=%d  codegen-columnar=%d", len(rb), len(cb))
+	if len(cb) > len(rb)+len(rb)/50 { // allow 2% slack (shape-id framing differences)
+		t.Fatalf("codegen columnar wire %d exceeds reflect columnar %d by >2%%", len(cb), len(rb))
+	}
+	// And a bare []GenMetric must be much larger (row-major fallback) — proves
+	// the wrapper is what unlocks the win.
+	bare, err := qdf.Marshal(gmh.Metrics, qdf.OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wire: bare []GenMetric (row-major)=%d", len(bare))
+	if len(bare) <= len(cb) {
+		t.Fatalf("bare []GenMetric %d should exceed columnar wrapper %d", len(bare), len(cb))
+	}
+}
+
+func BenchmarkMetricHost_ReflectColumnar_Encode(b *testing.B) {
+	mh, _ := benchMetricHosts()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = qdf.Marshal(mh, qdf.OptBalanced)
+	}
+}
+
+func BenchmarkMetricHost_CodegenColumnar_Encode(b *testing.B) {
+	_, gmh := benchMetricHosts()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = qdf.Marshal(gmh, qdf.OptBalanced)
+	}
+}
+
+func BenchmarkMetricHost_ReflectColumnar_Decode(b *testing.B) {
+	mh, _ := benchMetricHosts()
+	buf, _ := qdf.Marshal(mh, qdf.OptBalanced)
+	b.ReportAllocs()
+	for b.Loop() {
+		var out MetricHost
+		_ = qdf.Unmarshal(buf, &out)
+	}
+}
+
+func BenchmarkMetricHost_CodegenColumnar_Decode(b *testing.B) {
+	_, gmh := benchMetricHosts()
+	buf, _ := qdf.Marshal(gmh, qdf.OptBalanced)
+	b.ReportAllocs()
+	for b.Loop() {
+		var out GenMetricHost
+		_ = qdf.Unmarshal(buf, &out)
+	}
+}

--- a/cmd/qdf-bench/types.go
+++ b/cmd/qdf-bench/types.go
@@ -164,11 +164,43 @@ type Privilege struct {
 // data — proving code generation handles arbitrary values, not only static
 // schema. They are zero-cost conversions of the real types (identical layout).
 //
-//go:generate go run github.com/alex60217101990/qdf/cmd/qdfgen -type GenService,GenTask,GenHost -output types_qdf_gen.go .
+//go:generate go run github.com/alex60217101990/qdf/cmd/qdfgen -type GenService,GenTask,GenHost,GenMetric,GenMetricHost -output types_qdf_gen.go .
 type (
 	GenService Service
 	GenTask    Task
 )
+
+// Metric is an all-scalar telemetry sample. As a plain type (no MarshalQDF) the
+// reflection path columnar-encodes a []Metric; GenMetric (below) is the same
+// layout but carries qdfgen-generated methods so its slice takes the
+// monomorphized columnar transpose path — the numeric lever Phase 2 recovers.
+type Metric struct {
+	TS     int64   `json:"ts"`
+	CPU    float64 `json:"cpu"`
+	Mem    uint64  `json:"mem"`
+	Errors uint32  `json:"errors"`
+	Up     bool    `json:"up"`
+}
+
+// GenMetric is the code-generated twin of Metric (identical layout, zero-cost
+// conversion). Its generated slice encode/decode go through WriteColStructHeader
+// + WriteXColumn (no reflection), matching the reflect columnar wire.
+type GenMetric Metric
+
+// MetricHost is a plain wrapper (no methods): the reflection path columnar-
+// encodes its Metrics field, the baseline GenMetricHost is compared against.
+type MetricHost struct {
+	Host    string   `json:"host"`
+	Metrics []Metric `json:"metrics"`
+}
+
+// GenMetricHost is the code-generated twin of MetricHost. Its Metrics field
+// takes the monomorphized columnar transpose — recovering the columnar win a
+// bare []GenMetric (Marshaler element) loses to the row-major fallback.
+type GenMetricHost struct {
+	Host    string      `json:"host"`
+	Metrics []GenMetric `json:"metrics"`
+}
 
 // GenHost is a code-generated wrapper holding slices of GenService / GenTask, so
 // the bench can exercise the THREADED encode/decode path: host.MarshalQDF()

--- a/cmd/qdf-bench/types_qdf_gen.go
+++ b/cmd/qdf-bench/types_qdf_gen.go
@@ -11,27 +11,39 @@ import (
 var (
 	qdfFieldHdr_services_1              = []byte{0x88, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73}
 	qdfFieldHdr_tasks_2                 = []byte{0x85, 0x74, 0x61, 0x73, 0x6b, 0x73}
-	qdfFieldHdr_RegistryOwner_9         = []byte{0x8d, 0x52, 0x65, 0x67, 0x69, 0x73, 0x74, 0x72, 0x79, 0x4f, 0x77, 0x6e, 0x65, 0x72}
-	qdfFieldHdr_RegistryDACL_10         = []byte{0x8c, 0x52, 0x65, 0x67, 0x69, 0x73, 0x74, 0x72, 0x79, 0x44, 0x41, 0x43, 0x4c}
-	qdfFieldHdr_Name_11                 = []byte{0x84, 0x4e, 0x61, 0x6d, 0x65}
-	qdfFieldHdr_DisplayName_12          = []byte{0x8b, 0x44, 0x69, 0x73, 0x70, 0x6c, 0x61, 0x79, 0x4e, 0x61, 0x6d, 0x65}
-	qdfFieldHdr_Description_13          = []byte{0x8b, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e}
-	qdfFieldHdr_ImagePath_14            = []byte{0x89, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x50, 0x61, 0x74, 0x68}
-	qdfFieldHdr_ImageExecutable_15      = []byte{0x8f, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65}
-	qdfFieldHdr_ImageExecutableOwner_16 = []byte{0x94, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x4f, 0x77, 0x6e, 0x65, 0x72}
-	qdfFieldHdr_ImageExecutableDACL_17  = []byte{0x93, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x44, 0x41, 0x43, 0x4c}
-	qdfFieldHdr_Start_18                = []byte{0x85, 0x53, 0x74, 0x61, 0x72, 0x74}
-	qdfFieldHdr_Type_19                 = []byte{0x84, 0x54, 0x79, 0x70, 0x65}
-	qdfFieldHdr_Account_20              = []byte{0x87, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74}
-	qdfFieldHdr_RequiredPrivileges_21   = []byte{0x92, 0x52, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x50, 0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73}
-	qdfFieldHdr_Path_38                 = []byte{0x84, 0x50, 0x61, 0x74, 0x68}
-	qdfFieldHdr_Definition_39           = []byte{0x8a, 0x44, 0x65, 0x66, 0x69, 0x6e, 0x69, 0x74, 0x69, 0x6f, 0x6e}
-	qdfFieldHdr_Enabled_40              = []byte{0x87, 0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64}
-	qdfFieldHdr_State_41                = []byte{0x85, 0x53, 0x74, 0x61, 0x74, 0x65}
-	qdfFieldHdr_MissedRuns_42           = []byte{0x8a, 0x4d, 0x69, 0x73, 0x73, 0x65, 0x64, 0x52, 0x75, 0x6e, 0x73}
-	qdfFieldHdr_NextRunTime_43          = []byte{0x8b, 0x4e, 0x65, 0x78, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
-	qdfFieldHdr_LastRunTime_44          = []byte{0x8b, 0x4c, 0x61, 0x73, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
+	qdfFieldHdr_ts_9                    = []byte{0x82, 0x74, 0x73}
+	qdfFieldHdr_cpu_10                  = []byte{0x83, 0x63, 0x70, 0x75}
+	qdfFieldHdr_mem_11                  = []byte{0x83, 0x6d, 0x65, 0x6d}
+	qdfFieldHdr_errors_12               = []byte{0x86, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73}
+	qdfFieldHdr_up_13                   = []byte{0x82, 0x75, 0x70}
+	qdfFieldHdr_host_19                 = []byte{0x84, 0x68, 0x6f, 0x73, 0x74}
+	qdfFieldHdr_metrics_20              = []byte{0x87, 0x6d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73}
+	qdfFieldHdr_RegistryOwner_40        = []byte{0x8d, 0x52, 0x65, 0x67, 0x69, 0x73, 0x74, 0x72, 0x79, 0x4f, 0x77, 0x6e, 0x65, 0x72}
+	qdfFieldHdr_RegistryDACL_41         = []byte{0x8c, 0x52, 0x65, 0x67, 0x69, 0x73, 0x74, 0x72, 0x79, 0x44, 0x41, 0x43, 0x4c}
+	qdfFieldHdr_Name_42                 = []byte{0x84, 0x4e, 0x61, 0x6d, 0x65}
+	qdfFieldHdr_DisplayName_43          = []byte{0x8b, 0x44, 0x69, 0x73, 0x70, 0x6c, 0x61, 0x79, 0x4e, 0x61, 0x6d, 0x65}
+	qdfFieldHdr_Description_44          = []byte{0x8b, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e}
+	qdfFieldHdr_ImagePath_45            = []byte{0x89, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x50, 0x61, 0x74, 0x68}
+	qdfFieldHdr_ImageExecutable_46      = []byte{0x8f, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65}
+	qdfFieldHdr_ImageExecutableOwner_47 = []byte{0x94, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x4f, 0x77, 0x6e, 0x65, 0x72}
+	qdfFieldHdr_ImageExecutableDACL_48  = []byte{0x93, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x44, 0x41, 0x43, 0x4c}
+	qdfFieldHdr_Start_49                = []byte{0x85, 0x53, 0x74, 0x61, 0x72, 0x74}
+	qdfFieldHdr_Type_50                 = []byte{0x84, 0x54, 0x79, 0x70, 0x65}
+	qdfFieldHdr_Account_51              = []byte{0x87, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74}
+	qdfFieldHdr_RequiredPrivileges_52   = []byte{0x92, 0x52, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x50, 0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73}
+	qdfFieldHdr_Path_69                 = []byte{0x84, 0x50, 0x61, 0x74, 0x68}
+	qdfFieldHdr_Definition_70           = []byte{0x8a, 0x44, 0x65, 0x66, 0x69, 0x6e, 0x69, 0x74, 0x69, 0x6f, 0x6e}
+	qdfFieldHdr_Enabled_71              = []byte{0x87, 0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64}
+	qdfFieldHdr_State_72                = []byte{0x85, 0x53, 0x74, 0x61, 0x74, 0x65}
+	qdfFieldHdr_MissedRuns_73           = []byte{0x8a, 0x4d, 0x69, 0x73, 0x73, 0x65, 0x64, 0x52, 0x75, 0x6e, 0x73}
+	qdfFieldHdr_NextRunTime_74          = []byte{0x8b, 0x4e, 0x65, 0x78, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
+	qdfFieldHdr_LastRunTime_75          = []byte{0x8b, 0x4c, 0x61, 0x73, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
 )
+
+// Columnar shape descriptors: per element-type column names and kind
+// bytes for the monomorphized tagColStruct transpose path.
+var qdfColNames_GenMetric = []string{"ts", "cpu", "mem", "errors", "up"}
+var qdfColKinds_GenMetric = []byte{0x00, 0x02, 0x01, 0x01, 0x03}
 
 // MarshalQDF appends a qdf-encoded representation of v to dst and returns
 // the extended slice.
@@ -200,6 +212,379 @@ func (v *GenHost) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int,
 
 // MarshalQDF appends a qdf-encoded representation of v to dst and returns
 // the extended slice.
+func (v *GenMetric) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenMetric byte
+var qdfFieldHdrs_GenMetric = [][]byte{qdfFieldHdr_ts_9, qdfFieldHdr_cpu_10, qdfFieldHdr_mem_11, qdfFieldHdr_errors_12, qdfFieldHdr_up_13}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenMetric) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenMetric, qdfFieldHdrs_GenMetric)
+	e.WriteInt(int64(v.TS))
+	e.WriteFloat64(float64(v.CPU))
+	e.WriteUint(uint64(v.Mem))
+	e.WriteUint(uint64(v.Errors))
+	e.WriteBool(bool(v.Up))
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenMetric) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenMetric) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "ts":
+		{
+			rv14, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v.TS = int64(rv14)
+		}
+	case "cpu":
+		{
+			rv15, err := d.ReadFloat64()
+			if err != nil {
+				return err
+			}
+			v.CPU = rv15
+		}
+	case "mem":
+		{
+			rv16, err := d.ReadUint()
+			if err != nil {
+				return err
+			}
+			v.Mem = uint64(rv16)
+		}
+	case "errors":
+		{
+			rv17, err := d.ReadUint()
+			if err != nil {
+				return err
+			}
+			v.Errors = uint32(rv17)
+		}
+	case "up":
+		{
+			rv18, err := d.ReadBool()
+			if err != nil {
+				return err
+			}
+			v.Up = rv18
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenMetric) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenMetric) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenMetric) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
+func (v *GenMetricHost) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenMetricHost byte
+var qdfFieldHdrs_GenMetricHost = [][]byte{qdfFieldHdr_host_19, qdfFieldHdr_metrics_20}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenMetricHost) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenMetricHost, qdfFieldHdrs_GenMetricHost)
+	e.WriteString(string(v.Host))
+	if v.Metrics == nil {
+		e.WriteNil()
+	} else if len(v.Metrics) >= 16 { // columnarMinElems
+		col21 := v.Metrics
+		e.WriteColStructHeader(len(col21), qdfColNames_GenMetric, qdfColKinds_GenMetric)
+		c22 := e.ScratchInt(len(col21))
+		for i := range col21 {
+			c22[i] = int64(col21[i].TS)
+		}
+		if err := e.WriteIntColumn(c22); err != nil {
+			return err
+		}
+		c23 := e.ScratchFloat64(len(col21))
+		for i := range col21 {
+			c23[i] = float64(col21[i].CPU)
+		}
+		if err := e.WriteFloat64Column(c23); err != nil {
+			return err
+		}
+		c24 := e.ScratchUint(len(col21))
+		for i := range col21 {
+			c24[i] = uint64(col21[i].Mem)
+		}
+		if err := e.WriteUintColumn(c24); err != nil {
+			return err
+		}
+		c25 := e.ScratchUint(len(col21))
+		for i := range col21 {
+			c25[i] = uint64(col21[i].Errors)
+		}
+		if err := e.WriteUintColumn(c25); err != nil {
+			return err
+		}
+		c26 := e.ScratchBool(len(col21))
+		for i := range col21 {
+			c26[i] = col21[i].Up
+		}
+		if err := e.WriteBoolColumn(c26); err != nil {
+			return err
+		}
+	} else {
+		e.WriteArrayHeader(len(v.Metrics))
+		for i27 := range v.Metrics {
+			if err := qdf.EncodeNested(e, &v.Metrics[i27]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenMetricHost) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenMetricHost) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "host":
+		{
+			rv28, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Host = rv28
+		}
+	case "metrics":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Metrics = nil
+			} else if d.PeekColStruct() {
+				n29, names30, kinds31, err := d.ReadColStructHeader()
+				if err != nil {
+					return err
+				}
+				_ = kinds31
+				v.Metrics = make([]GenMetric, n29)
+				for ci32 := range names30 {
+					switch names30[ci32] {
+					case "ts":
+						col33, err := d.ReadIntColumn(n29)
+						if err != nil {
+							return err
+						}
+						for i := range col33 {
+							v.Metrics[i].TS = int64(col33[i])
+						}
+					case "cpu":
+						col34, err := d.ReadFloat64Column(n29)
+						if err != nil {
+							return err
+						}
+						for i := range col34 {
+							v.Metrics[i].CPU = float64(col34[i])
+						}
+					case "mem":
+						col35, err := d.ReadUintColumn(n29)
+						if err != nil {
+							return err
+						}
+						for i := range col35 {
+							v.Metrics[i].Mem = uint64(col35[i])
+						}
+					case "errors":
+						col36, err := d.ReadUintColumn(n29)
+						if err != nil {
+							return err
+						}
+						for i := range col36 {
+							v.Metrics[i].Errors = uint32(col36[i])
+						}
+					case "up":
+						col37, err := d.ReadBoolColumn(n29)
+						if err != nil {
+							return err
+						}
+						for i := range col37 {
+							v.Metrics[i].Up = col37[i]
+						}
+					default:
+						return qdf.ErrTypeMismatch
+					}
+				}
+			} else {
+				n38, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n38, 1); err != nil {
+					return err
+				}
+				v.Metrics = make([]GenMetric, n38)
+				for i39 := range n38 {
+					if err := qdf.DecodeNested(d, &v.Metrics[i39]); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenMetricHost) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenMetricHost) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenMetricHost) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
 func (v *GenService) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
@@ -215,7 +600,7 @@ func (v *GenService) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenService byte
-var qdfFieldHdrs_GenService = [][]byte{qdfFieldHdr_RegistryOwner_9, qdfFieldHdr_RegistryDACL_10, qdfFieldHdr_Name_11, qdfFieldHdr_DisplayName_12, qdfFieldHdr_Description_13, qdfFieldHdr_ImagePath_14, qdfFieldHdr_ImageExecutable_15, qdfFieldHdr_ImageExecutableOwner_16, qdfFieldHdr_ImageExecutableDACL_17, qdfFieldHdr_Start_18, qdfFieldHdr_Type_19, qdfFieldHdr_Account_20, qdfFieldHdr_RequiredPrivileges_21}
+var qdfFieldHdrs_GenService = [][]byte{qdfFieldHdr_RegistryOwner_40, qdfFieldHdr_RegistryDACL_41, qdfFieldHdr_Name_42, qdfFieldHdr_DisplayName_43, qdfFieldHdr_Description_44, qdfFieldHdr_ImagePath_45, qdfFieldHdr_ImageExecutable_46, qdfFieldHdr_ImageExecutableOwner_47, qdfFieldHdr_ImageExecutableDACL_48, qdfFieldHdr_Start_49, qdfFieldHdr_Type_50, qdfFieldHdr_Account_51, qdfFieldHdr_RequiredPrivileges_52}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -237,8 +622,8 @@ func (v *GenService) EncodeQDF(e *qdf.Encoder) error {
 		e.WriteNil()
 	} else {
 		e.WriteArrayHeader(len(v.RequiredPrivileges))
-		for i22 := range v.RequiredPrivileges {
-			e.WriteString(string(v.RequiredPrivileges[i22]))
+		for i53 := range v.RequiredPrivileges {
+			e.WriteString(string(v.RequiredPrivileges[i53]))
 		}
 	}
 	return nil
@@ -275,99 +660,99 @@ func (v *GenService) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "RegistryOwner":
 		{
-			rv23, err := d.ReadString()
+			rv54, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.RegistryOwner = rv23
+			v.RegistryOwner = rv54
 		}
 	case "RegistryDACL":
 		{
-			rv24, err := d.ReadString()
+			rv55, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.RegistryDACL = rv24
+			v.RegistryDACL = rv55
 		}
 	case "Name":
 		{
-			rv25, err := d.ReadString()
+			rv56, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv25
+			v.Name = rv56
 		}
 	case "DisplayName":
 		{
-			rv26, err := d.ReadString()
+			rv57, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.DisplayName = rv26
+			v.DisplayName = rv57
 		}
 	case "Description":
 		{
-			rv27, err := d.ReadString()
+			rv58, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Description = rv27
+			v.Description = rv58
 		}
 	case "ImagePath":
 		{
-			rv28, err := d.ReadString()
+			rv59, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.ImagePath = rv28
+			v.ImagePath = rv59
 		}
 	case "ImageExecutable":
 		{
-			rv29, err := d.ReadString()
+			rv60, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.ImageExecutable = rv29
+			v.ImageExecutable = rv60
 		}
 	case "ImageExecutableOwner":
 		{
-			rv30, err := d.ReadString()
+			rv61, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.ImageExecutableOwner = rv30
+			v.ImageExecutableOwner = rv61
 		}
 	case "ImageExecutableDACL":
 		{
-			rv31, err := d.ReadString()
+			rv62, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.ImageExecutableDACL = rv31
+			v.ImageExecutableDACL = rv62
 		}
 	case "Start":
 		{
-			rv32, err := d.ReadInt()
+			rv63, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.Start = int(rv32)
+			v.Start = int(rv63)
 		}
 	case "Type":
 		{
-			rv33, err := d.ReadInt()
+			rv64, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.Type = int(rv33)
+			v.Type = int(rv64)
 		}
 	case "Account":
 		{
-			rv34, err := d.ReadString()
+			rv65, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Account = rv34
+			v.Account = rv65
 		}
 	case "RequiredPrivileges":
 		{
@@ -378,21 +763,21 @@ func (v *GenService) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.RequiredPrivileges = nil
 			} else {
-				n35, err := d.ReadArrayHeader()
+				n66, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n35, 1); err != nil {
+				if err := d.CheckLength(n66, 1); err != nil {
 					return err
 				}
-				v.RequiredPrivileges = make([]string, n35)
-				for i36 := range n35 {
+				v.RequiredPrivileges = make([]string, n66)
+				for i67 := range n66 {
 					{
-						rv37, err := d.ReadString()
+						rv68, err := d.ReadString()
 						if err != nil {
 							return err
 						}
-						v.RequiredPrivileges[i36] = rv37
+						v.RequiredPrivileges[i67] = rv68
 					}
 				}
 			}
@@ -456,7 +841,7 @@ func (v *GenTask) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenTask byte
-var qdfFieldHdrs_GenTask = [][]byte{qdfFieldHdr_Name_11, qdfFieldHdr_Path_38, qdfFieldHdr_Definition_39, qdfFieldHdr_Enabled_40, qdfFieldHdr_State_41, qdfFieldHdr_MissedRuns_42, qdfFieldHdr_NextRunTime_43, qdfFieldHdr_LastRunTime_44}
+var qdfFieldHdrs_GenTask = [][]byte{qdfFieldHdr_Name_42, qdfFieldHdr_Path_69, qdfFieldHdr_Definition_70, qdfFieldHdr_Enabled_71, qdfFieldHdr_State_72, qdfFieldHdr_MissedRuns_73, qdfFieldHdr_NextRunTime_74, qdfFieldHdr_LastRunTime_75}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -468,9 +853,9 @@ func (v *GenTask) EncodeQDF(e *qdf.Encoder) error {
 		e.WriteNil()
 	} else {
 		e.WriteMapHeader(len(v.Definition))
-		for k45, vv46 := range v.Definition {
-			e.WriteString(string(k45))
-			if err := e.EncodeValue(vv46); err != nil {
+		for k76, vv77 := range v.Definition {
+			e.WriteString(string(k76))
+			if err := e.EncodeValue(vv77); err != nil {
 				return err
 			}
 		}
@@ -514,19 +899,19 @@ func (v *GenTask) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "Name":
 		{
-			rv47, err := d.ReadString()
+			rv78, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv47
+			v.Name = rv78
 		}
 	case "Path":
 		{
-			rv48, err := d.ReadString()
+			rv79, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Path = rv48
+			v.Path = rv79
 		}
 	case "Definition":
 		{
@@ -537,68 +922,68 @@ func (v *GenTask) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Definition = nil
 			} else {
-				n49, err := d.ReadMapHeader()
+				n80, err := d.ReadMapHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n49, 1); err != nil {
+				if err := d.CheckLength(n80, 1); err != nil {
 					return err
 				}
-				v.Definition = make(map[string]any, n49)
-				for range n49 {
-					var k50 string
-					var vv51 any
-					kb52, err := d.ReadStringBytes()
+				v.Definition = make(map[string]any, n80)
+				for range n80 {
+					var k81 string
+					var vv82 any
+					kb83, err := d.ReadStringBytes()
 					if err != nil {
 						return err
 					}
-					k50 = string(d.InternKey(kb52))
-					if err := d.DecodeValue(&vv51); err != nil {
+					k81 = string(d.InternKey(kb83))
+					if err := d.DecodeValue(&vv82); err != nil {
 						return err
 					}
-					v.Definition[k50] = vv51
+					v.Definition[k81] = vv82
 				}
 			}
 		}
 	case "Enabled":
 		{
-			rv53, err := d.ReadBool()
+			rv84, err := d.ReadBool()
 			if err != nil {
 				return err
 			}
-			v.Enabled = rv53
+			v.Enabled = rv84
 		}
 	case "State":
 		{
-			rv54, err := d.ReadString()
+			rv85, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.State = rv54
+			v.State = rv85
 		}
 	case "MissedRuns":
 		{
-			rv55, err := d.ReadInt()
+			rv86, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.MissedRuns = int(rv55)
+			v.MissedRuns = int(rv86)
 		}
 	case "NextRunTime":
 		{
-			rv56, err := d.ReadString()
+			rv87, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.NextRunTime = rv56
+			v.NextRunTime = rv87
 		}
 	case "LastRunTime":
 		{
-			rv57, err := d.ReadString()
+			rv88, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.LastRunTime = rv57
+			v.LastRunTime = rv88
 		}
 	default:
 		if err := d.Skip(); err != nil {

--- a/cmd/qdf-bench/types_qdf_gen.go
+++ b/cmd/qdf-bench/types_qdf_gen.go
@@ -9,39 +9,43 @@ import (
 // Pre-encoded field-name headers (fixstr / strN). Lets the hot path
 // emit a name with a single append, no per-call sizing.
 var (
-	qdfFieldHdr_services_1              = []byte{0x88, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73}
-	qdfFieldHdr_tasks_2                 = []byte{0x85, 0x74, 0x61, 0x73, 0x6b, 0x73}
-	qdfFieldHdr_ts_9                    = []byte{0x82, 0x74, 0x73}
-	qdfFieldHdr_cpu_10                  = []byte{0x83, 0x63, 0x70, 0x75}
-	qdfFieldHdr_mem_11                  = []byte{0x83, 0x6d, 0x65, 0x6d}
-	qdfFieldHdr_errors_12               = []byte{0x86, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73}
-	qdfFieldHdr_up_13                   = []byte{0x82, 0x75, 0x70}
-	qdfFieldHdr_host_19                 = []byte{0x84, 0x68, 0x6f, 0x73, 0x74}
-	qdfFieldHdr_metrics_20              = []byte{0x87, 0x6d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73}
-	qdfFieldHdr_RegistryOwner_40        = []byte{0x8d, 0x52, 0x65, 0x67, 0x69, 0x73, 0x74, 0x72, 0x79, 0x4f, 0x77, 0x6e, 0x65, 0x72}
-	qdfFieldHdr_RegistryDACL_41         = []byte{0x8c, 0x52, 0x65, 0x67, 0x69, 0x73, 0x74, 0x72, 0x79, 0x44, 0x41, 0x43, 0x4c}
-	qdfFieldHdr_Name_42                 = []byte{0x84, 0x4e, 0x61, 0x6d, 0x65}
-	qdfFieldHdr_DisplayName_43          = []byte{0x8b, 0x44, 0x69, 0x73, 0x70, 0x6c, 0x61, 0x79, 0x4e, 0x61, 0x6d, 0x65}
-	qdfFieldHdr_Description_44          = []byte{0x8b, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e}
-	qdfFieldHdr_ImagePath_45            = []byte{0x89, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x50, 0x61, 0x74, 0x68}
-	qdfFieldHdr_ImageExecutable_46      = []byte{0x8f, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65}
-	qdfFieldHdr_ImageExecutableOwner_47 = []byte{0x94, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x4f, 0x77, 0x6e, 0x65, 0x72}
-	qdfFieldHdr_ImageExecutableDACL_48  = []byte{0x93, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x44, 0x41, 0x43, 0x4c}
-	qdfFieldHdr_Start_49                = []byte{0x85, 0x53, 0x74, 0x61, 0x72, 0x74}
-	qdfFieldHdr_Type_50                 = []byte{0x84, 0x54, 0x79, 0x70, 0x65}
-	qdfFieldHdr_Account_51              = []byte{0x87, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74}
-	qdfFieldHdr_RequiredPrivileges_52   = []byte{0x92, 0x52, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x50, 0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73}
-	qdfFieldHdr_Path_69                 = []byte{0x84, 0x50, 0x61, 0x74, 0x68}
-	qdfFieldHdr_Definition_70           = []byte{0x8a, 0x44, 0x65, 0x66, 0x69, 0x6e, 0x69, 0x74, 0x69, 0x6f, 0x6e}
-	qdfFieldHdr_Enabled_71              = []byte{0x87, 0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64}
-	qdfFieldHdr_State_72                = []byte{0x85, 0x53, 0x74, 0x61, 0x74, 0x65}
-	qdfFieldHdr_MissedRuns_73           = []byte{0x8a, 0x4d, 0x69, 0x73, 0x73, 0x65, 0x64, 0x52, 0x75, 0x6e, 0x73}
-	qdfFieldHdr_NextRunTime_74          = []byte{0x8b, 0x4e, 0x65, 0x78, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
-	qdfFieldHdr_LastRunTime_75          = []byte{0x8b, 0x4c, 0x61, 0x73, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
+	qdfFieldHdr_services_1               = []byte{0x88, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73}
+	qdfFieldHdr_tasks_2                  = []byte{0x85, 0x74, 0x61, 0x73, 0x6b, 0x73}
+	qdfFieldHdr_ts_69                    = []byte{0x82, 0x74, 0x73}
+	qdfFieldHdr_cpu_70                   = []byte{0x83, 0x63, 0x70, 0x75}
+	qdfFieldHdr_mem_71                   = []byte{0x83, 0x6d, 0x65, 0x6d}
+	qdfFieldHdr_errors_72                = []byte{0x86, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73}
+	qdfFieldHdr_up_73                    = []byte{0x82, 0x75, 0x70}
+	qdfFieldHdr_host_79                  = []byte{0x84, 0x68, 0x6f, 0x73, 0x74}
+	qdfFieldHdr_metrics_80               = []byte{0x87, 0x6d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73}
+	qdfFieldHdr_RegistryOwner_100        = []byte{0x8d, 0x52, 0x65, 0x67, 0x69, 0x73, 0x74, 0x72, 0x79, 0x4f, 0x77, 0x6e, 0x65, 0x72}
+	qdfFieldHdr_RegistryDACL_101         = []byte{0x8c, 0x52, 0x65, 0x67, 0x69, 0x73, 0x74, 0x72, 0x79, 0x44, 0x41, 0x43, 0x4c}
+	qdfFieldHdr_Name_102                 = []byte{0x84, 0x4e, 0x61, 0x6d, 0x65}
+	qdfFieldHdr_DisplayName_103          = []byte{0x8b, 0x44, 0x69, 0x73, 0x70, 0x6c, 0x61, 0x79, 0x4e, 0x61, 0x6d, 0x65}
+	qdfFieldHdr_Description_104          = []byte{0x8b, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e}
+	qdfFieldHdr_ImagePath_105            = []byte{0x89, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x50, 0x61, 0x74, 0x68}
+	qdfFieldHdr_ImageExecutable_106      = []byte{0x8f, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65}
+	qdfFieldHdr_ImageExecutableOwner_107 = []byte{0x94, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x4f, 0x77, 0x6e, 0x65, 0x72}
+	qdfFieldHdr_ImageExecutableDACL_108  = []byte{0x93, 0x49, 0x6d, 0x61, 0x67, 0x65, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x44, 0x41, 0x43, 0x4c}
+	qdfFieldHdr_Start_109                = []byte{0x85, 0x53, 0x74, 0x61, 0x72, 0x74}
+	qdfFieldHdr_Type_110                 = []byte{0x84, 0x54, 0x79, 0x70, 0x65}
+	qdfFieldHdr_Account_111              = []byte{0x87, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74}
+	qdfFieldHdr_RequiredPrivileges_112   = []byte{0x92, 0x52, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x50, 0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73}
+	qdfFieldHdr_Path_129                 = []byte{0x84, 0x50, 0x61, 0x74, 0x68}
+	qdfFieldHdr_Definition_130           = []byte{0x8a, 0x44, 0x65, 0x66, 0x69, 0x6e, 0x69, 0x74, 0x69, 0x6f, 0x6e}
+	qdfFieldHdr_Enabled_131              = []byte{0x87, 0x45, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64}
+	qdfFieldHdr_State_132                = []byte{0x85, 0x53, 0x74, 0x61, 0x74, 0x65}
+	qdfFieldHdr_MissedRuns_133           = []byte{0x8a, 0x4d, 0x69, 0x73, 0x73, 0x65, 0x64, 0x52, 0x75, 0x6e, 0x73}
+	qdfFieldHdr_NextRunTime_134          = []byte{0x8b, 0x4e, 0x65, 0x78, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
+	qdfFieldHdr_LastRunTime_135          = []byte{0x8b, 0x4c, 0x61, 0x73, 0x74, 0x52, 0x75, 0x6e, 0x54, 0x69, 0x6d, 0x65}
 )
 
 // Columnar shape descriptors: per element-type column names and kind
 // bytes for the monomorphized tagColStruct transpose path.
+var qdfHybNames_GenService = []string{"RegistryOwner", "RegistryDACL", "Name", "DisplayName", "Description", "ImagePath", "ImageExecutable", "ImageExecutableOwner", "ImageExecutableDACL", "Start", "Type", "Account", "RequiredPrivileges"}
+var qdfHybKinds_GenService = []byte{0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x00, 0x00, 0x04, 0xff}
+var qdfHybNames_GenTask = []string{"Name", "Path", "Definition", "Enabled", "State", "MissedRuns", "NextRunTime", "LastRunTime"}
+var qdfHybKinds_GenTask = []byte{0x04, 0x04, 0xff, 0x03, 0x04, 0x00, 0x04, 0x04}
 var qdfColNames_GenMetric = []string{"ts", "cpu", "mem", "errors", "up"}
 var qdfColKinds_GenMetric = []byte{0x00, 0x02, 0x01, 0x01, 0x03}
 
@@ -70,20 +74,152 @@ func (v *GenHost) EncodeQDF(e *qdf.Encoder) error {
 	e.StructShape(&qdfShapeTok_GenHost, qdfFieldHdrs_GenHost)
 	if v.Services == nil {
 		e.WriteNil()
+	} else if len(v.Services) >= 16 { // columnarMinElems
+		col3 := v.Services
+		e.WriteHybridColStructHeader(len(col3), qdfHybNames_GenService, qdfHybKinds_GenService)
+		c4 := e.ScratchString(len(col3))
+		for i := range col3 {
+			c4[i] = string(col3[i].RegistryOwner)
+		}
+		e.WriteStringColumn(c4)
+		c5 := e.ScratchString(len(col3))
+		for i := range col3 {
+			c5[i] = string(col3[i].RegistryDACL)
+		}
+		e.WriteStringColumn(c5)
+		c6 := e.ScratchString(len(col3))
+		for i := range col3 {
+			c6[i] = string(col3[i].Name)
+		}
+		e.WriteStringColumn(c6)
+		c7 := e.ScratchString(len(col3))
+		for i := range col3 {
+			c7[i] = string(col3[i].DisplayName)
+		}
+		e.WriteStringColumn(c7)
+		c8 := e.ScratchString(len(col3))
+		for i := range col3 {
+			c8[i] = string(col3[i].Description)
+		}
+		e.WriteStringColumn(c8)
+		c9 := e.ScratchString(len(col3))
+		for i := range col3 {
+			c9[i] = string(col3[i].ImagePath)
+		}
+		e.WriteStringColumn(c9)
+		c10 := e.ScratchString(len(col3))
+		for i := range col3 {
+			c10[i] = string(col3[i].ImageExecutable)
+		}
+		e.WriteStringColumn(c10)
+		c11 := e.ScratchString(len(col3))
+		for i := range col3 {
+			c11[i] = string(col3[i].ImageExecutableOwner)
+		}
+		e.WriteStringColumn(c11)
+		c12 := e.ScratchString(len(col3))
+		for i := range col3 {
+			c12[i] = string(col3[i].ImageExecutableDACL)
+		}
+		e.WriteStringColumn(c12)
+		c13 := e.ScratchInt(len(col3))
+		for i := range col3 {
+			c13[i] = int64(col3[i].Start)
+		}
+		if err := e.WriteIntColumn(c13); err != nil {
+			return err
+		}
+		c14 := e.ScratchInt(len(col3))
+		for i := range col3 {
+			c14[i] = int64(col3[i].Type)
+		}
+		if err := e.WriteIntColumn(c14); err != nil {
+			return err
+		}
+		c15 := e.ScratchString(len(col3))
+		for i := range col3 {
+			c15[i] = string(col3[i].Account)
+		}
+		e.WriteStringColumn(c15)
+		for i16 := range col3 {
+			if col3[i16].RequiredPrivileges == nil {
+				e.WriteNil()
+			} else {
+				e.WriteArrayHeader(len(col3[i16].RequiredPrivileges))
+				for i17 := range col3[i16].RequiredPrivileges {
+					e.WriteString(string(col3[i16].RequiredPrivileges[i17]))
+				}
+			}
+		}
 	} else {
 		e.WriteArrayHeader(len(v.Services))
-		for i3 := range v.Services {
-			if err := qdf.EncodeNested(e, &v.Services[i3]); err != nil {
+		for i18 := range v.Services {
+			if err := qdf.EncodeNested(e, &v.Services[i18]); err != nil {
 				return err
 			}
 		}
 	}
 	if v.Tasks == nil {
 		e.WriteNil()
+	} else if len(v.Tasks) >= 16 { // columnarMinElems
+		col19 := v.Tasks
+		e.WriteHybridColStructHeader(len(col19), qdfHybNames_GenTask, qdfHybKinds_GenTask)
+		c20 := e.ScratchString(len(col19))
+		for i := range col19 {
+			c20[i] = string(col19[i].Name)
+		}
+		e.WriteStringColumn(c20)
+		c21 := e.ScratchString(len(col19))
+		for i := range col19 {
+			c21[i] = string(col19[i].Path)
+		}
+		e.WriteStringColumn(c21)
+		c22 := e.ScratchBool(len(col19))
+		for i := range col19 {
+			c22[i] = col19[i].Enabled
+		}
+		if err := e.WriteBoolColumn(c22); err != nil {
+			return err
+		}
+		c23 := e.ScratchString(len(col19))
+		for i := range col19 {
+			c23[i] = string(col19[i].State)
+		}
+		e.WriteStringColumn(c23)
+		c24 := e.ScratchInt(len(col19))
+		for i := range col19 {
+			c24[i] = int64(col19[i].MissedRuns)
+		}
+		if err := e.WriteIntColumn(c24); err != nil {
+			return err
+		}
+		c25 := e.ScratchString(len(col19))
+		for i := range col19 {
+			c25[i] = string(col19[i].NextRunTime)
+		}
+		e.WriteStringColumn(c25)
+		c26 := e.ScratchString(len(col19))
+		for i := range col19 {
+			c26[i] = string(col19[i].LastRunTime)
+		}
+		e.WriteStringColumn(c26)
+		for i27 := range col19 {
+			if col19[i27].Definition == nil {
+				e.WriteNil()
+			} else {
+				e.WriteMapHeader(len(col19[i27].Definition))
+				for k28, vv29 := range col19[i27].Definition {
+					e.WriteString(string(k28))
+					if err := e.EncodeValue(vv29); err != nil {
+						return err
+					}
+				}
+			}
+		}
 	} else {
 		e.WriteArrayHeader(len(v.Tasks))
-		for i4 := range v.Tasks {
-			if err := qdf.EncodeNested(e, &v.Tasks[i4]); err != nil {
+		for i30 := range v.Tasks {
+			if err := qdf.EncodeNested(e, &v.Tasks[i30]); err != nil {
 				return err
 			}
 		}
@@ -128,17 +264,139 @@ func (v *GenHost) decodeQDFField(d *qdf.Decoder, name string) error {
 			}
 			if isNil {
 				v.Services = nil
-			} else {
-				n5, err := d.ReadArrayHeader()
+			} else if d.PeekHybridColStruct() {
+				n31, names32, kinds33, err := d.ReadHybridColStructHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n5, 1); err != nil {
+				_ = names32
+				_ = kinds33
+				v.Services = make([]GenService, n31)
+				col34, err := d.ReadStringColumn(n31)
+				if err != nil {
 					return err
 				}
-				v.Services = make([]GenService, n5)
-				for i6 := range n5 {
-					if err := qdf.DecodeNested(d, &v.Services[i6]); err != nil {
+				for i := range col34 {
+					v.Services[i].RegistryOwner = string(col34[i])
+				}
+				col35, err := d.ReadStringColumn(n31)
+				if err != nil {
+					return err
+				}
+				for i := range col35 {
+					v.Services[i].RegistryDACL = string(col35[i])
+				}
+				col36, err := d.ReadStringColumn(n31)
+				if err != nil {
+					return err
+				}
+				for i := range col36 {
+					v.Services[i].Name = string(col36[i])
+				}
+				col37, err := d.ReadStringColumn(n31)
+				if err != nil {
+					return err
+				}
+				for i := range col37 {
+					v.Services[i].DisplayName = string(col37[i])
+				}
+				col38, err := d.ReadStringColumn(n31)
+				if err != nil {
+					return err
+				}
+				for i := range col38 {
+					v.Services[i].Description = string(col38[i])
+				}
+				col39, err := d.ReadStringColumn(n31)
+				if err != nil {
+					return err
+				}
+				for i := range col39 {
+					v.Services[i].ImagePath = string(col39[i])
+				}
+				col40, err := d.ReadStringColumn(n31)
+				if err != nil {
+					return err
+				}
+				for i := range col40 {
+					v.Services[i].ImageExecutable = string(col40[i])
+				}
+				col41, err := d.ReadStringColumn(n31)
+				if err != nil {
+					return err
+				}
+				for i := range col41 {
+					v.Services[i].ImageExecutableOwner = string(col41[i])
+				}
+				col42, err := d.ReadStringColumn(n31)
+				if err != nil {
+					return err
+				}
+				for i := range col42 {
+					v.Services[i].ImageExecutableDACL = string(col42[i])
+				}
+				col43, err := d.ReadIntColumn(n31)
+				if err != nil {
+					return err
+				}
+				for i := range col43 {
+					v.Services[i].Start = int(col43[i])
+				}
+				col44, err := d.ReadIntColumn(n31)
+				if err != nil {
+					return err
+				}
+				for i := range col44 {
+					v.Services[i].Type = int(col44[i])
+				}
+				col45, err := d.ReadStringColumn(n31)
+				if err != nil {
+					return err
+				}
+				for i := range col45 {
+					v.Services[i].Account = string(col45[i])
+				}
+				d.ClearColMaxLen()
+				for i46 := range v.Services {
+					{
+						isNil, err := d.IsNil()
+						if err != nil {
+							return err
+						}
+						if isNil {
+							v.Services[i46].RequiredPrivileges = nil
+						} else {
+							n47, err := d.ReadArrayHeader()
+							if err != nil {
+								return err
+							}
+							if err := d.CheckLength(n47, 1); err != nil {
+								return err
+							}
+							v.Services[i46].RequiredPrivileges = make([]string, n47)
+							for i48 := range n47 {
+								{
+									rv49, err := d.ReadString()
+									if err != nil {
+										return err
+									}
+									v.Services[i46].RequiredPrivileges[i48] = rv49
+								}
+							}
+						}
+					}
+				}
+			} else {
+				n50, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n50, 1); err != nil {
+					return err
+				}
+				v.Services = make([]GenService, n50)
+				for i51 := range n50 {
+					if err := qdf.DecodeNested(d, &v.Services[i51]); err != nil {
 						return err
 					}
 				}
@@ -152,17 +410,108 @@ func (v *GenHost) decodeQDFField(d *qdf.Decoder, name string) error {
 			}
 			if isNil {
 				v.Tasks = nil
-			} else {
-				n7, err := d.ReadArrayHeader()
+			} else if d.PeekHybridColStruct() {
+				n52, names53, kinds54, err := d.ReadHybridColStructHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n7, 1); err != nil {
+				_ = names53
+				_ = kinds54
+				v.Tasks = make([]GenTask, n52)
+				col55, err := d.ReadStringColumn(n52)
+				if err != nil {
 					return err
 				}
-				v.Tasks = make([]GenTask, n7)
-				for i8 := range n7 {
-					if err := qdf.DecodeNested(d, &v.Tasks[i8]); err != nil {
+				for i := range col55 {
+					v.Tasks[i].Name = string(col55[i])
+				}
+				col56, err := d.ReadStringColumn(n52)
+				if err != nil {
+					return err
+				}
+				for i := range col56 {
+					v.Tasks[i].Path = string(col56[i])
+				}
+				col57, err := d.ReadBoolColumn(n52)
+				if err != nil {
+					return err
+				}
+				for i := range col57 {
+					v.Tasks[i].Enabled = col57[i]
+				}
+				col58, err := d.ReadStringColumn(n52)
+				if err != nil {
+					return err
+				}
+				for i := range col58 {
+					v.Tasks[i].State = string(col58[i])
+				}
+				col59, err := d.ReadIntColumn(n52)
+				if err != nil {
+					return err
+				}
+				for i := range col59 {
+					v.Tasks[i].MissedRuns = int(col59[i])
+				}
+				col60, err := d.ReadStringColumn(n52)
+				if err != nil {
+					return err
+				}
+				for i := range col60 {
+					v.Tasks[i].NextRunTime = string(col60[i])
+				}
+				col61, err := d.ReadStringColumn(n52)
+				if err != nil {
+					return err
+				}
+				for i := range col61 {
+					v.Tasks[i].LastRunTime = string(col61[i])
+				}
+				d.ClearColMaxLen()
+				for i62 := range v.Tasks {
+					{
+						isNil, err := d.IsNil()
+						if err != nil {
+							return err
+						}
+						if isNil {
+							v.Tasks[i62].Definition = nil
+						} else {
+							n63, err := d.ReadMapHeader()
+							if err != nil {
+								return err
+							}
+							if err := d.CheckLength(n63, 1); err != nil {
+								return err
+							}
+							v.Tasks[i62].Definition = make(map[string]any, n63)
+							for range n63 {
+								var k64 string
+								var vv65 any
+								kb66, err := d.ReadStringBytes()
+								if err != nil {
+									return err
+								}
+								k64 = string(d.InternKey(kb66))
+								if err := d.DecodeValue(&vv65); err != nil {
+									return err
+								}
+								v.Tasks[i62].Definition[k64] = vv65
+							}
+						}
+					}
+				}
+			} else {
+				n67, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n67, 1); err != nil {
+					return err
+				}
+				v.Tasks = make([]GenTask, n67)
+				for i68 := range n67 {
+					if err := qdf.DecodeNested(d, &v.Tasks[i68]); err != nil {
 						return err
 					}
 				}
@@ -227,7 +576,7 @@ func (v *GenMetric) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenMetric byte
-var qdfFieldHdrs_GenMetric = [][]byte{qdfFieldHdr_ts_9, qdfFieldHdr_cpu_10, qdfFieldHdr_mem_11, qdfFieldHdr_errors_12, qdfFieldHdr_up_13}
+var qdfFieldHdrs_GenMetric = [][]byte{qdfFieldHdr_ts_69, qdfFieldHdr_cpu_70, qdfFieldHdr_mem_71, qdfFieldHdr_errors_72, qdfFieldHdr_up_73}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -272,43 +621,43 @@ func (v *GenMetric) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "ts":
 		{
-			rv14, err := d.ReadInt()
+			rv74, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.TS = int64(rv14)
+			v.TS = int64(rv74)
 		}
 	case "cpu":
 		{
-			rv15, err := d.ReadFloat64()
+			rv75, err := d.ReadFloat64()
 			if err != nil {
 				return err
 			}
-			v.CPU = rv15
+			v.CPU = rv75
 		}
 	case "mem":
 		{
-			rv16, err := d.ReadUint()
+			rv76, err := d.ReadUint()
 			if err != nil {
 				return err
 			}
-			v.Mem = uint64(rv16)
+			v.Mem = uint64(rv76)
 		}
 	case "errors":
 		{
-			rv17, err := d.ReadUint()
+			rv77, err := d.ReadUint()
 			if err != nil {
 				return err
 			}
-			v.Errors = uint32(rv17)
+			v.Errors = uint32(rv77)
 		}
 	case "up":
 		{
-			rv18, err := d.ReadBool()
+			rv78, err := d.ReadBool()
 			if err != nil {
 				return err
 			}
-			v.Up = rv18
+			v.Up = rv78
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -369,7 +718,7 @@ func (v *GenMetricHost) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenMetricHost byte
-var qdfFieldHdrs_GenMetricHost = [][]byte{qdfFieldHdr_host_19, qdfFieldHdr_metrics_20}
+var qdfFieldHdrs_GenMetricHost = [][]byte{qdfFieldHdr_host_79, qdfFieldHdr_metrics_80}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -379,47 +728,47 @@ func (v *GenMetricHost) EncodeQDF(e *qdf.Encoder) error {
 	if v.Metrics == nil {
 		e.WriteNil()
 	} else if len(v.Metrics) >= 16 { // columnarMinElems
-		col21 := v.Metrics
-		e.WriteColStructHeader(len(col21), qdfColNames_GenMetric, qdfColKinds_GenMetric)
-		c22 := e.ScratchInt(len(col21))
-		for i := range col21 {
-			c22[i] = int64(col21[i].TS)
+		col81 := v.Metrics
+		e.WriteColStructHeader(len(col81), qdfColNames_GenMetric, qdfColKinds_GenMetric)
+		c82 := e.ScratchInt(len(col81))
+		for i := range col81 {
+			c82[i] = int64(col81[i].TS)
 		}
-		if err := e.WriteIntColumn(c22); err != nil {
+		if err := e.WriteIntColumn(c82); err != nil {
 			return err
 		}
-		c23 := e.ScratchFloat64(len(col21))
-		for i := range col21 {
-			c23[i] = float64(col21[i].CPU)
+		c83 := e.ScratchFloat64(len(col81))
+		for i := range col81 {
+			c83[i] = float64(col81[i].CPU)
 		}
-		if err := e.WriteFloat64Column(c23); err != nil {
+		if err := e.WriteFloat64Column(c83); err != nil {
 			return err
 		}
-		c24 := e.ScratchUint(len(col21))
-		for i := range col21 {
-			c24[i] = uint64(col21[i].Mem)
+		c84 := e.ScratchUint(len(col81))
+		for i := range col81 {
+			c84[i] = uint64(col81[i].Mem)
 		}
-		if err := e.WriteUintColumn(c24); err != nil {
+		if err := e.WriteUintColumn(c84); err != nil {
 			return err
 		}
-		c25 := e.ScratchUint(len(col21))
-		for i := range col21 {
-			c25[i] = uint64(col21[i].Errors)
+		c85 := e.ScratchUint(len(col81))
+		for i := range col81 {
+			c85[i] = uint64(col81[i].Errors)
 		}
-		if err := e.WriteUintColumn(c25); err != nil {
+		if err := e.WriteUintColumn(c85); err != nil {
 			return err
 		}
-		c26 := e.ScratchBool(len(col21))
-		for i := range col21 {
-			c26[i] = col21[i].Up
+		c86 := e.ScratchBool(len(col81))
+		for i := range col81 {
+			c86[i] = col81[i].Up
 		}
-		if err := e.WriteBoolColumn(c26); err != nil {
+		if err := e.WriteBoolColumn(c86); err != nil {
 			return err
 		}
 	} else {
 		e.WriteArrayHeader(len(v.Metrics))
-		for i27 := range v.Metrics {
-			if err := qdf.EncodeNested(e, &v.Metrics[i27]); err != nil {
+		for i87 := range v.Metrics {
+			if err := qdf.EncodeNested(e, &v.Metrics[i87]); err != nil {
 				return err
 			}
 		}
@@ -458,11 +807,11 @@ func (v *GenMetricHost) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "host":
 		{
-			rv28, err := d.ReadString()
+			rv88, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Host = rv28
+			v.Host = rv88
 		}
 	case "metrics":
 		{
@@ -473,69 +822,69 @@ func (v *GenMetricHost) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Metrics = nil
 			} else if d.PeekColStruct() {
-				n29, names30, kinds31, err := d.ReadColStructHeader()
+				n89, names90, kinds91, err := d.ReadColStructHeader()
 				if err != nil {
 					return err
 				}
-				_ = kinds31
-				v.Metrics = make([]GenMetric, n29)
-				for ci32 := range names30 {
-					switch names30[ci32] {
+				_ = kinds91
+				v.Metrics = make([]GenMetric, n89)
+				for ci92 := range names90 {
+					switch names90[ci92] {
 					case "ts":
-						col33, err := d.ReadIntColumn(n29)
+						col93, err := d.ReadIntColumn(n89)
 						if err != nil {
 							return err
 						}
-						for i := range col33 {
-							v.Metrics[i].TS = int64(col33[i])
+						for i := range col93 {
+							v.Metrics[i].TS = int64(col93[i])
 						}
 					case "cpu":
-						col34, err := d.ReadFloat64Column(n29)
+						col94, err := d.ReadFloat64Column(n89)
 						if err != nil {
 							return err
 						}
-						for i := range col34 {
-							v.Metrics[i].CPU = float64(col34[i])
+						for i := range col94 {
+							v.Metrics[i].CPU = float64(col94[i])
 						}
 					case "mem":
-						col35, err := d.ReadUintColumn(n29)
+						col95, err := d.ReadUintColumn(n89)
 						if err != nil {
 							return err
 						}
-						for i := range col35 {
-							v.Metrics[i].Mem = uint64(col35[i])
+						for i := range col95 {
+							v.Metrics[i].Mem = uint64(col95[i])
 						}
 					case "errors":
-						col36, err := d.ReadUintColumn(n29)
+						col96, err := d.ReadUintColumn(n89)
 						if err != nil {
 							return err
 						}
-						for i := range col36 {
-							v.Metrics[i].Errors = uint32(col36[i])
+						for i := range col96 {
+							v.Metrics[i].Errors = uint32(col96[i])
 						}
 					case "up":
-						col37, err := d.ReadBoolColumn(n29)
+						col97, err := d.ReadBoolColumn(n89)
 						if err != nil {
 							return err
 						}
-						for i := range col37 {
-							v.Metrics[i].Up = col37[i]
+						for i := range col97 {
+							v.Metrics[i].Up = col97[i]
 						}
 					default:
 						return qdf.ErrTypeMismatch
 					}
 				}
 			} else {
-				n38, err := d.ReadArrayHeader()
+				n98, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n38, 1); err != nil {
+				if err := d.CheckLength(n98, 1); err != nil {
 					return err
 				}
-				v.Metrics = make([]GenMetric, n38)
-				for i39 := range n38 {
-					if err := qdf.DecodeNested(d, &v.Metrics[i39]); err != nil {
+				v.Metrics = make([]GenMetric, n98)
+				for i99 := range n98 {
+					if err := qdf.DecodeNested(d, &v.Metrics[i99]); err != nil {
 						return err
 					}
 				}
@@ -600,7 +949,7 @@ func (v *GenService) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenService byte
-var qdfFieldHdrs_GenService = [][]byte{qdfFieldHdr_RegistryOwner_40, qdfFieldHdr_RegistryDACL_41, qdfFieldHdr_Name_42, qdfFieldHdr_DisplayName_43, qdfFieldHdr_Description_44, qdfFieldHdr_ImagePath_45, qdfFieldHdr_ImageExecutable_46, qdfFieldHdr_ImageExecutableOwner_47, qdfFieldHdr_ImageExecutableDACL_48, qdfFieldHdr_Start_49, qdfFieldHdr_Type_50, qdfFieldHdr_Account_51, qdfFieldHdr_RequiredPrivileges_52}
+var qdfFieldHdrs_GenService = [][]byte{qdfFieldHdr_RegistryOwner_100, qdfFieldHdr_RegistryDACL_101, qdfFieldHdr_Name_102, qdfFieldHdr_DisplayName_103, qdfFieldHdr_Description_104, qdfFieldHdr_ImagePath_105, qdfFieldHdr_ImageExecutable_106, qdfFieldHdr_ImageExecutableOwner_107, qdfFieldHdr_ImageExecutableDACL_108, qdfFieldHdr_Start_109, qdfFieldHdr_Type_110, qdfFieldHdr_Account_111, qdfFieldHdr_RequiredPrivileges_112}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -622,8 +971,8 @@ func (v *GenService) EncodeQDF(e *qdf.Encoder) error {
 		e.WriteNil()
 	} else {
 		e.WriteArrayHeader(len(v.RequiredPrivileges))
-		for i53 := range v.RequiredPrivileges {
-			e.WriteString(string(v.RequiredPrivileges[i53]))
+		for i113 := range v.RequiredPrivileges {
+			e.WriteString(string(v.RequiredPrivileges[i113]))
 		}
 	}
 	return nil
@@ -660,99 +1009,99 @@ func (v *GenService) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "RegistryOwner":
 		{
-			rv54, err := d.ReadString()
+			rv114, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.RegistryOwner = rv54
+			v.RegistryOwner = rv114
 		}
 	case "RegistryDACL":
 		{
-			rv55, err := d.ReadString()
+			rv115, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.RegistryDACL = rv55
+			v.RegistryDACL = rv115
 		}
 	case "Name":
 		{
-			rv56, err := d.ReadString()
+			rv116, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv56
+			v.Name = rv116
 		}
 	case "DisplayName":
 		{
-			rv57, err := d.ReadString()
+			rv117, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.DisplayName = rv57
+			v.DisplayName = rv117
 		}
 	case "Description":
 		{
-			rv58, err := d.ReadString()
+			rv118, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Description = rv58
+			v.Description = rv118
 		}
 	case "ImagePath":
 		{
-			rv59, err := d.ReadString()
+			rv119, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.ImagePath = rv59
+			v.ImagePath = rv119
 		}
 	case "ImageExecutable":
 		{
-			rv60, err := d.ReadString()
+			rv120, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.ImageExecutable = rv60
+			v.ImageExecutable = rv120
 		}
 	case "ImageExecutableOwner":
 		{
-			rv61, err := d.ReadString()
+			rv121, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.ImageExecutableOwner = rv61
+			v.ImageExecutableOwner = rv121
 		}
 	case "ImageExecutableDACL":
 		{
-			rv62, err := d.ReadString()
+			rv122, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.ImageExecutableDACL = rv62
+			v.ImageExecutableDACL = rv122
 		}
 	case "Start":
 		{
-			rv63, err := d.ReadInt()
+			rv123, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.Start = int(rv63)
+			v.Start = int(rv123)
 		}
 	case "Type":
 		{
-			rv64, err := d.ReadInt()
+			rv124, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.Type = int(rv64)
+			v.Type = int(rv124)
 		}
 	case "Account":
 		{
-			rv65, err := d.ReadString()
+			rv125, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Account = rv65
+			v.Account = rv125
 		}
 	case "RequiredPrivileges":
 		{
@@ -763,21 +1112,21 @@ func (v *GenService) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.RequiredPrivileges = nil
 			} else {
-				n66, err := d.ReadArrayHeader()
+				n126, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n66, 1); err != nil {
+				if err := d.CheckLength(n126, 1); err != nil {
 					return err
 				}
-				v.RequiredPrivileges = make([]string, n66)
-				for i67 := range n66 {
+				v.RequiredPrivileges = make([]string, n126)
+				for i127 := range n126 {
 					{
-						rv68, err := d.ReadString()
+						rv128, err := d.ReadString()
 						if err != nil {
 							return err
 						}
-						v.RequiredPrivileges[i67] = rv68
+						v.RequiredPrivileges[i127] = rv128
 					}
 				}
 			}
@@ -841,7 +1190,7 @@ func (v *GenTask) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenTask byte
-var qdfFieldHdrs_GenTask = [][]byte{qdfFieldHdr_Name_42, qdfFieldHdr_Path_69, qdfFieldHdr_Definition_70, qdfFieldHdr_Enabled_71, qdfFieldHdr_State_72, qdfFieldHdr_MissedRuns_73, qdfFieldHdr_NextRunTime_74, qdfFieldHdr_LastRunTime_75}
+var qdfFieldHdrs_GenTask = [][]byte{qdfFieldHdr_Name_102, qdfFieldHdr_Path_129, qdfFieldHdr_Definition_130, qdfFieldHdr_Enabled_131, qdfFieldHdr_State_132, qdfFieldHdr_MissedRuns_133, qdfFieldHdr_NextRunTime_134, qdfFieldHdr_LastRunTime_135}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -853,9 +1202,9 @@ func (v *GenTask) EncodeQDF(e *qdf.Encoder) error {
 		e.WriteNil()
 	} else {
 		e.WriteMapHeader(len(v.Definition))
-		for k76, vv77 := range v.Definition {
-			e.WriteString(string(k76))
-			if err := e.EncodeValue(vv77); err != nil {
+		for k136, vv137 := range v.Definition {
+			e.WriteString(string(k136))
+			if err := e.EncodeValue(vv137); err != nil {
 				return err
 			}
 		}
@@ -899,19 +1248,19 @@ func (v *GenTask) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "Name":
 		{
-			rv78, err := d.ReadString()
+			rv138, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv78
+			v.Name = rv138
 		}
 	case "Path":
 		{
-			rv79, err := d.ReadString()
+			rv139, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Path = rv79
+			v.Path = rv139
 		}
 	case "Definition":
 		{
@@ -922,68 +1271,68 @@ func (v *GenTask) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Definition = nil
 			} else {
-				n80, err := d.ReadMapHeader()
+				n140, err := d.ReadMapHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n80, 1); err != nil {
+				if err := d.CheckLength(n140, 1); err != nil {
 					return err
 				}
-				v.Definition = make(map[string]any, n80)
-				for range n80 {
-					var k81 string
-					var vv82 any
-					kb83, err := d.ReadStringBytes()
+				v.Definition = make(map[string]any, n140)
+				for range n140 {
+					var k141 string
+					var vv142 any
+					kb143, err := d.ReadStringBytes()
 					if err != nil {
 						return err
 					}
-					k81 = string(d.InternKey(kb83))
-					if err := d.DecodeValue(&vv82); err != nil {
+					k141 = string(d.InternKey(kb143))
+					if err := d.DecodeValue(&vv142); err != nil {
 						return err
 					}
-					v.Definition[k81] = vv82
+					v.Definition[k141] = vv142
 				}
 			}
 		}
 	case "Enabled":
 		{
-			rv84, err := d.ReadBool()
+			rv144, err := d.ReadBool()
 			if err != nil {
 				return err
 			}
-			v.Enabled = rv84
+			v.Enabled = rv144
 		}
 	case "State":
 		{
-			rv85, err := d.ReadString()
+			rv145, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.State = rv85
+			v.State = rv145
 		}
 	case "MissedRuns":
 		{
-			rv86, err := d.ReadInt()
+			rv146, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.MissedRuns = int(rv86)
+			v.MissedRuns = int(rv146)
 		}
 	case "NextRunTime":
 		{
-			rv87, err := d.ReadString()
+			rv147, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.NextRunTime = rv87
+			v.NextRunTime = rv147
 		}
 	case "LastRunTime":
 		{
-			rv88, err := d.ReadString()
+			rv148, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.LastRunTime = rv88
+			v.LastRunTime = rv148
 		}
 	default:
 		if err := d.Skip(); err != nil {

--- a/cmd/qdfgen/README.md
+++ b/cmd/qdfgen/README.md
@@ -55,6 +55,30 @@ The generated code uses the public `qdf` API only:
 `Decoder.CheckLength`, pre-encoded field-name headers, etc. There is no
 `reflect.*` on the hot path.
 
+## Columnar `[]struct` fields
+
+A `[]NamedStruct` field whose element is columnar-eligible is emitted as a
+**monomorphized columnar transpose** instead of a row-major per-element loop:
+the struct slice is transposed to per-column arrays at compile-time-known field
+offsets and each column is written through `qdf`'s adaptive codecs (FOR / Delta /
+RLE / dictionary / PFOR for numbers; dict / FSST / raw-slab / constant for
+strings) — zero reflection, recovering the columnar wire win a `Marshaler`
+element otherwise loses (a generated type can't use the reflect columnar path).
+
+- **Eligible columns**: scalar `int*`/`uint*`/`float*`/`bool`, `string`,
+  `time.Time`, `[]byte`, and pointers to scalar/string (`*T` → a **nullable**
+  column with a presence bitmap; `nil` vs empty stays distinct).
+- **Pure** frame (`tagColStruct`, `0xEF`) when every field is eligible;
+  **hybrid** frame (`tagHybridColStruct`, `0xF7`) when some fields (nested
+  struct, map, non-byte slice, `*struct`, interface) stay as a per-row residual
+  tail.
+- **Gated**: fires only at `len >= 16`; shorter/`nil` slices stay row-major. A
+  string-only element runs a cardinality probe so high-cardinality strings stay
+  row-major (columnar would not shrink them).
+- The wire layout is byte-identical to the reflect columnar path, so a generated
+  type cross-decodes with reflect `Unmarshal` (which delegates to the generated
+  method anyway).
+
 ## Supported types
 
 - All primitives (`bool`, every `int*`/`uint*`, `float32`, `float64`,

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -1194,23 +1194,88 @@ func (g *gen) emitDecodeSlice(w io.Writer, lhs string, s *types.Slice, indent st
 	fmt.Fprintf(w, "%s{\n", indent)
 	fmt.Fprintf(w, "%s\tisNil, err := d.IsNil()\n", indent)
 	fmt.Fprintf(w, "%s\tif err != nil {\n%s\t\treturn err\n%s\t}\n", indent, indent, indent)
-	fmt.Fprintf(w, "%s\tif isNil {\n%s\t\t%s = nil\n%s\t} else {\n", indent, indent, lhs, indent)
+	plan, columnar := g.columnarElemPlan(elem)
+	fmt.Fprintf(w, "%s\tif isNil {\n%s\t\t%s = nil\n", indent, indent, lhs)
+	if columnar {
+		fmt.Fprintf(w, "%s\t} else if d.PeekColStruct() {\n", indent)
+		if err := g.emitDecodeColumnarBody(w, lhs, elem, plan, indent+"\t\t"); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintf(w, "%s\t} else {\n", indent)
+	if err := g.emitDecodeSliceRowMajorBody(w, lhs, elem, indent+"\t\t"); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "%s\t}\n", indent)
+	fmt.Fprintf(w, "%s}\n", indent)
+	return nil
+}
+
+// emitDecodeSliceRowMajorBody emits the ReadArrayHeader + make + per-element
+// loop for a non-nil slice (the caller writes the surrounding nil guard).
+func (g *gen) emitDecodeSliceRowMajorBody(w io.Writer, lhs string, elem types.Type, indent string) error {
 	nVar := g.fresh("n")
-	fmt.Fprintf(w, "%s\t\t%s, err := d.ReadArrayHeader()\n", indent, nVar)
-	fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn err\n%s\t\t}\n", indent, indent, indent)
+	fmt.Fprintf(w, "%s%s, err := d.ReadArrayHeader()\n", indent, nVar)
+	fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
 	// Bound the allocation by remaining input so a hostile length header
 	// can't trigger a multi-GB make before any element is read (matches the
 	// reflect decoder's CheckLength gate).
-	fmt.Fprintf(w, "%s\t\tif err := d.CheckLength(%s, 1); err != nil {\n%s\t\t\treturn err\n%s\t\t}\n", indent, nVar, indent, indent)
-	fmt.Fprintf(w, "%s\t\t%s = make([]%s, %s)\n", indent, lhs, g.typeExprFromType(elem), nVar)
+	fmt.Fprintf(w, "%sif err := d.CheckLength(%s, 1); err != nil {\n%s\treturn err\n%s}\n", indent, nVar, indent, indent)
+	fmt.Fprintf(w, "%s%s = make([]%s, %s)\n", indent, lhs, g.typeExprFromType(elem), nVar)
 	loopVar := g.fresh("i")
-	fmt.Fprintf(w, "%s\t\tfor %s := range %s {\n", indent, loopVar, nVar)
-	if err := g.emitDecodeValue(w, lhs+"["+loopVar+"]", elem, indent+"\t\t\t"); err != nil {
+	fmt.Fprintf(w, "%sfor %s := range %s {\n", indent, loopVar, nVar)
+	if err := g.emitDecodeValue(w, lhs+"["+loopVar+"]", elem, indent+"\t"); err != nil {
 		return err
 	}
-	fmt.Fprintf(w, "%s\t\t}\n", indent)
-	fmt.Fprintf(w, "%s\t}\n", indent)
 	fmt.Fprintf(w, "%s}\n", indent)
+	return nil
+}
+
+// emitDecodeColumnarBody emits decode for the tagColStruct frame: read the
+// header (row count + column shape), allocate the slice, then decode each
+// declared column by name and scatter it into the matching struct field
+// (narrowing per field type). The slice is bounded by maxColumnarElems inside
+// ReadColStructHeader (the reflect path's cap), so columns may be compressed
+// below n bytes without a false length rejection. Unknown columns are not
+// tolerated in v1 (the generated decoder requires its exact declared set).
+func (g *gen) emitDecodeColumnarBody(w io.Writer, lhs string, elem types.Type, plan colElemPlan, indent string) error {
+	nVar := g.fresh("n")
+	namesVar := g.fresh("names")
+	kindsVar := g.fresh("kinds")
+	idxVar := g.fresh("ci")
+	fmt.Fprintf(w, "%s%s, %s, %s, err := d.ReadColStructHeader()\n", indent, nVar, namesVar, kindsVar)
+	fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
+	fmt.Fprintf(w, "%s_ = %s\n", indent, kindsVar)
+	fmt.Fprintf(w, "%s%s = make([]%s, %s)\n", indent, lhs, g.typeExprFromType(elem), nVar)
+	fmt.Fprintf(w, "%sfor %s := range %s {\n", indent, idxVar, namesVar)
+	fmt.Fprintf(w, "%s\tswitch %s[%s] {\n", indent, namesVar, idxVar)
+	for _, c := range plan.Columns {
+		colv := g.fresh("col")
+		fmt.Fprintf(w, "%s\tcase %s:\n", indent, strconv.Quote(c.WireName))
+		var readFn string
+		switch c.ColAPI {
+		case "Int":
+			readFn = "ReadIntColumn"
+		case "Uint":
+			readFn = "ReadUintColumn"
+		case "Float64":
+			readFn = "ReadFloat64Column"
+		case "Float32":
+			readFn = "ReadFloat32Column"
+		case "Bool":
+			readFn = "ReadBoolColumn"
+		}
+		fmt.Fprintf(w, "%s\t\t%s, err := d.%s(%s)\n", indent, colv, readFn, nVar)
+		fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn err\n%s\t\t}\n", indent, indent, indent)
+		if c.ColAPI == "Bool" {
+			fmt.Fprintf(w, "%s\t\tfor i := range %s {\n%s\t\t\t%s[i].%s = %s[i]\n%s\t\t}\n", indent, colv, indent, lhs, c.Access, colv, indent)
+		} else {
+			fmt.Fprintf(w, "%s\t\tfor i := range %s {\n%s\t\t\t%s[i].%s = %s(%s[i])\n%s\t\t}\n", indent, colv, indent, lhs, c.Access, c.GoType, colv, indent)
+		}
+	}
+	fmt.Fprintf(w, "%s\tdefault:\n%s\t\treturn qdf.ErrTypeMismatch\n", indent, indent)
+	fmt.Fprintf(w, "%s\t}\n", indent) // switch
+	fmt.Fprintf(w, "%s}\n", indent)   // for
 	return nil
 }
 

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -185,6 +185,9 @@ type gen struct {
 
 	headerNames map[string]string // field-name -> generated var ident
 
+	colVars    bytes.Buffer    // var-block of columnar shape (names/kinds) decls
+	colVarSeen map[string]bool // dedupe columnar shape vars by ident
+
 	// uniqCounter ensures generated identifiers stay unique.
 	uniqCounter int
 
@@ -204,6 +207,7 @@ func newGen(pkg *packages.Package) *gen {
 		imports:     map[string]string{"github.com/alex60217101990/qdf": ""},
 		headerNames: map[string]string{},
 		emitted:     map[string]bool{},
+		colVarSeen:  map[string]bool{},
 	}
 }
 
@@ -240,6 +244,15 @@ func (g *gen) bytes() ([]byte, error) {
 		out.WriteString("var (\n")
 		out.Write(g.header.Bytes())
 		out.WriteString(")\n\n")
+	}
+
+	// Emit columnar shape vars (column names + kind bytes) for scalar []struct
+	// fields encoded via the columnar transpose path.
+	if g.colVars.Len() > 0 {
+		out.WriteString("// Columnar shape descriptors: per element-type column names and kind\n")
+		out.WriteString("// bytes for the monomorphized tagColStruct transpose path.\n")
+		out.Write(g.colVars.Bytes())
+		out.WriteString("\n")
 	}
 
 	// Function bodies.
@@ -760,6 +773,117 @@ func (g *gen) emitEncodePointer(w io.Writer, expr string, p *types.Pointer, inde
 	return nil
 }
 
+// colColumn / colElemPlan describe an all-scalar slice element eligible for
+// monomorphized columnar transpose. Built without reflection from go/types at
+// generate time; the emitted code itself never uses reflection.
+type colColumn struct {
+	WireName string // column name on the wire (field WireKey: qdf>json>name)
+	Access   string // Go field selector from the element, e.g. "TS" or "Base.X"
+	KindByte byte   // colKind wire byte: 0/1/2/3/6
+	GoType   string // rendered field type, e.g. "int32", for scatter narrowing
+	ColAPI   string // "Int"|"Uint"|"Float64"|"Float32"|"Bool"
+}
+
+type colElemPlan struct {
+	ElemType string // rendered element type, e.g. "GenMetric"
+	Columns  []colColumn
+}
+
+// columnarElemPlan returns a plan when elem is a named struct whose every
+// (flattened) field is a scalar basic type — the v1 columnar-eligibility set.
+// Otherwise ok=false and the caller emits the row-major path. Any String,
+// time.Time, nested struct, slice, map, pointer, array, or interface field
+// disqualifies the element (those need string/hybrid columns, out of scope).
+func (g *gen) columnarElemPlan(elem types.Type) (colElemPlan, bool) {
+	named, isNamed := types.Unalias(elem).(*types.Named)
+	if !isNamed {
+		return colElemPlan{}, false
+	}
+	if isTimeTime(elem) {
+		return colElemPlan{}, false
+	}
+	st, isStruct := named.Underlying().(*types.Struct)
+	if !isStruct {
+		return colElemPlan{}, false
+	}
+	// Reuse collectFields so embedded-struct flattening and the qdf>json>name
+	// tag precedence match the reflect columnar path's column names exactly.
+	fields := collectFields(st)
+	if len(fields) == 0 {
+		return colElemPlan{}, false
+	}
+	cols := make([]colColumn, 0, len(fields))
+	for i := range fields {
+		fi := &fields[i]
+		b, isBasic := fi.Field.Type().Underlying().(*types.Basic)
+		if !isBasic {
+			return colElemPlan{}, false
+		}
+		kb, api, ok := basicColKind(b.Kind())
+		if !ok {
+			return colElemPlan{}, false
+		}
+		cols = append(cols, colColumn{
+			WireName: fi.WireKey,
+			Access:   fi.Access,
+			KindByte: kb,
+			GoType:   g.typeExprFromType(fi.Field.Type()),
+			ColAPI:   api,
+		})
+	}
+	return colElemPlan{ElemType: g.typeExprFromType(elem), Columns: cols}, true
+}
+
+// basicColKind maps a basic kind to its colKind wire byte + the WriteX/ReadX
+// API suffix. Must match classifyColKind: int*->0, uint*->1, float64->2,
+// bool->3, float32->6.
+func basicColKind(k types.BasicKind) (byte, string, bool) {
+	switch k {
+	case types.Bool:
+		return 3, "Bool", true
+	case types.Int, types.Int8, types.Int16, types.Int32, types.Int64:
+		return 0, "Int", true
+	case types.Uint, types.Uint8, types.Uint16, types.Uint32, types.Uint64, types.Uintptr:
+		return 1, "Uint", true
+	case types.Float32:
+		return 6, "Float32", true
+	case types.Float64:
+		return 2, "Float64", true
+	default:
+		return 0, "", false
+	}
+}
+
+// colNamesVar emits (once per element type) a file-level []string of column
+// names and returns its ident.
+func (g *gen) colNamesVar(plan colElemPlan) string {
+	name := "qdfColNames_" + sanitizeIdent(plan.ElemType)
+	if !g.colVarSeen[name] {
+		g.colVarSeen[name] = true
+		parts := make([]string, len(plan.Columns))
+		for i, c := range plan.Columns {
+			parts[i] = strconv.Quote(c.WireName)
+		}
+		fmt.Fprintf(&g.colVars, "var %s = []string{%s}\n", name, strings.Join(parts, ", "))
+	}
+	return name
+}
+
+// colKindsVar emits (once per element type) a file-level []byte of column kind
+// bytes and returns its ident.
+func (g *gen) colKindsVar(plan colElemPlan) string {
+	name := "qdfColKinds_" + sanitizeIdent(plan.ElemType)
+	if !g.colVarSeen[name] {
+		g.colVarSeen[name] = true
+		parts := make([]string, len(plan.Columns))
+		for i, c := range plan.Columns {
+			parts[i] = fmt.Sprintf("0x%02x", c.KindByte)
+		}
+		fmt.Fprintf(&g.colVars, "var %s = []byte{%s}\n", name, strings.Join(parts, ", "))
+	}
+	return name
+}
+
 func (g *gen) emitEncodeSlice(w io.Writer, expr string, s *types.Slice, indent string) error {
 	elem := s.Elem()
 	if b, ok := elem.(*types.Basic); ok && b.Kind() == types.Uint8 {
@@ -768,14 +892,73 @@ func (g *gen) emitEncodeSlice(w io.Writer, expr string, s *types.Slice, indent s
 		fmt.Fprintf(w, "%s}\n", indent)
 		return nil
 	}
+	if plan, ok := g.columnarElemPlan(elem); ok {
+		return g.emitEncodeColumnarSlice(w, expr, elem, plan, indent)
+	}
 	fmt.Fprintf(w, "%sif %s == nil {\n%s\te.WriteNil()\n%s} else {\n", indent, expr, indent, indent)
-	fmt.Fprintf(w, "%s\te.WriteArrayHeader(len(%s))\n", indent, expr)
-	loopVar := g.fresh("i")
-	fmt.Fprintf(w, "%s\tfor %s := range %s {\n", indent, loopVar, expr)
-	if err := g.emitEncodeValue(w, expr+"["+loopVar+"]", elem, indent+"\t\t"); err != nil {
+	if err := g.emitEncodeSliceRowMajorBody(w, expr, elem, indent+"\t"); err != nil {
 		return err
 	}
-	fmt.Fprintf(w, "%s\t}\n", indent)
+	fmt.Fprintf(w, "%s}\n", indent)
+	return nil
+}
+
+// emitEncodeSliceRowMajorBody emits the WriteArrayHeader + per-element loop for
+// a non-nil slice (the caller writes the nil guard). Shared by the row-major
+// path and the columnar emitter's short-slice fallback.
+func (g *gen) emitEncodeSliceRowMajorBody(w io.Writer, expr string, elem types.Type, indent string) error {
+	fmt.Fprintf(w, "%se.WriteArrayHeader(len(%s))\n", indent, expr)
+	loopVar := g.fresh("i")
+	fmt.Fprintf(w, "%sfor %s := range %s {\n", indent, loopVar, expr)
+	if err := g.emitEncodeValue(w, expr+"["+loopVar+"]", elem, indent+"\t"); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "%s}\n", indent)
+	return nil
+}
+
+// emitEncodeColumnarSlice emits a compile-time transpose of a scalar []struct
+// into the tagColStruct frame, with a runtime length gate: slices shorter than
+// columnarMinElems (16) stay row-major (frame overhead not worth it), and a nil
+// slice emits WriteNil to preserve the nil/empty distinction.
+func (g *gen) emitEncodeColumnarSlice(w io.Writer, expr string, elem types.Type, plan colElemPlan, indent string) error {
+	namesVar := g.colNamesVar(plan)
+	kindsVar := g.colKindsVar(plan)
+	s := g.fresh("col")
+	fmt.Fprintf(w, "%sif %s == nil {\n", indent, expr)
+	fmt.Fprintf(w, "%s\te.WriteNil()\n", indent)
+	fmt.Fprintf(w, "%s} else if len(%s) >= 16 { // columnarMinElems\n", indent, expr)
+	fmt.Fprintf(w, "%s\t%s := %s\n", indent, s, expr)
+	fmt.Fprintf(w, "%s\te.WriteColStructHeader(len(%s), %s, %s)\n", indent, s, namesVar, kindsVar)
+	for _, c := range plan.Columns {
+		col := g.fresh("c")
+		switch c.ColAPI {
+		case "Int":
+			fmt.Fprintf(w, "%s\t%s := make([]int64, len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = int64(%s[i].%s) }\n", indent, s, col, s, c.Access)
+			fmt.Fprintf(w, "%s\tif err := e.WriteIntColumn(%s); err != nil { return err }\n", indent, col)
+		case "Uint":
+			fmt.Fprintf(w, "%s\t%s := make([]uint64, len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = uint64(%s[i].%s) }\n", indent, s, col, s, c.Access)
+			fmt.Fprintf(w, "%s\tif err := e.WriteUintColumn(%s); err != nil { return err }\n", indent, col)
+		case "Float64":
+			fmt.Fprintf(w, "%s\t%s := make([]float64, len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = float64(%s[i].%s) }\n", indent, s, col, s, c.Access)
+			fmt.Fprintf(w, "%s\tif err := e.WriteFloat64Column(%s); err != nil { return err }\n", indent, col)
+		case "Float32":
+			fmt.Fprintf(w, "%s\t%s := make([]float32, len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = float32(%s[i].%s) }\n", indent, s, col, s, c.Access)
+			fmt.Fprintf(w, "%s\tif err := e.WriteFloat32Column(%s); err != nil { return err }\n", indent, col)
+		case "Bool":
+			fmt.Fprintf(w, "%s\t%s := make([]bool, len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = %s[i].%s }\n", indent, s, col, s, c.Access)
+			fmt.Fprintf(w, "%s\tif err := e.WriteBoolColumn(%s); err != nil { return err }\n", indent, col)
+		}
+	}
+	fmt.Fprintf(w, "%s} else {\n", indent) // row-major fallback for short slices
+	if err := g.emitEncodeSliceRowMajorBody(w, expr, elem, indent+"\t"); err != nil {
+		return err
+	}
 	fmt.Fprintf(w, "%s}\n", indent)
 	return nil
 }

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -872,10 +872,13 @@ func (g *gen) classifyColField(wireName, access string, ft types.Type) (colColum
 	if isTimeTime(ft) {
 		return colColumn{WireName: wireName, Access: access, KindByte: 5, GoType: "time.Time", ColAPI: "Time"}, true
 	}
-	// []byte (slice of uint8) → string column over an unsafe byte view.
+	// []byte (slice of uint8) → a NULLABLE string column over an unsafe byte
+	// view: nil is a distinct state from empty for a []byte, so it travels as
+	// the presence bit (nil → absent, empty/non-nil → present "") to preserve
+	// the nil-vs-empty distinction (a plain string column would collapse them).
 	if sl, ok := ft.Underlying().(*types.Slice); ok {
 		if eb, ok := sl.Elem().Underlying().(*types.Basic); ok && eb.Kind() == types.Uint8 {
-			return colColumn{WireName: wireName, Access: access, KindByte: 4, GoType: g.typeExprFromType(ft), ColAPI: "Bytes"}, true
+			return colColumn{WireName: wireName, Access: access, KindByte: 4 | 0x80, GoType: g.typeExprFromType(ft), ColAPI: "Bytes", Nullable: true}, true
 		}
 		return colColumn{}, false
 	}
@@ -1147,14 +1150,6 @@ func (g *gen) emitEncodeColumnGathers(w io.Writer, s string, plan colElemPlan, i
 			fmt.Fprintf(w, "%s%s := e.ScratchString(len(%s))\n", indent, col, s)
 			fmt.Fprintf(w, "%sfor i := range %s { %s[i] = string(%s[i].%s) }\n", indent, s, col, s, c.Access)
 			fmt.Fprintf(w, "%se.WriteStringColumn(%s)\n", indent, col)
-		case "Bytes":
-			// []byte → string column over a zero-copy byte view (valid for the
-			// duration of the column write; the codec copies what it keeps).
-			g.imports["unsafe"] = ""
-			fmt.Fprintf(w, "%s%s := e.ScratchString(len(%s))\n", indent, col, s)
-			fmt.Fprintf(w, "%sfor i := range %s { %s[i] = unsafe.String(unsafe.SliceData(%s[i].%s), len(%s[i].%s)) }\n",
-				indent, s, col, s, c.Access, s, c.Access)
-			fmt.Fprintf(w, "%se.WriteStringColumn(%s)\n", indent, col)
 		case "Time":
 			sec := g.fresh("sec")
 			ns := g.fresh("ns")
@@ -1213,6 +1208,21 @@ func (g *gen) emitEncodeNullableColumn(w io.Writer, s string, c colColumn, inden
 		fmt.Fprintf(w, "%s\tif %s[i].%s != nil {\n", indent, s, c.Access)
 		fmt.Fprintf(w, "%s\t\t%s[i>>3] |= 1 << uint(i&7)\n", indent, mask)
 		fmt.Fprintf(w, "%s\t\t%s[%s] = string(*%s[i].%s)\n", indent, col, di, s, c.Access)
+		fmt.Fprintf(w, "%s\t\t%s++\n%s\t}\n%s}\n", indent, di, indent, indent)
+		fmt.Fprintf(w, "%se.WriteColNullMask(%s)\n", indent, mask)
+		fmt.Fprintf(w, "%se.WriteStringColumn(%s[:%s])\n", indent, col, di)
+	case "Bytes":
+		// []byte presence = (field != nil); present values travel as a string
+		// column over a zero-copy byte view. nil stays absent (decodes to nil),
+		// empty []byte{} is present (decodes to a non-nil empty slice).
+		g.imports["unsafe"] = ""
+		col := g.fresh("c")
+		fmt.Fprintf(w, "%s%s := e.ScratchString(len(%s))\n", indent, col, s)
+		fmt.Fprintf(w, "%s%s := 0\n", indent, di)
+		fmt.Fprintf(w, "%sfor i := range %s {\n", indent, s)
+		fmt.Fprintf(w, "%s\tif %s[i].%s != nil {\n", indent, s, c.Access)
+		fmt.Fprintf(w, "%s\t\t%s[i>>3] |= 1 << uint(i&7)\n", indent, mask)
+		fmt.Fprintf(w, "%s\t\t%s[%s] = unsafe.String(unsafe.SliceData(%s[i].%s), len(%s[i].%s))\n", indent, col, di, s, c.Access, s, c.Access)
 		fmt.Fprintf(w, "%s\t\t%s++\n%s\t}\n%s}\n", indent, di, indent, indent)
 		fmt.Fprintf(w, "%se.WriteColNullMask(%s)\n", indent, mask)
 		fmt.Fprintf(w, "%se.WriteStringColumn(%s[:%s])\n", indent, col, di)
@@ -1588,18 +1598,24 @@ func (g *gen) emitDecodeNullableColumn(w io.Writer, lhs, nVar string, c colColum
 	readFn := map[string]string{
 		"Int": "ReadIntColumn", "Uint": "ReadUintColumn", "Float64": "ReadFloat64Column",
 		"Float32": "ReadFloat32Column", "Bool": "ReadBoolColumn", "String": "ReadStringColumn",
+		"Bytes": "ReadStringColumn",
 	}[c.ColAPI]
 	fmt.Fprintf(w, "%s%s, err := d.%s(%s)\n", indent, colv, readFn, present)
 	fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
 	fmt.Fprintf(w, "%s%s := 0\n", indent, di)
 	fmt.Fprintf(w, "%sfor i := range %s {\n", indent, lhs)
 	fmt.Fprintf(w, "%s\tif %s[i>>3]&(1<<uint(i&7)) != 0 {\n", indent, mask)
-	if c.ColAPI == "Bool" {
+	switch c.ColAPI {
+	case "Bytes":
+		// present []byte: a fresh owned copy (incl. a non-nil empty slice for "").
+		fmt.Fprintf(w, "%s\t\t%s[i].%s = %s([]byte(%s[%s]))\n", indent, lhs, c.Access, c.GoType, colv, di)
+	case "Bool":
 		fmt.Fprintf(w, "%s\t\t%s := %s[%s]\n", indent, v, colv, di)
-	} else {
+		fmt.Fprintf(w, "%s\t\t%s[i].%s = &%s\n", indent, lhs, c.Access, v)
+	default:
 		fmt.Fprintf(w, "%s\t\t%s := %s(%s[%s])\n", indent, v, c.GoType, colv, di)
+		fmt.Fprintf(w, "%s\t\t%s[i].%s = &%s\n", indent, lhs, c.Access, v)
 	}
-	fmt.Fprintf(w, "%s\t\t%s[i].%s = &%s\n", indent, lhs, c.Access, v)
 	fmt.Fprintf(w, "%s\t\t%s++\n", indent, di)
 	fmt.Fprintf(w, "%s\t} else {\n%s\t\t%s[i].%s = nil\n%s\t}\n%s}\n", indent, indent, lhs, c.Access, indent, indent)
 }

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -286,7 +286,7 @@ func (g *gen) fieldNameVar(name string) string {
 		return v
 	}
 	g.uniqCounter++
-	ident := fmt.Sprintf("qdfFieldHdr_%s_%d", sanitizeIdent(name), g.uniqCounter)
+	ident := "qdfFieldHdr_" + sanitizeIdent(name) + "_" + strconv.Itoa(g.uniqCounter)
 	g.headerNames[name] = ident
 	g.header.WriteString("\t")
 	g.header.WriteString(ident)
@@ -568,14 +568,17 @@ func (g *gen) emitMarshal(typeName string, fields []fieldInfo) error {
 	// keys the field-name shape on, and the field-name headers in field order.
 	// EncodeQDF declares the shape once per encoder (StructShape) so a slice of
 	// this struct threaded through one encoder writes the names once.
-	shapeTok := fmt.Sprintf("qdfShapeTok_%s", typeName)
-	hdrsVar := fmt.Sprintf("qdfFieldHdrs_%s", typeName)
-	hdrNames := make([]string, len(fields))
-	for i, f := range fields {
-		hdrNames[i] = g.fieldNameVar(f.WireKey)
-	}
+	shapeTok := "qdfShapeTok_" + typeName
+	hdrsVar := "qdfFieldHdrs_" + typeName
 	fmt.Fprintf(w, "var %s byte\n", shapeTok)
-	fmt.Fprintf(w, "var %s = [][]byte{%s}\n\n", hdrsVar, strings.Join(hdrNames, ", "))
+	fmt.Fprintf(w, "var %s = [][]byte{", hdrsVar)
+	for i, f := range fields {
+		if i > 0 {
+			w.WriteString(", ")
+		}
+		w.WriteString(g.fieldNameVar(f.WireKey))
+	}
+	w.WriteString("}\n\n")
 
 	// Encoder-based body — writes v's fields into a shared encoder. A parent
 	// threads one encoder through nested values via qdf.EncodeNested, avoiding
@@ -939,30 +942,54 @@ func basicColKind(k types.BasicKind) (byte, string, bool) {
 	}
 }
 
-// colNamesVar emits (once per ident) a file-level []string and returns its ident.
+// colNamesVar emits (once per ident) a file-level []string and returns its
+// ident. Appends straight to the var buffer (no intermediate parts slice +
+// strings.Join + fmt format-string parse).
 func (g *gen) colNamesVar(ident string, names []string) string {
 	if !g.colVarSeen[ident] {
 		g.colVarSeen[ident] = true
-		parts := make([]string, len(names))
+		b := &g.colVars
+		b.WriteString("var ")
+		b.WriteString(ident)
+		b.WriteString(" = []string{")
 		for i, nm := range names {
-			parts[i] = strconv.Quote(nm)
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(strconv.Quote(nm))
 		}
-		fmt.Fprintf(&g.colVars, "var %s = []string{%s}\n", ident, strings.Join(parts, ", "))
+		b.WriteString("}\n")
 	}
 	return ident
 }
 
 // colKindsVar emits (once per ident) a file-level []byte and returns its ident.
+// Appends each kind as a 0xNN literal directly (no fmt.Sprintf per element).
 func (g *gen) colKindsVar(ident string, kinds []byte) string {
 	if !g.colVarSeen[ident] {
 		g.colVarSeen[ident] = true
-		parts := make([]string, len(kinds))
+		b := &g.colVars
+		b.WriteString("var ")
+		b.WriteString(ident)
+		b.WriteString(" = []byte{")
 		for i, k := range kinds {
-			parts[i] = fmt.Sprintf("0x%02x", k)
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			writeHexByteLiteral(b, k)
 		}
-		fmt.Fprintf(&g.colVars, "var %s = []byte{%s}\n", ident, strings.Join(parts, ", "))
+		b.WriteString("}\n")
 	}
 	return ident
+}
+
+// writeHexByteLiteral appends a Go 0xNN byte literal for k.
+func writeHexByteLiteral(b *bytes.Buffer, k byte) {
+	const hexd = "0123456789abcdef"
+	b.WriteByte('0')
+	b.WriteByte('x')
+	b.WriteByte(hexd[k>>4])
+	b.WriteByte(hexd[k&0xf])
 }
 
 // eligNamesKinds returns the eligible columns' wire names + kind bytes (the
@@ -1707,10 +1734,12 @@ func (g *gen) typeExprFromType(t types.Type) string {
 	return types.TypeString(t, qf)
 }
 
-// fresh returns a unique identifier starting with the given prefix.
+// fresh returns a unique identifier starting with the given prefix. Hot (one
+// call per emitted temporary), so it concatenates directly instead of going
+// through fmt's format-string parsing + reflection.
 func (g *gen) fresh(prefix string) string {
 	g.uniqCounter++
-	return fmt.Sprintf("%s%d", prefix, g.uniqCounter)
+	return prefix + strconv.Itoa(g.uniqCounter)
 }
 
 // isTimeTime reports whether t resolves to the standard library's time.Time.

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -779,9 +779,10 @@ func (g *gen) emitEncodePointer(w io.Writer, expr string, p *types.Pointer, inde
 type colColumn struct {
 	WireName string // column name on the wire (field WireKey: qdf>json>name)
 	Access   string // Go field selector from the element, e.g. "TS" or "Base.X"
-	KindByte byte   // colKind wire byte: int0 uint1 f64 2 bool3 str4 time5 f32 6
-	GoType   string // rendered field type, e.g. "int32", for scatter narrowing
-	ColAPI   string // "Int"|"Uint"|"Float64"|"Float32"|"Bool"|"String"|"Time"
+	KindByte byte   // colKind wire byte: int0 uint1 f64 2 bool3 str4 time5 f32 6; |0x80 nullable
+	GoType   string // rendered field type for scatter narrowing (non-nullable: the field; nullable: the pointed-to elem)
+	ColAPI   string // "Int"|"Uint"|"Float64"|"Float32"|"Bool"|"String"|"Time"|"Bytes"
+	Nullable bool   // *T field: presence bitmap + dense column of present values
 }
 
 type colResidual struct {
@@ -838,7 +839,10 @@ func (g *gen) columnarElemPlan(elem types.Type) (colElemPlan, bool) {
 			plan.Columns = append(plan.Columns, col)
 			plan.HybridNames = append(plan.HybridNames, fi.WireKey)
 			plan.HybridKinds = append(plan.HybridKinds, col.KindByte)
-			if col.ColAPI == "String" {
+			// A plain (non-nullable) string column is the only kind whose
+			// columnar benefit is data-dependent → gates the string-only probe.
+			// []byte (raw-slab decode win) and nullable columns always benefit.
+			if col.ColAPI == "String" && !col.Nullable {
 				plan.HasString = true
 			} else {
 				plan.HasNumericOrTime = true
@@ -856,12 +860,28 @@ func (g *gen) columnarElemPlan(elem types.Type) (colElemPlan, bool) {
 }
 
 // classifyColField maps a struct field to its columnar column descriptor, or
-// returns ok=false for a residual (non-columnar) field. time.Time and string
-// are eligible (matching classifyColKind: str->4, time->5); []byte, nested
-// structs, maps, slices, pointers, arrays, interfaces are residual.
+// returns ok=false for a residual (non-columnar) field. Eligible: scalar basics,
+// string, time.Time, []byte (str column via the byte view), and pointers to any
+// of the scalar/string kinds (nullable column: presence bitmap + dense values).
+// Residual: *time.Time, *struct, nested struct, map, non-byte slice, array,
+// interface.
 func (g *gen) classifyColField(wireName, access string, ft types.Type) (colColumn, bool) {
 	if isTimeTime(ft) {
 		return colColumn{WireName: wireName, Access: access, KindByte: 5, GoType: "time.Time", ColAPI: "Time"}, true
+	}
+	// []byte (slice of uint8) → string column over an unsafe byte view.
+	if sl, ok := ft.Underlying().(*types.Slice); ok {
+		if eb, ok := sl.Elem().Underlying().(*types.Basic); ok && eb.Kind() == types.Uint8 {
+			return colColumn{WireName: wireName, Access: access, KindByte: 4, GoType: g.typeExprFromType(ft), ColAPI: "Bytes"}, true
+		}
+		return colColumn{}, false
+	}
+	// Pointer to a scalar/string → nullable column.
+	if ptr, ok := ft.Underlying().(*types.Pointer); ok {
+		if c, isCol := g.classifyNullableElem(wireName, access, ptr.Elem()); isCol {
+			return c, true
+		}
+		return colColumn{}, false
 	}
 	b, ok := ft.Underlying().(*types.Basic)
 	if !ok {
@@ -875,6 +895,28 @@ func (g *gen) classifyColField(wireName, access string, ft types.Type) (colColum
 		return colColumn{}, false
 	}
 	return colColumn{WireName: wireName, Access: access, KindByte: kb, GoType: g.typeExprFromType(ft), ColAPI: api}, true
+}
+
+// classifyNullableElem maps the pointed-to type of a *T field to a nullable
+// column (KindByte | 0x80 = colKindNullable). Eligible elem kinds: scalar
+// basics and string. *time.Time / *struct / others stay residual. GoType is the
+// element type (the value the scatter allocates and points at).
+func (g *gen) classifyNullableElem(wireName, access string, elem types.Type) (colColumn, bool) {
+	if isTimeTime(elem) {
+		return colColumn{}, false // *time.Time → residual (scope)
+	}
+	b, ok := elem.Underlying().(*types.Basic)
+	if !ok {
+		return colColumn{}, false
+	}
+	if b.Kind() == types.String {
+		return colColumn{WireName: wireName, Access: access, KindByte: 4 | 0x80, GoType: g.typeExprFromType(elem), ColAPI: "String", Nullable: true}, true
+	}
+	kb, api, ok := basicColKind(b.Kind())
+	if !ok {
+		return colColumn{}, false
+	}
+	return colColumn{WireName: wireName, Access: access, KindByte: kb | 0x80, GoType: g.typeExprFromType(elem), ColAPI: api, Nullable: true}, true
 }
 
 // basicColKind maps a numeric/bool basic kind to its colKind wire byte + the
@@ -1048,6 +1090,10 @@ func (g *gen) emitEncodeColumnarFrame(w io.Writer, s string, plan colElemPlan, i
 // hybrid frames.
 func (g *gen) emitEncodeColumnGathers(w io.Writer, s string, plan colElemPlan, indent string) error {
 	for _, c := range plan.Columns {
+		if c.Nullable {
+			g.emitEncodeNullableColumn(w, s, c, indent)
+			continue
+		}
 		col := g.fresh("c")
 		switch c.ColAPI {
 		case "Int":
@@ -1074,6 +1120,14 @@ func (g *gen) emitEncodeColumnGathers(w io.Writer, s string, plan colElemPlan, i
 			fmt.Fprintf(w, "%s%s := e.ScratchString(len(%s))\n", indent, col, s)
 			fmt.Fprintf(w, "%sfor i := range %s { %s[i] = string(%s[i].%s) }\n", indent, s, col, s, c.Access)
 			fmt.Fprintf(w, "%se.WriteStringColumn(%s)\n", indent, col)
+		case "Bytes":
+			// []byte → string column over a zero-copy byte view (valid for the
+			// duration of the column write; the codec copies what it keeps).
+			g.imports["unsafe"] = ""
+			fmt.Fprintf(w, "%s%s := e.ScratchString(len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%sfor i := range %s { %s[i] = unsafe.String(unsafe.SliceData(%s[i].%s), len(%s[i].%s)) }\n",
+				indent, s, col, s, c.Access, s, c.Access)
+			fmt.Fprintf(w, "%se.WriteStringColumn(%s)\n", indent, col)
 		case "Time":
 			sec := g.fresh("sec")
 			ns := g.fresh("ns")
@@ -1086,6 +1140,56 @@ func (g *gen) emitEncodeColumnGathers(w io.Writer, s string, plan colElemPlan, i
 		}
 	}
 	return nil
+}
+
+// emitEncodeNullableColumn emits a *T field's nullable column: a presence
+// bitmap followed by the dense column of present (non-nil) values, matching
+// encodeNullableColumn's wire layout (KindByte carries the 0x80 nullable bit).
+func (g *gen) emitEncodeNullableColumn(w io.Writer, s string, c colColumn, indent string) {
+	mask := g.fresh("mask")
+	di := g.fresh("di")
+	fmt.Fprintf(w, "%s%s := e.ScratchMask(len(%s))\n", indent, mask, s)
+	switch c.ColAPI {
+	case "Int", "Uint", "Float64", "Float32", "Bool":
+		col := g.fresh("c")
+		var scratchFn, conv string
+		switch c.ColAPI {
+		case "Int":
+			scratchFn, conv = "ScratchInt", "int64"
+		case "Uint":
+			scratchFn, conv = "ScratchUint", "uint64"
+		case "Float64":
+			scratchFn, conv = "ScratchFloat64", "float64"
+		case "Float32":
+			scratchFn, conv = "ScratchFloat32", "float32"
+		case "Bool":
+			scratchFn, conv = "ScratchBool", ""
+		}
+		fmt.Fprintf(w, "%s%s := e.%s(len(%s))\n", indent, col, scratchFn, s)
+		fmt.Fprintf(w, "%s%s := 0\n", indent, di)
+		fmt.Fprintf(w, "%sfor i := range %s {\n", indent, s)
+		fmt.Fprintf(w, "%s\tif %s[i].%s != nil {\n", indent, s, c.Access)
+		fmt.Fprintf(w, "%s\t\t%s[i>>3] |= 1 << uint(i&7)\n", indent, mask)
+		if conv == "" {
+			fmt.Fprintf(w, "%s\t\t%s[%s] = *%s[i].%s\n", indent, col, di, s, c.Access)
+		} else {
+			fmt.Fprintf(w, "%s\t\t%s[%s] = %s(*%s[i].%s)\n", indent, col, di, conv, s, c.Access)
+		}
+		fmt.Fprintf(w, "%s\t\t%s++\n%s\t}\n%s}\n", indent, di, indent, indent)
+		fmt.Fprintf(w, "%se.WriteColNullMask(%s)\n", indent, mask)
+		fmt.Fprintf(w, "%sif err := e.Write%sColumn(%s[:%s]); err != nil { return err }\n", indent, c.ColAPI, col, di)
+	case "String":
+		col := g.fresh("c")
+		fmt.Fprintf(w, "%s%s := e.ScratchString(len(%s))\n", indent, col, s)
+		fmt.Fprintf(w, "%s%s := 0\n", indent, di)
+		fmt.Fprintf(w, "%sfor i := range %s {\n", indent, s)
+		fmt.Fprintf(w, "%s\tif %s[i].%s != nil {\n", indent, s, c.Access)
+		fmt.Fprintf(w, "%s\t\t%s[i>>3] |= 1 << uint(i&7)\n", indent, mask)
+		fmt.Fprintf(w, "%s\t\t%s[%s] = string(*%s[i].%s)\n", indent, col, di, s, c.Access)
+		fmt.Fprintf(w, "%s\t\t%s++\n%s\t}\n%s}\n", indent, di, indent, indent)
+		fmt.Fprintf(w, "%se.WriteColNullMask(%s)\n", indent, mask)
+		fmt.Fprintf(w, "%se.WriteStringColumn(%s[:%s])\n", indent, col, di)
+	}
 }
 
 func (g *gen) emitEncodeArray(w io.Writer, expr string, a *types.Array, indent string) error {
@@ -1395,12 +1499,20 @@ func (g *gen) emitDecodeColumnarBody(w io.Writer, lhs string, elem types.Type, p
 // Used by the pure name-switch decode (inside a case) and the hybrid positional
 // decode. lhs is the output slice; nVar the row count local.
 func (g *gen) emitDecodeColumnScatter(w io.Writer, lhs, nVar string, c colColumn, indent string) {
+	if c.Nullable {
+		g.emitDecodeNullableColumn(w, lhs, nVar, c, indent)
+		return
+	}
 	colv := g.fresh("col")
 	switch c.ColAPI {
 	case "String":
 		fmt.Fprintf(w, "%s%s, err := d.ReadStringColumn(%s)\n", indent, colv, nVar)
 		fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
 		fmt.Fprintf(w, "%sfor i := range %s { %s[i].%s = %s(%s[i]) }\n", indent, colv, lhs, c.Access, c.GoType, colv)
+	case "Bytes":
+		fmt.Fprintf(w, "%s%s, err := d.ReadStringColumn(%s)\n", indent, colv, nVar)
+		fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%sfor i := range %s { %s[i].%s = %s([]byte(%s[i])) }\n", indent, colv, lhs, c.Access, c.GoType, colv)
 	case "Time":
 		g.imports["time"] = ""
 		secv := g.fresh("sec")
@@ -1428,6 +1540,36 @@ func (g *gen) emitDecodeColumnScatter(w io.Writer, lhs, nVar string, c colColumn
 		fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
 		fmt.Fprintf(w, "%sfor i := range %s { %s[i].%s = %s(%s[i]) }\n", indent, colv, lhs, c.Access, c.GoType, colv)
 	}
+}
+
+// emitDecodeNullableColumn emits decode for a *T nullable column: read the
+// presence bitmap + dense column of present values, then scatter — a set bit
+// allocates a fresh element and points the field at it, a clear bit leaves nil.
+func (g *gen) emitDecodeNullableColumn(w io.Writer, lhs, nVar string, c colColumn, indent string) {
+	mask := g.fresh("mask")
+	present := g.fresh("present")
+	colv := g.fresh("col")
+	di := g.fresh("di")
+	v := g.fresh("v")
+	fmt.Fprintf(w, "%s%s, %s, err := d.ReadColNullMask(%s)\n", indent, mask, present, nVar)
+	fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
+	readFn := map[string]string{
+		"Int": "ReadIntColumn", "Uint": "ReadUintColumn", "Float64": "ReadFloat64Column",
+		"Float32": "ReadFloat32Column", "Bool": "ReadBoolColumn", "String": "ReadStringColumn",
+	}[c.ColAPI]
+	fmt.Fprintf(w, "%s%s, err := d.%s(%s)\n", indent, colv, readFn, present)
+	fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
+	fmt.Fprintf(w, "%s%s := 0\n", indent, di)
+	fmt.Fprintf(w, "%sfor i := range %s {\n", indent, lhs)
+	fmt.Fprintf(w, "%s\tif %s[i>>3]&(1<<uint(i&7)) != 0 {\n", indent, mask)
+	if c.ColAPI == "Bool" {
+		fmt.Fprintf(w, "%s\t\t%s := %s[%s]\n", indent, v, colv, di)
+	} else {
+		fmt.Fprintf(w, "%s\t\t%s := %s(%s[%s])\n", indent, v, c.GoType, colv, di)
+	}
+	fmt.Fprintf(w, "%s\t\t%s[i].%s = &%s\n", indent, lhs, c.Access, v)
+	fmt.Fprintf(w, "%s\t\t%s++\n", indent, di)
+	fmt.Fprintf(w, "%s\t} else {\n%s\t\t%s[i].%s = nil\n%s\t}\n%s}\n", indent, indent, lhs, c.Access, indent, indent)
 }
 
 // emitDecodeHybridBody emits decode for the tagHybridColStruct frame: read the

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -779,21 +779,40 @@ func (g *gen) emitEncodePointer(w io.Writer, expr string, p *types.Pointer, inde
 type colColumn struct {
 	WireName string // column name on the wire (field WireKey: qdf>json>name)
 	Access   string // Go field selector from the element, e.g. "TS" or "Base.X"
-	KindByte byte   // colKind wire byte: 0/1/2/3/6
+	KindByte byte   // colKind wire byte: int0 uint1 f64 2 bool3 str4 time5 f32 6
 	GoType   string // rendered field type, e.g. "int32", for scatter narrowing
-	ColAPI   string // "Int"|"Uint"|"Float64"|"Float32"|"Bool"
+	ColAPI   string // "Int"|"Uint"|"Float64"|"Float32"|"Bool"|"String"|"Time"
+}
+
+type colResidual struct {
+	Access string     // Go field selector from the element
+	Type   types.Type // field type, for the row-major encode/decode emitters
 }
 
 type colElemPlan struct {
-	ElemType string // rendered element type, e.g. "GenMetric"
-	Columns  []colColumn
+	ElemType         string // rendered element type, e.g. "GenMetric"
+	Columns          []colColumn
+	Residual         []colResidual // non-columnar fields, declaration order
+	HybridNames      []string      // ALL fields, declaration order (hybrid shape)
+	HybridKinds      []byte        // colKind per field; 0xFF (residualKind) for residual
+	HasNumericOrTime bool          // int/uint/float/bool/time column present
+	HasString        bool          // string column present
 }
 
-// columnarElemPlan returns a plan when elem is a named struct whose every
-// (flattened) field is a scalar basic type — the v1 columnar-eligibility set.
-// Otherwise ok=false and the caller emits the row-major path. Any String,
-// time.Time, nested struct, slice, map, pointer, array, or interface field
-// disqualifies the element (those need string/hybrid columns, out of scope).
+// hybrid reports whether the element has non-columnar (residual) fields, so it
+// encodes as a tagHybridColStruct frame rather than a pure tagColStruct.
+func (p *colElemPlan) hybrid() bool { return len(p.Residual) > 0 }
+
+// stringOnly reports whether the only columnar benefit is from string columns,
+// so the encoder must run a cardinality probe (numeric/time columns always make
+// columnar worthwhile, strings only when low-cardinality).
+func (p *colElemPlan) stringOnly() bool { return p.HasString && !p.HasNumericOrTime }
+
+// columnarElemPlan returns a plan when elem is a named struct with at least one
+// columnar-eligible field (scalar int/uint/float/bool, string, or time.Time).
+// Non-eligible fields (nested struct, map, slice, []byte, pointer, array,
+// interface) become residual fields carried row-major in a hybrid frame. ok is
+// false (→ full row-major) only when no field is eligible.
 func (g *gen) columnarElemPlan(elem types.Type) (colElemPlan, bool) {
 	named, isNamed := types.Unalias(elem).(*types.Named)
 	if !isNamed {
@@ -812,31 +831,55 @@ func (g *gen) columnarElemPlan(elem types.Type) (colElemPlan, bool) {
 	if len(fields) == 0 {
 		return colElemPlan{}, false
 	}
-	cols := make([]colColumn, 0, len(fields))
+	plan := colElemPlan{ElemType: g.typeExprFromType(elem)}
 	for i := range fields {
 		fi := &fields[i]
-		b, isBasic := fi.Field.Type().Underlying().(*types.Basic)
-		if !isBasic {
-			return colElemPlan{}, false
+		if col, isCol := g.classifyColField(fi.WireKey, fi.Access, fi.Field.Type()); isCol {
+			plan.Columns = append(plan.Columns, col)
+			plan.HybridNames = append(plan.HybridNames, fi.WireKey)
+			plan.HybridKinds = append(plan.HybridKinds, col.KindByte)
+			if col.ColAPI == "String" {
+				plan.HasString = true
+			} else {
+				plan.HasNumericOrTime = true
+			}
+			continue
 		}
-		kb, api, ok := basicColKind(b.Kind())
-		if !ok {
-			return colElemPlan{}, false
-		}
-		cols = append(cols, colColumn{
-			WireName: fi.WireKey,
-			Access:   fi.Access,
-			KindByte: kb,
-			GoType:   g.typeExprFromType(fi.Field.Type()),
-			ColAPI:   api,
-		})
+		plan.Residual = append(plan.Residual, colResidual{Access: fi.Access, Type: fi.Field.Type()})
+		plan.HybridNames = append(plan.HybridNames, fi.WireKey)
+		plan.HybridKinds = append(plan.HybridKinds, 0xFF) // residualKind
 	}
-	return colElemPlan{ElemType: g.typeExprFromType(elem), Columns: cols}, true
+	if len(plan.Columns) == 0 {
+		return colElemPlan{}, false // no columnar benefit — full row-major
+	}
+	return plan, true
 }
 
-// basicColKind maps a basic kind to its colKind wire byte + the WriteX/ReadX
-// API suffix. Must match classifyColKind: int*->0, uint*->1, float64->2,
-// bool->3, float32->6.
+// classifyColField maps a struct field to its columnar column descriptor, or
+// returns ok=false for a residual (non-columnar) field. time.Time and string
+// are eligible (matching classifyColKind: str->4, time->5); []byte, nested
+// structs, maps, slices, pointers, arrays, interfaces are residual.
+func (g *gen) classifyColField(wireName, access string, ft types.Type) (colColumn, bool) {
+	if isTimeTime(ft) {
+		return colColumn{WireName: wireName, Access: access, KindByte: 5, GoType: "time.Time", ColAPI: "Time"}, true
+	}
+	b, ok := ft.Underlying().(*types.Basic)
+	if !ok {
+		return colColumn{}, false
+	}
+	if b.Kind() == types.String {
+		return colColumn{WireName: wireName, Access: access, KindByte: 4, GoType: g.typeExprFromType(ft), ColAPI: "String"}, true
+	}
+	kb, api, ok := basicColKind(b.Kind())
+	if !ok {
+		return colColumn{}, false
+	}
+	return colColumn{WireName: wireName, Access: access, KindByte: kb, GoType: g.typeExprFromType(ft), ColAPI: api}, true
+}
+
+// basicColKind maps a numeric/bool basic kind to its colKind wire byte + the
+// WriteX/ReadX API suffix. Must match classifyColKind: int*->0, uint*->1,
+// float64->2, bool->3, float32->6. (String/time handled in classifyColField.)
 func basicColKind(k types.BasicKind) (byte, string, bool) {
 	switch k {
 	case types.Bool:
@@ -854,34 +897,42 @@ func basicColKind(k types.BasicKind) (byte, string, bool) {
 	}
 }
 
-// colNamesVar emits (once per element type) a file-level []string of column
-// names and returns its ident.
-func (g *gen) colNamesVar(plan colElemPlan) string {
-	name := "qdfColNames_" + sanitizeIdent(plan.ElemType)
-	if !g.colVarSeen[name] {
-		g.colVarSeen[name] = true
-		parts := make([]string, len(plan.Columns))
-		for i, c := range plan.Columns {
-			parts[i] = strconv.Quote(c.WireName)
+// colNamesVar emits (once per ident) a file-level []string and returns its ident.
+func (g *gen) colNamesVar(ident string, names []string) string {
+	if !g.colVarSeen[ident] {
+		g.colVarSeen[ident] = true
+		parts := make([]string, len(names))
+		for i, nm := range names {
+			parts[i] = strconv.Quote(nm)
 		}
-		fmt.Fprintf(&g.colVars, "var %s = []string{%s}\n", name, strings.Join(parts, ", "))
+		fmt.Fprintf(&g.colVars, "var %s = []string{%s}\n", ident, strings.Join(parts, ", "))
 	}
-	return name
+	return ident
 }
 
-// colKindsVar emits (once per element type) a file-level []byte of column kind
-// bytes and returns its ident.
-func (g *gen) colKindsVar(plan colElemPlan) string {
-	name := "qdfColKinds_" + sanitizeIdent(plan.ElemType)
-	if !g.colVarSeen[name] {
-		g.colVarSeen[name] = true
-		parts := make([]string, len(plan.Columns))
-		for i, c := range plan.Columns {
-			parts[i] = fmt.Sprintf("0x%02x", c.KindByte)
+// colKindsVar emits (once per ident) a file-level []byte and returns its ident.
+func (g *gen) colKindsVar(ident string, kinds []byte) string {
+	if !g.colVarSeen[ident] {
+		g.colVarSeen[ident] = true
+		parts := make([]string, len(kinds))
+		for i, k := range kinds {
+			parts[i] = fmt.Sprintf("0x%02x", k)
 		}
-		fmt.Fprintf(&g.colVars, "var %s = []byte{%s}\n", name, strings.Join(parts, ", "))
+		fmt.Fprintf(&g.colVars, "var %s = []byte{%s}\n", ident, strings.Join(parts, ", "))
 	}
-	return name
+	return ident
+}
+
+// eligNamesKinds returns the eligible columns' wire names + kind bytes (the
+// pure tagColStruct shape).
+func (p *colElemPlan) eligNamesKinds() ([]string, []byte) {
+	names := make([]string, len(p.Columns))
+	kinds := make([]byte, len(p.Columns))
+	for i, c := range p.Columns {
+		names[i] = c.WireName
+		kinds[i] = c.KindByte
+	}
+	return names, kinds
 }
 
 func (g *gen) emitEncodeSlice(w io.Writer, expr string, s *types.Slice, indent string) error {
@@ -917,42 +968,41 @@ func (g *gen) emitEncodeSliceRowMajorBody(w io.Writer, expr string, elem types.T
 	return nil
 }
 
-// emitEncodeColumnarSlice emits a compile-time transpose of a scalar []struct
-// into the tagColStruct frame, with a runtime length gate: slices shorter than
-// columnarMinElems (16) stay row-major (frame overhead not worth it), and a nil
-// slice emits WriteNil to preserve the nil/empty distinction.
+// emitEncodeColumnarSlice emits a compile-time transpose of a []struct into the
+// columnar frame (pure tagColStruct, or tagHybridColStruct when residual fields
+// are present), with a runtime length gate (>= columnarMinElems). A nil slice
+// emits WriteNil; short slices fall back to row-major. A string-only element
+// runs a cardinality probe so high-cardinality strings stay row-major (matching
+// the reflect columnarProbe), while any numeric/time column makes columnar
+// unconditional.
 func (g *gen) emitEncodeColumnarSlice(w io.Writer, expr string, elem types.Type, plan colElemPlan, indent string) error {
-	namesVar := g.colNamesVar(plan)
-	kindsVar := g.colKindsVar(plan)
 	s := g.fresh("col")
 	fmt.Fprintf(w, "%sif %s == nil {\n", indent, expr)
 	fmt.Fprintf(w, "%s\te.WriteNil()\n", indent)
 	fmt.Fprintf(w, "%s} else if len(%s) >= 16 { // columnarMinElems\n", indent, expr)
 	fmt.Fprintf(w, "%s\t%s := %s\n", indent, s, expr)
-	fmt.Fprintf(w, "%s\te.WriteColStructHeader(len(%s), %s, %s)\n", indent, s, namesVar, kindsVar)
-	for _, c := range plan.Columns {
-		col := g.fresh("c")
-		switch c.ColAPI {
-		case "Int":
-			fmt.Fprintf(w, "%s\t%s := e.ScratchInt(len(%s))\n", indent, col, s)
-			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = int64(%s[i].%s) }\n", indent, s, col, s, c.Access)
-			fmt.Fprintf(w, "%s\tif err := e.WriteIntColumn(%s); err != nil { return err }\n", indent, col)
-		case "Uint":
-			fmt.Fprintf(w, "%s\t%s := e.ScratchUint(len(%s))\n", indent, col, s)
-			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = uint64(%s[i].%s) }\n", indent, s, col, s, c.Access)
-			fmt.Fprintf(w, "%s\tif err := e.WriteUintColumn(%s); err != nil { return err }\n", indent, col)
-		case "Float64":
-			fmt.Fprintf(w, "%s\t%s := e.ScratchFloat64(len(%s))\n", indent, col, s)
-			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = float64(%s[i].%s) }\n", indent, s, col, s, c.Access)
-			fmt.Fprintf(w, "%s\tif err := e.WriteFloat64Column(%s); err != nil { return err }\n", indent, col)
-		case "Float32":
-			fmt.Fprintf(w, "%s\t%s := e.ScratchFloat32(len(%s))\n", indent, col, s)
-			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = float32(%s[i].%s) }\n", indent, s, col, s, c.Access)
-			fmt.Fprintf(w, "%s\tif err := e.WriteFloat32Column(%s); err != nil { return err }\n", indent, col)
-		case "Bool":
-			fmt.Fprintf(w, "%s\t%s := e.ScratchBool(len(%s))\n", indent, col, s)
-			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = %s[i].%s }\n", indent, s, col, s, c.Access)
-			fmt.Fprintf(w, "%s\tif err := e.WriteBoolColumn(%s); err != nil { return err }\n", indent, col)
+	if plan.stringOnly() {
+		// Probe a sample of each string column; columnar only if low-cardinality.
+		ben := g.fresh("ben")
+		pb := g.fresh("pb")
+		fmt.Fprintf(w, "%s\t%s := false\n", indent, ben)
+		fmt.Fprintf(w, "%s\t%s := e.ScratchString(min(len(%s), 32))\n", indent, pb, s)
+		for _, c := range plan.Columns {
+			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = string(%s[i].%s) }\n", indent, pb, pb, s, c.Access)
+			fmt.Fprintf(w, "%s\tif qdf.StringColumnsBeneficial(%s) { %s = true }\n", indent, pb, ben)
+		}
+		fmt.Fprintf(w, "%s\tif %s {\n", indent, ben)
+		if err := g.emitEncodeColumnarFrame(w, s, plan, indent+"\t\t"); err != nil {
+			return err
+		}
+		fmt.Fprintf(w, "%s\t} else {\n", indent)
+		if err := g.emitEncodeSliceRowMajorBody(w, s, elem, indent+"\t\t"); err != nil {
+			return err
+		}
+		fmt.Fprintf(w, "%s\t}\n", indent)
+	} else {
+		if err := g.emitEncodeColumnarFrame(w, s, plan, indent+"\t"); err != nil {
+			return err
 		}
 	}
 	fmt.Fprintf(w, "%s} else {\n", indent) // row-major fallback for short slices
@@ -960,6 +1010,81 @@ func (g *gen) emitEncodeColumnarSlice(w io.Writer, expr string, elem types.Type,
 		return err
 	}
 	fmt.Fprintf(w, "%s}\n", indent)
+	return nil
+}
+
+// emitEncodeColumnarFrame emits the header + eligible-column transpose (+ the
+// hybrid residual block). s is a non-nil slice local of length >= 16.
+func (g *gen) emitEncodeColumnarFrame(w io.Writer, s string, plan colElemPlan, indent string) error {
+	id := sanitizeIdent(plan.ElemType)
+	if plan.hybrid() {
+		nv := g.colNamesVar("qdfHybNames_"+id, plan.HybridNames)
+		kv := g.colKindsVar("qdfHybKinds_"+id, plan.HybridKinds)
+		fmt.Fprintf(w, "%se.WriteHybridColStructHeader(len(%s), %s, %s)\n", indent, s, nv, kv)
+	} else {
+		names, kinds := plan.eligNamesKinds()
+		nv := g.colNamesVar("qdfColNames_"+id, names)
+		kv := g.colKindsVar("qdfColKinds_"+id, kinds)
+		fmt.Fprintf(w, "%se.WriteColStructHeader(len(%s), %s, %s)\n", indent, s, nv, kv)
+	}
+	if err := g.emitEncodeColumnGathers(w, s, plan, indent); err != nil {
+		return err
+	}
+	if plan.hybrid() {
+		ri := g.fresh("i")
+		fmt.Fprintf(w, "%sfor %s := range %s {\n", indent, ri, s)
+		for _, rf := range plan.Residual {
+			if err := g.emitEncodeValue(w, s+"["+ri+"]."+rf.Access, rf.Type, indent+"\t"); err != nil {
+				return err
+			}
+		}
+		fmt.Fprintf(w, "%s}\n", indent)
+	}
+	return nil
+}
+
+// emitEncodeColumnGathers emits the per-eligible-column gather-into-scratch +
+// WriteXColumn for each column in declaration order. Shared by the pure and
+// hybrid frames.
+func (g *gen) emitEncodeColumnGathers(w io.Writer, s string, plan colElemPlan, indent string) error {
+	for _, c := range plan.Columns {
+		col := g.fresh("c")
+		switch c.ColAPI {
+		case "Int":
+			fmt.Fprintf(w, "%s%s := e.ScratchInt(len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%sfor i := range %s { %s[i] = int64(%s[i].%s) }\n", indent, s, col, s, c.Access)
+			fmt.Fprintf(w, "%sif err := e.WriteIntColumn(%s); err != nil { return err }\n", indent, col)
+		case "Uint":
+			fmt.Fprintf(w, "%s%s := e.ScratchUint(len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%sfor i := range %s { %s[i] = uint64(%s[i].%s) }\n", indent, s, col, s, c.Access)
+			fmt.Fprintf(w, "%sif err := e.WriteUintColumn(%s); err != nil { return err }\n", indent, col)
+		case "Float64":
+			fmt.Fprintf(w, "%s%s := e.ScratchFloat64(len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%sfor i := range %s { %s[i] = float64(%s[i].%s) }\n", indent, s, col, s, c.Access)
+			fmt.Fprintf(w, "%sif err := e.WriteFloat64Column(%s); err != nil { return err }\n", indent, col)
+		case "Float32":
+			fmt.Fprintf(w, "%s%s := e.ScratchFloat32(len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%sfor i := range %s { %s[i] = float32(%s[i].%s) }\n", indent, s, col, s, c.Access)
+			fmt.Fprintf(w, "%sif err := e.WriteFloat32Column(%s); err != nil { return err }\n", indent, col)
+		case "Bool":
+			fmt.Fprintf(w, "%s%s := e.ScratchBool(len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%sfor i := range %s { %s[i] = %s[i].%s }\n", indent, s, col, s, c.Access)
+			fmt.Fprintf(w, "%sif err := e.WriteBoolColumn(%s); err != nil { return err }\n", indent, col)
+		case "String":
+			fmt.Fprintf(w, "%s%s := e.ScratchString(len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%sfor i := range %s { %s[i] = string(%s[i].%s) }\n", indent, s, col, s, c.Access)
+			fmt.Fprintf(w, "%se.WriteStringColumn(%s)\n", indent, col)
+		case "Time":
+			sec := g.fresh("sec")
+			ns := g.fresh("ns")
+			tv := g.fresh("t")
+			fmt.Fprintf(w, "%s%s := e.ScratchInt(len(%s))\n", indent, sec, s)
+			fmt.Fprintf(w, "%s%s := e.ScratchUint(len(%s))\n", indent, ns, s)
+			fmt.Fprintf(w, "%sfor i := range %s { %s := %s[i].%s.UTC(); %s[i] = %s.Unix(); %s[i] = uint64(%s.Nanosecond()) }\n",
+				indent, s, tv, s, c.Access, sec, tv, ns, tv)
+			fmt.Fprintf(w, "%sif err := e.WriteTimeColumn(%s, %s); err != nil { return err }\n", indent, sec, ns)
+		}
+	}
 	return nil
 }
 
@@ -1197,9 +1322,16 @@ func (g *gen) emitDecodeSlice(w io.Writer, lhs string, s *types.Slice, indent st
 	plan, columnar := g.columnarElemPlan(elem)
 	fmt.Fprintf(w, "%s\tif isNil {\n%s\t\t%s = nil\n", indent, indent, lhs)
 	if columnar {
-		fmt.Fprintf(w, "%s\t} else if d.PeekColStruct() {\n", indent)
-		if err := g.emitDecodeColumnarBody(w, lhs, elem, plan, indent+"\t\t"); err != nil {
-			return err
+		if plan.hybrid() {
+			fmt.Fprintf(w, "%s\t} else if d.PeekHybridColStruct() {\n", indent)
+			if err := g.emitDecodeHybridBody(w, lhs, elem, plan, indent+"\t\t"); err != nil {
+				return err
+			}
+		} else {
+			fmt.Fprintf(w, "%s\t} else if d.PeekColStruct() {\n", indent)
+			if err := g.emitDecodeColumnarBody(w, lhs, elem, plan, indent+"\t\t"); err != nil {
+				return err
+			}
 		}
 	}
 	fmt.Fprintf(w, "%s\t} else {\n", indent)
@@ -1250,8 +1382,37 @@ func (g *gen) emitDecodeColumnarBody(w io.Writer, lhs string, elem types.Type, p
 	fmt.Fprintf(w, "%sfor %s := range %s {\n", indent, idxVar, namesVar)
 	fmt.Fprintf(w, "%s\tswitch %s[%s] {\n", indent, namesVar, idxVar)
 	for _, c := range plan.Columns {
-		colv := g.fresh("col")
 		fmt.Fprintf(w, "%s\tcase %s:\n", indent, strconv.Quote(c.WireName))
+		g.emitDecodeColumnScatter(w, lhs, nVar, c, indent+"\t\t")
+	}
+	fmt.Fprintf(w, "%s\tdefault:\n%s\t\treturn qdf.ErrTypeMismatch\n", indent, indent)
+	fmt.Fprintf(w, "%s\t}\n", indent) // switch
+	fmt.Fprintf(w, "%s}\n", indent)   // for
+	return nil
+}
+
+// emitDecodeColumnScatter emits a single column's read + scatter into lhs[i].
+// Used by the pure name-switch decode (inside a case) and the hybrid positional
+// decode. lhs is the output slice; nVar the row count local.
+func (g *gen) emitDecodeColumnScatter(w io.Writer, lhs, nVar string, c colColumn, indent string) {
+	colv := g.fresh("col")
+	switch c.ColAPI {
+	case "String":
+		fmt.Fprintf(w, "%s%s, err := d.ReadStringColumn(%s)\n", indent, colv, nVar)
+		fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%sfor i := range %s { %s[i].%s = %s(%s[i]) }\n", indent, colv, lhs, c.Access, c.GoType, colv)
+	case "Time":
+		g.imports["time"] = ""
+		secv := g.fresh("sec")
+		nsv := g.fresh("ns")
+		fmt.Fprintf(w, "%s%s, %s, err := d.ReadTimeColumn(%s)\n", indent, secv, nsv, nVar)
+		fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%sfor i := range %s { %s[i].%s = time.Unix(%s[i], int64(%s[i])).UTC() }\n", indent, secv, lhs, c.Access, secv, nsv)
+	case "Bool":
+		fmt.Fprintf(w, "%s%s, err := d.ReadBoolColumn(%s)\n", indent, colv, nVar)
+		fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%sfor i := range %s { %s[i].%s = %s[i] }\n", indent, colv, lhs, c.Access, colv)
+	default:
 		var readFn string
 		switch c.ColAPI {
 		case "Int":
@@ -1262,20 +1423,39 @@ func (g *gen) emitDecodeColumnarBody(w io.Writer, lhs string, elem types.Type, p
 			readFn = "ReadFloat64Column"
 		case "Float32":
 			readFn = "ReadFloat32Column"
-		case "Bool":
-			readFn = "ReadBoolColumn"
 		}
-		fmt.Fprintf(w, "%s\t\t%s, err := d.%s(%s)\n", indent, colv, readFn, nVar)
-		fmt.Fprintf(w, "%s\t\tif err != nil {\n%s\t\t\treturn err\n%s\t\t}\n", indent, indent, indent)
-		if c.ColAPI == "Bool" {
-			fmt.Fprintf(w, "%s\t\tfor i := range %s {\n%s\t\t\t%s[i].%s = %s[i]\n%s\t\t}\n", indent, colv, indent, lhs, c.Access, colv, indent)
-		} else {
-			fmt.Fprintf(w, "%s\t\tfor i := range %s {\n%s\t\t\t%s[i].%s = %s(%s[i])\n%s\t\t}\n", indent, colv, indent, lhs, c.Access, c.GoType, colv, indent)
+		fmt.Fprintf(w, "%s%s, err := d.%s(%s)\n", indent, colv, readFn, nVar)
+		fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
+		fmt.Fprintf(w, "%sfor i := range %s { %s[i].%s = %s(%s[i]) }\n", indent, colv, lhs, c.Access, c.GoType, colv)
+	}
+}
+
+// emitDecodeHybridBody emits decode for the tagHybridColStruct frame: read the
+// header, allocate the slice, decode the eligible columns positionally (wire
+// order == declaration order == plan.Columns order), then the residual block
+// row-major per element. Mirrors decodeHybridColumnar.
+func (g *gen) emitDecodeHybridBody(w io.Writer, lhs string, elem types.Type, plan colElemPlan, indent string) error {
+	nVar := g.fresh("n")
+	namesVar := g.fresh("names")
+	kindsVar := g.fresh("kinds")
+	fmt.Fprintf(w, "%s%s, %s, %s, err := d.ReadHybridColStructHeader()\n", indent, nVar, namesVar, kindsVar)
+	fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
+	fmt.Fprintf(w, "%s_ = %s\n%s_ = %s\n", indent, namesVar, indent, kindsVar)
+	fmt.Fprintf(w, "%s%s = make([]%s, %s)\n", indent, lhs, g.typeExprFromType(elem), nVar)
+	for _, c := range plan.Columns {
+		g.emitDecodeColumnScatter(w, lhs, nVar, c, indent)
+	}
+	// Residual block: clear the per-column length bound, then row-major decode
+	// each residual field per element.
+	fmt.Fprintf(w, "%sd.ClearColMaxLen()\n", indent)
+	ri := g.fresh("i")
+	fmt.Fprintf(w, "%sfor %s := range %s {\n", indent, ri, lhs)
+	for _, rf := range plan.Residual {
+		if err := g.emitDecodeValue(w, lhs+"["+ri+"]."+rf.Access, rf.Type, indent+"\t"); err != nil {
+			return err
 		}
 	}
-	fmt.Fprintf(w, "%s\tdefault:\n%s\t\treturn qdf.ErrTypeMismatch\n", indent, indent)
-	fmt.Fprintf(w, "%s\t}\n", indent) // switch
-	fmt.Fprintf(w, "%s}\n", indent)   // for
+	fmt.Fprintf(w, "%s}\n", indent)
 	return nil
 }
 

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -1492,6 +1492,11 @@ func (g *gen) emitDecodeColumnarBody(w io.Writer, lhs string, elem types.Type, p
 	fmt.Fprintf(w, "%s\tdefault:\n%s\t\treturn qdf.ErrTypeMismatch\n", indent, indent)
 	fmt.Fprintf(w, "%s\t}\n", indent) // switch
 	fmt.Fprintf(w, "%s}\n", indent)   // for
+	// Clear the per-column length bound set by ReadColStructHeader so a sibling
+	// slice/map/column decoded afterward on this (shared, threaded) decoder is
+	// not wrongly bounded by n — mirrors decodeColumnar's deferred reset and the
+	// hybrid path's ClearColMaxLen.
+	fmt.Fprintf(w, "%sd.ClearColMaxLen()\n", indent)
 	return nil
 }
 

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -934,23 +934,23 @@ func (g *gen) emitEncodeColumnarSlice(w io.Writer, expr string, elem types.Type,
 		col := g.fresh("c")
 		switch c.ColAPI {
 		case "Int":
-			fmt.Fprintf(w, "%s\t%s := make([]int64, len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%s\t%s := e.ScratchInt(len(%s))\n", indent, col, s)
 			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = int64(%s[i].%s) }\n", indent, s, col, s, c.Access)
 			fmt.Fprintf(w, "%s\tif err := e.WriteIntColumn(%s); err != nil { return err }\n", indent, col)
 		case "Uint":
-			fmt.Fprintf(w, "%s\t%s := make([]uint64, len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%s\t%s := e.ScratchUint(len(%s))\n", indent, col, s)
 			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = uint64(%s[i].%s) }\n", indent, s, col, s, c.Access)
 			fmt.Fprintf(w, "%s\tif err := e.WriteUintColumn(%s); err != nil { return err }\n", indent, col)
 		case "Float64":
-			fmt.Fprintf(w, "%s\t%s := make([]float64, len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%s\t%s := e.ScratchFloat64(len(%s))\n", indent, col, s)
 			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = float64(%s[i].%s) }\n", indent, s, col, s, c.Access)
 			fmt.Fprintf(w, "%s\tif err := e.WriteFloat64Column(%s); err != nil { return err }\n", indent, col)
 		case "Float32":
-			fmt.Fprintf(w, "%s\t%s := make([]float32, len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%s\t%s := e.ScratchFloat32(len(%s))\n", indent, col, s)
 			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = float32(%s[i].%s) }\n", indent, s, col, s, c.Access)
 			fmt.Fprintf(w, "%s\tif err := e.WriteFloat32Column(%s); err != nil { return err }\n", indent, col)
 		case "Bool":
-			fmt.Fprintf(w, "%s\t%s := make([]bool, len(%s))\n", indent, col, s)
+			fmt.Fprintf(w, "%s\t%s := e.ScratchBool(len(%s))\n", indent, col, s)
 			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = %s[i].%s }\n", indent, s, col, s, c.Access)
 			fmt.Fprintf(w, "%s\tif err := e.WriteBoolColumn(%s); err != nil { return err }\n", indent, col)
 		}

--- a/colcodegen.go
+++ b/colcodegen.go
@@ -2,6 +2,7 @@ package qdf
 
 import (
 	"math"
+	"math/bits"
 	"unsafe"
 )
 
@@ -138,6 +139,45 @@ func (e *Encoder) WriteFloat32Column(s []float32) error {
 
 // WriteBoolColumn encodes a bool column.
 func (e *Encoder) WriteBoolColumn(s []bool) error { return encodeSliceBool(e, unsafe.Pointer(&s)) }
+
+// ScratchMask returns a zeroed reusable presence bitmap covering n rows
+// ((n+7)/8 bytes). Generated code sets bit i for a present (non-nil) nullable
+// column row, then passes it to WriteColNullMask.
+func (e *Encoder) ScratchMask(n int) []byte {
+	st := e.colState()
+	mb := (n + 7) >> 3
+	if cap(st.colMaskScratch) < mb {
+		st.colMaskScratch = make([]byte, mb)
+	}
+	st.colMaskScratch = st.colMaskScratch[:mb]
+	clear(st.colMaskScratch)
+	return st.colMaskScratch
+}
+
+// WriteColNullMask appends a nullable column's presence bitmap (raw bytes, bit i
+// set ⇒ row i present), written before the dense column of present values.
+// Layout matches encodeNullableColumn so the reflect path can cross-decode.
+func (e *Encoder) WriteColNullMask(mask []byte) { e.buf = append(e.buf, mask...) }
+
+// ReadColNullMask reads a nullable column's presence bitmap for n rows and
+// returns it (aliased into the input buffer, read-only) plus the present
+// (set-bit) count. The dense column that follows has exactly that many values.
+func (d *Decoder) ReadColNullMask(n int) ([]byte, int, error) {
+	mb := (n + 7) >> 3
+	if d.i+mb > len(d.buf) {
+		return nil, 0, ErrShortBuffer
+	}
+	mask := d.buf[d.i : d.i+mb]
+	d.i += mb
+	present := 0
+	for _, b := range mask {
+		present += bits.OnesCount8(b)
+	}
+	if present > n {
+		return nil, 0, ErrInvalidLength
+	}
+	return mask, present, nil
+}
 
 // ScratchString returns a reusable []string of length n for a string column.
 func (e *Encoder) ScratchString(n int) []string {

--- a/colcodegen.go
+++ b/colcodegen.go
@@ -42,6 +42,71 @@ func (e *Encoder) WriteColStructHeader(n int, names []string, kinds []byte) {
 	st.colShapeDeclare(names, ck)
 }
 
+// colState lazily initializes and returns the encoder's columnar state, which
+// owns the reusable per-column transpose scratch.
+func (e *Encoder) colState() *encState {
+	if e.state == nil {
+		e.state = newEncState()
+	}
+	return e.state
+}
+
+// The ScratchX getters hand generated code a reusable column buffer of length n,
+// grown from the encoder's pooled columnar scratch (shared with the reflect
+// path, which never runs concurrently on the same encoder). Generated code
+// fills the buffer and passes it straight to the matching WriteXColumn, so a
+// whole columnar []struct encodes with zero per-column allocation.
+
+// ScratchInt returns a reusable []int64 of length n for a signed column.
+func (e *Encoder) ScratchInt(n int) []int64 {
+	st := e.colState()
+	if cap(st.colScratchI64) < n {
+		st.colScratchI64 = make([]int64, n)
+	}
+	st.colScratchI64 = st.colScratchI64[:n]
+	return st.colScratchI64
+}
+
+// ScratchUint returns a reusable []uint64 of length n for an unsigned column.
+func (e *Encoder) ScratchUint(n int) []uint64 {
+	st := e.colState()
+	if cap(st.colScratchU64) < n {
+		st.colScratchU64 = make([]uint64, n)
+	}
+	st.colScratchU64 = st.colScratchU64[:n]
+	return st.colScratchU64
+}
+
+// ScratchFloat64 returns a reusable []float64 of length n for a float64 column.
+func (e *Encoder) ScratchFloat64(n int) []float64 {
+	st := e.colState()
+	if cap(st.colScratchF64) < n {
+		st.colScratchF64 = make([]float64, n)
+	}
+	st.colScratchF64 = st.colScratchF64[:n]
+	return st.colScratchF64
+}
+
+// ScratchFloat32 returns a reusable []float32 of length n for a float32 column.
+func (e *Encoder) ScratchFloat32(n int) []float32 {
+	st := e.colState()
+	if cap(st.colScratchF32) < n {
+		st.colScratchF32 = make([]float32, n)
+	}
+	st.colScratchF32 = st.colScratchF32[:n]
+	return st.colScratchF32
+}
+
+// ScratchBool returns a reusable []bool of length n for a bool column.
+func (e *Encoder) ScratchBool(n int) []bool {
+	st := e.colState()
+	if cap(st.colScratchBool) < n {
+		st.colScratchBool = make([]bool, n)
+	}
+	st.colScratchBool = st.colScratchBool[:n]
+	return st.colScratchBool
+}
+
 // WriteIntColumn encodes a column gathered from a signed-integer field. The
 // adaptive picker chooses raw/FOR/Delta/RLE/Dict/PFOR per value range.
 func (e *Encoder) WriteIntColumn(s []int64) error { return encodeSliceInt64(e, unsafe.Pointer(&s)) }
@@ -56,11 +121,18 @@ func (e *Encoder) WriteFloat64Column(s []float64) error {
 
 // WriteFloat32Column encodes a float32 column as its 32-bit patterns through
 // the unsigned codec, bit-exact and matching the reflect colKindFloat32 path.
+// The bit-conversion temp reuses colScratchU64 (free once any uint column it
+// shares the buffer with has already been encoded), so no allocation.
 func (e *Encoder) WriteFloat32Column(s []float32) error {
-	u := make([]uint64, len(s))
+	st := e.colState()
+	if cap(st.colScratchU64) < len(s) {
+		st.colScratchU64 = make([]uint64, len(s))
+	}
+	u := st.colScratchU64[:len(s)]
 	for i, v := range s {
 		u[i] = uint64(math.Float32bits(v))
 	}
+	st.colScratchU64 = u
 	return encodeSliceUint64(e, unsafe.Pointer(&u))
 }
 
@@ -91,12 +163,30 @@ func (d *Decoder) ReadColStructHeader() (int, []string, []byte, error) {
 	return cs.n, cs.sh.names, kinds, nil
 }
 
+// colStateDec lazily initializes and returns the decoder's columnar state,
+// which owns the reusable per-column scatter scratch. ReadColStructHeader has
+// already created it, but guard anyway for direct callers.
+func (d *Decoder) colStateDec() *decState {
+	if d.state == nil {
+		d.state = newDecState()
+	}
+	return d.state
+}
+
+// The ReadXColumn readers decode one column of n values into the decoder's
+// pooled columnar scratch and return it. Generated decode scatters the values
+// into struct fields immediately, before the next column read reuses the same
+// buffer — so a whole columnar []struct decodes with zero per-column transient
+// allocation beyond the result slice itself.
+
 // ReadIntColumn decodes one signed-integer column of n values.
 func (d *Decoder) ReadIntColumn(n int) ([]int64, error) {
-	var s []int64
+	st := d.colStateDec()
+	s := st.colScratchI64[:0]
 	if err := decodeSliceInt64Into(d, &s); err != nil {
 		return nil, err
 	}
+	st.colScratchI64 = s
 	if len(s) != n {
 		return nil, ErrTypeMismatch
 	}
@@ -105,10 +195,12 @@ func (d *Decoder) ReadIntColumn(n int) ([]int64, error) {
 
 // ReadUintColumn decodes one unsigned-integer column of n values.
 func (d *Decoder) ReadUintColumn(n int) ([]uint64, error) {
-	var s []uint64
+	st := d.colStateDec()
+	s := st.colScratchU64[:0]
 	if err := decodeSliceUint64Into(d, &s); err != nil {
 		return nil, err
 	}
+	st.colScratchU64 = s
 	if len(s) != n {
 		return nil, ErrTypeMismatch
 	}
@@ -117,10 +209,12 @@ func (d *Decoder) ReadUintColumn(n int) ([]uint64, error) {
 
 // ReadFloat64Column decodes one float64 column of n values.
 func (d *Decoder) ReadFloat64Column(n int) ([]float64, error) {
-	var s []float64
+	st := d.colStateDec()
+	s := st.colScratchF64[:0]
 	if err := decodeSliceFloat64Into(d, &s); err != nil {
 		return nil, err
 	}
+	st.colScratchF64 = s
 	if len(s) != n {
 		return nil, ErrTypeMismatch
 	}
@@ -128,28 +222,37 @@ func (d *Decoder) ReadFloat64Column(n int) ([]float64, error) {
 }
 
 // ReadFloat32Column decodes one float32 column (32-bit patterns via the
-// unsigned codec, mirroring WriteFloat32Column).
+// unsigned codec, mirroring WriteFloat32Column). The bits land in colScratchU64
+// and are widened into colScratchF32.
 func (d *Decoder) ReadFloat32Column(n int) ([]float32, error) {
-	var u []uint64
+	st := d.colStateDec()
+	u := st.colScratchU64[:0]
 	if err := decodeSliceUint64Into(d, &u); err != nil {
 		return nil, err
 	}
+	st.colScratchU64 = u
 	if len(u) != n {
 		return nil, ErrTypeMismatch
 	}
-	out := make([]float32, n)
+	if cap(st.colScratchF32) < n {
+		st.colScratchF32 = make([]float32, n)
+	}
+	out := st.colScratchF32[:n]
 	for i, v := range u {
 		out[i] = math.Float32frombits(uint32(v))
 	}
+	st.colScratchF32 = out
 	return out, nil
 }
 
 // ReadBoolColumn decodes one bool column of n values.
 func (d *Decoder) ReadBoolColumn(n int) ([]bool, error) {
-	var s []bool
+	st := d.colStateDec()
+	s := st.colScratchBool[:0]
 	if err := decodeSliceBoolInto(d, &s); err != nil {
 		return nil, err
 	}
+	st.colScratchBool = s
 	if len(s) != n {
 		return nil, ErrTypeMismatch
 	}

--- a/colcodegen.go
+++ b/colcodegen.go
@@ -18,6 +18,10 @@ import (
 // path. kinds[i] is the colKind byte for column i (see classifyColKind:
 // int*->0, uint*->1, float64->2, bool->3, float32->6); it must match what the
 // reflect encoder would emit for the same field so cross-decoding works.
+//
+// names and kinds back the encoder's shape-id cache by reference on the
+// declaring call; the caller must NOT mutate or recycle them for a different
+// shape afterward (generated code passes immutable package-level vars).
 func (e *Encoder) WriteColStructHeader(n int, names []string, kinds []byte) {
 	if e.state == nil {
 		e.state = newEncState()

--- a/colcodegen.go
+++ b/colcodegen.go
@@ -1,0 +1,68 @@
+package qdf
+
+import (
+	"math"
+	"unsafe"
+)
+
+// This file exposes the no-reflect columnar primitives that qdfgen-generated
+// code calls to transpose a []struct field into the tagColStruct wire frame.
+// The byte layout is identical to encodeColumnar (columnar.go) so the reflect
+// path and generated code interoperate. Generated code never uses reflection.
+
+// WriteColStructHeader writes the columnar container header: tagColStruct,
+// the row count n, and the column shape (field names + kind bytes). The shape
+// is declared inline the first time this encoder sees it and reused by id
+// afterwards, sharing encState's colStruct shape-id space with the reflect
+// path. kinds[i] is the colKind byte for column i (see classifyColKind:
+// int*->0, uint*->1, float64->2, bool->3, float32->6); it must match what the
+// reflect encoder would emit for the same field so cross-decoding works.
+func (e *Encoder) WriteColStructHeader(n int, names []string, kinds []byte) {
+	if e.state == nil {
+		e.state = newEncState()
+	}
+	st := e.state
+	e.buf = append(e.buf, tagColStruct)
+	e.buf = appendUvarint(e.buf, uint64(n))
+	// colKind is a uint8; reinterpret the kinds byte slice without copying.
+	var ck []colKind
+	if len(kinds) > 0 {
+		ck = unsafe.Slice((*colKind)(unsafe.Pointer(&kinds[0])), len(kinds))
+	}
+	if id := st.colShapeFor(names, ck); id != 0 {
+		e.buf = appendUvarint(e.buf, uint64(id))
+		return
+	}
+	e.buf = appendUvarint(e.buf, 0)
+	e.buf = appendUvarint(e.buf, uint64(len(names)))
+	for i := range names {
+		e.WriteString(names[i])
+		e.buf = append(e.buf, kinds[i])
+	}
+	st.colShapeDeclare(names, ck)
+}
+
+// WriteIntColumn encodes a column gathered from a signed-integer field. The
+// adaptive picker chooses raw/FOR/Delta/RLE/Dict/PFOR per value range.
+func (e *Encoder) WriteIntColumn(s []int64) error { return encodeSliceInt64(e, unsafe.Pointer(&s)) }
+
+// WriteUintColumn encodes an unsigned-integer column.
+func (e *Encoder) WriteUintColumn(s []uint64) error { return encodeSliceUint64(e, unsafe.Pointer(&s)) }
+
+// WriteFloat64Column encodes a float64 column.
+func (e *Encoder) WriteFloat64Column(s []float64) error {
+	return encodeSliceFloat64(e, unsafe.Pointer(&s))
+}
+
+// WriteFloat32Column encodes a float32 column as its 32-bit patterns through
+// the unsigned codec, bit-exact and matching the reflect colKindFloat32 path.
+func (e *Encoder) WriteFloat32Column(s []float32) error {
+	u := make([]uint64, len(s))
+	for i, v := range s {
+		u[i] = uint64(math.Float32bits(v))
+	}
+	return encodeSliceUint64(e, unsafe.Pointer(&u))
+}
+
+// WriteBoolColumn encodes a bool column.
+func (e *Encoder) WriteBoolColumn(s []bool) error { return encodeSliceBool(e, unsafe.Pointer(&s)) }

--- a/colcodegen.go
+++ b/colcodegen.go
@@ -139,6 +139,57 @@ func (e *Encoder) WriteFloat32Column(s []float32) error {
 // WriteBoolColumn encodes a bool column.
 func (e *Encoder) WriteBoolColumn(s []bool) error { return encodeSliceBool(e, unsafe.Pointer(&s)) }
 
+// ScratchString returns a reusable []string of length n for a string column.
+func (e *Encoder) ScratchString(n int) []string {
+	st := e.colState()
+	if cap(st.colScratchStr) < n {
+		st.colScratchStr = make([]string, n)
+	}
+	st.colScratchStr = st.colScratchStr[:n]
+	return st.colScratchStr
+}
+
+// WriteStringColumn encodes a string column, reusing the Balanced string-column
+// picker (dictionary / FSST / raw-slab / plain), which is never larger than the
+// per-value row-major encoding. Same wire as the reflect colKindString path.
+func (e *Encoder) WriteStringColumn(s []string) { e.writeStringColumn(s) }
+
+// WriteTimeColumn encodes a time.Time column as two sub-columns — sec ([]int64,
+// Delta+FOR compresses monotonic series) then nsec ([]uint64) — matching the
+// reflect colKindTime path. The caller gathers secs/nsec from the time fields
+// (t.UTC().Unix() / t.Nanosecond()); reuse ScratchInt/ScratchUint for them.
+func (e *Encoder) WriteTimeColumn(secs []int64, nsec []uint64) error {
+	if err := encodeSliceInt64(e, unsafe.Pointer(&secs)); err != nil {
+		return err
+	}
+	return encodeSliceUint64(e, unsafe.Pointer(&nsec))
+}
+
+// WriteHybridColStructHeader writes the hybrid columnar container header
+// (tagHybridColStruct, row count, shape). The shape lists EVERY field in
+// declaration order; residual (non-columnar) fields carry kind byte 0xFF
+// (residualKind). Shares the hybrid shape-id space with the reflect path.
+func (e *Encoder) WriteHybridColStructHeader(n int, names []string, kinds []byte) {
+	st := e.colState()
+	e.buf = append(e.buf, tagHybridColStruct)
+	e.buf = appendUvarint(e.buf, uint64(n))
+	var ck []colKind
+	if len(kinds) > 0 {
+		ck = unsafe.Slice((*colKind)(unsafe.Pointer(&kinds[0])), len(kinds))
+	}
+	if id := st.hybridShapeFor(names, ck); id != 0 {
+		e.buf = appendUvarint(e.buf, uint64(id))
+		return
+	}
+	e.buf = appendUvarint(e.buf, 0)
+	e.buf = appendUvarint(e.buf, uint64(len(names)))
+	for i := range names {
+		e.WriteString(names[i])
+		e.buf = append(e.buf, kinds[i])
+	}
+	st.hybridShapeDeclare(names, ck)
+}
+
 // PeekColStruct reports whether the next byte is a columnar container frame,
 // without consuming it. Generated decode uses this to pick the columnar path
 // vs the row-major fallback (a tiny slice the encoder kept row-major, or a
@@ -258,3 +309,147 @@ func (d *Decoder) ReadBoolColumn(n int) ([]bool, error) {
 	}
 	return s, nil
 }
+
+// ReadStringColumn decodes one string column of n values, mirroring the reflect
+// colKindString decode: a dictionary / FSST / raw-slab block (tag present) goes
+// through the shared block reader; otherwise the plain per-value path reads via
+// ReadString so state-ref / MTF / repeat encodings written by the picker's
+// plain fallback resolve correctly (and share the decode intern cache). The
+// returned slice is reused scratch on the plain path; scatter before the next
+// column read.
+func (d *Decoder) ReadStringColumn(n int) ([]string, error) {
+	if n > 0 && d.i < len(d.buf) && (d.buf[d.i] == tagColStrDict || d.buf[d.i] == tagColStrFSST || d.buf[d.i] == tagColStrRaw) {
+		s, err := d.readStringColumn(n)
+		if err != nil {
+			return nil, err
+		}
+		if len(s) != n {
+			return nil, ErrTypeMismatch
+		}
+		return s, nil
+	}
+	st := d.colStateDec()
+	if cap(st.colScratchStr) < n {
+		st.colScratchStr = make([]string, n)
+	}
+	out := st.colScratchStr[:n]
+	for i := range n {
+		s, err := d.ReadString()
+		if err != nil {
+			return nil, err
+		}
+		out[i] = s
+	}
+	st.colScratchStr = out
+	return out, nil
+}
+
+// ReadTimeColumn decodes a time.Time column's two sub-columns and returns the
+// sec / nsec slices; the caller reconstructs each value as
+// time.Unix(sec[i], int64(nsec[i])).UTC(). nsec is validated in range.
+func (d *Decoder) ReadTimeColumn(n int) ([]int64, []uint64, error) {
+	st := d.colStateDec()
+	sec := st.colScratchI64[:0]
+	if err := decodeSliceInt64Into(d, &sec); err != nil {
+		return nil, nil, err
+	}
+	st.colScratchI64 = sec
+	if len(sec) != n {
+		return nil, nil, ErrTypeMismatch
+	}
+	nsec := st.colScratchU64[:0]
+	if err := decodeSliceUint64Into(d, &nsec); err != nil {
+		return nil, nil, err
+	}
+	st.colScratchU64 = nsec
+	if len(nsec) != n {
+		return nil, nil, ErrTypeMismatch
+	}
+	if err := checkNsecColumn(nsec); err != nil {
+		return nil, nil, err
+	}
+	return sec, nsec, nil
+}
+
+// PeekHybridColStruct reports whether the next byte is a hybrid columnar frame
+// (some fields columnar, some residual row-major), without consuming it.
+func (d *Decoder) PeekHybridColStruct() bool {
+	return d.i < len(d.buf) && d.buf[d.i] == tagHybridColStruct
+}
+
+// ReadHybridColStructHeader consumes the hybrid columnar header and returns the
+// row count and full shape (every field in declaration order; residual fields
+// carry kind byte 0xFF). n is bounded by maxColumnarElems.
+func (d *Decoder) ReadHybridColStructHeader() (int, []string, []byte, error) {
+	n, sh, err := d.readHybridColShape(maxColumnarElems)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	d.colMaxLen = n
+	kinds := make([]byte, len(sh.kinds))
+	for i, k := range sh.kinds {
+		kinds[i] = byte(k)
+	}
+	return n, sh.names, kinds, nil
+}
+
+// ClearColMaxLen resets the per-column length bound. Generated hybrid decode
+// calls it between the eligible columns (bounded to n) and the residual block
+// (whose nested slices/maps may legitimately exceed n), mirroring
+// decodeHybridColumnar.
+func (d *Decoder) ClearColMaxLen() { d.colMaxLen = 0 }
+
+// stringColumnsBeneficial samples the given string columns and reports whether a
+// dictionary string column would beat plain per-value row-major encoding by the
+// columnar min-gain threshold. Reflection-free; reuses bitsForDistinct and the
+// same estimate the reflect columnarProbe uses for colKindString. Generated
+// code calls this only for string-ONLY elements (any numeric/time column makes
+// columnar unconditionally beneficial), so a high-cardinality string struct
+// (e.g. unique names) stays row-major exactly as the reflect probe decides.
+func stringColumnsBeneficial(cols ...[]string) bool {
+	if len(cols) == 0 || len(cols[0]) == 0 {
+		return false
+	}
+	sample := min(len(cols[0]), columnarProbeSample)
+	var colBytes, rowBytes int
+	for _, strs := range cols {
+		var seen [columnarProbeSample]string
+		nseen := 0
+		var tableBytes, perValue int
+		prev := ""
+		first := true
+		for i := range sample {
+			s := strs[i]
+			fresh := true
+			for j := 0; j < nseen; j++ {
+				if seen[j] == s {
+					fresh = false
+					break
+				}
+			}
+			if fresh && nseen < len(seen) {
+				seen[nseen] = s
+				nseen++
+				tableBytes += 2 + len(s)
+			}
+			if !first && s == prev {
+				perValue++
+			} else {
+				perValue += 2 + len(s)
+			}
+			rowBytes += 2 + len(s)
+			prev = s
+			first = false
+		}
+		dictBytes := tableBytes + (sample*bitsForDistinct(nseen)+7)/8
+		colBytes += min(perValue, dictBytes)
+	}
+	if rowBytes == 0 {
+		return false
+	}
+	return colBytes*100 <= rowBytes*(100-columnarMinGainPct)
+}
+
+// StringColumnsBeneficial is the exported entry generated code calls to gate a
+// string-only element's columnar encode (see stringColumnsBeneficial).
+func StringColumnsBeneficial(cols ...[]string) bool { return stringColumnsBeneficial(cols...) }

--- a/colcodegen.go
+++ b/colcodegen.go
@@ -247,11 +247,18 @@ func (d *Decoder) ReadColStructHeader() (int, []string, []byte, error) {
 		return 0, nil, nil, err
 	}
 	d.colMaxLen = cs.n
-	kinds := make([]byte, len(cs.sh.kinds))
-	for i, k := range cs.sh.kinds {
-		kinds[i] = byte(k)
+	return cs.n, cs.sh.names, colKindsAsBytes(cs.sh.kinds), nil
+}
+
+// colKindsAsBytes reinterprets a cached []colKind (a uint8 alias) as []byte with
+// no copy. The result is read-only and transient — valid only until the decoder
+// reuses its shape cache; generated code consumes it immediately (or discards
+// it), avoiding a per-decode allocation of the kinds slice.
+func colKindsAsBytes(kinds []colKind) []byte {
+	if len(kinds) == 0 {
+		return nil
 	}
-	return cs.n, cs.sh.names, kinds, nil
+	return unsafe.Slice((*byte)(unsafe.Pointer(&kinds[0])), len(kinds))
 }
 
 // colStateDec lazily initializes and returns the decoder's columnar state,
@@ -426,11 +433,7 @@ func (d *Decoder) ReadHybridColStructHeader() (int, []string, []byte, error) {
 		return 0, nil, nil, err
 	}
 	d.colMaxLen = n
-	kinds := make([]byte, len(sh.kinds))
-	for i, k := range sh.kinds {
-		kinds[i] = byte(k)
-	}
-	return n, sh.names, kinds, nil
+	return n, sh.names, colKindsAsBytes(sh.kinds), nil
 }
 
 // ClearColMaxLen resets the per-column length bound. Generated hybrid decode

--- a/colcodegen.go
+++ b/colcodegen.go
@@ -66,3 +66,92 @@ func (e *Encoder) WriteFloat32Column(s []float32) error {
 
 // WriteBoolColumn encodes a bool column.
 func (e *Encoder) WriteBoolColumn(s []bool) error { return encodeSliceBool(e, unsafe.Pointer(&s)) }
+
+// PeekColStruct reports whether the next byte is a columnar container frame,
+// without consuming it. Generated decode uses this to pick the columnar path
+// vs the row-major fallback (a tiny slice the encoder kept row-major, or a
+// reflect-produced row-major encoding of the same field).
+func (d *Decoder) PeekColStruct() bool {
+	return d.i < len(d.buf) && d.buf[d.i] == tagColStruct
+}
+
+// ReadColStructHeader consumes the columnar container header and returns the
+// row count and column shape (names + kind bytes). It mirrors readColShape's
+// non-index path. n is bounded by maxColumnarElems.
+func (d *Decoder) ReadColStructHeader() (int, []string, []byte, error) {
+	cs, err := d.readColShape(maxColumnarElems)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	d.colMaxLen = cs.n
+	kinds := make([]byte, len(cs.sh.kinds))
+	for i, k := range cs.sh.kinds {
+		kinds[i] = byte(k)
+	}
+	return cs.n, cs.sh.names, kinds, nil
+}
+
+// ReadIntColumn decodes one signed-integer column of n values.
+func (d *Decoder) ReadIntColumn(n int) ([]int64, error) {
+	var s []int64
+	if err := decodeSliceInt64Into(d, &s); err != nil {
+		return nil, err
+	}
+	if len(s) != n {
+		return nil, ErrTypeMismatch
+	}
+	return s, nil
+}
+
+// ReadUintColumn decodes one unsigned-integer column of n values.
+func (d *Decoder) ReadUintColumn(n int) ([]uint64, error) {
+	var s []uint64
+	if err := decodeSliceUint64Into(d, &s); err != nil {
+		return nil, err
+	}
+	if len(s) != n {
+		return nil, ErrTypeMismatch
+	}
+	return s, nil
+}
+
+// ReadFloat64Column decodes one float64 column of n values.
+func (d *Decoder) ReadFloat64Column(n int) ([]float64, error) {
+	var s []float64
+	if err := decodeSliceFloat64Into(d, &s); err != nil {
+		return nil, err
+	}
+	if len(s) != n {
+		return nil, ErrTypeMismatch
+	}
+	return s, nil
+}
+
+// ReadFloat32Column decodes one float32 column (32-bit patterns via the
+// unsigned codec, mirroring WriteFloat32Column).
+func (d *Decoder) ReadFloat32Column(n int) ([]float32, error) {
+	var u []uint64
+	if err := decodeSliceUint64Into(d, &u); err != nil {
+		return nil, err
+	}
+	if len(u) != n {
+		return nil, ErrTypeMismatch
+	}
+	out := make([]float32, n)
+	for i, v := range u {
+		out[i] = math.Float32frombits(uint32(v))
+	}
+	return out, nil
+}
+
+// ReadBoolColumn decodes one bool column of n values.
+func (d *Decoder) ReadBoolColumn(n int) ([]bool, error) {
+	var s []bool
+	if err := decodeSliceBoolInto(d, &s); err != nil {
+		return nil, err
+	}
+	if len(s) != n {
+		return nil, ErrTypeMismatch
+	}
+	return s, nil
+}

--- a/colcodegen.go
+++ b/colcodegen.go
@@ -318,7 +318,7 @@ func (d *Decoder) ReadBoolColumn(n int) ([]bool, error) {
 // returned slice is reused scratch on the plain path; scatter before the next
 // column read.
 func (d *Decoder) ReadStringColumn(n int) ([]string, error) {
-	if n > 0 && d.i < len(d.buf) && (d.buf[d.i] == tagColStrDict || d.buf[d.i] == tagColStrFSST || d.buf[d.i] == tagColStrRaw) {
+	if n > 0 && d.i < len(d.buf) && isStringColumnBlockTag(d.buf[d.i]) {
 		s, err := d.readStringColumn(n)
 		if err != nil {
 			return nil, err

--- a/colcodegen_test.go
+++ b/colcodegen_test.go
@@ -133,3 +133,105 @@ func TestWriteColumns_RoundTripViaReadColShape(t *testing.T) {
 		t.Fatal("no colStruct frame emitted")
 	}
 }
+
+func TestStringColumn_RoundTrip(t *testing.T) {
+	e := NewEncoderOnBuf(nil, Fast)
+	e.EnsureHeader()
+	e.WriteColStructHeader(5, []string{"name"}, []byte{4}) // colKindString
+	in := []string{"alpha", "beta", "alpha", "gamma", "beta"}
+	e.WriteStringColumn(in)
+	d := NewDecoderOnBuf(e.Bytes())
+	if err := d.readHeader(); err != nil {
+		t.Fatal(err)
+	}
+	if !d.PeekColStruct() {
+		t.Fatal("want colStruct frame")
+	}
+	n, names, kinds, err := d.ReadColStructHeader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 5 || names[0] != "name" || kinds[0] != 4 {
+		t.Fatalf("header: n=%d names=%v kinds=%v", n, names, kinds)
+	}
+	got, err := d.ReadStringColumn(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range in {
+		if got[i] != in[i] {
+			t.Fatalf("string[%d]=%q want %q", i, got[i], in[i])
+		}
+	}
+}
+
+func TestTimeColumn_RoundTrip(t *testing.T) {
+	e := NewEncoderOnBuf(nil, Fast)
+	e.EnsureHeader()
+	base := int64(1_700_000_000)
+	secs := []int64{base, base + 1, base + 2, base + 60}
+	nsec := []uint64{0, 500, 999_999_999, 12345}
+	e.WriteColStructHeader(4, []string{"ts"}, []byte{5}) // colKindTime
+	if err := e.WriteTimeColumn(secs, nsec); err != nil {
+		t.Fatal(err)
+	}
+	d := NewDecoderOnBuf(e.Bytes())
+	if err := d.readHeader(); err != nil {
+		t.Fatal(err)
+	}
+	n, _, kinds, err := d.ReadColStructHeader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kinds[0] != 5 {
+		t.Fatalf("kind=%d want 5", kinds[0])
+	}
+	gs, gn, err := d.ReadTimeColumn(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range secs {
+		if gs[i] != secs[i] || gn[i] != nsec[i] {
+			t.Fatalf("time[%d]=(%d,%d) want (%d,%d)", i, gs[i], gn[i], secs[i], nsec[i])
+		}
+	}
+}
+
+func TestHybridColStructHeader_RoundTrip(t *testing.T) {
+	e := NewEncoderOnBuf(nil, Fast)
+	e.EnsureHeader()
+	names := []string{"ts", "nested", "v"}
+	kinds := []byte{0, 0xFF, 2} // int, residual, float64
+	e.WriteHybridColStructHeader(7, names, kinds)
+	d := NewDecoderOnBuf(e.Bytes())
+	if err := d.readHeader(); err != nil {
+		t.Fatal(err)
+	}
+	if !d.PeekHybridColStruct() {
+		t.Fatal("want hybrid frame")
+	}
+	n, gn, gk, err := d.ReadHybridColStructHeader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 7 || len(gn) != 3 || gn[1] != "nested" || gk[1] != 0xFF || gk[0] != 0 || gk[2] != 2 {
+		t.Fatalf("hybrid header: n=%d names=%v kinds=%v", n, gn, gk)
+	}
+}
+
+func TestStringColumnsBeneficial(t *testing.T) {
+	lowCard := make([]string, 64)
+	for i := range lowCard {
+		lowCard[i] = []string{"GET", "POST", "PUT"}[i%3]
+	}
+	if !stringColumnsBeneficial(lowCard) {
+		t.Fatal("low-cardinality string column should be columnar-beneficial")
+	}
+	highCard := make([]string, 64)
+	for i := range highCard {
+		highCard[i] = "unique-value-" + string(rune('a'+i%26)) + string(rune('0'+i%10)) + string(rune('A'+(i*7)%26))
+	}
+	if stringColumnsBeneficial(highCard) {
+		t.Fatal("high-cardinality string column should stay row-major")
+	}
+}

--- a/colcodegen_test.go
+++ b/colcodegen_test.go
@@ -1,0 +1,47 @@
+package qdf
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWriteColStructHeader_DeclareThenReuse(t *testing.T) {
+	e := NewEncoderOnBuf(nil, Fast)
+	e.EnsureHeader()
+	names := []string{"a", "b"}
+	kinds := []byte{0, 2} // colKindInt, colKindFloat
+	start := len(e.Bytes())
+	e.WriteColStructHeader(3, names, kinds)
+	first := append([]byte(nil), e.Bytes()[start:]...)
+	// First emission declares the shape inline: tag, uvarint(n=3), uvarint(0=declare),
+	// uvarint(2 cols), then per-col name+kind.
+	if first[0] != tagColStruct {
+		t.Fatalf("want tagColStruct 0x%x, got 0x%x", tagColStruct, first[0])
+	}
+	// Second emission of the same shape reuses by id (much shorter, no names).
+	mid := len(e.Bytes())
+	e.WriteColStructHeader(3, names, kinds)
+	second := e.Bytes()[mid:]
+	if len(second) >= len(first) {
+		t.Fatalf("reuse (%d bytes) should be shorter than declare (%d bytes)", len(second), len(first))
+	}
+	if second[0] != tagColStruct {
+		t.Fatalf("reuse tag wrong: 0x%x", second[0])
+	}
+}
+
+func TestWriteColumns_RoundTripViaReadColShape(t *testing.T) {
+	e := NewEncoderOnBuf(nil, Fast)
+	e.EnsureHeader()
+	e.WriteColStructHeader(4, []string{"x", "y"}, []byte{0, 3}) // int, bool
+	if err := e.WriteIntColumn([]int64{10, 20, 30, 40}); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.WriteBoolColumn([]bool{true, false, true, false}); err != nil {
+		t.Fatal(err)
+	}
+	buf := e.Bytes()
+	if !bytes.Contains(buf, []byte{tagColStruct}) {
+		t.Fatal("no colStruct frame emitted")
+	}
+}

--- a/colcodegen_test.go
+++ b/colcodegen_test.go
@@ -235,3 +235,72 @@ func TestStringColumnsBeneficial(t *testing.T) {
 		t.Fatal("high-cardinality string column should stay row-major")
 	}
 }
+
+func TestStringColumn_ConstFallback_Fast(t *testing.T) {
+	// All-identical column under Fast → tagColStrConst: tiny wire, round-trips.
+	e := NewEncoderOnBuf(nil, Fast)
+	e.EnsureHeader()
+	n := 500
+	same := make([]string, n)
+	for i := range same {
+		same[i] = "constant-value"
+	}
+	e.WriteColStructHeader(n, []string{"s"}, []byte{4})
+	e.WriteStringColumn(same)
+	buf := e.Bytes()
+	if !bytes.Contains(buf, []byte{tagColStrConst}) {
+		t.Fatal("all-identical string column should use tagColStrConst under Fast")
+	}
+	if len(buf) > 100 {
+		t.Fatalf("const column wire %d too large (not deduped)", len(buf))
+	}
+	d := NewDecoderOnBuf(buf)
+	if err := d.readHeader(); err != nil {
+		t.Fatal(err)
+	}
+	cn, _, _, err := d.ReadColStructHeader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.ReadStringColumn(cn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != n || got[0] != "constant-value" || got[n-1] != "constant-value" {
+		t.Fatalf("const round-trip wrong: len=%d", len(got))
+	}
+}
+
+func TestStringColumn_RawFallback_Fast(t *testing.T) {
+	// High-cardinality under Fast → tagColStrRaw: one-slab decode, round-trips.
+	e := NewEncoderOnBuf(nil, Fast)
+	e.EnsureHeader()
+	n := 300
+	in := make([]string, n)
+	for i := range in {
+		in[i] = "unique-" + string(rune('a'+i%26)) + string(rune('0'+i%10)) + string(rune('A'+(i*7)%26))
+	}
+	e.WriteColStructHeader(n, []string{"s"}, []byte{4})
+	e.WriteStringColumn(in)
+	buf := e.Bytes()
+	if !bytes.Contains(buf, []byte{tagColStrRaw}) {
+		t.Fatal("high-cardinality string column should use tagColStrRaw under Fast")
+	}
+	d := NewDecoderOnBuf(buf)
+	if err := d.readHeader(); err != nil {
+		t.Fatal(err)
+	}
+	cn, _, _, err := d.ReadColStructHeader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.ReadStringColumn(cn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range in {
+		if got[i] != in[i] {
+			t.Fatalf("raw round-trip[%d]=%q want %q", i, got[i], in[i])
+		}
+	}
+}

--- a/colcodegen_test.go
+++ b/colcodegen_test.go
@@ -30,6 +30,94 @@ func TestWriteColStructHeader_DeclareThenReuse(t *testing.T) {
 	}
 }
 
+func TestColStruct_RoundTripExposedAPI(t *testing.T) {
+	e := NewEncoderOnBuf(nil, Fast)
+	e.EnsureHeader()
+	e.WriteColStructHeader(4, []string{"x", "y"}, []byte{0, 3}) // int, bool
+	if err := e.WriteIntColumn([]int64{10, 20, 30, 40}); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.WriteBoolColumn([]bool{true, false, true, false}); err != nil {
+		t.Fatal(err)
+	}
+	buf := e.Bytes()
+
+	d := NewDecoderOnBuf(buf)
+	if err := d.readHeader(); err != nil {
+		t.Fatal(err)
+	}
+	if !d.PeekColStruct() {
+		t.Fatal("PeekColStruct = false, want true")
+	}
+	n, names, kinds, err := d.ReadColStructHeader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 4 || len(names) != 2 || names[0] != "x" || names[1] != "y" {
+		t.Fatalf("header mismatch: n=%d names=%v", n, names)
+	}
+	if kinds[0] != 0 || kinds[1] != 3 {
+		t.Fatalf("kinds mismatch: %v", kinds)
+	}
+	xs, err := d.ReadIntColumn(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ys, err := d.ReadBoolColumn(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(xs) != 4 || xs[0] != 10 || xs[3] != 40 {
+		t.Fatalf("int column wrong: %v", xs)
+	}
+	if len(ys) != 4 || !ys[0] || ys[1] {
+		t.Fatalf("bool column wrong: %v", ys)
+	}
+}
+
+func TestPeekColStruct_FalseOnArrayHeader(t *testing.T) {
+	e := NewEncoderOnBuf(nil, Fast)
+	e.EnsureHeader()
+	e.WriteArrayHeader(2)
+	d := NewDecoderOnBuf(e.Bytes())
+	if err := d.readHeader(); err != nil {
+		t.Fatal(err)
+	}
+	if d.PeekColStruct() {
+		t.Fatal("PeekColStruct = true on an array header, want false")
+	}
+}
+
+func TestColStruct_ReflectEncodeDecodesViaExposedReader(t *testing.T) {
+	type metric struct {
+		A int64
+		B float64
+	}
+	// Reflect path columnar-encodes a plain []struct (>= columnarMinElems).
+	in := make([]metric, 32)
+	for i := range in {
+		in[i] = metric{A: int64(i), B: float64(i) * 1.5}
+	}
+	buf, err := Marshal(in, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := NewDecoderOnBuf(buf)
+	if err := d.readHeader(); err != nil {
+		t.Fatal(err)
+	}
+	if !d.PeekColStruct() {
+		t.Skip("reflect did not choose columnar for this shape; interop check N/A")
+	}
+	n, names, kinds, err := d.ReadColStructHeader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 32 || len(names) != 2 || kinds[0] != 0 || kinds[1] != 2 {
+		t.Fatalf("interop header mismatch n=%d names=%v kinds=%v", n, names, kinds)
+	}
+}
+
 func TestWriteColumns_RoundTripViaReadColShape(t *testing.T) {
 	e := NewEncoderOnBuf(nil, Fast)
 	e.EnsureHeader()

--- a/colstr_const.go
+++ b/colstr_const.go
@@ -1,0 +1,63 @@
+package qdf
+
+// Constant (single-distinct) string column codec: when every value in a string
+// column is identical, store it once + the row count instead of n copies. See
+// tagColStrConst (wire.go) for the format. Wire-minimal and decodes to a single
+// allocation regardless of encoder mode, so it fixes the codegen/Fast path where
+// the per-value fallback does not intern repeats.
+
+// tryWriteStringColumnConst writes a constant string column if every element of
+// strs is identical, returning true. The all-equal scan bails on the first
+// mismatch, so a multi-distinct column costs O(1) here.
+func (e *Encoder) tryWriteStringColumnConst(strs []string) bool {
+	n := len(strs)
+	if n < 2 {
+		return false // a 0/1-element column is not worth a dedicated frame
+	}
+	first := strs[0]
+	for i := 1; i < n; i++ {
+		if strs[i] != first {
+			return false
+		}
+	}
+	e.writeHeader()
+	out := e.buf
+	out = append(out, tagColStrConst)
+	out = appendUvarint(out, uint64(len(first)))
+	out = append(out, first...)
+	out = appendUvarint(out, uint64(n))
+	e.buf = out
+	return true
+}
+
+// readStringColumnConst decodes a tagColStrConst block (tag at d.i) and returns
+// n shares of the single owned string value. The block's row count must equal
+// the columnar header's n (which bounds it), so a tiny input cannot drive a
+// large allocation.
+func (d *Decoder) readStringColumnConst(n int) ([]string, error) {
+	d.i++ // consume tagColStrConst
+	l64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, ErrInvalidLength
+	}
+	d.i += nr
+	if l64 > uint64(len(d.buf)-d.i) {
+		return nil, ErrShortBuffer
+	}
+	l := int(l64)
+	v := string(d.buf[d.i : d.i+l]) // one owned copy, shared by every row
+	d.i += l
+	cnt64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, ErrInvalidLength
+	}
+	d.i += nr
+	if int(cnt64) != n {
+		return nil, ErrTypeMismatch
+	}
+	out := make([]string, n)
+	for i := range out {
+		out[i] = v
+	}
+	return out, nil
+}

--- a/columnar.go
+++ b/columnar.go
@@ -2323,6 +2323,17 @@ func classifyColKind(fd *typeDesc) (ck colKind, width uintptr, isByte bool, ok b
 		return colKindString, 0, false, true
 	case reflect.Slice:
 		if fd.rType.Elem().Kind() == reflect.Uint8 { // []byte
+			// Known limitation: a []byte column is a plain string column (no
+			// per-row presence bit), kept that way so it stays wire-compatible
+			// with a string column for the string<->[]byte schema interchange
+			// (TestColumnarStringIntoByteField). The consequence is that the
+			// reflect columnar path (n >= columnarMinElems) cannot distinguish a
+			// nil []byte from an empty []byte{} — both decode to nil. The
+			// row-major path (n < columnarMinElems) preserves the distinction.
+			// Same inherent columnar-lossiness class as int->int64 widening and
+			// time monotonic-clock stripping. (The qdfgen codegen path, which has
+			// no string<->[]byte interchange to preserve, routes []byte through a
+			// nullable column and keeps nil vs empty distinct.)
 			return colKindString, 0, true, true
 		}
 		return 0, 0, false, false

--- a/columnar.go
+++ b/columnar.go
@@ -957,7 +957,7 @@ func (d *Decoder) decodeColumnVals(kind colKind, n int, isByte bool) (colVals, e
 		}
 		cv.b = s
 	case colKindString:
-		if d.i < len(d.buf) && (d.buf[d.i] == tagColStrDict || d.buf[d.i] == tagColStrFSST || d.buf[d.i] == tagColStrRaw) {
+		if d.i < len(d.buf) && isStringColumnBlockTag(d.buf[d.i]) {
 			s, err := d.readStringColumn(n)
 			if err != nil {
 				return cv, err
@@ -1681,7 +1681,7 @@ func (d *Decoder) decodeColumnInto(base unsafe.Pointer, plan *columnarPlan, col 
 			*(*bool)(unsafe.Add(base, uintptr(i)*plan.stride+col.offset)) = s[i]
 		}
 	case colKindString:
-		if d.i < len(d.buf) && (d.buf[d.i] == tagColStrDict || d.buf[d.i] == tagColStrFSST || d.buf[d.i] == tagColStrRaw) {
+		if d.i < len(d.buf) && isStringColumnBlockTag(d.buf[d.i]) {
 			strs, err := d.readStringColumn(n)
 			if err != nil {
 				return err
@@ -1771,7 +1771,7 @@ func (d *Decoder) skipColumnValue(kind colKind, n int) error {
 		var s []bool
 		return decodeSliceBool(d, unsafe.Pointer(&s))
 	case colKindString:
-		if d.i < len(d.buf) && (d.buf[d.i] == tagColStrDict || d.buf[d.i] == tagColStrFSST || d.buf[d.i] == tagColStrRaw) {
+		if d.i < len(d.buf) && isStringColumnBlockTag(d.buf[d.i]) {
 			_, err := d.readStringColumn(n)
 			return err
 		}
@@ -2067,7 +2067,7 @@ func decodeColumnarAny(d *Decoder) (any, error) {
 				}
 			}
 		case colKindString:
-			if d.i < len(d.buf) && (d.buf[d.i] == tagColStrDict || d.buf[d.i] == tagColStrFSST || d.buf[d.i] == tagColStrRaw) {
+			if d.i < len(d.buf) && isStringColumnBlockTag(d.buf[d.i]) {
 				strs, err := d.readStringColumn(n)
 				if err != nil {
 					return nil, err
@@ -2201,7 +2201,7 @@ func (d *Decoder) decodeColumnBodyAny(kind colKind, name string, n int, store bo
 			}
 		}
 	case colKindString:
-		if d.i < len(d.buf) && (d.buf[d.i] == tagColStrDict || d.buf[d.i] == tagColStrFSST || d.buf[d.i] == tagColStrRaw) {
+		if d.i < len(d.buf) && isStringColumnBlockTag(d.buf[d.i]) {
 			strs, err := d.readStringColumn(n)
 			if err != nil {
 				return err

--- a/diagrams/wire-format.md
+++ b/diagrams/wire-format.md
@@ -46,7 +46,7 @@ bit:  7   6   5   4      3            2          1          0
 | Flag | Hex | Meaning |
 |------|-----|---------|
 | `FlagDense` | `0x01` | Body uses Dense intern dialect; state-ref tags (`0xE0`–`0xEA`, `0xEC`) are present |
-| `FlagQPack` | `0x02` | Body may carry QPack codec tags (`0xE3`–`0xEF`, `0xF4`–`0xF6`); early hint so readers can reject unsupported codecs before parsing |
+| `FlagQPack` | `0x02` | Body may carry QPack codec tags (`0xE3`–`0xEF`, `0xF4`–`0xF9`); early hint so readers can reject unsupported codecs before parsing |
 | `FlagRANS` | `0x04` | Body is rANS-compressed: `varuint(origLen)` + 256-entry freq table + rANS stream. Decoder decompresses before reading tags. Set only when rANS form is strictly smaller. |
 | `FlagColIndex` | `0x08` | A `tagColStruct` payload carries a fixed-width column-length index (K × `uint32` LE) right after the shape declaration. Backpatched by the encoder; never set on non-columnar payloads. |
 
@@ -98,6 +98,9 @@ bit:  7   6   5   4      3            2          1          0
 | `tagPackALP` | `0xF4` | ALP decimal-coded `[]float64` |
 | `tagColStrDict` | `0xF5` | Dictionary-coded string column (inside `tagColStruct`) |
 | `tagColStrFSST` | `0xF6` | FSST-coded string column (symbol table + per-row code streams), inside `tagColStruct` |
+| `tagHybridColStruct` | `0xF7` | Hybrid columnar container: a `[]struct` with mixed fields — eligible columns transposed, the rest kept as a per-row residual tail. Shape lists every field; residual entries carry kind byte `0xFF`. |
+| `tagColStrRaw` | `0xF8` | Bulk-materialized string column (inside `tagColStruct`): every value laid down once, length-prefixed, so the decoder builds the whole column in ONE slab allocation. High-cardinality counterpart to `tagColStrDict`. |
+| `tagColStrConst` | `0xF9` | Constant (single-distinct) string column (inside `tagColStruct`): one value + the row count, decoded as `n` shares of one owned string. Emitted on the codegen/`Fast` path where the per-value form does not intern repeats. |
 
 **Other**:
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -198,9 +198,12 @@ So far so msgpack-shaped. The qdf-specific tags start at 0xE0:
 0xF4  tagPackALP        (QPack)   ALP decimal-coded []float64 slice
 0xF5  tagColStrDict     (QPack)   dictionary-coded string column (inside columnar)
 0xF6  tagColStrFSST     (QPack)   FSST-coded string column (inside columnar)
+0xF7  tagHybridColStruct (QPack)  hybrid columnar container (mixed []struct)
+0xF8  tagColStrRaw      (QPack)   bulk-slab string column (inside columnar)
+0xF9  tagColStrConst    (QPack)   constant string column (inside columnar)
 ```
 
-Tags 0xF7..0xFF are reserved.
+Tags 0xFA..0xFF are reserved.
 
 A `tagStateRef` payload is `varuint(id)`. A `tagStateMTF` payload is
 `varuint(rank)` where rank 0 means "most recently emitted". A

--- a/internal/codegen_test/codegen_columnar_test.go
+++ b/internal/codegen_test/codegen_columnar_test.go
@@ -229,3 +229,77 @@ func BenchmarkColumnarCodegen_EventLog_Decode(b *testing.B) {
 		}
 	}
 }
+
+func TestColumnarCodegen_BlobColumn_RoundTrip(t *testing.T) {
+	in := GenBlobSet{}
+	for i := 0; i < 40; i++ {
+		in.Rows = append(in.Rows, GenBlobRow{ID: int64(i), Data: []byte{byte(i), byte(i + 1), byte(i * 2)}})
+	}
+	buf, err := (&in).MarshalQDF(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(buf, []byte{0xEF}) {
+		t.Fatal("expected columnar frame for []byte column")
+	}
+	var got GenBlobSet
+	if _, err := (&got).UnmarshalQDF(buf); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Rows) != len(in.Rows) {
+		t.Fatalf("len mismatch %d", len(got.Rows))
+	}
+	for i := range in.Rows {
+		if got.Rows[i].ID != in.Rows[i].ID || !bytes.Equal(got.Rows[i].Data, in.Rows[i].Data) {
+			t.Fatalf("row[%d]=%+v want %+v", i, got.Rows[i], in.Rows[i])
+		}
+	}
+}
+
+func TestColumnarCodegen_NullableColumns_RoundTrip(t *testing.T) {
+	pi := func(v int32) *int32 { return &v }
+	ps := func(v string) *string { return &v }
+	pb := func(v bool) *bool { return &v }
+	pf := func(v float64) *float64 { return &v }
+	in := GenOptSet{}
+	for i := 0; i < 40; i++ {
+		var r GenOpt
+		if i%2 == 0 {
+			r.A = pi(int32(i))
+		}
+		if i%3 == 0 {
+			r.B = ps([]string{"x", "y"}[i%2])
+		}
+		if i%5 == 0 {
+			r.C = pb(i%10 == 0)
+		}
+		if i%4 == 0 {
+			r.D = pf(float64(i) * 1.25)
+		}
+		in.Rows = append(in.Rows, r)
+	}
+	buf, err := (&in).MarshalQDF(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(buf, []byte{0xEF}) {
+		t.Fatal("expected columnar frame for nullable columns")
+	}
+	var got GenOptSet
+	if _, err := (&got).UnmarshalQDF(buf); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Rows) != len(in.Rows) {
+		t.Fatalf("len mismatch %d", len(got.Rows))
+	}
+	eqI := func(a, b *int32) bool { return (a == nil) == (b == nil) && (a == nil || *a == *b) }
+	eqS := func(a, b *string) bool { return (a == nil) == (b == nil) && (a == nil || *a == *b) }
+	eqB := func(a, b *bool) bool { return (a == nil) == (b == nil) && (a == nil || *a == *b) }
+	eqF := func(a, b *float64) bool { return (a == nil) == (b == nil) && (a == nil || *a == *b) }
+	for i := range in.Rows {
+		g, w := got.Rows[i], in.Rows[i]
+		if !eqI(g.A, w.A) || !eqS(g.B, w.B) || !eqB(g.C, w.C) || !eqF(g.D, w.D) {
+			t.Fatalf("row[%d] mismatch: got %+v want %+v", i, g, w)
+		}
+	}
+}

--- a/internal/codegen_test/codegen_columnar_test.go
+++ b/internal/codegen_test/codegen_columnar_test.go
@@ -3,6 +3,8 @@ package cgsample
 import (
 	"bytes"
 	"testing"
+
+	"github.com/alex60217101990/qdf"
 )
 
 func sampleBatch(n int) GenMetricBatch {
@@ -29,5 +31,51 @@ func TestColumnarCodegen_EncodesColStructFrame(t *testing.T) {
 	// 0xEF == tagColStruct: the Metrics field must be columnar-encoded.
 	if !bytes.Contains(buf, []byte{0xEF}) {
 		t.Fatal("expected a columnar frame (0xEF) in the encoded batch")
+	}
+}
+
+func TestColumnarCodegen_RoundTrip(t *testing.T) {
+	for _, n := range []int{0, 1, 8, 16, 64, 257} { // span gate boundary + nil-ish
+		b := sampleBatch(n)
+		mm := any(&b).(interface {
+			MarshalQDF([]byte) ([]byte, error)
+		})
+		buf, err := mm.MarshalQDF(nil)
+		if err != nil {
+			t.Fatalf("n=%d marshal: %v", n, err)
+		}
+		var got GenMetricBatch
+		um := any(&got).(interface {
+			UnmarshalQDF([]byte) (int, error)
+		})
+		if _, err := um.UnmarshalQDF(buf); err != nil {
+			t.Fatalf("n=%d unmarshal: %v", n, err)
+		}
+		if got.Name != b.Name || len(got.Metrics) != len(b.Metrics) {
+			t.Fatalf("n=%d shape mismatch: %+v", n, got)
+		}
+		for i := range b.Metrics {
+			if got.Metrics[i] != b.Metrics[i] {
+				t.Fatalf("n=%d metric[%d] = %+v, want %+v", n, i, got.Metrics[i], b.Metrics[i])
+			}
+		}
+	}
+}
+
+func TestColumnarCodegen_ReflectInterop(t *testing.T) {
+	b := sampleBatch(64)
+	mm := any(&b).(interface{ MarshalQDF([]byte) ([]byte, error) })
+	buf, err := mm.MarshalQDF(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Reflect decode of generated columnar bytes (GenMetricBatch is Unmarshaler,
+	// so reflect delegates to the generated DecodeQDF).
+	var got GenMetricBatch
+	if err := qdf.Unmarshal(buf, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Metrics) != 64 || got.Metrics[63] != b.Metrics[63] {
+		t.Fatalf("reflect interop mismatch: %+v", got.Metrics[63])
 	}
 }

--- a/internal/codegen_test/codegen_columnar_test.go
+++ b/internal/codegen_test/codegen_columnar_test.go
@@ -193,3 +193,39 @@ func TestColumnarCodegen_NameList_StringOnlyProbe(t *testing.T) {
 		}
 	}
 }
+
+func benchEventLog() GenEventLog {
+	in := GenEventLog{Source: "svc"}
+	msgs := []string{"connection established", "request handled", "cache miss", "retry scheduled", "auth ok"}
+	for i := 0; i < 2000; i++ {
+		in.Events = append(in.Events, GenEvent{
+			TS:    time.Unix(int64(1_700_000_000+i), int64(i*1000)).UTC(),
+			Level: []string{"INFO", "WARN", "ERROR"}[i%3],
+			Code:  int32(i % 13),
+			Msg:   msgs[i%len(msgs)], // low-cardinality → dict-coded column
+		})
+	}
+	return in
+}
+
+func BenchmarkColumnarCodegen_EventLog_Encode(b *testing.B) {
+	in := benchEventLog()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := (&in).MarshalQDF(nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkColumnarCodegen_EventLog_Decode(b *testing.B) {
+	in := benchEventLog()
+	buf, _ := (&in).MarshalQDF(nil)
+	b.ReportAllocs()
+	for b.Loop() {
+		var out GenEventLog
+		if _, err := (&out).UnmarshalQDF(buf); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/codegen_test/codegen_columnar_test.go
+++ b/internal/codegen_test/codegen_columnar_test.go
@@ -3,6 +3,7 @@ package cgsample
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/alex60217101990/qdf"
 )
@@ -77,5 +78,118 @@ func TestColumnarCodegen_ReflectInterop(t *testing.T) {
 	}
 	if len(got.Metrics) != 64 || got.Metrics[63] != b.Metrics[63] {
 		t.Fatalf("reflect interop mismatch: %+v", got.Metrics[63])
+	}
+}
+
+func marshalQDF(t *testing.T, v interface{ MarshalQDF([]byte) ([]byte, error) }) []byte {
+	t.Helper()
+	b, err := v.MarshalQDF(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestColumnarCodegen_EventLog_PureStringTimeNumeric(t *testing.T) {
+	in := GenEventLog{Source: "svc"}
+	for i := 0; i < 64; i++ {
+		in.Events = append(in.Events, GenEvent{
+			TS:    time.Unix(int64(1_700_000_000+i), int64(i*1000)).UTC(),
+			Level: []string{"INFO", "WARN", "ERROR"}[i%3],
+			Code:  int32(i % 13),
+			Msg:   "event message",
+		})
+	}
+	buf := marshalQDF(t, &in)
+	if !bytes.Contains(buf, []byte{0xEF}) {
+		t.Fatal("expected pure columnar frame (0xEF)")
+	}
+	var got GenEventLog
+	if _, err := (&got).UnmarshalQDF(buf); err != nil {
+		t.Fatal(err)
+	}
+	if got.Source != in.Source || len(got.Events) != len(in.Events) {
+		t.Fatalf("shape mismatch: %+v", got)
+	}
+	for i := range in.Events {
+		if !got.Events[i].TS.Equal(in.Events[i].TS) || got.Events[i] != in.Events[i] {
+			t.Fatalf("event[%d]=%+v want %+v", i, got.Events[i], in.Events[i])
+		}
+	}
+}
+
+func TestColumnarCodegen_RowSet_Hybrid(t *testing.T) {
+	in := GenRowSet{}
+	for i := 0; i < 40; i++ {
+		in.Rows = append(in.Rows, GenRow{
+			ID:    int64(i),
+			Name:  []string{"a", "b"}[i%2],
+			Inner: GenRowInner{X: i * 2, Y: "inner"},
+			Tags:  map[string]int{"k": i, "z": i + 1},
+		})
+	}
+	buf := marshalQDF(t, &in)
+	if !bytes.Contains(buf, []byte{0xF7}) {
+		t.Fatal("expected hybrid columnar frame (0xF7)")
+	}
+	var got GenRowSet
+	if _, err := (&got).UnmarshalQDF(buf); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Rows) != len(in.Rows) {
+		t.Fatalf("len mismatch: %d", len(got.Rows))
+	}
+	for i := range in.Rows {
+		if got.Rows[i].ID != in.Rows[i].ID || got.Rows[i].Name != in.Rows[i].Name ||
+			got.Rows[i].Inner != in.Rows[i].Inner || len(got.Rows[i].Tags) != len(in.Rows[i].Tags) {
+			t.Fatalf("row[%d]=%+v want %+v", i, got.Rows[i], in.Rows[i])
+		}
+		for k, v := range in.Rows[i].Tags {
+			if got.Rows[i].Tags[k] != v {
+				t.Fatalf("row[%d].Tags[%s]=%d want %d", i, k, got.Rows[i].Tags[k], v)
+			}
+		}
+	}
+}
+
+func TestColumnarCodegen_NameList_StringOnlyProbe(t *testing.T) {
+	// Low-cardinality → columnar (probe accepts).
+	lo := GenNameList{}
+	for i := 0; i < 64; i++ {
+		lo.Names = append(lo.Names, GenName{First: []string{"Ann", "Bob"}[i%2], Last: "Lee"})
+	}
+	loBuf := marshalQDF(t, &lo)
+	if !bytes.Contains(loBuf, []byte{0xEF}) {
+		t.Fatal("low-cardinality string-only should be columnar")
+	}
+	var loGot GenNameList
+	if _, err := (&loGot).UnmarshalQDF(loBuf); err != nil {
+		t.Fatal(err)
+	}
+	for i := range lo.Names {
+		if loGot.Names[i] != lo.Names[i] {
+			t.Fatalf("lo name[%d]=%v want %v", i, loGot.Names[i], lo.Names[i])
+		}
+	}
+	// High-cardinality → row-major (probe declines), still round-trips.
+	hi := GenNameList{}
+	for i := 0; i < 64; i++ {
+		hi.Names = append(hi.Names, GenName{
+			First: "first-" + string(rune('a'+i%26)) + string(rune('0'+i%10)),
+			Last:  "last-" + string(rune('A'+i%26)) + string(rune('5'+i%5)),
+		})
+	}
+	hiBuf := marshalQDF(t, &hi)
+	if bytes.Contains(hiBuf, []byte{0xEF}) {
+		t.Fatal("high-cardinality string-only should stay row-major")
+	}
+	var hiGot GenNameList
+	if _, err := (&hiGot).UnmarshalQDF(hiBuf); err != nil {
+		t.Fatal(err)
+	}
+	for i := range hi.Names {
+		if hiGot.Names[i] != hi.Names[i] {
+			t.Fatalf("hi name[%d]=%v want %v", i, hiGot.Names[i], hi.Names[i])
+		}
 	}
 }

--- a/internal/codegen_test/codegen_columnar_test.go
+++ b/internal/codegen_test/codegen_columnar_test.go
@@ -1,0 +1,33 @@
+package cgsample
+
+import (
+	"bytes"
+	"testing"
+)
+
+func sampleBatch(n int) GenMetricBatch {
+	b := GenMetricBatch{Name: "host1", Metrics: make([]GenMetric, n)}
+	for i := range b.Metrics {
+		b.Metrics[i] = GenMetric{
+			TS: int64(1000 + i), Value: float64(i) * 0.25,
+			Count: uint32(i * 3), OK: i%2 == 0, Ratio: float32(i) * 1.5,
+		}
+	}
+	return b
+}
+
+func TestColumnarCodegen_EncodesColStructFrame(t *testing.T) {
+	b := sampleBatch(64)
+	m, ok := any(&b).(interface{ MarshalQDF([]byte) ([]byte, error) })
+	if !ok {
+		t.Fatal("GenMetricBatch has no generated MarshalQDF")
+	}
+	buf, err := m.MarshalQDF(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 0xEF == tagColStruct: the Metrics field must be columnar-encoded.
+	if !bytes.Contains(buf, []byte{0xEF}) {
+		t.Fatal("expected a columnar frame (0xEF) in the encoded batch")
+	}
+}

--- a/internal/codegen_test/codegen_columnar_test.go
+++ b/internal/codegen_test/codegen_columnar_test.go
@@ -303,3 +303,33 @@ func TestColumnarCodegen_NullableColumns_RoundTrip(t *testing.T) {
 		}
 	}
 }
+
+// Regression: an all-nil *string nullable column has present=0, so its dense
+// string part is empty. The empty column must emit nothing (not a stray raw
+// block) or the decode cursor desyncs. (agent bug-hunt 2026-06-19)
+func TestColumnarCodegen_AllNilNullableString(t *testing.T) {
+	pi := func(v int32) *int32 { return &v }
+	in := GenOptSet{}
+	for i := 0; i < 20; i++ {
+		in.Rows = append(in.Rows, GenOpt{A: pi(int32(i))}) // B (*string), C, D all nil
+	}
+	buf, err := (&in).MarshalQDF(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got GenOptSet
+	if _, err := (&got).UnmarshalQDF(buf); err != nil {
+		t.Fatalf("all-nil nullable string desync: %v", err)
+	}
+	if len(got.Rows) != len(in.Rows) {
+		t.Fatalf("len mismatch %d", len(got.Rows))
+	}
+	for i := range in.Rows {
+		if got.Rows[i].B != nil {
+			t.Fatalf("row[%d].B should be nil, got %q", i, *got.Rows[i].B)
+		}
+		if got.Rows[i].A == nil || *got.Rows[i].A != int32(i) {
+			t.Fatalf("row[%d].A wrong: %v", i, got.Rows[i].A)
+		}
+	}
+}

--- a/internal/codegen_test/codegen_columnar_test.go
+++ b/internal/codegen_test/codegen_columnar_test.go
@@ -333,3 +333,64 @@ func TestColumnarCodegen_AllNilNullableString(t *testing.T) {
 		}
 	}
 }
+
+// Regression (agent round 2): a nil []byte must decode back to nil (not a
+// non-nil empty slice), and []byte{} must stay non-nil — preserved by routing
+// []byte through the nullable column (presence bit = field != nil).
+func TestColumnarCodegen_NilEmptyByteColumn(t *testing.T) {
+	in := GenBlobSet{}
+	for i := 0; i < 32; i++ {
+		var d []byte
+		switch i % 3 {
+		case 0:
+			d = []byte{byte(i), byte(i + 1)}
+		case 1:
+			d = []byte{} // empty, non-nil
+		default:
+			d = nil // nil
+		}
+		in.Rows = append(in.Rows, GenBlobRow{ID: int64(i), Data: d})
+	}
+	buf, err := (&in).MarshalQDF(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got GenBlobSet
+	if _, err := (&got).UnmarshalQDF(buf); err != nil {
+		t.Fatal(err)
+	}
+	for i := range in.Rows {
+		gn, wn := got.Rows[i].Data == nil, in.Rows[i].Data == nil
+		if gn != wn {
+			t.Fatalf("row[%d] nil-ness: got nil=%v want nil=%v", i, gn, wn)
+		}
+		if !bytes.Equal(got.Rows[i].Data, in.Rows[i].Data) {
+			t.Fatalf("row[%d] data: got %v want %v", i, got.Rows[i].Data, in.Rows[i].Data)
+		}
+	}
+}
+
+// Regression (agent round 2 coverage gap): fields AFTER the columnar []struct
+// field must decode correctly on the shared decoder (colMaxLen reset).
+func TestColumnarCodegen_FieldsAfterColumnar(t *testing.T) {
+	in := GenTrailed{Note: "trailing note", Tail: []int64{7, 8, 9, 10, 11}}
+	for i := 0; i < 40; i++ {
+		in.Rows = append(in.Rows, GenMetric{TS: int64(i), Value: float64(i), Count: uint32(i), OK: i%2 == 0, Ratio: float32(i)})
+	}
+	buf, err := (&in).MarshalQDF(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got GenTrailed
+	if _, err := (&got).UnmarshalQDF(buf); err != nil {
+		t.Fatal(err)
+	}
+	if got.Note != in.Note || len(got.Rows) != len(in.Rows) || len(got.Tail) != len(in.Tail) {
+		t.Fatalf("shape: note=%q rows=%d tail=%v", got.Note, len(got.Rows), got.Tail)
+	}
+	for i := range in.Tail {
+		if got.Tail[i] != in.Tail[i] {
+			t.Fatalf("tail[%d]=%d want %d", i, got.Tail[i], in.Tail[i])
+		}
+	}
+}

--- a/internal/codegen_test/codegen_test.go
+++ b/internal/codegen_test/codegen_test.go
@@ -17,7 +17,7 @@ const generatedFile = "sample_qdf.go"
 func TestGenerate(t *testing.T) {
 	dir, _ := filepath.Abs(".")
 	err := qdfgen.Generate([]string{"./..."}, qdfgen.Options{
-		Types:   []string{"Sample", "Inner", "Edge", "GenMetric", "GenMetricBatch", "GenEvent", "GenEventLog", "GenRowInner", "GenRow", "GenRowSet", "GenName", "GenNameList", "GenBlobRow", "GenBlobSet", "GenOpt", "GenOptSet"},
+		Types:   []string{"Sample", "Inner", "Edge", "GenMetric", "GenMetricBatch", "GenEvent", "GenEventLog", "GenRowInner", "GenRow", "GenRowSet", "GenName", "GenNameList", "GenBlobRow", "GenBlobSet", "GenOpt", "GenOptSet", "GenTrailed"},
 		OutFile: filepath.Join(dir, generatedFile),
 		Verbose: testing.Verbose(),
 	})

--- a/internal/codegen_test/codegen_test.go
+++ b/internal/codegen_test/codegen_test.go
@@ -17,7 +17,7 @@ const generatedFile = "sample_qdf.go"
 func TestGenerate(t *testing.T) {
 	dir, _ := filepath.Abs(".")
 	err := qdfgen.Generate([]string{"./..."}, qdfgen.Options{
-		Types:   []string{"Sample", "Inner", "Edge", "GenMetric", "GenMetricBatch"},
+		Types:   []string{"Sample", "Inner", "Edge", "GenMetric", "GenMetricBatch", "GenEvent", "GenEventLog", "GenRowInner", "GenRow", "GenRowSet", "GenName", "GenNameList"},
 		OutFile: filepath.Join(dir, generatedFile),
 		Verbose: testing.Verbose(),
 	})

--- a/internal/codegen_test/codegen_test.go
+++ b/internal/codegen_test/codegen_test.go
@@ -17,7 +17,7 @@ const generatedFile = "sample_qdf.go"
 func TestGenerate(t *testing.T) {
 	dir, _ := filepath.Abs(".")
 	err := qdfgen.Generate([]string{"./..."}, qdfgen.Options{
-		Types:   []string{"Sample", "Inner", "Edge", "GenMetric", "GenMetricBatch", "GenEvent", "GenEventLog", "GenRowInner", "GenRow", "GenRowSet", "GenName", "GenNameList"},
+		Types:   []string{"Sample", "Inner", "Edge", "GenMetric", "GenMetricBatch", "GenEvent", "GenEventLog", "GenRowInner", "GenRow", "GenRowSet", "GenName", "GenNameList", "GenBlobRow", "GenBlobSet", "GenOpt", "GenOptSet"},
 		OutFile: filepath.Join(dir, generatedFile),
 		Verbose: testing.Verbose(),
 	})

--- a/internal/codegen_test/codegen_test.go
+++ b/internal/codegen_test/codegen_test.go
@@ -17,7 +17,7 @@ const generatedFile = "sample_qdf.go"
 func TestGenerate(t *testing.T) {
 	dir, _ := filepath.Abs(".")
 	err := qdfgen.Generate([]string{"./..."}, qdfgen.Options{
-		Types:   []string{"Sample", "Inner", "Edge"},
+		Types:   []string{"Sample", "Inner", "Edge", "GenMetric", "GenMetricBatch"},
 		OutFile: filepath.Join(dir, generatedFile),
 		Verbose: testing.Verbose(),
 	})

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -405,35 +405,35 @@ func (v *GenMetricBatch) EncodeQDF(e *qdf.Encoder) error {
 	} else if len(v.Metrics) >= 16 { // columnarMinElems
 		col29 := v.Metrics
 		e.WriteColStructHeader(len(col29), qdfColNames_GenMetric, qdfColKinds_GenMetric)
-		c30 := make([]int64, len(col29))
+		c30 := e.ScratchInt(len(col29))
 		for i := range col29 {
 			c30[i] = int64(col29[i].TS)
 		}
 		if err := e.WriteIntColumn(c30); err != nil {
 			return err
 		}
-		c31 := make([]float64, len(col29))
+		c31 := e.ScratchFloat64(len(col29))
 		for i := range col29 {
 			c31[i] = float64(col29[i].Value)
 		}
 		if err := e.WriteFloat64Column(c31); err != nil {
 			return err
 		}
-		c32 := make([]uint64, len(col29))
+		c32 := e.ScratchUint(len(col29))
 		for i := range col29 {
 			c32[i] = uint64(col29[i].Count)
 		}
 		if err := e.WriteUintColumn(c32); err != nil {
 			return err
 		}
-		c33 := make([]bool, len(col29))
+		c33 := e.ScratchBool(len(col29))
 		for i := range col29 {
 			c33[i] = col29[i].OK
 		}
 		if err := e.WriteBoolColumn(c33); err != nil {
 			return err
 		}
-		c34 := make([]float32, len(col29))
+		c34 := e.ScratchFloat32(len(col29))
 		for i := range col29 {
 			c34[i] = float32(col29[i].Ratio)
 		}

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -10,25 +10,36 @@ import (
 // Pre-encoded field-name headers (fixstr / strN). Lets the hot path
 // emit a name with a single append, no per-call sizing.
 var (
-	qdfFieldHdr_base_a_1  = []byte{0x86, 0x62, 0x61, 0x73, 0x65, 0x5f, 0x61}
-	qdfFieldHdr_base_b_2  = []byte{0x86, 0x62, 0x61, 0x73, 0x65, 0x5f, 0x62}
-	qdfFieldHdr_labels_3  = []byte{0x86, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x73}
-	qdfFieldHdr_ptr_4     = []byte{0x83, 0x70, 0x74, 0x72}
-	qdfFieldHdr_tail_5    = []byte{0x84, 0x74, 0x61, 0x69, 0x6c}
-	qdfFieldHdr_x_17      = []byte{0x81, 0x78}
-	qdfFieldHdr_y_18      = []byte{0x81, 0x79}
-	qdfFieldHdr_name_21   = []byte{0x84, 0x6e, 0x61, 0x6d, 0x65}
-	qdfFieldHdr_age_22    = []byte{0x83, 0x61, 0x67, 0x65}
-	qdfFieldHdr_active_23 = []byte{0x86, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65}
-	qdfFieldHdr_score_24  = []byte{0x85, 0x73, 0x63, 0x6f, 0x72, 0x65}
-	qdfFieldHdr_tags_25   = []byte{0x84, 0x74, 0x61, 0x67, 0x73}
-	qdfFieldHdr_meta_26   = []byte{0x84, 0x6d, 0x65, 0x74, 0x61}
-	qdfFieldHdr_inner_27  = []byte{0x85, 0x69, 0x6e, 0x6e, 0x65, 0x72}
-	qdfFieldHdr_when_28   = []byte{0x84, 0x77, 0x68, 0x65, 0x6e}
-	qdfFieldHdr_buf_29    = []byte{0x83, 0x62, 0x75, 0x66}
-	qdfFieldHdr_opt_30    = []byte{0x83, 0x6f, 0x70, 0x74}
-	qdfFieldHdr_counts_31 = []byte{0x86, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73}
+	qdfFieldHdr_base_a_1   = []byte{0x86, 0x62, 0x61, 0x73, 0x65, 0x5f, 0x61}
+	qdfFieldHdr_base_b_2   = []byte{0x86, 0x62, 0x61, 0x73, 0x65, 0x5f, 0x62}
+	qdfFieldHdr_labels_3   = []byte{0x86, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x73}
+	qdfFieldHdr_ptr_4      = []byte{0x83, 0x70, 0x74, 0x72}
+	qdfFieldHdr_tail_5     = []byte{0x84, 0x74, 0x61, 0x69, 0x6c}
+	qdfFieldHdr_ts_17      = []byte{0x82, 0x74, 0x73}
+	qdfFieldHdr_value_18   = []byte{0x85, 0x76, 0x61, 0x6c, 0x75, 0x65}
+	qdfFieldHdr_count_19   = []byte{0x85, 0x63, 0x6f, 0x75, 0x6e, 0x74}
+	qdfFieldHdr_ok_20      = []byte{0x82, 0x6f, 0x6b}
+	qdfFieldHdr_ratio_21   = []byte{0x85, 0x72, 0x61, 0x74, 0x69, 0x6f}
+	qdfFieldHdr_name_27    = []byte{0x84, 0x6e, 0x61, 0x6d, 0x65}
+	qdfFieldHdr_metrics_28 = []byte{0x87, 0x6d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73}
+	qdfFieldHdr_x_39       = []byte{0x81, 0x78}
+	qdfFieldHdr_y_40       = []byte{0x81, 0x79}
+	qdfFieldHdr_age_43     = []byte{0x83, 0x61, 0x67, 0x65}
+	qdfFieldHdr_active_44  = []byte{0x86, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65}
+	qdfFieldHdr_score_45   = []byte{0x85, 0x73, 0x63, 0x6f, 0x72, 0x65}
+	qdfFieldHdr_tags_46    = []byte{0x84, 0x74, 0x61, 0x67, 0x73}
+	qdfFieldHdr_meta_47    = []byte{0x84, 0x6d, 0x65, 0x74, 0x61}
+	qdfFieldHdr_inner_48   = []byte{0x85, 0x69, 0x6e, 0x6e, 0x65, 0x72}
+	qdfFieldHdr_when_49    = []byte{0x84, 0x77, 0x68, 0x65, 0x6e}
+	qdfFieldHdr_buf_50     = []byte{0x83, 0x62, 0x75, 0x66}
+	qdfFieldHdr_opt_51     = []byte{0x83, 0x6f, 0x70, 0x74}
+	qdfFieldHdr_counts_52  = []byte{0x86, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73}
 )
+
+// Columnar shape descriptors: per element-type column names and kind
+// bytes for the monomorphized tagColStruct transpose path.
+var qdfColNames_GenMetric = []string{"ts", "value", "count", "ok", "ratio"}
+var qdfColKinds_GenMetric = []byte{0x00, 0x02, 0x01, 0x03, 0x06}
 
 // MarshalQDF appends a qdf-encoded representation of v to dst and returns
 // the extended slice.
@@ -225,6 +236,326 @@ func (v *Edge) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, er
 
 // MarshalQDF appends a qdf-encoded representation of v to dst and returns
 // the extended slice.
+func (v *GenMetric) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenMetric byte
+var qdfFieldHdrs_GenMetric = [][]byte{qdfFieldHdr_ts_17, qdfFieldHdr_value_18, qdfFieldHdr_count_19, qdfFieldHdr_ok_20, qdfFieldHdr_ratio_21}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenMetric) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenMetric, qdfFieldHdrs_GenMetric)
+	e.WriteInt(int64(v.TS))
+	e.WriteFloat64(float64(v.Value))
+	e.WriteUint(uint64(v.Count))
+	e.WriteBool(bool(v.OK))
+	e.WriteFloat32(float32(v.Ratio))
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenMetric) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenMetric) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "ts":
+		{
+			rv22, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v.TS = int64(rv22)
+		}
+	case "value":
+		{
+			rv23, err := d.ReadFloat64()
+			if err != nil {
+				return err
+			}
+			v.Value = rv23
+		}
+	case "count":
+		{
+			rv24, err := d.ReadUint()
+			if err != nil {
+				return err
+			}
+			v.Count = uint32(rv24)
+		}
+	case "ok":
+		{
+			rv25, err := d.ReadBool()
+			if err != nil {
+				return err
+			}
+			v.OK = rv25
+		}
+	case "ratio":
+		{
+			rv26, err := d.ReadFloat32()
+			if err != nil {
+				return err
+			}
+			v.Ratio = rv26
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenMetric) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenMetric) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenMetric) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
+func (v *GenMetricBatch) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenMetricBatch byte
+var qdfFieldHdrs_GenMetricBatch = [][]byte{qdfFieldHdr_name_27, qdfFieldHdr_metrics_28}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenMetricBatch) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenMetricBatch, qdfFieldHdrs_GenMetricBatch)
+	e.WriteString(string(v.Name))
+	if v.Metrics == nil {
+		e.WriteNil()
+	} else if len(v.Metrics) >= 16 { // columnarMinElems
+		col29 := v.Metrics
+		e.WriteColStructHeader(len(col29), qdfColNames_GenMetric, qdfColKinds_GenMetric)
+		c30 := make([]int64, len(col29))
+		for i := range col29 {
+			c30[i] = int64(col29[i].TS)
+		}
+		if err := e.WriteIntColumn(c30); err != nil {
+			return err
+		}
+		c31 := make([]float64, len(col29))
+		for i := range col29 {
+			c31[i] = float64(col29[i].Value)
+		}
+		if err := e.WriteFloat64Column(c31); err != nil {
+			return err
+		}
+		c32 := make([]uint64, len(col29))
+		for i := range col29 {
+			c32[i] = uint64(col29[i].Count)
+		}
+		if err := e.WriteUintColumn(c32); err != nil {
+			return err
+		}
+		c33 := make([]bool, len(col29))
+		for i := range col29 {
+			c33[i] = col29[i].OK
+		}
+		if err := e.WriteBoolColumn(c33); err != nil {
+			return err
+		}
+		c34 := make([]float32, len(col29))
+		for i := range col29 {
+			c34[i] = float32(col29[i].Ratio)
+		}
+		if err := e.WriteFloat32Column(c34); err != nil {
+			return err
+		}
+	} else {
+		e.WriteArrayHeader(len(v.Metrics))
+		for i35 := range v.Metrics {
+			if err := qdf.EncodeNested(e, &v.Metrics[i35]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenMetricBatch) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "name":
+		{
+			rv36, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Name = rv36
+		}
+	case "metrics":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Metrics = nil
+			} else {
+				n37, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n37, 1); err != nil {
+					return err
+				}
+				v.Metrics = make([]GenMetric, n37)
+				for i38 := range n37 {
+					if err := qdf.DecodeNested(d, &v.Metrics[i38]); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenMetricBatch) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenMetricBatch) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenMetricBatch) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
 func (v *Inner) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
@@ -240,7 +571,7 @@ func (v *Inner) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_Inner byte
-var qdfFieldHdrs_Inner = [][]byte{qdfFieldHdr_x_17, qdfFieldHdr_y_18}
+var qdfFieldHdrs_Inner = [][]byte{qdfFieldHdr_x_39, qdfFieldHdr_y_40}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -282,19 +613,19 @@ func (v *Inner) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "x":
 		{
-			rv19, err := d.ReadInt()
+			rv41, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.X = int(rv19)
+			v.X = int(rv41)
 		}
 	case "y":
 		{
-			rv20, err := d.ReadFloat64()
+			rv42, err := d.ReadFloat64()
 			if err != nil {
 				return err
 			}
-			v.Y = rv20
+			v.Y = rv42
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -355,7 +686,7 @@ func (v *Sample) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_Sample byte
-var qdfFieldHdrs_Sample = [][]byte{qdfFieldHdr_name_21, qdfFieldHdr_age_22, qdfFieldHdr_active_23, qdfFieldHdr_score_24, qdfFieldHdr_tags_25, qdfFieldHdr_meta_26, qdfFieldHdr_inner_27, qdfFieldHdr_when_28, qdfFieldHdr_buf_29, qdfFieldHdr_opt_30, qdfFieldHdr_counts_31}
+var qdfFieldHdrs_Sample = [][]byte{qdfFieldHdr_name_27, qdfFieldHdr_age_43, qdfFieldHdr_active_44, qdfFieldHdr_score_45, qdfFieldHdr_tags_46, qdfFieldHdr_meta_47, qdfFieldHdr_inner_48, qdfFieldHdr_when_49, qdfFieldHdr_buf_50, qdfFieldHdr_opt_51, qdfFieldHdr_counts_52}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -369,17 +700,17 @@ func (v *Sample) EncodeQDF(e *qdf.Encoder) error {
 		e.WriteNil()
 	} else {
 		e.WriteArrayHeader(len(v.Tags))
-		for i32 := range v.Tags {
-			e.WriteString(string(v.Tags[i32]))
+		for i53 := range v.Tags {
+			e.WriteString(string(v.Tags[i53]))
 		}
 	}
 	if v.Meta == nil {
 		e.WriteNil()
 	} else {
 		e.WriteMapHeader(len(v.Meta))
-		for k33, vv34 := range v.Meta {
-			e.WriteString(string(k33))
-			e.WriteString(string(vv34))
+		for k54, vv55 := range v.Meta {
+			e.WriteString(string(k54))
+			e.WriteString(string(vv55))
 		}
 	}
 	if err := qdf.EncodeNested(e, &v.Inner); err != nil {
@@ -402,8 +733,8 @@ func (v *Sample) EncodeQDF(e *qdf.Encoder) error {
 		}
 	}
 	e.WriteArrayHeader(3)
-	for i35 := range v.Counts {
-		e.WriteInt(int64(v.Counts[i35]))
+	for i56 := range v.Counts {
+		e.WriteInt(int64(v.Counts[i56]))
 	}
 	return nil
 }
@@ -439,35 +770,35 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "name":
 		{
-			rv36, err := d.ReadString()
+			rv57, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv36
+			v.Name = rv57
 		}
 	case "age":
 		{
-			rv37, err := d.ReadInt()
+			rv58, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.Age = int(rv37)
+			v.Age = int(rv58)
 		}
 	case "active":
 		{
-			rv38, err := d.ReadBool()
+			rv59, err := d.ReadBool()
 			if err != nil {
 				return err
 			}
-			v.Active = rv38
+			v.Active = rv59
 		}
 	case "score":
 		{
-			rv39, err := d.ReadFloat64()
+			rv60, err := d.ReadFloat64()
 			if err != nil {
 				return err
 			}
-			v.Score = rv39
+			v.Score = rv60
 		}
 	case "tags":
 		{
@@ -478,21 +809,21 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Tags = nil
 			} else {
-				n40, err := d.ReadArrayHeader()
+				n61, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n40, 1); err != nil {
+				if err := d.CheckLength(n61, 1); err != nil {
 					return err
 				}
-				v.Tags = make([]string, n40)
-				for i41 := range n40 {
+				v.Tags = make([]string, n61)
+				for i62 := range n61 {
 					{
-						rv42, err := d.ReadString()
+						rv63, err := d.ReadString()
 						if err != nil {
 							return err
 						}
-						v.Tags[i41] = rv42
+						v.Tags[i62] = rv63
 					}
 				}
 			}
@@ -506,30 +837,30 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Meta = nil
 			} else {
-				n43, err := d.ReadMapHeader()
+				n64, err := d.ReadMapHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n43, 1); err != nil {
+				if err := d.CheckLength(n64, 1); err != nil {
 					return err
 				}
-				v.Meta = make(map[string]string, n43)
-				for range n43 {
-					var k44 string
-					var vv45 string
-					kb46, err := d.ReadStringBytes()
+				v.Meta = make(map[string]string, n64)
+				for range n64 {
+					var k65 string
+					var vv66 string
+					kb67, err := d.ReadStringBytes()
 					if err != nil {
 						return err
 					}
-					k44 = string(d.InternKey(kb46))
+					k65 = string(d.InternKey(kb67))
 					{
-						rv47, err := d.ReadString()
+						rv68, err := d.ReadString()
 						if err != nil {
 							return err
 						}
-						vv45 = rv47
+						vv66 = rv68
 					}
-					v.Meta[k44] = vv45
+					v.Meta[k65] = vv66
 				}
 			}
 		}
@@ -539,11 +870,11 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 		}
 	case "when":
 		{
-			sec48, nsec49, err := d.ReadTimestamp()
+			sec69, nsec70, err := d.ReadTimestamp()
 			if err != nil {
 				return err
 			}
-			v.When = time.Unix(sec48, int64(nsec49)).UTC()
+			v.When = time.Unix(sec69, int64(nsec70)).UTC()
 		}
 	case "buf":
 		{
@@ -578,20 +909,20 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 		}
 	case "counts":
 		{
-			n50, err := d.ReadArrayHeader()
+			n71, err := d.ReadArrayHeader()
 			if err != nil {
 				return err
 			}
-			if n50 != 3 {
+			if n71 != 3 {
 				return qdf.ErrTypeMismatch
 			}
-			for i51 := range 3 {
+			for i72 := range 3 {
 				{
-					rv52, err := d.ReadInt()
+					rv73, err := d.ReadInt()
 					if err != nil {
 						return err
 					}
-					v.Counts[i51] = int32(rv52)
+					v.Counts[i72] = int32(rv73)
 				}
 			}
 		}

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -5,6 +5,7 @@ package cgsample
 import (
 	"github.com/alex60217101990/qdf"
 	"time"
+	"unsafe"
 )
 
 // Pre-encoded field-name headers (fixstr / strN). Lets the hot path
@@ -15,45 +16,54 @@ var (
 	qdfFieldHdr_labels_3   = []byte{0x86, 0x6c, 0x61, 0x62, 0x65, 0x6c, 0x73}
 	qdfFieldHdr_ptr_4      = []byte{0x83, 0x70, 0x74, 0x72}
 	qdfFieldHdr_tail_5     = []byte{0x84, 0x74, 0x61, 0x69, 0x6c}
-	qdfFieldHdr_ts_17      = []byte{0x82, 0x74, 0x73}
-	qdfFieldHdr_level_18   = []byte{0x85, 0x6c, 0x65, 0x76, 0x65, 0x6c}
-	qdfFieldHdr_code_19    = []byte{0x84, 0x63, 0x6f, 0x64, 0x65}
-	qdfFieldHdr_msg_20     = []byte{0x83, 0x6d, 0x73, 0x67}
-	qdfFieldHdr_source_26  = []byte{0x86, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65}
-	qdfFieldHdr_events_27  = []byte{0x86, 0x65, 0x76, 0x65, 0x6e, 0x74, 0x73}
-	qdfFieldHdr_value_50   = []byte{0x85, 0x76, 0x61, 0x6c, 0x75, 0x65}
-	qdfFieldHdr_count_51   = []byte{0x85, 0x63, 0x6f, 0x75, 0x6e, 0x74}
-	qdfFieldHdr_ok_52      = []byte{0x82, 0x6f, 0x6b}
-	qdfFieldHdr_ratio_53   = []byte{0x85, 0x72, 0x61, 0x74, 0x69, 0x6f}
-	qdfFieldHdr_name_59    = []byte{0x84, 0x6e, 0x61, 0x6d, 0x65}
-	qdfFieldHdr_metrics_60 = []byte{0x87, 0x6d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73}
-	qdfFieldHdr_first_80   = []byte{0x85, 0x66, 0x69, 0x72, 0x73, 0x74}
-	qdfFieldHdr_last_81    = []byte{0x84, 0x6c, 0x61, 0x73, 0x74}
-	qdfFieldHdr_names_84   = []byte{0x85, 0x6e, 0x61, 0x6d, 0x65, 0x73}
-	qdfFieldHdr_id_100     = []byte{0x82, 0x69, 0x64}
-	qdfFieldHdr_inner_101  = []byte{0x85, 0x69, 0x6e, 0x6e, 0x65, 0x72}
-	qdfFieldHdr_tags_102   = []byte{0x84, 0x74, 0x61, 0x67, 0x73}
-	qdfFieldHdr_x_112      = []byte{0x81, 0x78}
-	qdfFieldHdr_y_113      = []byte{0x81, 0x79}
-	qdfFieldHdr_rows_116   = []byte{0x84, 0x72, 0x6f, 0x77, 0x73}
-	qdfFieldHdr_age_139    = []byte{0x83, 0x61, 0x67, 0x65}
-	qdfFieldHdr_active_140 = []byte{0x86, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65}
-	qdfFieldHdr_score_141  = []byte{0x85, 0x73, 0x63, 0x6f, 0x72, 0x65}
-	qdfFieldHdr_meta_142   = []byte{0x84, 0x6d, 0x65, 0x74, 0x61}
-	qdfFieldHdr_when_143   = []byte{0x84, 0x77, 0x68, 0x65, 0x6e}
-	qdfFieldHdr_buf_144    = []byte{0x83, 0x62, 0x75, 0x66}
-	qdfFieldHdr_opt_145    = []byte{0x83, 0x6f, 0x70, 0x74}
-	qdfFieldHdr_counts_146 = []byte{0x86, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73}
+	qdfFieldHdr_id_17      = []byte{0x82, 0x69, 0x64}
+	qdfFieldHdr_data_18    = []byte{0x84, 0x64, 0x61, 0x74, 0x61}
+	qdfFieldHdr_rows_20    = []byte{0x84, 0x72, 0x6f, 0x77, 0x73}
+	qdfFieldHdr_ts_33      = []byte{0x82, 0x74, 0x73}
+	qdfFieldHdr_level_34   = []byte{0x85, 0x6c, 0x65, 0x76, 0x65, 0x6c}
+	qdfFieldHdr_code_35    = []byte{0x84, 0x63, 0x6f, 0x64, 0x65}
+	qdfFieldHdr_msg_36     = []byte{0x83, 0x6d, 0x73, 0x67}
+	qdfFieldHdr_source_42  = []byte{0x86, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65}
+	qdfFieldHdr_events_43  = []byte{0x86, 0x65, 0x76, 0x65, 0x6e, 0x74, 0x73}
+	qdfFieldHdr_value_66   = []byte{0x85, 0x76, 0x61, 0x6c, 0x75, 0x65}
+	qdfFieldHdr_count_67   = []byte{0x85, 0x63, 0x6f, 0x75, 0x6e, 0x74}
+	qdfFieldHdr_ok_68      = []byte{0x82, 0x6f, 0x6b}
+	qdfFieldHdr_ratio_69   = []byte{0x85, 0x72, 0x61, 0x74, 0x69, 0x6f}
+	qdfFieldHdr_name_75    = []byte{0x84, 0x6e, 0x61, 0x6d, 0x65}
+	qdfFieldHdr_metrics_76 = []byte{0x87, 0x6d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73}
+	qdfFieldHdr_first_96   = []byte{0x85, 0x66, 0x69, 0x72, 0x73, 0x74}
+	qdfFieldHdr_last_97    = []byte{0x84, 0x6c, 0x61, 0x73, 0x74}
+	qdfFieldHdr_names_100  = []byte{0x85, 0x6e, 0x61, 0x6d, 0x65, 0x73}
+	qdfFieldHdr_a_116      = []byte{0x81, 0x61}
+	qdfFieldHdr_b_117      = []byte{0x81, 0x62}
+	qdfFieldHdr_c_118      = []byte{0x81, 0x63}
+	qdfFieldHdr_d_119      = []byte{0x81, 0x64}
+	qdfFieldHdr_inner_164  = []byte{0x85, 0x69, 0x6e, 0x6e, 0x65, 0x72}
+	qdfFieldHdr_tags_165   = []byte{0x84, 0x74, 0x61, 0x67, 0x73}
+	qdfFieldHdr_x_175      = []byte{0x81, 0x78}
+	qdfFieldHdr_y_176      = []byte{0x81, 0x79}
+	qdfFieldHdr_age_201    = []byte{0x83, 0x61, 0x67, 0x65}
+	qdfFieldHdr_active_202 = []byte{0x86, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65}
+	qdfFieldHdr_score_203  = []byte{0x85, 0x73, 0x63, 0x6f, 0x72, 0x65}
+	qdfFieldHdr_meta_204   = []byte{0x84, 0x6d, 0x65, 0x74, 0x61}
+	qdfFieldHdr_when_205   = []byte{0x84, 0x77, 0x68, 0x65, 0x6e}
+	qdfFieldHdr_buf_206    = []byte{0x83, 0x62, 0x75, 0x66}
+	qdfFieldHdr_opt_207    = []byte{0x83, 0x6f, 0x70, 0x74}
+	qdfFieldHdr_counts_208 = []byte{0x86, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73}
 )
 
 // Columnar shape descriptors: per element-type column names and kind
 // bytes for the monomorphized tagColStruct transpose path.
+var qdfColNames_GenBlobRow = []string{"id", "data"}
+var qdfColKinds_GenBlobRow = []byte{0x00, 0x04}
 var qdfColNames_GenEvent = []string{"ts", "level", "code", "msg"}
 var qdfColKinds_GenEvent = []byte{0x05, 0x04, 0x00, 0x04}
 var qdfColNames_GenMetric = []string{"ts", "value", "count", "ok", "ratio"}
 var qdfColKinds_GenMetric = []byte{0x00, 0x02, 0x01, 0x03, 0x06}
 var qdfColNames_GenName = []string{"first", "last"}
 var qdfColKinds_GenName = []byte{0x04, 0x04}
+var qdfColNames_GenOpt = []string{"a", "b", "c", "d"}
+var qdfColKinds_GenOpt = []byte{0x80, 0x84, 0x83, 0x82}
 var qdfHybNames_GenRow = []string{"id", "name", "inner", "tags"}
 var qdfHybKinds_GenRow = []byte{0x00, 0x04, 0xff, 0xff}
 
@@ -252,6 +262,308 @@ func (v *Edge) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, er
 
 // MarshalQDF appends a qdf-encoded representation of v to dst and returns
 // the extended slice.
+func (v *GenBlobRow) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenBlobRow byte
+var qdfFieldHdrs_GenBlobRow = [][]byte{qdfFieldHdr_id_17, qdfFieldHdr_data_18}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenBlobRow) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenBlobRow, qdfFieldHdrs_GenBlobRow)
+	e.WriteInt(int64(v.ID))
+	if v.Data == nil {
+		e.WriteNil()
+	} else {
+		e.WriteBytes([]byte(v.Data))
+	}
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenBlobRow) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenBlobRow) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "id":
+		{
+			rv19, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v.ID = int64(rv19)
+		}
+	case "data":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Data = nil
+			} else {
+				_v, err := d.ReadBytes()
+				if err != nil {
+					return err
+				}
+				v.Data = _v
+			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenBlobRow) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenBlobRow) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenBlobRow) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
+func (v *GenBlobSet) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenBlobSet byte
+var qdfFieldHdrs_GenBlobSet = [][]byte{qdfFieldHdr_rows_20}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenBlobSet) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenBlobSet, qdfFieldHdrs_GenBlobSet)
+	if v.Rows == nil {
+		e.WriteNil()
+	} else if len(v.Rows) >= 16 { // columnarMinElems
+		col21 := v.Rows
+		e.WriteColStructHeader(len(col21), qdfColNames_GenBlobRow, qdfColKinds_GenBlobRow)
+		c22 := e.ScratchInt(len(col21))
+		for i := range col21 {
+			c22[i] = int64(col21[i].ID)
+		}
+		if err := e.WriteIntColumn(c22); err != nil {
+			return err
+		}
+		c23 := e.ScratchString(len(col21))
+		for i := range col21 {
+			c23[i] = unsafe.String(unsafe.SliceData(col21[i].Data), len(col21[i].Data))
+		}
+		e.WriteStringColumn(c23)
+	} else {
+		e.WriteArrayHeader(len(v.Rows))
+		for i24 := range v.Rows {
+			if err := qdf.EncodeNested(e, &v.Rows[i24]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenBlobSet) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenBlobSet) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "rows":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Rows = nil
+			} else if d.PeekColStruct() {
+				n25, names26, kinds27, err := d.ReadColStructHeader()
+				if err != nil {
+					return err
+				}
+				_ = kinds27
+				v.Rows = make([]GenBlobRow, n25)
+				for ci28 := range names26 {
+					switch names26[ci28] {
+					case "id":
+						col29, err := d.ReadIntColumn(n25)
+						if err != nil {
+							return err
+						}
+						for i := range col29 {
+							v.Rows[i].ID = int64(col29[i])
+						}
+					case "data":
+						col30, err := d.ReadStringColumn(n25)
+						if err != nil {
+							return err
+						}
+						for i := range col30 {
+							v.Rows[i].Data = []byte([]byte(col30[i]))
+						}
+					default:
+						return qdf.ErrTypeMismatch
+					}
+				}
+			} else {
+				n31, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n31, 1); err != nil {
+					return err
+				}
+				v.Rows = make([]GenBlobRow, n31)
+				for i32 := range n31 {
+					if err := qdf.DecodeNested(d, &v.Rows[i32]); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenBlobSet) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenBlobSet) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenBlobSet) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
 func (v *GenEvent) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
@@ -267,7 +579,7 @@ func (v *GenEvent) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenEvent byte
-var qdfFieldHdrs_GenEvent = [][]byte{qdfFieldHdr_ts_17, qdfFieldHdr_level_18, qdfFieldHdr_code_19, qdfFieldHdr_msg_20}
+var qdfFieldHdrs_GenEvent = [][]byte{qdfFieldHdr_ts_33, qdfFieldHdr_level_34, qdfFieldHdr_code_35, qdfFieldHdr_msg_36}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -314,35 +626,35 @@ func (v *GenEvent) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "ts":
 		{
-			sec21, nsec22, err := d.ReadTimestamp()
+			sec37, nsec38, err := d.ReadTimestamp()
 			if err != nil {
 				return err
 			}
-			v.TS = time.Unix(sec21, int64(nsec22)).UTC()
+			v.TS = time.Unix(sec37, int64(nsec38)).UTC()
 		}
 	case "level":
 		{
-			rv23, err := d.ReadString()
+			rv39, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Level = rv23
+			v.Level = rv39
 		}
 	case "code":
 		{
-			rv24, err := d.ReadInt()
+			rv40, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.Code = int32(rv24)
+			v.Code = int32(rv40)
 		}
 	case "msg":
 		{
-			rv25, err := d.ReadString()
+			rv41, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Msg = rv25
+			v.Msg = rv41
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -403,7 +715,7 @@ func (v *GenEventLog) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenEventLog byte
-var qdfFieldHdrs_GenEventLog = [][]byte{qdfFieldHdr_source_26, qdfFieldHdr_events_27}
+var qdfFieldHdrs_GenEventLog = [][]byte{qdfFieldHdr_source_42, qdfFieldHdr_events_43}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -413,39 +725,39 @@ func (v *GenEventLog) EncodeQDF(e *qdf.Encoder) error {
 	if v.Events == nil {
 		e.WriteNil()
 	} else if len(v.Events) >= 16 { // columnarMinElems
-		col28 := v.Events
-		e.WriteColStructHeader(len(col28), qdfColNames_GenEvent, qdfColKinds_GenEvent)
-		sec30 := e.ScratchInt(len(col28))
-		ns31 := e.ScratchUint(len(col28))
-		for i := range col28 {
-			t32 := col28[i].TS.UTC()
-			sec30[i] = t32.Unix()
-			ns31[i] = uint64(t32.Nanosecond())
+		col44 := v.Events
+		e.WriteColStructHeader(len(col44), qdfColNames_GenEvent, qdfColKinds_GenEvent)
+		sec46 := e.ScratchInt(len(col44))
+		ns47 := e.ScratchUint(len(col44))
+		for i := range col44 {
+			t48 := col44[i].TS.UTC()
+			sec46[i] = t48.Unix()
+			ns47[i] = uint64(t48.Nanosecond())
 		}
-		if err := e.WriteTimeColumn(sec30, ns31); err != nil {
+		if err := e.WriteTimeColumn(sec46, ns47); err != nil {
 			return err
 		}
-		c33 := e.ScratchString(len(col28))
-		for i := range col28 {
-			c33[i] = string(col28[i].Level)
+		c49 := e.ScratchString(len(col44))
+		for i := range col44 {
+			c49[i] = string(col44[i].Level)
 		}
-		e.WriteStringColumn(c33)
-		c34 := e.ScratchInt(len(col28))
-		for i := range col28 {
-			c34[i] = int64(col28[i].Code)
+		e.WriteStringColumn(c49)
+		c50 := e.ScratchInt(len(col44))
+		for i := range col44 {
+			c50[i] = int64(col44[i].Code)
 		}
-		if err := e.WriteIntColumn(c34); err != nil {
+		if err := e.WriteIntColumn(c50); err != nil {
 			return err
 		}
-		c35 := e.ScratchString(len(col28))
-		for i := range col28 {
-			c35[i] = string(col28[i].Msg)
+		c51 := e.ScratchString(len(col44))
+		for i := range col44 {
+			c51[i] = string(col44[i].Msg)
 		}
-		e.WriteStringColumn(c35)
+		e.WriteStringColumn(c51)
 	} else {
 		e.WriteArrayHeader(len(v.Events))
-		for i36 := range v.Events {
-			if err := qdf.EncodeNested(e, &v.Events[i36]); err != nil {
+		for i52 := range v.Events {
+			if err := qdf.EncodeNested(e, &v.Events[i52]); err != nil {
 				return err
 			}
 		}
@@ -484,11 +796,11 @@ func (v *GenEventLog) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "source":
 		{
-			rv37, err := d.ReadString()
+			rv53, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Source = rv37
+			v.Source = rv53
 		}
 	case "events":
 		{
@@ -499,61 +811,61 @@ func (v *GenEventLog) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Events = nil
 			} else if d.PeekColStruct() {
-				n38, names39, kinds40, err := d.ReadColStructHeader()
+				n54, names55, kinds56, err := d.ReadColStructHeader()
 				if err != nil {
 					return err
 				}
-				_ = kinds40
-				v.Events = make([]GenEvent, n38)
-				for ci41 := range names39 {
-					switch names39[ci41] {
+				_ = kinds56
+				v.Events = make([]GenEvent, n54)
+				for ci57 := range names55 {
+					switch names55[ci57] {
 					case "ts":
-						sec43, ns44, err := d.ReadTimeColumn(n38)
+						sec59, ns60, err := d.ReadTimeColumn(n54)
 						if err != nil {
 							return err
 						}
-						for i := range sec43 {
-							v.Events[i].TS = time.Unix(sec43[i], int64(ns44[i])).UTC()
+						for i := range sec59 {
+							v.Events[i].TS = time.Unix(sec59[i], int64(ns60[i])).UTC()
 						}
 					case "level":
-						col45, err := d.ReadStringColumn(n38)
+						col61, err := d.ReadStringColumn(n54)
 						if err != nil {
 							return err
 						}
-						for i := range col45 {
-							v.Events[i].Level = string(col45[i])
+						for i := range col61 {
+							v.Events[i].Level = string(col61[i])
 						}
 					case "code":
-						col46, err := d.ReadIntColumn(n38)
+						col62, err := d.ReadIntColumn(n54)
 						if err != nil {
 							return err
 						}
-						for i := range col46 {
-							v.Events[i].Code = int32(col46[i])
+						for i := range col62 {
+							v.Events[i].Code = int32(col62[i])
 						}
 					case "msg":
-						col47, err := d.ReadStringColumn(n38)
+						col63, err := d.ReadStringColumn(n54)
 						if err != nil {
 							return err
 						}
-						for i := range col47 {
-							v.Events[i].Msg = string(col47[i])
+						for i := range col63 {
+							v.Events[i].Msg = string(col63[i])
 						}
 					default:
 						return qdf.ErrTypeMismatch
 					}
 				}
 			} else {
-				n48, err := d.ReadArrayHeader()
+				n64, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n48, 1); err != nil {
+				if err := d.CheckLength(n64, 1); err != nil {
 					return err
 				}
-				v.Events = make([]GenEvent, n48)
-				for i49 := range n48 {
-					if err := qdf.DecodeNested(d, &v.Events[i49]); err != nil {
+				v.Events = make([]GenEvent, n64)
+				for i65 := range n64 {
+					if err := qdf.DecodeNested(d, &v.Events[i65]); err != nil {
 						return err
 					}
 				}
@@ -618,7 +930,7 @@ func (v *GenMetric) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenMetric byte
-var qdfFieldHdrs_GenMetric = [][]byte{qdfFieldHdr_ts_17, qdfFieldHdr_value_50, qdfFieldHdr_count_51, qdfFieldHdr_ok_52, qdfFieldHdr_ratio_53}
+var qdfFieldHdrs_GenMetric = [][]byte{qdfFieldHdr_ts_33, qdfFieldHdr_value_66, qdfFieldHdr_count_67, qdfFieldHdr_ok_68, qdfFieldHdr_ratio_69}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -663,43 +975,43 @@ func (v *GenMetric) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "ts":
 		{
-			rv54, err := d.ReadInt()
+			rv70, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.TS = int64(rv54)
+			v.TS = int64(rv70)
 		}
 	case "value":
 		{
-			rv55, err := d.ReadFloat64()
+			rv71, err := d.ReadFloat64()
 			if err != nil {
 				return err
 			}
-			v.Value = rv55
+			v.Value = rv71
 		}
 	case "count":
 		{
-			rv56, err := d.ReadUint()
+			rv72, err := d.ReadUint()
 			if err != nil {
 				return err
 			}
-			v.Count = uint32(rv56)
+			v.Count = uint32(rv72)
 		}
 	case "ok":
 		{
-			rv57, err := d.ReadBool()
+			rv73, err := d.ReadBool()
 			if err != nil {
 				return err
 			}
-			v.OK = rv57
+			v.OK = rv73
 		}
 	case "ratio":
 		{
-			rv58, err := d.ReadFloat32()
+			rv74, err := d.ReadFloat32()
 			if err != nil {
 				return err
 			}
-			v.Ratio = rv58
+			v.Ratio = rv74
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -760,7 +1072,7 @@ func (v *GenMetricBatch) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenMetricBatch byte
-var qdfFieldHdrs_GenMetricBatch = [][]byte{qdfFieldHdr_name_59, qdfFieldHdr_metrics_60}
+var qdfFieldHdrs_GenMetricBatch = [][]byte{qdfFieldHdr_name_75, qdfFieldHdr_metrics_76}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -770,47 +1082,47 @@ func (v *GenMetricBatch) EncodeQDF(e *qdf.Encoder) error {
 	if v.Metrics == nil {
 		e.WriteNil()
 	} else if len(v.Metrics) >= 16 { // columnarMinElems
-		col61 := v.Metrics
-		e.WriteColStructHeader(len(col61), qdfColNames_GenMetric, qdfColKinds_GenMetric)
-		c62 := e.ScratchInt(len(col61))
-		for i := range col61 {
-			c62[i] = int64(col61[i].TS)
+		col77 := v.Metrics
+		e.WriteColStructHeader(len(col77), qdfColNames_GenMetric, qdfColKinds_GenMetric)
+		c78 := e.ScratchInt(len(col77))
+		for i := range col77 {
+			c78[i] = int64(col77[i].TS)
 		}
-		if err := e.WriteIntColumn(c62); err != nil {
+		if err := e.WriteIntColumn(c78); err != nil {
 			return err
 		}
-		c63 := e.ScratchFloat64(len(col61))
-		for i := range col61 {
-			c63[i] = float64(col61[i].Value)
+		c79 := e.ScratchFloat64(len(col77))
+		for i := range col77 {
+			c79[i] = float64(col77[i].Value)
 		}
-		if err := e.WriteFloat64Column(c63); err != nil {
+		if err := e.WriteFloat64Column(c79); err != nil {
 			return err
 		}
-		c64 := e.ScratchUint(len(col61))
-		for i := range col61 {
-			c64[i] = uint64(col61[i].Count)
+		c80 := e.ScratchUint(len(col77))
+		for i := range col77 {
+			c80[i] = uint64(col77[i].Count)
 		}
-		if err := e.WriteUintColumn(c64); err != nil {
+		if err := e.WriteUintColumn(c80); err != nil {
 			return err
 		}
-		c65 := e.ScratchBool(len(col61))
-		for i := range col61 {
-			c65[i] = col61[i].OK
+		c81 := e.ScratchBool(len(col77))
+		for i := range col77 {
+			c81[i] = col77[i].OK
 		}
-		if err := e.WriteBoolColumn(c65); err != nil {
+		if err := e.WriteBoolColumn(c81); err != nil {
 			return err
 		}
-		c66 := e.ScratchFloat32(len(col61))
-		for i := range col61 {
-			c66[i] = float32(col61[i].Ratio)
+		c82 := e.ScratchFloat32(len(col77))
+		for i := range col77 {
+			c82[i] = float32(col77[i].Ratio)
 		}
-		if err := e.WriteFloat32Column(c66); err != nil {
+		if err := e.WriteFloat32Column(c82); err != nil {
 			return err
 		}
 	} else {
 		e.WriteArrayHeader(len(v.Metrics))
-		for i67 := range v.Metrics {
-			if err := qdf.EncodeNested(e, &v.Metrics[i67]); err != nil {
+		for i83 := range v.Metrics {
+			if err := qdf.EncodeNested(e, &v.Metrics[i83]); err != nil {
 				return err
 			}
 		}
@@ -849,11 +1161,11 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "name":
 		{
-			rv68, err := d.ReadString()
+			rv84, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv68
+			v.Name = rv84
 		}
 	case "metrics":
 		{
@@ -864,69 +1176,69 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Metrics = nil
 			} else if d.PeekColStruct() {
-				n69, names70, kinds71, err := d.ReadColStructHeader()
+				n85, names86, kinds87, err := d.ReadColStructHeader()
 				if err != nil {
 					return err
 				}
-				_ = kinds71
-				v.Metrics = make([]GenMetric, n69)
-				for ci72 := range names70 {
-					switch names70[ci72] {
+				_ = kinds87
+				v.Metrics = make([]GenMetric, n85)
+				for ci88 := range names86 {
+					switch names86[ci88] {
 					case "ts":
-						col73, err := d.ReadIntColumn(n69)
+						col89, err := d.ReadIntColumn(n85)
 						if err != nil {
 							return err
 						}
-						for i := range col73 {
-							v.Metrics[i].TS = int64(col73[i])
+						for i := range col89 {
+							v.Metrics[i].TS = int64(col89[i])
 						}
 					case "value":
-						col74, err := d.ReadFloat64Column(n69)
+						col90, err := d.ReadFloat64Column(n85)
 						if err != nil {
 							return err
 						}
-						for i := range col74 {
-							v.Metrics[i].Value = float64(col74[i])
+						for i := range col90 {
+							v.Metrics[i].Value = float64(col90[i])
 						}
 					case "count":
-						col75, err := d.ReadUintColumn(n69)
+						col91, err := d.ReadUintColumn(n85)
 						if err != nil {
 							return err
 						}
-						for i := range col75 {
-							v.Metrics[i].Count = uint32(col75[i])
+						for i := range col91 {
+							v.Metrics[i].Count = uint32(col91[i])
 						}
 					case "ok":
-						col76, err := d.ReadBoolColumn(n69)
+						col92, err := d.ReadBoolColumn(n85)
 						if err != nil {
 							return err
 						}
-						for i := range col76 {
-							v.Metrics[i].OK = col76[i]
+						for i := range col92 {
+							v.Metrics[i].OK = col92[i]
 						}
 					case "ratio":
-						col77, err := d.ReadFloat32Column(n69)
+						col93, err := d.ReadFloat32Column(n85)
 						if err != nil {
 							return err
 						}
-						for i := range col77 {
-							v.Metrics[i].Ratio = float32(col77[i])
+						for i := range col93 {
+							v.Metrics[i].Ratio = float32(col93[i])
 						}
 					default:
 						return qdf.ErrTypeMismatch
 					}
 				}
 			} else {
-				n78, err := d.ReadArrayHeader()
+				n94, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n78, 1); err != nil {
+				if err := d.CheckLength(n94, 1); err != nil {
 					return err
 				}
-				v.Metrics = make([]GenMetric, n78)
-				for i79 := range n78 {
-					if err := qdf.DecodeNested(d, &v.Metrics[i79]); err != nil {
+				v.Metrics = make([]GenMetric, n94)
+				for i95 := range n94 {
+					if err := qdf.DecodeNested(d, &v.Metrics[i95]); err != nil {
 						return err
 					}
 				}
@@ -991,7 +1303,7 @@ func (v *GenName) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenName byte
-var qdfFieldHdrs_GenName = [][]byte{qdfFieldHdr_first_80, qdfFieldHdr_last_81}
+var qdfFieldHdrs_GenName = [][]byte{qdfFieldHdr_first_96, qdfFieldHdr_last_97}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -1033,19 +1345,19 @@ func (v *GenName) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "first":
 		{
-			rv82, err := d.ReadString()
+			rv98, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.First = rv82
+			v.First = rv98
 		}
 	case "last":
 		{
-			rv83, err := d.ReadString()
+			rv99, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Last = rv83
+			v.Last = rv99
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -1106,7 +1418,7 @@ func (v *GenNameList) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenNameList byte
-var qdfFieldHdrs_GenNameList = [][]byte{qdfFieldHdr_names_84}
+var qdfFieldHdrs_GenNameList = [][]byte{qdfFieldHdr_names_100}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -1115,45 +1427,45 @@ func (v *GenNameList) EncodeQDF(e *qdf.Encoder) error {
 	if v.Names == nil {
 		e.WriteNil()
 	} else if len(v.Names) >= 16 { // columnarMinElems
-		col85 := v.Names
-		ben86 := false
-		pb87 := e.ScratchString(min(len(col85), 32))
-		for i := range pb87 {
-			pb87[i] = string(col85[i].First)
+		col101 := v.Names
+		ben102 := false
+		pb103 := e.ScratchString(min(len(col101), 32))
+		for i := range pb103 {
+			pb103[i] = string(col101[i].First)
 		}
-		if qdf.StringColumnsBeneficial(pb87) {
-			ben86 = true
+		if qdf.StringColumnsBeneficial(pb103) {
+			ben102 = true
 		}
-		for i := range pb87 {
-			pb87[i] = string(col85[i].Last)
+		for i := range pb103 {
+			pb103[i] = string(col101[i].Last)
 		}
-		if qdf.StringColumnsBeneficial(pb87) {
-			ben86 = true
+		if qdf.StringColumnsBeneficial(pb103) {
+			ben102 = true
 		}
-		if ben86 {
-			e.WriteColStructHeader(len(col85), qdfColNames_GenName, qdfColKinds_GenName)
-			c88 := e.ScratchString(len(col85))
-			for i := range col85 {
-				c88[i] = string(col85[i].First)
+		if ben102 {
+			e.WriteColStructHeader(len(col101), qdfColNames_GenName, qdfColKinds_GenName)
+			c104 := e.ScratchString(len(col101))
+			for i := range col101 {
+				c104[i] = string(col101[i].First)
 			}
-			e.WriteStringColumn(c88)
-			c89 := e.ScratchString(len(col85))
-			for i := range col85 {
-				c89[i] = string(col85[i].Last)
+			e.WriteStringColumn(c104)
+			c105 := e.ScratchString(len(col101))
+			for i := range col101 {
+				c105[i] = string(col101[i].Last)
 			}
-			e.WriteStringColumn(c89)
+			e.WriteStringColumn(c105)
 		} else {
-			e.WriteArrayHeader(len(col85))
-			for i90 := range col85 {
-				if err := qdf.EncodeNested(e, &col85[i90]); err != nil {
+			e.WriteArrayHeader(len(col101))
+			for i106 := range col101 {
+				if err := qdf.EncodeNested(e, &col101[i106]); err != nil {
 					return err
 				}
 			}
 		}
 	} else {
 		e.WriteArrayHeader(len(v.Names))
-		for i91 := range v.Names {
-			if err := qdf.EncodeNested(e, &v.Names[i91]); err != nil {
+		for i107 := range v.Names {
+			if err := qdf.EncodeNested(e, &v.Names[i107]); err != nil {
 				return err
 			}
 		}
@@ -1199,45 +1511,45 @@ func (v *GenNameList) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Names = nil
 			} else if d.PeekColStruct() {
-				n92, names93, kinds94, err := d.ReadColStructHeader()
+				n108, names109, kinds110, err := d.ReadColStructHeader()
 				if err != nil {
 					return err
 				}
-				_ = kinds94
-				v.Names = make([]GenName, n92)
-				for ci95 := range names93 {
-					switch names93[ci95] {
+				_ = kinds110
+				v.Names = make([]GenName, n108)
+				for ci111 := range names109 {
+					switch names109[ci111] {
 					case "first":
-						col96, err := d.ReadStringColumn(n92)
+						col112, err := d.ReadStringColumn(n108)
 						if err != nil {
 							return err
 						}
-						for i := range col96 {
-							v.Names[i].First = string(col96[i])
+						for i := range col112 {
+							v.Names[i].First = string(col112[i])
 						}
 					case "last":
-						col97, err := d.ReadStringColumn(n92)
+						col113, err := d.ReadStringColumn(n108)
 						if err != nil {
 							return err
 						}
-						for i := range col97 {
-							v.Names[i].Last = string(col97[i])
+						for i := range col113 {
+							v.Names[i].Last = string(col113[i])
 						}
 					default:
 						return qdf.ErrTypeMismatch
 					}
 				}
 			} else {
-				n98, err := d.ReadArrayHeader()
+				n114, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n98, 1); err != nil {
+				if err := d.CheckLength(n114, 1); err != nil {
 					return err
 				}
-				v.Names = make([]GenName, n98)
-				for i99 := range n98 {
-					if err := qdf.DecodeNested(d, &v.Names[i99]); err != nil {
+				v.Names = make([]GenName, n114)
+				for i115 := range n114 {
+					if err := qdf.DecodeNested(d, &v.Names[i115]); err != nil {
 						return err
 					}
 				}
@@ -1287,6 +1599,476 @@ func (v *GenNameList) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (
 
 // MarshalQDF appends a qdf-encoded representation of v to dst and returns
 // the extended slice.
+func (v *GenOpt) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenOpt byte
+var qdfFieldHdrs_GenOpt = [][]byte{qdfFieldHdr_a_116, qdfFieldHdr_b_117, qdfFieldHdr_c_118, qdfFieldHdr_d_119}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenOpt) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenOpt, qdfFieldHdrs_GenOpt)
+	if v.A == nil {
+		e.WriteNil()
+	} else {
+		e.WriteInt(int64((*v.A)))
+	}
+	if v.B == nil {
+		e.WriteNil()
+	} else {
+		e.WriteString(string((*v.B)))
+	}
+	if v.C == nil {
+		e.WriteNil()
+	} else {
+		e.WriteBool(bool((*v.C)))
+	}
+	if v.D == nil {
+		e.WriteNil()
+	} else {
+		e.WriteFloat64(float64((*v.D)))
+	}
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenOpt) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenOpt) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "a":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.A = nil
+			} else {
+				v.A = new(int32)
+				{
+					rv120, err := d.ReadInt()
+					if err != nil {
+						return err
+					}
+					(*v.A) = int32(rv120)
+				}
+			}
+		}
+	case "b":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.B = nil
+			} else {
+				v.B = new(string)
+				{
+					rv121, err := d.ReadString()
+					if err != nil {
+						return err
+					}
+					(*v.B) = rv121
+				}
+			}
+		}
+	case "c":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.C = nil
+			} else {
+				v.C = new(bool)
+				{
+					rv122, err := d.ReadBool()
+					if err != nil {
+						return err
+					}
+					(*v.C) = rv122
+				}
+			}
+		}
+	case "d":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.D = nil
+			} else {
+				v.D = new(float64)
+				{
+					rv123, err := d.ReadFloat64()
+					if err != nil {
+						return err
+					}
+					(*v.D) = rv123
+				}
+			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenOpt) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenOpt) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenOpt) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
+func (v *GenOptSet) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenOptSet byte
+var qdfFieldHdrs_GenOptSet = [][]byte{qdfFieldHdr_rows_20}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenOptSet) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenOptSet, qdfFieldHdrs_GenOptSet)
+	if v.Rows == nil {
+		e.WriteNil()
+	} else if len(v.Rows) >= 16 { // columnarMinElems
+		col124 := v.Rows
+		e.WriteColStructHeader(len(col124), qdfColNames_GenOpt, qdfColKinds_GenOpt)
+		mask125 := e.ScratchMask(len(col124))
+		c127 := e.ScratchInt(len(col124))
+		di126 := 0
+		for i := range col124 {
+			if col124[i].A != nil {
+				mask125[i>>3] |= 1 << uint(i&7)
+				c127[di126] = int64(*col124[i].A)
+				di126++
+			}
+		}
+		e.WriteColNullMask(mask125)
+		if err := e.WriteIntColumn(c127[:di126]); err != nil {
+			return err
+		}
+		mask128 := e.ScratchMask(len(col124))
+		c130 := e.ScratchString(len(col124))
+		di129 := 0
+		for i := range col124 {
+			if col124[i].B != nil {
+				mask128[i>>3] |= 1 << uint(i&7)
+				c130[di129] = string(*col124[i].B)
+				di129++
+			}
+		}
+		e.WriteColNullMask(mask128)
+		e.WriteStringColumn(c130[:di129])
+		mask131 := e.ScratchMask(len(col124))
+		c133 := e.ScratchBool(len(col124))
+		di132 := 0
+		for i := range col124 {
+			if col124[i].C != nil {
+				mask131[i>>3] |= 1 << uint(i&7)
+				c133[di132] = *col124[i].C
+				di132++
+			}
+		}
+		e.WriteColNullMask(mask131)
+		if err := e.WriteBoolColumn(c133[:di132]); err != nil {
+			return err
+		}
+		mask134 := e.ScratchMask(len(col124))
+		c136 := e.ScratchFloat64(len(col124))
+		di135 := 0
+		for i := range col124 {
+			if col124[i].D != nil {
+				mask134[i>>3] |= 1 << uint(i&7)
+				c136[di135] = float64(*col124[i].D)
+				di135++
+			}
+		}
+		e.WriteColNullMask(mask134)
+		if err := e.WriteFloat64Column(c136[:di135]); err != nil {
+			return err
+		}
+	} else {
+		e.WriteArrayHeader(len(v.Rows))
+		for i137 := range v.Rows {
+			if err := qdf.EncodeNested(e, &v.Rows[i137]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenOptSet) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenOptSet) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "rows":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Rows = nil
+			} else if d.PeekColStruct() {
+				n138, names139, kinds140, err := d.ReadColStructHeader()
+				if err != nil {
+					return err
+				}
+				_ = kinds140
+				v.Rows = make([]GenOpt, n138)
+				for ci141 := range names139 {
+					switch names139[ci141] {
+					case "a":
+						mask142, present143, err := d.ReadColNullMask(n138)
+						if err != nil {
+							return err
+						}
+						col144, err := d.ReadIntColumn(present143)
+						if err != nil {
+							return err
+						}
+						di145 := 0
+						for i := range v.Rows {
+							if mask142[i>>3]&(1<<uint(i&7)) != 0 {
+								v146 := int32(col144[di145])
+								v.Rows[i].A = &v146
+								di145++
+							} else {
+								v.Rows[i].A = nil
+							}
+						}
+					case "b":
+						mask147, present148, err := d.ReadColNullMask(n138)
+						if err != nil {
+							return err
+						}
+						col149, err := d.ReadStringColumn(present148)
+						if err != nil {
+							return err
+						}
+						di150 := 0
+						for i := range v.Rows {
+							if mask147[i>>3]&(1<<uint(i&7)) != 0 {
+								v151 := string(col149[di150])
+								v.Rows[i].B = &v151
+								di150++
+							} else {
+								v.Rows[i].B = nil
+							}
+						}
+					case "c":
+						mask152, present153, err := d.ReadColNullMask(n138)
+						if err != nil {
+							return err
+						}
+						col154, err := d.ReadBoolColumn(present153)
+						if err != nil {
+							return err
+						}
+						di155 := 0
+						for i := range v.Rows {
+							if mask152[i>>3]&(1<<uint(i&7)) != 0 {
+								v156 := col154[di155]
+								v.Rows[i].C = &v156
+								di155++
+							} else {
+								v.Rows[i].C = nil
+							}
+						}
+					case "d":
+						mask157, present158, err := d.ReadColNullMask(n138)
+						if err != nil {
+							return err
+						}
+						col159, err := d.ReadFloat64Column(present158)
+						if err != nil {
+							return err
+						}
+						di160 := 0
+						for i := range v.Rows {
+							if mask157[i>>3]&(1<<uint(i&7)) != 0 {
+								v161 := float64(col159[di160])
+								v.Rows[i].D = &v161
+								di160++
+							} else {
+								v.Rows[i].D = nil
+							}
+						}
+					default:
+						return qdf.ErrTypeMismatch
+					}
+				}
+			} else {
+				n162, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n162, 1); err != nil {
+					return err
+				}
+				v.Rows = make([]GenOpt, n162)
+				for i163 := range n162 {
+					if err := qdf.DecodeNested(d, &v.Rows[i163]); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenOptSet) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenOptSet) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenOptSet) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
 func (v *GenRow) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
@@ -1302,7 +2084,7 @@ func (v *GenRow) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenRow byte
-var qdfFieldHdrs_GenRow = [][]byte{qdfFieldHdr_id_100, qdfFieldHdr_name_59, qdfFieldHdr_inner_101, qdfFieldHdr_tags_102}
+var qdfFieldHdrs_GenRow = [][]byte{qdfFieldHdr_id_17, qdfFieldHdr_name_75, qdfFieldHdr_inner_164, qdfFieldHdr_tags_165}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -1317,9 +2099,9 @@ func (v *GenRow) EncodeQDF(e *qdf.Encoder) error {
 		e.WriteNil()
 	} else {
 		e.WriteMapHeader(len(v.Tags))
-		for k103, vv104 := range v.Tags {
-			e.WriteString(string(k103))
-			e.WriteInt(int64(vv104))
+		for k166, vv167 := range v.Tags {
+			e.WriteString(string(k166))
+			e.WriteInt(int64(vv167))
 		}
 	}
 	return nil
@@ -1356,19 +2138,19 @@ func (v *GenRow) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "id":
 		{
-			rv105, err := d.ReadInt()
+			rv168, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.ID = int64(rv105)
+			v.ID = int64(rv168)
 		}
 	case "name":
 		{
-			rv106, err := d.ReadString()
+			rv169, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv106
+			v.Name = rv169
 		}
 	case "inner":
 		if err := qdf.DecodeNested(d, &v.Inner); err != nil {
@@ -1383,30 +2165,30 @@ func (v *GenRow) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Tags = nil
 			} else {
-				n107, err := d.ReadMapHeader()
+				n170, err := d.ReadMapHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n107, 1); err != nil {
+				if err := d.CheckLength(n170, 1); err != nil {
 					return err
 				}
-				v.Tags = make(map[string]int, n107)
-				for range n107 {
-					var k108 string
-					var vv109 int
-					kb110, err := d.ReadStringBytes()
+				v.Tags = make(map[string]int, n170)
+				for range n170 {
+					var k171 string
+					var vv172 int
+					kb173, err := d.ReadStringBytes()
 					if err != nil {
 						return err
 					}
-					k108 = string(d.InternKey(kb110))
+					k171 = string(d.InternKey(kb173))
 					{
-						rv111, err := d.ReadInt()
+						rv174, err := d.ReadInt()
 						if err != nil {
 							return err
 						}
-						vv109 = int(rv111)
+						vv172 = int(rv174)
 					}
-					v.Tags[k108] = vv109
+					v.Tags[k171] = vv172
 				}
 			}
 		}
@@ -1469,7 +2251,7 @@ func (v *GenRowInner) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenRowInner byte
-var qdfFieldHdrs_GenRowInner = [][]byte{qdfFieldHdr_x_112, qdfFieldHdr_y_113}
+var qdfFieldHdrs_GenRowInner = [][]byte{qdfFieldHdr_x_175, qdfFieldHdr_y_176}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -1511,19 +2293,19 @@ func (v *GenRowInner) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "x":
 		{
-			rv114, err := d.ReadInt()
+			rv177, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.X = int(rv114)
+			v.X = int(rv177)
 		}
 	case "y":
 		{
-			rv115, err := d.ReadString()
+			rv178, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Y = rv115
+			v.Y = rv178
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -1584,7 +2366,7 @@ func (v *GenRowSet) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenRowSet byte
-var qdfFieldHdrs_GenRowSet = [][]byte{qdfFieldHdr_rows_116}
+var qdfFieldHdrs_GenRowSet = [][]byte{qdfFieldHdr_rows_20}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -1593,38 +2375,38 @@ func (v *GenRowSet) EncodeQDF(e *qdf.Encoder) error {
 	if v.Rows == nil {
 		e.WriteNil()
 	} else if len(v.Rows) >= 16 { // columnarMinElems
-		col117 := v.Rows
-		e.WriteHybridColStructHeader(len(col117), qdfHybNames_GenRow, qdfHybKinds_GenRow)
-		c118 := e.ScratchInt(len(col117))
-		for i := range col117 {
-			c118[i] = int64(col117[i].ID)
+		col179 := v.Rows
+		e.WriteHybridColStructHeader(len(col179), qdfHybNames_GenRow, qdfHybKinds_GenRow)
+		c180 := e.ScratchInt(len(col179))
+		for i := range col179 {
+			c180[i] = int64(col179[i].ID)
 		}
-		if err := e.WriteIntColumn(c118); err != nil {
+		if err := e.WriteIntColumn(c180); err != nil {
 			return err
 		}
-		c119 := e.ScratchString(len(col117))
-		for i := range col117 {
-			c119[i] = string(col117[i].Name)
+		c181 := e.ScratchString(len(col179))
+		for i := range col179 {
+			c181[i] = string(col179[i].Name)
 		}
-		e.WriteStringColumn(c119)
-		for i120 := range col117 {
-			if err := qdf.EncodeNested(e, &col117[i120].Inner); err != nil {
+		e.WriteStringColumn(c181)
+		for i182 := range col179 {
+			if err := qdf.EncodeNested(e, &col179[i182].Inner); err != nil {
 				return err
 			}
-			if col117[i120].Tags == nil {
+			if col179[i182].Tags == nil {
 				e.WriteNil()
 			} else {
-				e.WriteMapHeader(len(col117[i120].Tags))
-				for k121, vv122 := range col117[i120].Tags {
-					e.WriteString(string(k121))
-					e.WriteInt(int64(vv122))
+				e.WriteMapHeader(len(col179[i182].Tags))
+				for k183, vv184 := range col179[i182].Tags {
+					e.WriteString(string(k183))
+					e.WriteInt(int64(vv184))
 				}
 			}
 		}
 	} else {
 		e.WriteArrayHeader(len(v.Rows))
-		for i123 := range v.Rows {
-			if err := qdf.EncodeNested(e, &v.Rows[i123]); err != nil {
+		for i185 := range v.Rows {
+			if err := qdf.EncodeNested(e, &v.Rows[i185]); err != nil {
 				return err
 			}
 		}
@@ -1670,30 +2452,30 @@ func (v *GenRowSet) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Rows = nil
 			} else if d.PeekHybridColStruct() {
-				n124, names125, kinds126, err := d.ReadHybridColStructHeader()
+				n186, names187, kinds188, err := d.ReadHybridColStructHeader()
 				if err != nil {
 					return err
 				}
-				_ = names125
-				_ = kinds126
-				v.Rows = make([]GenRow, n124)
-				col127, err := d.ReadIntColumn(n124)
+				_ = names187
+				_ = kinds188
+				v.Rows = make([]GenRow, n186)
+				col189, err := d.ReadIntColumn(n186)
 				if err != nil {
 					return err
 				}
-				for i := range col127 {
-					v.Rows[i].ID = int64(col127[i])
+				for i := range col189 {
+					v.Rows[i].ID = int64(col189[i])
 				}
-				col128, err := d.ReadStringColumn(n124)
+				col190, err := d.ReadStringColumn(n186)
 				if err != nil {
 					return err
 				}
-				for i := range col128 {
-					v.Rows[i].Name = string(col128[i])
+				for i := range col190 {
+					v.Rows[i].Name = string(col190[i])
 				}
 				d.ClearColMaxLen()
-				for i129 := range v.Rows {
-					if err := qdf.DecodeNested(d, &v.Rows[i129].Inner); err != nil {
+				for i191 := range v.Rows {
+					if err := qdf.DecodeNested(d, &v.Rows[i191].Inner); err != nil {
 						return err
 					}
 					{
@@ -1702,47 +2484,47 @@ func (v *GenRowSet) decodeQDFField(d *qdf.Decoder, name string) error {
 							return err
 						}
 						if isNil {
-							v.Rows[i129].Tags = nil
+							v.Rows[i191].Tags = nil
 						} else {
-							n130, err := d.ReadMapHeader()
+							n192, err := d.ReadMapHeader()
 							if err != nil {
 								return err
 							}
-							if err := d.CheckLength(n130, 1); err != nil {
+							if err := d.CheckLength(n192, 1); err != nil {
 								return err
 							}
-							v.Rows[i129].Tags = make(map[string]int, n130)
-							for range n130 {
-								var k131 string
-								var vv132 int
-								kb133, err := d.ReadStringBytes()
+							v.Rows[i191].Tags = make(map[string]int, n192)
+							for range n192 {
+								var k193 string
+								var vv194 int
+								kb195, err := d.ReadStringBytes()
 								if err != nil {
 									return err
 								}
-								k131 = string(d.InternKey(kb133))
+								k193 = string(d.InternKey(kb195))
 								{
-									rv134, err := d.ReadInt()
+									rv196, err := d.ReadInt()
 									if err != nil {
 										return err
 									}
-									vv132 = int(rv134)
+									vv194 = int(rv196)
 								}
-								v.Rows[i129].Tags[k131] = vv132
+								v.Rows[i191].Tags[k193] = vv194
 							}
 						}
 					}
 				}
 			} else {
-				n135, err := d.ReadArrayHeader()
+				n197, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n135, 1); err != nil {
+				if err := d.CheckLength(n197, 1); err != nil {
 					return err
 				}
-				v.Rows = make([]GenRow, n135)
-				for i136 := range n135 {
-					if err := qdf.DecodeNested(d, &v.Rows[i136]); err != nil {
+				v.Rows = make([]GenRow, n197)
+				for i198 := range n197 {
+					if err := qdf.DecodeNested(d, &v.Rows[i198]); err != nil {
 						return err
 					}
 				}
@@ -1807,7 +2589,7 @@ func (v *Inner) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_Inner byte
-var qdfFieldHdrs_Inner = [][]byte{qdfFieldHdr_x_112, qdfFieldHdr_y_113}
+var qdfFieldHdrs_Inner = [][]byte{qdfFieldHdr_x_175, qdfFieldHdr_y_176}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -1849,19 +2631,19 @@ func (v *Inner) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "x":
 		{
-			rv137, err := d.ReadInt()
+			rv199, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.X = int(rv137)
+			v.X = int(rv199)
 		}
 	case "y":
 		{
-			rv138, err := d.ReadFloat64()
+			rv200, err := d.ReadFloat64()
 			if err != nil {
 				return err
 			}
-			v.Y = rv138
+			v.Y = rv200
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -1922,7 +2704,7 @@ func (v *Sample) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_Sample byte
-var qdfFieldHdrs_Sample = [][]byte{qdfFieldHdr_name_59, qdfFieldHdr_age_139, qdfFieldHdr_active_140, qdfFieldHdr_score_141, qdfFieldHdr_tags_102, qdfFieldHdr_meta_142, qdfFieldHdr_inner_101, qdfFieldHdr_when_143, qdfFieldHdr_buf_144, qdfFieldHdr_opt_145, qdfFieldHdr_counts_146}
+var qdfFieldHdrs_Sample = [][]byte{qdfFieldHdr_name_75, qdfFieldHdr_age_201, qdfFieldHdr_active_202, qdfFieldHdr_score_203, qdfFieldHdr_tags_165, qdfFieldHdr_meta_204, qdfFieldHdr_inner_164, qdfFieldHdr_when_205, qdfFieldHdr_buf_206, qdfFieldHdr_opt_207, qdfFieldHdr_counts_208}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -1936,17 +2718,17 @@ func (v *Sample) EncodeQDF(e *qdf.Encoder) error {
 		e.WriteNil()
 	} else {
 		e.WriteArrayHeader(len(v.Tags))
-		for i147 := range v.Tags {
-			e.WriteString(string(v.Tags[i147]))
+		for i209 := range v.Tags {
+			e.WriteString(string(v.Tags[i209]))
 		}
 	}
 	if v.Meta == nil {
 		e.WriteNil()
 	} else {
 		e.WriteMapHeader(len(v.Meta))
-		for k148, vv149 := range v.Meta {
-			e.WriteString(string(k148))
-			e.WriteString(string(vv149))
+		for k210, vv211 := range v.Meta {
+			e.WriteString(string(k210))
+			e.WriteString(string(vv211))
 		}
 	}
 	if err := qdf.EncodeNested(e, &v.Inner); err != nil {
@@ -1969,8 +2751,8 @@ func (v *Sample) EncodeQDF(e *qdf.Encoder) error {
 		}
 	}
 	e.WriteArrayHeader(3)
-	for i150 := range v.Counts {
-		e.WriteInt(int64(v.Counts[i150]))
+	for i212 := range v.Counts {
+		e.WriteInt(int64(v.Counts[i212]))
 	}
 	return nil
 }
@@ -2006,35 +2788,35 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "name":
 		{
-			rv151, err := d.ReadString()
+			rv213, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv151
+			v.Name = rv213
 		}
 	case "age":
 		{
-			rv152, err := d.ReadInt()
+			rv214, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.Age = int(rv152)
+			v.Age = int(rv214)
 		}
 	case "active":
 		{
-			rv153, err := d.ReadBool()
+			rv215, err := d.ReadBool()
 			if err != nil {
 				return err
 			}
-			v.Active = rv153
+			v.Active = rv215
 		}
 	case "score":
 		{
-			rv154, err := d.ReadFloat64()
+			rv216, err := d.ReadFloat64()
 			if err != nil {
 				return err
 			}
-			v.Score = rv154
+			v.Score = rv216
 		}
 	case "tags":
 		{
@@ -2045,21 +2827,21 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Tags = nil
 			} else {
-				n155, err := d.ReadArrayHeader()
+				n217, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n155, 1); err != nil {
+				if err := d.CheckLength(n217, 1); err != nil {
 					return err
 				}
-				v.Tags = make([]string, n155)
-				for i156 := range n155 {
+				v.Tags = make([]string, n217)
+				for i218 := range n217 {
 					{
-						rv157, err := d.ReadString()
+						rv219, err := d.ReadString()
 						if err != nil {
 							return err
 						}
-						v.Tags[i156] = rv157
+						v.Tags[i218] = rv219
 					}
 				}
 			}
@@ -2073,30 +2855,30 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Meta = nil
 			} else {
-				n158, err := d.ReadMapHeader()
+				n220, err := d.ReadMapHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n158, 1); err != nil {
+				if err := d.CheckLength(n220, 1); err != nil {
 					return err
 				}
-				v.Meta = make(map[string]string, n158)
-				for range n158 {
-					var k159 string
-					var vv160 string
-					kb161, err := d.ReadStringBytes()
+				v.Meta = make(map[string]string, n220)
+				for range n220 {
+					var k221 string
+					var vv222 string
+					kb223, err := d.ReadStringBytes()
 					if err != nil {
 						return err
 					}
-					k159 = string(d.InternKey(kb161))
+					k221 = string(d.InternKey(kb223))
 					{
-						rv162, err := d.ReadString()
+						rv224, err := d.ReadString()
 						if err != nil {
 							return err
 						}
-						vv160 = rv162
+						vv222 = rv224
 					}
-					v.Meta[k159] = vv160
+					v.Meta[k221] = vv222
 				}
 			}
 		}
@@ -2106,11 +2888,11 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 		}
 	case "when":
 		{
-			sec163, nsec164, err := d.ReadTimestamp()
+			sec225, nsec226, err := d.ReadTimestamp()
 			if err != nil {
 				return err
 			}
-			v.When = time.Unix(sec163, int64(nsec164)).UTC()
+			v.When = time.Unix(sec225, int64(nsec226)).UTC()
 		}
 	case "buf":
 		{
@@ -2145,20 +2927,20 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 		}
 	case "counts":
 		{
-			n165, err := d.ReadArrayHeader()
+			n227, err := d.ReadArrayHeader()
 			if err != nil {
 				return err
 			}
-			if n165 != 3 {
+			if n227 != 3 {
 				return qdf.ErrTypeMismatch
 			}
-			for i166 := range 3 {
+			for i228 := range 3 {
 				{
-					rv167, err := d.ReadInt()
+					rv229, err := d.ReadInt()
 					if err != nil {
 						return err
 					}
-					v.Counts[i166] = int32(rv167)
+					v.Counts[i228] = int32(rv229)
 				}
 			}
 		}

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -19,43 +19,44 @@ var (
 	qdfFieldHdr_id_17      = []byte{0x82, 0x69, 0x64}
 	qdfFieldHdr_data_18    = []byte{0x84, 0x64, 0x61, 0x74, 0x61}
 	qdfFieldHdr_rows_20    = []byte{0x84, 0x72, 0x6f, 0x77, 0x73}
-	qdfFieldHdr_ts_33      = []byte{0x82, 0x74, 0x73}
-	qdfFieldHdr_level_34   = []byte{0x85, 0x6c, 0x65, 0x76, 0x65, 0x6c}
-	qdfFieldHdr_code_35    = []byte{0x84, 0x63, 0x6f, 0x64, 0x65}
-	qdfFieldHdr_msg_36     = []byte{0x83, 0x6d, 0x73, 0x67}
-	qdfFieldHdr_source_42  = []byte{0x86, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65}
-	qdfFieldHdr_events_43  = []byte{0x86, 0x65, 0x76, 0x65, 0x6e, 0x74, 0x73}
-	qdfFieldHdr_value_66   = []byte{0x85, 0x76, 0x61, 0x6c, 0x75, 0x65}
-	qdfFieldHdr_count_67   = []byte{0x85, 0x63, 0x6f, 0x75, 0x6e, 0x74}
-	qdfFieldHdr_ok_68      = []byte{0x82, 0x6f, 0x6b}
-	qdfFieldHdr_ratio_69   = []byte{0x85, 0x72, 0x61, 0x74, 0x69, 0x6f}
-	qdfFieldHdr_name_75    = []byte{0x84, 0x6e, 0x61, 0x6d, 0x65}
-	qdfFieldHdr_metrics_76 = []byte{0x87, 0x6d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73}
-	qdfFieldHdr_first_96   = []byte{0x85, 0x66, 0x69, 0x72, 0x73, 0x74}
-	qdfFieldHdr_last_97    = []byte{0x84, 0x6c, 0x61, 0x73, 0x74}
-	qdfFieldHdr_names_100  = []byte{0x85, 0x6e, 0x61, 0x6d, 0x65, 0x73}
-	qdfFieldHdr_a_116      = []byte{0x81, 0x61}
-	qdfFieldHdr_b_117      = []byte{0x81, 0x62}
-	qdfFieldHdr_c_118      = []byte{0x81, 0x63}
-	qdfFieldHdr_d_119      = []byte{0x81, 0x64}
-	qdfFieldHdr_inner_164  = []byte{0x85, 0x69, 0x6e, 0x6e, 0x65, 0x72}
-	qdfFieldHdr_tags_165   = []byte{0x84, 0x74, 0x61, 0x67, 0x73}
-	qdfFieldHdr_x_175      = []byte{0x81, 0x78}
-	qdfFieldHdr_y_176      = []byte{0x81, 0x79}
-	qdfFieldHdr_age_201    = []byte{0x83, 0x61, 0x67, 0x65}
-	qdfFieldHdr_active_202 = []byte{0x86, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65}
-	qdfFieldHdr_score_203  = []byte{0x85, 0x73, 0x63, 0x6f, 0x72, 0x65}
-	qdfFieldHdr_meta_204   = []byte{0x84, 0x6d, 0x65, 0x74, 0x61}
-	qdfFieldHdr_when_205   = []byte{0x84, 0x77, 0x68, 0x65, 0x6e}
-	qdfFieldHdr_buf_206    = []byte{0x83, 0x62, 0x75, 0x66}
-	qdfFieldHdr_opt_207    = []byte{0x83, 0x6f, 0x70, 0x74}
-	qdfFieldHdr_counts_208 = []byte{0x86, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73}
+	qdfFieldHdr_ts_39      = []byte{0x82, 0x74, 0x73}
+	qdfFieldHdr_level_40   = []byte{0x85, 0x6c, 0x65, 0x76, 0x65, 0x6c}
+	qdfFieldHdr_code_41    = []byte{0x84, 0x63, 0x6f, 0x64, 0x65}
+	qdfFieldHdr_msg_42     = []byte{0x83, 0x6d, 0x73, 0x67}
+	qdfFieldHdr_source_48  = []byte{0x86, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65}
+	qdfFieldHdr_events_49  = []byte{0x86, 0x65, 0x76, 0x65, 0x6e, 0x74, 0x73}
+	qdfFieldHdr_value_72   = []byte{0x85, 0x76, 0x61, 0x6c, 0x75, 0x65}
+	qdfFieldHdr_count_73   = []byte{0x85, 0x63, 0x6f, 0x75, 0x6e, 0x74}
+	qdfFieldHdr_ok_74      = []byte{0x82, 0x6f, 0x6b}
+	qdfFieldHdr_ratio_75   = []byte{0x85, 0x72, 0x61, 0x74, 0x69, 0x6f}
+	qdfFieldHdr_name_81    = []byte{0x84, 0x6e, 0x61, 0x6d, 0x65}
+	qdfFieldHdr_metrics_82 = []byte{0x87, 0x6d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73}
+	qdfFieldHdr_first_102  = []byte{0x85, 0x66, 0x69, 0x72, 0x73, 0x74}
+	qdfFieldHdr_last_103   = []byte{0x84, 0x6c, 0x61, 0x73, 0x74}
+	qdfFieldHdr_names_106  = []byte{0x85, 0x6e, 0x61, 0x6d, 0x65, 0x73}
+	qdfFieldHdr_a_122      = []byte{0x81, 0x61}
+	qdfFieldHdr_b_123      = []byte{0x81, 0x62}
+	qdfFieldHdr_c_124      = []byte{0x81, 0x63}
+	qdfFieldHdr_d_125      = []byte{0x81, 0x64}
+	qdfFieldHdr_inner_170  = []byte{0x85, 0x69, 0x6e, 0x6e, 0x65, 0x72}
+	qdfFieldHdr_tags_171   = []byte{0x84, 0x74, 0x61, 0x67, 0x73}
+	qdfFieldHdr_x_181      = []byte{0x81, 0x78}
+	qdfFieldHdr_y_182      = []byte{0x81, 0x79}
+	qdfFieldHdr_note_205   = []byte{0x84, 0x6e, 0x6f, 0x74, 0x65}
+	qdfFieldHdr_age_231    = []byte{0x83, 0x61, 0x67, 0x65}
+	qdfFieldHdr_active_232 = []byte{0x86, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65}
+	qdfFieldHdr_score_233  = []byte{0x85, 0x73, 0x63, 0x6f, 0x72, 0x65}
+	qdfFieldHdr_meta_234   = []byte{0x84, 0x6d, 0x65, 0x74, 0x61}
+	qdfFieldHdr_when_235   = []byte{0x84, 0x77, 0x68, 0x65, 0x6e}
+	qdfFieldHdr_buf_236    = []byte{0x83, 0x62, 0x75, 0x66}
+	qdfFieldHdr_opt_237    = []byte{0x83, 0x6f, 0x70, 0x74}
+	qdfFieldHdr_counts_238 = []byte{0x86, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73}
 )
 
 // Columnar shape descriptors: per element-type column names and kind
 // bytes for the monomorphized tagColStruct transpose path.
 var qdfColNames_GenBlobRow = []string{"id", "data"}
-var qdfColKinds_GenBlobRow = []byte{0x00, 0x04}
+var qdfColKinds_GenBlobRow = []byte{0x00, 0x84}
 var qdfColNames_GenEvent = []string{"ts", "level", "code", "msg"}
 var qdfColKinds_GenEvent = []byte{0x05, 0x04, 0x00, 0x04}
 var qdfColNames_GenMetric = []string{"ts", "value", "count", "ok", "ratio"}
@@ -422,15 +423,22 @@ func (v *GenBlobSet) EncodeQDF(e *qdf.Encoder) error {
 		if err := e.WriteIntColumn(c22); err != nil {
 			return err
 		}
-		c23 := e.ScratchString(len(col21))
+		mask23 := e.ScratchMask(len(col21))
+		c25 := e.ScratchString(len(col21))
+		di24 := 0
 		for i := range col21 {
-			c23[i] = unsafe.String(unsafe.SliceData(col21[i].Data), len(col21[i].Data))
+			if col21[i].Data != nil {
+				mask23[i>>3] |= 1 << uint(i&7)
+				c25[di24] = unsafe.String(unsafe.SliceData(col21[i].Data), len(col21[i].Data))
+				di24++
+			}
 		}
-		e.WriteStringColumn(c23)
+		e.WriteColNullMask(mask23)
+		e.WriteStringColumn(c25[:di24])
 	} else {
 		e.WriteArrayHeader(len(v.Rows))
-		for i24 := range v.Rows {
-			if err := qdf.EncodeNested(e, &v.Rows[i24]); err != nil {
+		for i26 := range v.Rows {
+			if err := qdf.EncodeNested(e, &v.Rows[i26]); err != nil {
 				return err
 			}
 		}
@@ -476,29 +484,39 @@ func (v *GenBlobSet) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Rows = nil
 			} else if d.PeekColStruct() {
-				n25, names26, kinds27, err := d.ReadColStructHeader()
+				n27, names28, kinds29, err := d.ReadColStructHeader()
 				if err != nil {
 					return err
 				}
-				_ = kinds27
-				v.Rows = make([]GenBlobRow, n25)
-				for ci28 := range names26 {
-					switch names26[ci28] {
+				_ = kinds29
+				v.Rows = make([]GenBlobRow, n27)
+				for ci30 := range names28 {
+					switch names28[ci30] {
 					case "id":
-						col29, err := d.ReadIntColumn(n25)
+						col31, err := d.ReadIntColumn(n27)
 						if err != nil {
 							return err
 						}
-						for i := range col29 {
-							v.Rows[i].ID = int64(col29[i])
+						for i := range col31 {
+							v.Rows[i].ID = int64(col31[i])
 						}
 					case "data":
-						col30, err := d.ReadStringColumn(n25)
+						mask32, present33, err := d.ReadColNullMask(n27)
 						if err != nil {
 							return err
 						}
-						for i := range col30 {
-							v.Rows[i].Data = []byte([]byte(col30[i]))
+						col34, err := d.ReadStringColumn(present33)
+						if err != nil {
+							return err
+						}
+						di35 := 0
+						for i := range v.Rows {
+							if mask32[i>>3]&(1<<uint(i&7)) != 0 {
+								v.Rows[i].Data = []byte([]byte(col34[di35]))
+								di35++
+							} else {
+								v.Rows[i].Data = nil
+							}
 						}
 					default:
 						return qdf.ErrTypeMismatch
@@ -506,16 +524,16 @@ func (v *GenBlobSet) decodeQDFField(d *qdf.Decoder, name string) error {
 				}
 				d.ClearColMaxLen()
 			} else {
-				n31, err := d.ReadArrayHeader()
+				n37, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n31, 1); err != nil {
+				if err := d.CheckLength(n37, 1); err != nil {
 					return err
 				}
-				v.Rows = make([]GenBlobRow, n31)
-				for i32 := range n31 {
-					if err := qdf.DecodeNested(d, &v.Rows[i32]); err != nil {
+				v.Rows = make([]GenBlobRow, n37)
+				for i38 := range n37 {
+					if err := qdf.DecodeNested(d, &v.Rows[i38]); err != nil {
 						return err
 					}
 				}
@@ -580,7 +598,7 @@ func (v *GenEvent) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenEvent byte
-var qdfFieldHdrs_GenEvent = [][]byte{qdfFieldHdr_ts_33, qdfFieldHdr_level_34, qdfFieldHdr_code_35, qdfFieldHdr_msg_36}
+var qdfFieldHdrs_GenEvent = [][]byte{qdfFieldHdr_ts_39, qdfFieldHdr_level_40, qdfFieldHdr_code_41, qdfFieldHdr_msg_42}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -627,35 +645,35 @@ func (v *GenEvent) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "ts":
 		{
-			sec37, nsec38, err := d.ReadTimestamp()
+			sec43, nsec44, err := d.ReadTimestamp()
 			if err != nil {
 				return err
 			}
-			v.TS = time.Unix(sec37, int64(nsec38)).UTC()
+			v.TS = time.Unix(sec43, int64(nsec44)).UTC()
 		}
 	case "level":
 		{
-			rv39, err := d.ReadString()
+			rv45, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Level = rv39
+			v.Level = rv45
 		}
 	case "code":
 		{
-			rv40, err := d.ReadInt()
+			rv46, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.Code = int32(rv40)
+			v.Code = int32(rv46)
 		}
 	case "msg":
 		{
-			rv41, err := d.ReadString()
+			rv47, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Msg = rv41
+			v.Msg = rv47
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -716,7 +734,7 @@ func (v *GenEventLog) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenEventLog byte
-var qdfFieldHdrs_GenEventLog = [][]byte{qdfFieldHdr_source_42, qdfFieldHdr_events_43}
+var qdfFieldHdrs_GenEventLog = [][]byte{qdfFieldHdr_source_48, qdfFieldHdr_events_49}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -726,39 +744,39 @@ func (v *GenEventLog) EncodeQDF(e *qdf.Encoder) error {
 	if v.Events == nil {
 		e.WriteNil()
 	} else if len(v.Events) >= 16 { // columnarMinElems
-		col44 := v.Events
-		e.WriteColStructHeader(len(col44), qdfColNames_GenEvent, qdfColKinds_GenEvent)
-		sec46 := e.ScratchInt(len(col44))
-		ns47 := e.ScratchUint(len(col44))
-		for i := range col44 {
-			t48 := col44[i].TS.UTC()
-			sec46[i] = t48.Unix()
-			ns47[i] = uint64(t48.Nanosecond())
+		col50 := v.Events
+		e.WriteColStructHeader(len(col50), qdfColNames_GenEvent, qdfColKinds_GenEvent)
+		sec52 := e.ScratchInt(len(col50))
+		ns53 := e.ScratchUint(len(col50))
+		for i := range col50 {
+			t54 := col50[i].TS.UTC()
+			sec52[i] = t54.Unix()
+			ns53[i] = uint64(t54.Nanosecond())
 		}
-		if err := e.WriteTimeColumn(sec46, ns47); err != nil {
+		if err := e.WriteTimeColumn(sec52, ns53); err != nil {
 			return err
 		}
-		c49 := e.ScratchString(len(col44))
-		for i := range col44 {
-			c49[i] = string(col44[i].Level)
+		c55 := e.ScratchString(len(col50))
+		for i := range col50 {
+			c55[i] = string(col50[i].Level)
 		}
-		e.WriteStringColumn(c49)
-		c50 := e.ScratchInt(len(col44))
-		for i := range col44 {
-			c50[i] = int64(col44[i].Code)
+		e.WriteStringColumn(c55)
+		c56 := e.ScratchInt(len(col50))
+		for i := range col50 {
+			c56[i] = int64(col50[i].Code)
 		}
-		if err := e.WriteIntColumn(c50); err != nil {
+		if err := e.WriteIntColumn(c56); err != nil {
 			return err
 		}
-		c51 := e.ScratchString(len(col44))
-		for i := range col44 {
-			c51[i] = string(col44[i].Msg)
+		c57 := e.ScratchString(len(col50))
+		for i := range col50 {
+			c57[i] = string(col50[i].Msg)
 		}
-		e.WriteStringColumn(c51)
+		e.WriteStringColumn(c57)
 	} else {
 		e.WriteArrayHeader(len(v.Events))
-		for i52 := range v.Events {
-			if err := qdf.EncodeNested(e, &v.Events[i52]); err != nil {
+		for i58 := range v.Events {
+			if err := qdf.EncodeNested(e, &v.Events[i58]); err != nil {
 				return err
 			}
 		}
@@ -797,11 +815,11 @@ func (v *GenEventLog) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "source":
 		{
-			rv53, err := d.ReadString()
+			rv59, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Source = rv53
+			v.Source = rv59
 		}
 	case "events":
 		{
@@ -812,45 +830,45 @@ func (v *GenEventLog) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Events = nil
 			} else if d.PeekColStruct() {
-				n54, names55, kinds56, err := d.ReadColStructHeader()
+				n60, names61, kinds62, err := d.ReadColStructHeader()
 				if err != nil {
 					return err
 				}
-				_ = kinds56
-				v.Events = make([]GenEvent, n54)
-				for ci57 := range names55 {
-					switch names55[ci57] {
+				_ = kinds62
+				v.Events = make([]GenEvent, n60)
+				for ci63 := range names61 {
+					switch names61[ci63] {
 					case "ts":
-						sec59, ns60, err := d.ReadTimeColumn(n54)
+						sec65, ns66, err := d.ReadTimeColumn(n60)
 						if err != nil {
 							return err
 						}
-						for i := range sec59 {
-							v.Events[i].TS = time.Unix(sec59[i], int64(ns60[i])).UTC()
+						for i := range sec65 {
+							v.Events[i].TS = time.Unix(sec65[i], int64(ns66[i])).UTC()
 						}
 					case "level":
-						col61, err := d.ReadStringColumn(n54)
+						col67, err := d.ReadStringColumn(n60)
 						if err != nil {
 							return err
 						}
-						for i := range col61 {
-							v.Events[i].Level = string(col61[i])
+						for i := range col67 {
+							v.Events[i].Level = string(col67[i])
 						}
 					case "code":
-						col62, err := d.ReadIntColumn(n54)
+						col68, err := d.ReadIntColumn(n60)
 						if err != nil {
 							return err
 						}
-						for i := range col62 {
-							v.Events[i].Code = int32(col62[i])
+						for i := range col68 {
+							v.Events[i].Code = int32(col68[i])
 						}
 					case "msg":
-						col63, err := d.ReadStringColumn(n54)
+						col69, err := d.ReadStringColumn(n60)
 						if err != nil {
 							return err
 						}
-						for i := range col63 {
-							v.Events[i].Msg = string(col63[i])
+						for i := range col69 {
+							v.Events[i].Msg = string(col69[i])
 						}
 					default:
 						return qdf.ErrTypeMismatch
@@ -858,16 +876,16 @@ func (v *GenEventLog) decodeQDFField(d *qdf.Decoder, name string) error {
 				}
 				d.ClearColMaxLen()
 			} else {
-				n64, err := d.ReadArrayHeader()
+				n70, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n64, 1); err != nil {
+				if err := d.CheckLength(n70, 1); err != nil {
 					return err
 				}
-				v.Events = make([]GenEvent, n64)
-				for i65 := range n64 {
-					if err := qdf.DecodeNested(d, &v.Events[i65]); err != nil {
+				v.Events = make([]GenEvent, n70)
+				for i71 := range n70 {
+					if err := qdf.DecodeNested(d, &v.Events[i71]); err != nil {
 						return err
 					}
 				}
@@ -932,7 +950,7 @@ func (v *GenMetric) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenMetric byte
-var qdfFieldHdrs_GenMetric = [][]byte{qdfFieldHdr_ts_33, qdfFieldHdr_value_66, qdfFieldHdr_count_67, qdfFieldHdr_ok_68, qdfFieldHdr_ratio_69}
+var qdfFieldHdrs_GenMetric = [][]byte{qdfFieldHdr_ts_39, qdfFieldHdr_value_72, qdfFieldHdr_count_73, qdfFieldHdr_ok_74, qdfFieldHdr_ratio_75}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -977,43 +995,43 @@ func (v *GenMetric) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "ts":
 		{
-			rv70, err := d.ReadInt()
+			rv76, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.TS = int64(rv70)
+			v.TS = int64(rv76)
 		}
 	case "value":
 		{
-			rv71, err := d.ReadFloat64()
+			rv77, err := d.ReadFloat64()
 			if err != nil {
 				return err
 			}
-			v.Value = rv71
+			v.Value = rv77
 		}
 	case "count":
 		{
-			rv72, err := d.ReadUint()
+			rv78, err := d.ReadUint()
 			if err != nil {
 				return err
 			}
-			v.Count = uint32(rv72)
+			v.Count = uint32(rv78)
 		}
 	case "ok":
 		{
-			rv73, err := d.ReadBool()
+			rv79, err := d.ReadBool()
 			if err != nil {
 				return err
 			}
-			v.OK = rv73
+			v.OK = rv79
 		}
 	case "ratio":
 		{
-			rv74, err := d.ReadFloat32()
+			rv80, err := d.ReadFloat32()
 			if err != nil {
 				return err
 			}
-			v.Ratio = rv74
+			v.Ratio = rv80
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -1074,7 +1092,7 @@ func (v *GenMetricBatch) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenMetricBatch byte
-var qdfFieldHdrs_GenMetricBatch = [][]byte{qdfFieldHdr_name_75, qdfFieldHdr_metrics_76}
+var qdfFieldHdrs_GenMetricBatch = [][]byte{qdfFieldHdr_name_81, qdfFieldHdr_metrics_82}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -1084,47 +1102,47 @@ func (v *GenMetricBatch) EncodeQDF(e *qdf.Encoder) error {
 	if v.Metrics == nil {
 		e.WriteNil()
 	} else if len(v.Metrics) >= 16 { // columnarMinElems
-		col77 := v.Metrics
-		e.WriteColStructHeader(len(col77), qdfColNames_GenMetric, qdfColKinds_GenMetric)
-		c78 := e.ScratchInt(len(col77))
-		for i := range col77 {
-			c78[i] = int64(col77[i].TS)
+		col83 := v.Metrics
+		e.WriteColStructHeader(len(col83), qdfColNames_GenMetric, qdfColKinds_GenMetric)
+		c84 := e.ScratchInt(len(col83))
+		for i := range col83 {
+			c84[i] = int64(col83[i].TS)
 		}
-		if err := e.WriteIntColumn(c78); err != nil {
+		if err := e.WriteIntColumn(c84); err != nil {
 			return err
 		}
-		c79 := e.ScratchFloat64(len(col77))
-		for i := range col77 {
-			c79[i] = float64(col77[i].Value)
+		c85 := e.ScratchFloat64(len(col83))
+		for i := range col83 {
+			c85[i] = float64(col83[i].Value)
 		}
-		if err := e.WriteFloat64Column(c79); err != nil {
+		if err := e.WriteFloat64Column(c85); err != nil {
 			return err
 		}
-		c80 := e.ScratchUint(len(col77))
-		for i := range col77 {
-			c80[i] = uint64(col77[i].Count)
+		c86 := e.ScratchUint(len(col83))
+		for i := range col83 {
+			c86[i] = uint64(col83[i].Count)
 		}
-		if err := e.WriteUintColumn(c80); err != nil {
+		if err := e.WriteUintColumn(c86); err != nil {
 			return err
 		}
-		c81 := e.ScratchBool(len(col77))
-		for i := range col77 {
-			c81[i] = col77[i].OK
+		c87 := e.ScratchBool(len(col83))
+		for i := range col83 {
+			c87[i] = col83[i].OK
 		}
-		if err := e.WriteBoolColumn(c81); err != nil {
+		if err := e.WriteBoolColumn(c87); err != nil {
 			return err
 		}
-		c82 := e.ScratchFloat32(len(col77))
-		for i := range col77 {
-			c82[i] = float32(col77[i].Ratio)
+		c88 := e.ScratchFloat32(len(col83))
+		for i := range col83 {
+			c88[i] = float32(col83[i].Ratio)
 		}
-		if err := e.WriteFloat32Column(c82); err != nil {
+		if err := e.WriteFloat32Column(c88); err != nil {
 			return err
 		}
 	} else {
 		e.WriteArrayHeader(len(v.Metrics))
-		for i83 := range v.Metrics {
-			if err := qdf.EncodeNested(e, &v.Metrics[i83]); err != nil {
+		for i89 := range v.Metrics {
+			if err := qdf.EncodeNested(e, &v.Metrics[i89]); err != nil {
 				return err
 			}
 		}
@@ -1163,11 +1181,11 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "name":
 		{
-			rv84, err := d.ReadString()
+			rv90, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv84
+			v.Name = rv90
 		}
 	case "metrics":
 		{
@@ -1178,53 +1196,53 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Metrics = nil
 			} else if d.PeekColStruct() {
-				n85, names86, kinds87, err := d.ReadColStructHeader()
+				n91, names92, kinds93, err := d.ReadColStructHeader()
 				if err != nil {
 					return err
 				}
-				_ = kinds87
-				v.Metrics = make([]GenMetric, n85)
-				for ci88 := range names86 {
-					switch names86[ci88] {
+				_ = kinds93
+				v.Metrics = make([]GenMetric, n91)
+				for ci94 := range names92 {
+					switch names92[ci94] {
 					case "ts":
-						col89, err := d.ReadIntColumn(n85)
+						col95, err := d.ReadIntColumn(n91)
 						if err != nil {
 							return err
 						}
-						for i := range col89 {
-							v.Metrics[i].TS = int64(col89[i])
+						for i := range col95 {
+							v.Metrics[i].TS = int64(col95[i])
 						}
 					case "value":
-						col90, err := d.ReadFloat64Column(n85)
+						col96, err := d.ReadFloat64Column(n91)
 						if err != nil {
 							return err
 						}
-						for i := range col90 {
-							v.Metrics[i].Value = float64(col90[i])
+						for i := range col96 {
+							v.Metrics[i].Value = float64(col96[i])
 						}
 					case "count":
-						col91, err := d.ReadUintColumn(n85)
+						col97, err := d.ReadUintColumn(n91)
 						if err != nil {
 							return err
 						}
-						for i := range col91 {
-							v.Metrics[i].Count = uint32(col91[i])
+						for i := range col97 {
+							v.Metrics[i].Count = uint32(col97[i])
 						}
 					case "ok":
-						col92, err := d.ReadBoolColumn(n85)
+						col98, err := d.ReadBoolColumn(n91)
 						if err != nil {
 							return err
 						}
-						for i := range col92 {
-							v.Metrics[i].OK = col92[i]
+						for i := range col98 {
+							v.Metrics[i].OK = col98[i]
 						}
 					case "ratio":
-						col93, err := d.ReadFloat32Column(n85)
+						col99, err := d.ReadFloat32Column(n91)
 						if err != nil {
 							return err
 						}
-						for i := range col93 {
-							v.Metrics[i].Ratio = float32(col93[i])
+						for i := range col99 {
+							v.Metrics[i].Ratio = float32(col99[i])
 						}
 					default:
 						return qdf.ErrTypeMismatch
@@ -1232,16 +1250,16 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 				}
 				d.ClearColMaxLen()
 			} else {
-				n94, err := d.ReadArrayHeader()
+				n100, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n94, 1); err != nil {
+				if err := d.CheckLength(n100, 1); err != nil {
 					return err
 				}
-				v.Metrics = make([]GenMetric, n94)
-				for i95 := range n94 {
-					if err := qdf.DecodeNested(d, &v.Metrics[i95]); err != nil {
+				v.Metrics = make([]GenMetric, n100)
+				for i101 := range n100 {
+					if err := qdf.DecodeNested(d, &v.Metrics[i101]); err != nil {
 						return err
 					}
 				}
@@ -1306,7 +1324,7 @@ func (v *GenName) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenName byte
-var qdfFieldHdrs_GenName = [][]byte{qdfFieldHdr_first_96, qdfFieldHdr_last_97}
+var qdfFieldHdrs_GenName = [][]byte{qdfFieldHdr_first_102, qdfFieldHdr_last_103}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -1348,19 +1366,19 @@ func (v *GenName) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "first":
 		{
-			rv98, err := d.ReadString()
+			rv104, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.First = rv98
+			v.First = rv104
 		}
 	case "last":
 		{
-			rv99, err := d.ReadString()
+			rv105, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Last = rv99
+			v.Last = rv105
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -1421,7 +1439,7 @@ func (v *GenNameList) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenNameList byte
-var qdfFieldHdrs_GenNameList = [][]byte{qdfFieldHdr_names_100}
+var qdfFieldHdrs_GenNameList = [][]byte{qdfFieldHdr_names_106}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -1430,45 +1448,45 @@ func (v *GenNameList) EncodeQDF(e *qdf.Encoder) error {
 	if v.Names == nil {
 		e.WriteNil()
 	} else if len(v.Names) >= 16 { // columnarMinElems
-		col101 := v.Names
-		ben102 := false
-		pb103 := e.ScratchString(min(len(col101), 32))
-		for i := range pb103 {
-			pb103[i] = string(col101[i].First)
+		col107 := v.Names
+		ben108 := false
+		pb109 := e.ScratchString(min(len(col107), 32))
+		for i := range pb109 {
+			pb109[i] = string(col107[i].First)
 		}
-		if qdf.StringColumnsBeneficial(pb103) {
-			ben102 = true
+		if qdf.StringColumnsBeneficial(pb109) {
+			ben108 = true
 		}
-		for i := range pb103 {
-			pb103[i] = string(col101[i].Last)
+		for i := range pb109 {
+			pb109[i] = string(col107[i].Last)
 		}
-		if qdf.StringColumnsBeneficial(pb103) {
-			ben102 = true
+		if qdf.StringColumnsBeneficial(pb109) {
+			ben108 = true
 		}
-		if ben102 {
-			e.WriteColStructHeader(len(col101), qdfColNames_GenName, qdfColKinds_GenName)
-			c104 := e.ScratchString(len(col101))
-			for i := range col101 {
-				c104[i] = string(col101[i].First)
+		if ben108 {
+			e.WriteColStructHeader(len(col107), qdfColNames_GenName, qdfColKinds_GenName)
+			c110 := e.ScratchString(len(col107))
+			for i := range col107 {
+				c110[i] = string(col107[i].First)
 			}
-			e.WriteStringColumn(c104)
-			c105 := e.ScratchString(len(col101))
-			for i := range col101 {
-				c105[i] = string(col101[i].Last)
+			e.WriteStringColumn(c110)
+			c111 := e.ScratchString(len(col107))
+			for i := range col107 {
+				c111[i] = string(col107[i].Last)
 			}
-			e.WriteStringColumn(c105)
+			e.WriteStringColumn(c111)
 		} else {
-			e.WriteArrayHeader(len(col101))
-			for i106 := range col101 {
-				if err := qdf.EncodeNested(e, &col101[i106]); err != nil {
+			e.WriteArrayHeader(len(col107))
+			for i112 := range col107 {
+				if err := qdf.EncodeNested(e, &col107[i112]); err != nil {
 					return err
 				}
 			}
 		}
 	} else {
 		e.WriteArrayHeader(len(v.Names))
-		for i107 := range v.Names {
-			if err := qdf.EncodeNested(e, &v.Names[i107]); err != nil {
+		for i113 := range v.Names {
+			if err := qdf.EncodeNested(e, &v.Names[i113]); err != nil {
 				return err
 			}
 		}
@@ -1514,29 +1532,29 @@ func (v *GenNameList) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Names = nil
 			} else if d.PeekColStruct() {
-				n108, names109, kinds110, err := d.ReadColStructHeader()
+				n114, names115, kinds116, err := d.ReadColStructHeader()
 				if err != nil {
 					return err
 				}
-				_ = kinds110
-				v.Names = make([]GenName, n108)
-				for ci111 := range names109 {
-					switch names109[ci111] {
+				_ = kinds116
+				v.Names = make([]GenName, n114)
+				for ci117 := range names115 {
+					switch names115[ci117] {
 					case "first":
-						col112, err := d.ReadStringColumn(n108)
+						col118, err := d.ReadStringColumn(n114)
 						if err != nil {
 							return err
 						}
-						for i := range col112 {
-							v.Names[i].First = string(col112[i])
+						for i := range col118 {
+							v.Names[i].First = string(col118[i])
 						}
 					case "last":
-						col113, err := d.ReadStringColumn(n108)
+						col119, err := d.ReadStringColumn(n114)
 						if err != nil {
 							return err
 						}
-						for i := range col113 {
-							v.Names[i].Last = string(col113[i])
+						for i := range col119 {
+							v.Names[i].Last = string(col119[i])
 						}
 					default:
 						return qdf.ErrTypeMismatch
@@ -1544,16 +1562,16 @@ func (v *GenNameList) decodeQDFField(d *qdf.Decoder, name string) error {
 				}
 				d.ClearColMaxLen()
 			} else {
-				n114, err := d.ReadArrayHeader()
+				n120, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n114, 1); err != nil {
+				if err := d.CheckLength(n120, 1); err != nil {
 					return err
 				}
-				v.Names = make([]GenName, n114)
-				for i115 := range n114 {
-					if err := qdf.DecodeNested(d, &v.Names[i115]); err != nil {
+				v.Names = make([]GenName, n120)
+				for i121 := range n120 {
+					if err := qdf.DecodeNested(d, &v.Names[i121]); err != nil {
 						return err
 					}
 				}
@@ -1618,7 +1636,7 @@ func (v *GenOpt) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenOpt byte
-var qdfFieldHdrs_GenOpt = [][]byte{qdfFieldHdr_a_116, qdfFieldHdr_b_117, qdfFieldHdr_c_118, qdfFieldHdr_d_119}
+var qdfFieldHdrs_GenOpt = [][]byte{qdfFieldHdr_a_122, qdfFieldHdr_b_123, qdfFieldHdr_c_124, qdfFieldHdr_d_125}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -1687,11 +1705,11 @@ func (v *GenOpt) decodeQDFField(d *qdf.Decoder, name string) error {
 			} else {
 				v.A = new(int32)
 				{
-					rv120, err := d.ReadInt()
+					rv126, err := d.ReadInt()
 					if err != nil {
 						return err
 					}
-					(*v.A) = int32(rv120)
+					(*v.A) = int32(rv126)
 				}
 			}
 		}
@@ -1706,11 +1724,11 @@ func (v *GenOpt) decodeQDFField(d *qdf.Decoder, name string) error {
 			} else {
 				v.B = new(string)
 				{
-					rv121, err := d.ReadString()
+					rv127, err := d.ReadString()
 					if err != nil {
 						return err
 					}
-					(*v.B) = rv121
+					(*v.B) = rv127
 				}
 			}
 		}
@@ -1725,11 +1743,11 @@ func (v *GenOpt) decodeQDFField(d *qdf.Decoder, name string) error {
 			} else {
 				v.C = new(bool)
 				{
-					rv122, err := d.ReadBool()
+					rv128, err := d.ReadBool()
 					if err != nil {
 						return err
 					}
-					(*v.C) = rv122
+					(*v.C) = rv128
 				}
 			}
 		}
@@ -1744,11 +1762,11 @@ func (v *GenOpt) decodeQDFField(d *qdf.Decoder, name string) error {
 			} else {
 				v.D = new(float64)
 				{
-					rv123, err := d.ReadFloat64()
+					rv129, err := d.ReadFloat64()
 					if err != nil {
 						return err
 					}
-					(*v.D) = rv123
+					(*v.D) = rv129
 				}
 			}
 		}
@@ -1820,66 +1838,66 @@ func (v *GenOptSet) EncodeQDF(e *qdf.Encoder) error {
 	if v.Rows == nil {
 		e.WriteNil()
 	} else if len(v.Rows) >= 16 { // columnarMinElems
-		col124 := v.Rows
-		e.WriteColStructHeader(len(col124), qdfColNames_GenOpt, qdfColKinds_GenOpt)
-		mask125 := e.ScratchMask(len(col124))
-		c127 := e.ScratchInt(len(col124))
-		di126 := 0
-		for i := range col124 {
-			if col124[i].A != nil {
-				mask125[i>>3] |= 1 << uint(i&7)
-				c127[di126] = int64(*col124[i].A)
-				di126++
-			}
-		}
-		e.WriteColNullMask(mask125)
-		if err := e.WriteIntColumn(c127[:di126]); err != nil {
-			return err
-		}
-		mask128 := e.ScratchMask(len(col124))
-		c130 := e.ScratchString(len(col124))
-		di129 := 0
-		for i := range col124 {
-			if col124[i].B != nil {
-				mask128[i>>3] |= 1 << uint(i&7)
-				c130[di129] = string(*col124[i].B)
-				di129++
-			}
-		}
-		e.WriteColNullMask(mask128)
-		e.WriteStringColumn(c130[:di129])
-		mask131 := e.ScratchMask(len(col124))
-		c133 := e.ScratchBool(len(col124))
+		col130 := v.Rows
+		e.WriteColStructHeader(len(col130), qdfColNames_GenOpt, qdfColKinds_GenOpt)
+		mask131 := e.ScratchMask(len(col130))
+		c133 := e.ScratchInt(len(col130))
 		di132 := 0
-		for i := range col124 {
-			if col124[i].C != nil {
+		for i := range col130 {
+			if col130[i].A != nil {
 				mask131[i>>3] |= 1 << uint(i&7)
-				c133[di132] = *col124[i].C
+				c133[di132] = int64(*col130[i].A)
 				di132++
 			}
 		}
 		e.WriteColNullMask(mask131)
-		if err := e.WriteBoolColumn(c133[:di132]); err != nil {
+		if err := e.WriteIntColumn(c133[:di132]); err != nil {
 			return err
 		}
-		mask134 := e.ScratchMask(len(col124))
-		c136 := e.ScratchFloat64(len(col124))
+		mask134 := e.ScratchMask(len(col130))
+		c136 := e.ScratchString(len(col130))
 		di135 := 0
-		for i := range col124 {
-			if col124[i].D != nil {
+		for i := range col130 {
+			if col130[i].B != nil {
 				mask134[i>>3] |= 1 << uint(i&7)
-				c136[di135] = float64(*col124[i].D)
+				c136[di135] = string(*col130[i].B)
 				di135++
 			}
 		}
 		e.WriteColNullMask(mask134)
-		if err := e.WriteFloat64Column(c136[:di135]); err != nil {
+		e.WriteStringColumn(c136[:di135])
+		mask137 := e.ScratchMask(len(col130))
+		c139 := e.ScratchBool(len(col130))
+		di138 := 0
+		for i := range col130 {
+			if col130[i].C != nil {
+				mask137[i>>3] |= 1 << uint(i&7)
+				c139[di138] = *col130[i].C
+				di138++
+			}
+		}
+		e.WriteColNullMask(mask137)
+		if err := e.WriteBoolColumn(c139[:di138]); err != nil {
+			return err
+		}
+		mask140 := e.ScratchMask(len(col130))
+		c142 := e.ScratchFloat64(len(col130))
+		di141 := 0
+		for i := range col130 {
+			if col130[i].D != nil {
+				mask140[i>>3] |= 1 << uint(i&7)
+				c142[di141] = float64(*col130[i].D)
+				di141++
+			}
+		}
+		e.WriteColNullMask(mask140)
+		if err := e.WriteFloat64Column(c142[:di141]); err != nil {
 			return err
 		}
 	} else {
 		e.WriteArrayHeader(len(v.Rows))
-		for i137 := range v.Rows {
-			if err := qdf.EncodeNested(e, &v.Rows[i137]); err != nil {
+		for i143 := range v.Rows {
+			if err := qdf.EncodeNested(e, &v.Rows[i143]); err != nil {
 				return err
 			}
 		}
@@ -1925,86 +1943,86 @@ func (v *GenOptSet) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Rows = nil
 			} else if d.PeekColStruct() {
-				n138, names139, kinds140, err := d.ReadColStructHeader()
+				n144, names145, kinds146, err := d.ReadColStructHeader()
 				if err != nil {
 					return err
 				}
-				_ = kinds140
-				v.Rows = make([]GenOpt, n138)
-				for ci141 := range names139 {
-					switch names139[ci141] {
+				_ = kinds146
+				v.Rows = make([]GenOpt, n144)
+				for ci147 := range names145 {
+					switch names145[ci147] {
 					case "a":
-						mask142, present143, err := d.ReadColNullMask(n138)
+						mask148, present149, err := d.ReadColNullMask(n144)
 						if err != nil {
 							return err
 						}
-						col144, err := d.ReadIntColumn(present143)
+						col150, err := d.ReadIntColumn(present149)
 						if err != nil {
 							return err
 						}
-						di145 := 0
+						di151 := 0
 						for i := range v.Rows {
-							if mask142[i>>3]&(1<<uint(i&7)) != 0 {
-								v146 := int32(col144[di145])
-								v.Rows[i].A = &v146
-								di145++
+							if mask148[i>>3]&(1<<uint(i&7)) != 0 {
+								v152 := int32(col150[di151])
+								v.Rows[i].A = &v152
+								di151++
 							} else {
 								v.Rows[i].A = nil
 							}
 						}
 					case "b":
-						mask147, present148, err := d.ReadColNullMask(n138)
+						mask153, present154, err := d.ReadColNullMask(n144)
 						if err != nil {
 							return err
 						}
-						col149, err := d.ReadStringColumn(present148)
+						col155, err := d.ReadStringColumn(present154)
 						if err != nil {
 							return err
 						}
-						di150 := 0
+						di156 := 0
 						for i := range v.Rows {
-							if mask147[i>>3]&(1<<uint(i&7)) != 0 {
-								v151 := string(col149[di150])
-								v.Rows[i].B = &v151
-								di150++
+							if mask153[i>>3]&(1<<uint(i&7)) != 0 {
+								v157 := string(col155[di156])
+								v.Rows[i].B = &v157
+								di156++
 							} else {
 								v.Rows[i].B = nil
 							}
 						}
 					case "c":
-						mask152, present153, err := d.ReadColNullMask(n138)
+						mask158, present159, err := d.ReadColNullMask(n144)
 						if err != nil {
 							return err
 						}
-						col154, err := d.ReadBoolColumn(present153)
+						col160, err := d.ReadBoolColumn(present159)
 						if err != nil {
 							return err
 						}
-						di155 := 0
+						di161 := 0
 						for i := range v.Rows {
-							if mask152[i>>3]&(1<<uint(i&7)) != 0 {
-								v156 := col154[di155]
-								v.Rows[i].C = &v156
-								di155++
+							if mask158[i>>3]&(1<<uint(i&7)) != 0 {
+								v162 := col160[di161]
+								v.Rows[i].C = &v162
+								di161++
 							} else {
 								v.Rows[i].C = nil
 							}
 						}
 					case "d":
-						mask157, present158, err := d.ReadColNullMask(n138)
+						mask163, present164, err := d.ReadColNullMask(n144)
 						if err != nil {
 							return err
 						}
-						col159, err := d.ReadFloat64Column(present158)
+						col165, err := d.ReadFloat64Column(present164)
 						if err != nil {
 							return err
 						}
-						di160 := 0
+						di166 := 0
 						for i := range v.Rows {
-							if mask157[i>>3]&(1<<uint(i&7)) != 0 {
-								v161 := float64(col159[di160])
-								v.Rows[i].D = &v161
-								di160++
+							if mask163[i>>3]&(1<<uint(i&7)) != 0 {
+								v167 := float64(col165[di166])
+								v.Rows[i].D = &v167
+								di166++
 							} else {
 								v.Rows[i].D = nil
 							}
@@ -2015,16 +2033,16 @@ func (v *GenOptSet) decodeQDFField(d *qdf.Decoder, name string) error {
 				}
 				d.ClearColMaxLen()
 			} else {
-				n162, err := d.ReadArrayHeader()
+				n168, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n162, 1); err != nil {
+				if err := d.CheckLength(n168, 1); err != nil {
 					return err
 				}
-				v.Rows = make([]GenOpt, n162)
-				for i163 := range n162 {
-					if err := qdf.DecodeNested(d, &v.Rows[i163]); err != nil {
+				v.Rows = make([]GenOpt, n168)
+				for i169 := range n168 {
+					if err := qdf.DecodeNested(d, &v.Rows[i169]); err != nil {
 						return err
 					}
 				}
@@ -2089,7 +2107,7 @@ func (v *GenRow) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenRow byte
-var qdfFieldHdrs_GenRow = [][]byte{qdfFieldHdr_id_17, qdfFieldHdr_name_75, qdfFieldHdr_inner_164, qdfFieldHdr_tags_165}
+var qdfFieldHdrs_GenRow = [][]byte{qdfFieldHdr_id_17, qdfFieldHdr_name_81, qdfFieldHdr_inner_170, qdfFieldHdr_tags_171}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -2104,9 +2122,9 @@ func (v *GenRow) EncodeQDF(e *qdf.Encoder) error {
 		e.WriteNil()
 	} else {
 		e.WriteMapHeader(len(v.Tags))
-		for k166, vv167 := range v.Tags {
-			e.WriteString(string(k166))
-			e.WriteInt(int64(vv167))
+		for k172, vv173 := range v.Tags {
+			e.WriteString(string(k172))
+			e.WriteInt(int64(vv173))
 		}
 	}
 	return nil
@@ -2143,19 +2161,19 @@ func (v *GenRow) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "id":
 		{
-			rv168, err := d.ReadInt()
+			rv174, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.ID = int64(rv168)
+			v.ID = int64(rv174)
 		}
 	case "name":
 		{
-			rv169, err := d.ReadString()
+			rv175, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv169
+			v.Name = rv175
 		}
 	case "inner":
 		if err := qdf.DecodeNested(d, &v.Inner); err != nil {
@@ -2170,30 +2188,30 @@ func (v *GenRow) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Tags = nil
 			} else {
-				n170, err := d.ReadMapHeader()
+				n176, err := d.ReadMapHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n170, 1); err != nil {
+				if err := d.CheckLength(n176, 1); err != nil {
 					return err
 				}
-				v.Tags = make(map[string]int, n170)
-				for range n170 {
-					var k171 string
-					var vv172 int
-					kb173, err := d.ReadStringBytes()
+				v.Tags = make(map[string]int, n176)
+				for range n176 {
+					var k177 string
+					var vv178 int
+					kb179, err := d.ReadStringBytes()
 					if err != nil {
 						return err
 					}
-					k171 = string(d.InternKey(kb173))
+					k177 = string(d.InternKey(kb179))
 					{
-						rv174, err := d.ReadInt()
+						rv180, err := d.ReadInt()
 						if err != nil {
 							return err
 						}
-						vv172 = int(rv174)
+						vv178 = int(rv180)
 					}
-					v.Tags[k171] = vv172
+					v.Tags[k177] = vv178
 				}
 			}
 		}
@@ -2256,7 +2274,7 @@ func (v *GenRowInner) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenRowInner byte
-var qdfFieldHdrs_GenRowInner = [][]byte{qdfFieldHdr_x_175, qdfFieldHdr_y_176}
+var qdfFieldHdrs_GenRowInner = [][]byte{qdfFieldHdr_x_181, qdfFieldHdr_y_182}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -2298,19 +2316,19 @@ func (v *GenRowInner) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "x":
 		{
-			rv177, err := d.ReadInt()
+			rv183, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.X = int(rv177)
+			v.X = int(rv183)
 		}
 	case "y":
 		{
-			rv178, err := d.ReadString()
+			rv184, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Y = rv178
+			v.Y = rv184
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -2380,38 +2398,38 @@ func (v *GenRowSet) EncodeQDF(e *qdf.Encoder) error {
 	if v.Rows == nil {
 		e.WriteNil()
 	} else if len(v.Rows) >= 16 { // columnarMinElems
-		col179 := v.Rows
-		e.WriteHybridColStructHeader(len(col179), qdfHybNames_GenRow, qdfHybKinds_GenRow)
-		c180 := e.ScratchInt(len(col179))
-		for i := range col179 {
-			c180[i] = int64(col179[i].ID)
+		col185 := v.Rows
+		e.WriteHybridColStructHeader(len(col185), qdfHybNames_GenRow, qdfHybKinds_GenRow)
+		c186 := e.ScratchInt(len(col185))
+		for i := range col185 {
+			c186[i] = int64(col185[i].ID)
 		}
-		if err := e.WriteIntColumn(c180); err != nil {
+		if err := e.WriteIntColumn(c186); err != nil {
 			return err
 		}
-		c181 := e.ScratchString(len(col179))
-		for i := range col179 {
-			c181[i] = string(col179[i].Name)
+		c187 := e.ScratchString(len(col185))
+		for i := range col185 {
+			c187[i] = string(col185[i].Name)
 		}
-		e.WriteStringColumn(c181)
-		for i182 := range col179 {
-			if err := qdf.EncodeNested(e, &col179[i182].Inner); err != nil {
+		e.WriteStringColumn(c187)
+		for i188 := range col185 {
+			if err := qdf.EncodeNested(e, &col185[i188].Inner); err != nil {
 				return err
 			}
-			if col179[i182].Tags == nil {
+			if col185[i188].Tags == nil {
 				e.WriteNil()
 			} else {
-				e.WriteMapHeader(len(col179[i182].Tags))
-				for k183, vv184 := range col179[i182].Tags {
-					e.WriteString(string(k183))
-					e.WriteInt(int64(vv184))
+				e.WriteMapHeader(len(col185[i188].Tags))
+				for k189, vv190 := range col185[i188].Tags {
+					e.WriteString(string(k189))
+					e.WriteInt(int64(vv190))
 				}
 			}
 		}
 	} else {
 		e.WriteArrayHeader(len(v.Rows))
-		for i185 := range v.Rows {
-			if err := qdf.EncodeNested(e, &v.Rows[i185]); err != nil {
+		for i191 := range v.Rows {
+			if err := qdf.EncodeNested(e, &v.Rows[i191]); err != nil {
 				return err
 			}
 		}
@@ -2457,30 +2475,30 @@ func (v *GenRowSet) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Rows = nil
 			} else if d.PeekHybridColStruct() {
-				n186, names187, kinds188, err := d.ReadHybridColStructHeader()
+				n192, names193, kinds194, err := d.ReadHybridColStructHeader()
 				if err != nil {
 					return err
 				}
-				_ = names187
-				_ = kinds188
-				v.Rows = make([]GenRow, n186)
-				col189, err := d.ReadIntColumn(n186)
+				_ = names193
+				_ = kinds194
+				v.Rows = make([]GenRow, n192)
+				col195, err := d.ReadIntColumn(n192)
 				if err != nil {
 					return err
 				}
-				for i := range col189 {
-					v.Rows[i].ID = int64(col189[i])
+				for i := range col195 {
+					v.Rows[i].ID = int64(col195[i])
 				}
-				col190, err := d.ReadStringColumn(n186)
+				col196, err := d.ReadStringColumn(n192)
 				if err != nil {
 					return err
 				}
-				for i := range col190 {
-					v.Rows[i].Name = string(col190[i])
+				for i := range col196 {
+					v.Rows[i].Name = string(col196[i])
 				}
 				d.ClearColMaxLen()
-				for i191 := range v.Rows {
-					if err := qdf.DecodeNested(d, &v.Rows[i191].Inner); err != nil {
+				for i197 := range v.Rows {
+					if err := qdf.DecodeNested(d, &v.Rows[i197].Inner); err != nil {
 						return err
 					}
 					{
@@ -2489,47 +2507,47 @@ func (v *GenRowSet) decodeQDFField(d *qdf.Decoder, name string) error {
 							return err
 						}
 						if isNil {
-							v.Rows[i191].Tags = nil
+							v.Rows[i197].Tags = nil
 						} else {
-							n192, err := d.ReadMapHeader()
+							n198, err := d.ReadMapHeader()
 							if err != nil {
 								return err
 							}
-							if err := d.CheckLength(n192, 1); err != nil {
+							if err := d.CheckLength(n198, 1); err != nil {
 								return err
 							}
-							v.Rows[i191].Tags = make(map[string]int, n192)
-							for range n192 {
-								var k193 string
-								var vv194 int
-								kb195, err := d.ReadStringBytes()
+							v.Rows[i197].Tags = make(map[string]int, n198)
+							for range n198 {
+								var k199 string
+								var vv200 int
+								kb201, err := d.ReadStringBytes()
 								if err != nil {
 									return err
 								}
-								k193 = string(d.InternKey(kb195))
+								k199 = string(d.InternKey(kb201))
 								{
-									rv196, err := d.ReadInt()
+									rv202, err := d.ReadInt()
 									if err != nil {
 										return err
 									}
-									vv194 = int(rv196)
+									vv200 = int(rv202)
 								}
-								v.Rows[i191].Tags[k193] = vv194
+								v.Rows[i197].Tags[k199] = vv200
 							}
 						}
 					}
 				}
 			} else {
-				n197, err := d.ReadArrayHeader()
+				n203, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n197, 1); err != nil {
+				if err := d.CheckLength(n203, 1); err != nil {
 					return err
 				}
-				v.Rows = make([]GenRow, n197)
-				for i198 := range n197 {
-					if err := qdf.DecodeNested(d, &v.Rows[i198]); err != nil {
+				v.Rows = make([]GenRow, n203)
+				for i204 := range n203 {
+					if err := qdf.DecodeNested(d, &v.Rows[i204]); err != nil {
 						return err
 					}
 				}
@@ -2579,6 +2597,274 @@ func (v *GenRowSet) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (in
 
 // MarshalQDF appends a qdf-encoded representation of v to dst and returns
 // the extended slice.
+func (v *GenTrailed) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenTrailed byte
+var qdfFieldHdrs_GenTrailed = [][]byte{qdfFieldHdr_rows_20, qdfFieldHdr_note_205, qdfFieldHdr_tail_5}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenTrailed) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenTrailed, qdfFieldHdrs_GenTrailed)
+	if v.Rows == nil {
+		e.WriteNil()
+	} else if len(v.Rows) >= 16 { // columnarMinElems
+		col206 := v.Rows
+		e.WriteColStructHeader(len(col206), qdfColNames_GenMetric, qdfColKinds_GenMetric)
+		c207 := e.ScratchInt(len(col206))
+		for i := range col206 {
+			c207[i] = int64(col206[i].TS)
+		}
+		if err := e.WriteIntColumn(c207); err != nil {
+			return err
+		}
+		c208 := e.ScratchFloat64(len(col206))
+		for i := range col206 {
+			c208[i] = float64(col206[i].Value)
+		}
+		if err := e.WriteFloat64Column(c208); err != nil {
+			return err
+		}
+		c209 := e.ScratchUint(len(col206))
+		for i := range col206 {
+			c209[i] = uint64(col206[i].Count)
+		}
+		if err := e.WriteUintColumn(c209); err != nil {
+			return err
+		}
+		c210 := e.ScratchBool(len(col206))
+		for i := range col206 {
+			c210[i] = col206[i].OK
+		}
+		if err := e.WriteBoolColumn(c210); err != nil {
+			return err
+		}
+		c211 := e.ScratchFloat32(len(col206))
+		for i := range col206 {
+			c211[i] = float32(col206[i].Ratio)
+		}
+		if err := e.WriteFloat32Column(c211); err != nil {
+			return err
+		}
+	} else {
+		e.WriteArrayHeader(len(v.Rows))
+		for i212 := range v.Rows {
+			if err := qdf.EncodeNested(e, &v.Rows[i212]); err != nil {
+				return err
+			}
+		}
+	}
+	e.WriteString(string(v.Note))
+	if v.Tail == nil {
+		e.WriteNil()
+	} else {
+		e.WriteArrayHeader(len(v.Tail))
+		for i213 := range v.Tail {
+			e.WriteInt(int64(v.Tail[i213]))
+		}
+	}
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenTrailed) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenTrailed) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "rows":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Rows = nil
+			} else if d.PeekColStruct() {
+				n214, names215, kinds216, err := d.ReadColStructHeader()
+				if err != nil {
+					return err
+				}
+				_ = kinds216
+				v.Rows = make([]GenMetric, n214)
+				for ci217 := range names215 {
+					switch names215[ci217] {
+					case "ts":
+						col218, err := d.ReadIntColumn(n214)
+						if err != nil {
+							return err
+						}
+						for i := range col218 {
+							v.Rows[i].TS = int64(col218[i])
+						}
+					case "value":
+						col219, err := d.ReadFloat64Column(n214)
+						if err != nil {
+							return err
+						}
+						for i := range col219 {
+							v.Rows[i].Value = float64(col219[i])
+						}
+					case "count":
+						col220, err := d.ReadUintColumn(n214)
+						if err != nil {
+							return err
+						}
+						for i := range col220 {
+							v.Rows[i].Count = uint32(col220[i])
+						}
+					case "ok":
+						col221, err := d.ReadBoolColumn(n214)
+						if err != nil {
+							return err
+						}
+						for i := range col221 {
+							v.Rows[i].OK = col221[i]
+						}
+					case "ratio":
+						col222, err := d.ReadFloat32Column(n214)
+						if err != nil {
+							return err
+						}
+						for i := range col222 {
+							v.Rows[i].Ratio = float32(col222[i])
+						}
+					default:
+						return qdf.ErrTypeMismatch
+					}
+				}
+				d.ClearColMaxLen()
+			} else {
+				n223, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n223, 1); err != nil {
+					return err
+				}
+				v.Rows = make([]GenMetric, n223)
+				for i224 := range n223 {
+					if err := qdf.DecodeNested(d, &v.Rows[i224]); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	case "note":
+		{
+			rv225, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Note = rv225
+		}
+	case "tail":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Tail = nil
+			} else {
+				n226, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n226, 1); err != nil {
+					return err
+				}
+				v.Tail = make([]int64, n226)
+				for i227 := range n226 {
+					{
+						rv228, err := d.ReadInt()
+						if err != nil {
+							return err
+						}
+						v.Tail[i227] = int64(rv228)
+					}
+				}
+			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenTrailed) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenTrailed) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenTrailed) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
 func (v *Inner) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
@@ -2594,7 +2880,7 @@ func (v *Inner) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_Inner byte
-var qdfFieldHdrs_Inner = [][]byte{qdfFieldHdr_x_175, qdfFieldHdr_y_176}
+var qdfFieldHdrs_Inner = [][]byte{qdfFieldHdr_x_181, qdfFieldHdr_y_182}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -2636,19 +2922,19 @@ func (v *Inner) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "x":
 		{
-			rv199, err := d.ReadInt()
+			rv229, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.X = int(rv199)
+			v.X = int(rv229)
 		}
 	case "y":
 		{
-			rv200, err := d.ReadFloat64()
+			rv230, err := d.ReadFloat64()
 			if err != nil {
 				return err
 			}
-			v.Y = rv200
+			v.Y = rv230
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -2709,7 +2995,7 @@ func (v *Sample) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_Sample byte
-var qdfFieldHdrs_Sample = [][]byte{qdfFieldHdr_name_75, qdfFieldHdr_age_201, qdfFieldHdr_active_202, qdfFieldHdr_score_203, qdfFieldHdr_tags_165, qdfFieldHdr_meta_204, qdfFieldHdr_inner_164, qdfFieldHdr_when_205, qdfFieldHdr_buf_206, qdfFieldHdr_opt_207, qdfFieldHdr_counts_208}
+var qdfFieldHdrs_Sample = [][]byte{qdfFieldHdr_name_81, qdfFieldHdr_age_231, qdfFieldHdr_active_232, qdfFieldHdr_score_233, qdfFieldHdr_tags_171, qdfFieldHdr_meta_234, qdfFieldHdr_inner_170, qdfFieldHdr_when_235, qdfFieldHdr_buf_236, qdfFieldHdr_opt_237, qdfFieldHdr_counts_238}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -2723,17 +3009,17 @@ func (v *Sample) EncodeQDF(e *qdf.Encoder) error {
 		e.WriteNil()
 	} else {
 		e.WriteArrayHeader(len(v.Tags))
-		for i209 := range v.Tags {
-			e.WriteString(string(v.Tags[i209]))
+		for i239 := range v.Tags {
+			e.WriteString(string(v.Tags[i239]))
 		}
 	}
 	if v.Meta == nil {
 		e.WriteNil()
 	} else {
 		e.WriteMapHeader(len(v.Meta))
-		for k210, vv211 := range v.Meta {
-			e.WriteString(string(k210))
-			e.WriteString(string(vv211))
+		for k240, vv241 := range v.Meta {
+			e.WriteString(string(k240))
+			e.WriteString(string(vv241))
 		}
 	}
 	if err := qdf.EncodeNested(e, &v.Inner); err != nil {
@@ -2756,8 +3042,8 @@ func (v *Sample) EncodeQDF(e *qdf.Encoder) error {
 		}
 	}
 	e.WriteArrayHeader(3)
-	for i212 := range v.Counts {
-		e.WriteInt(int64(v.Counts[i212]))
+	for i242 := range v.Counts {
+		e.WriteInt(int64(v.Counts[i242]))
 	}
 	return nil
 }
@@ -2793,35 +3079,35 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "name":
 		{
-			rv213, err := d.ReadString()
+			rv243, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv213
+			v.Name = rv243
 		}
 	case "age":
 		{
-			rv214, err := d.ReadInt()
+			rv244, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.Age = int(rv214)
+			v.Age = int(rv244)
 		}
 	case "active":
 		{
-			rv215, err := d.ReadBool()
+			rv245, err := d.ReadBool()
 			if err != nil {
 				return err
 			}
-			v.Active = rv215
+			v.Active = rv245
 		}
 	case "score":
 		{
-			rv216, err := d.ReadFloat64()
+			rv246, err := d.ReadFloat64()
 			if err != nil {
 				return err
 			}
-			v.Score = rv216
+			v.Score = rv246
 		}
 	case "tags":
 		{
@@ -2832,21 +3118,21 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Tags = nil
 			} else {
-				n217, err := d.ReadArrayHeader()
+				n247, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n217, 1); err != nil {
+				if err := d.CheckLength(n247, 1); err != nil {
 					return err
 				}
-				v.Tags = make([]string, n217)
-				for i218 := range n217 {
+				v.Tags = make([]string, n247)
+				for i248 := range n247 {
 					{
-						rv219, err := d.ReadString()
+						rv249, err := d.ReadString()
 						if err != nil {
 							return err
 						}
-						v.Tags[i218] = rv219
+						v.Tags[i248] = rv249
 					}
 				}
 			}
@@ -2860,30 +3146,30 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Meta = nil
 			} else {
-				n220, err := d.ReadMapHeader()
+				n250, err := d.ReadMapHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n220, 1); err != nil {
+				if err := d.CheckLength(n250, 1); err != nil {
 					return err
 				}
-				v.Meta = make(map[string]string, n220)
-				for range n220 {
-					var k221 string
-					var vv222 string
-					kb223, err := d.ReadStringBytes()
+				v.Meta = make(map[string]string, n250)
+				for range n250 {
+					var k251 string
+					var vv252 string
+					kb253, err := d.ReadStringBytes()
 					if err != nil {
 						return err
 					}
-					k221 = string(d.InternKey(kb223))
+					k251 = string(d.InternKey(kb253))
 					{
-						rv224, err := d.ReadString()
+						rv254, err := d.ReadString()
 						if err != nil {
 							return err
 						}
-						vv222 = rv224
+						vv252 = rv254
 					}
-					v.Meta[k221] = vv222
+					v.Meta[k251] = vv252
 				}
 			}
 		}
@@ -2893,11 +3179,11 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 		}
 	case "when":
 		{
-			sec225, nsec226, err := d.ReadTimestamp()
+			sec255, nsec256, err := d.ReadTimestamp()
 			if err != nil {
 				return err
 			}
-			v.When = time.Unix(sec225, int64(nsec226)).UTC()
+			v.When = time.Unix(sec255, int64(nsec256)).UTC()
 		}
 	case "buf":
 		{
@@ -2932,20 +3218,20 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 		}
 	case "counts":
 		{
-			n227, err := d.ReadArrayHeader()
+			n257, err := d.ReadArrayHeader()
 			if err != nil {
 				return err
 			}
-			if n227 != 3 {
+			if n257 != 3 {
 				return qdf.ErrTypeMismatch
 			}
-			for i228 := range 3 {
+			for i258 := range 3 {
 				{
-					rv229, err := d.ReadInt()
+					rv259, err := d.ReadInt()
 					if err != nil {
 						return err
 					}
-					v.Counts[i228] = int32(rv229)
+					v.Counts[i258] = int32(rv259)
 				}
 			}
 		}

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -504,6 +504,7 @@ func (v *GenBlobSet) decodeQDFField(d *qdf.Decoder, name string) error {
 						return qdf.ErrTypeMismatch
 					}
 				}
+				d.ClearColMaxLen()
 			} else {
 				n31, err := d.ReadArrayHeader()
 				if err != nil {
@@ -855,6 +856,7 @@ func (v *GenEventLog) decodeQDFField(d *qdf.Decoder, name string) error {
 						return qdf.ErrTypeMismatch
 					}
 				}
+				d.ClearColMaxLen()
 			} else {
 				n64, err := d.ReadArrayHeader()
 				if err != nil {
@@ -1228,6 +1230,7 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 						return qdf.ErrTypeMismatch
 					}
 				}
+				d.ClearColMaxLen()
 			} else {
 				n94, err := d.ReadArrayHeader()
 				if err != nil {
@@ -1539,6 +1542,7 @@ func (v *GenNameList) decodeQDFField(d *qdf.Decoder, name string) error {
 						return qdf.ErrTypeMismatch
 					}
 				}
+				d.ClearColMaxLen()
 			} else {
 				n114, err := d.ReadArrayHeader()
 				if err != nil {
@@ -2009,6 +2013,7 @@ func (v *GenOptSet) decodeQDFField(d *qdf.Decoder, name string) error {
 						return qdf.ErrTypeMismatch
 					}
 				}
+				d.ClearColMaxLen()
 			} else {
 				n162, err := d.ReadArrayHeader()
 				if err != nil {

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -22,18 +22,18 @@ var (
 	qdfFieldHdr_ratio_21   = []byte{0x85, 0x72, 0x61, 0x74, 0x69, 0x6f}
 	qdfFieldHdr_name_27    = []byte{0x84, 0x6e, 0x61, 0x6d, 0x65}
 	qdfFieldHdr_metrics_28 = []byte{0x87, 0x6d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73}
-	qdfFieldHdr_x_39       = []byte{0x81, 0x78}
-	qdfFieldHdr_y_40       = []byte{0x81, 0x79}
-	qdfFieldHdr_age_43     = []byte{0x83, 0x61, 0x67, 0x65}
-	qdfFieldHdr_active_44  = []byte{0x86, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65}
-	qdfFieldHdr_score_45   = []byte{0x85, 0x73, 0x63, 0x6f, 0x72, 0x65}
-	qdfFieldHdr_tags_46    = []byte{0x84, 0x74, 0x61, 0x67, 0x73}
-	qdfFieldHdr_meta_47    = []byte{0x84, 0x6d, 0x65, 0x74, 0x61}
-	qdfFieldHdr_inner_48   = []byte{0x85, 0x69, 0x6e, 0x6e, 0x65, 0x72}
-	qdfFieldHdr_when_49    = []byte{0x84, 0x77, 0x68, 0x65, 0x6e}
-	qdfFieldHdr_buf_50     = []byte{0x83, 0x62, 0x75, 0x66}
-	qdfFieldHdr_opt_51     = []byte{0x83, 0x6f, 0x70, 0x74}
-	qdfFieldHdr_counts_52  = []byte{0x86, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73}
+	qdfFieldHdr_x_48       = []byte{0x81, 0x78}
+	qdfFieldHdr_y_49       = []byte{0x81, 0x79}
+	qdfFieldHdr_age_52     = []byte{0x83, 0x61, 0x67, 0x65}
+	qdfFieldHdr_active_53  = []byte{0x86, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65}
+	qdfFieldHdr_score_54   = []byte{0x85, 0x73, 0x63, 0x6f, 0x72, 0x65}
+	qdfFieldHdr_tags_55    = []byte{0x84, 0x74, 0x61, 0x67, 0x73}
+	qdfFieldHdr_meta_56    = []byte{0x84, 0x6d, 0x65, 0x74, 0x61}
+	qdfFieldHdr_inner_57   = []byte{0x85, 0x69, 0x6e, 0x6e, 0x65, 0x72}
+	qdfFieldHdr_when_58    = []byte{0x84, 0x77, 0x68, 0x65, 0x6e}
+	qdfFieldHdr_buf_59     = []byte{0x83, 0x62, 0x75, 0x66}
+	qdfFieldHdr_opt_60     = []byte{0x83, 0x6f, 0x70, 0x74}
+	qdfFieldHdr_counts_61  = []byte{0x86, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73}
 )
 
 // Columnar shape descriptors: per element-type column names and kind
@@ -496,17 +496,70 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 			}
 			if isNil {
 				v.Metrics = nil
-			} else {
-				n37, err := d.ReadArrayHeader()
+			} else if d.PeekColStruct() {
+				n37, names38, kinds39, err := d.ReadColStructHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n37, 1); err != nil {
+				_ = kinds39
+				v.Metrics = make([]GenMetric, n37)
+				for ci40 := range names38 {
+					switch names38[ci40] {
+					case "ts":
+						col41, err := d.ReadIntColumn(n37)
+						if err != nil {
+							return err
+						}
+						for i := range col41 {
+							v.Metrics[i].TS = int64(col41[i])
+						}
+					case "value":
+						col42, err := d.ReadFloat64Column(n37)
+						if err != nil {
+							return err
+						}
+						for i := range col42 {
+							v.Metrics[i].Value = float64(col42[i])
+						}
+					case "count":
+						col43, err := d.ReadUintColumn(n37)
+						if err != nil {
+							return err
+						}
+						for i := range col43 {
+							v.Metrics[i].Count = uint32(col43[i])
+						}
+					case "ok":
+						col44, err := d.ReadBoolColumn(n37)
+						if err != nil {
+							return err
+						}
+						for i := range col44 {
+							v.Metrics[i].OK = col44[i]
+						}
+					case "ratio":
+						col45, err := d.ReadFloat32Column(n37)
+						if err != nil {
+							return err
+						}
+						for i := range col45 {
+							v.Metrics[i].Ratio = float32(col45[i])
+						}
+					default:
+						return qdf.ErrTypeMismatch
+					}
+				}
+			} else {
+				n46, err := d.ReadArrayHeader()
+				if err != nil {
 					return err
 				}
-				v.Metrics = make([]GenMetric, n37)
-				for i38 := range n37 {
-					if err := qdf.DecodeNested(d, &v.Metrics[i38]); err != nil {
+				if err := d.CheckLength(n46, 1); err != nil {
+					return err
+				}
+				v.Metrics = make([]GenMetric, n46)
+				for i47 := range n46 {
+					if err := qdf.DecodeNested(d, &v.Metrics[i47]); err != nil {
 						return err
 					}
 				}
@@ -571,7 +624,7 @@ func (v *Inner) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_Inner byte
-var qdfFieldHdrs_Inner = [][]byte{qdfFieldHdr_x_39, qdfFieldHdr_y_40}
+var qdfFieldHdrs_Inner = [][]byte{qdfFieldHdr_x_48, qdfFieldHdr_y_49}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -613,19 +666,19 @@ func (v *Inner) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "x":
 		{
-			rv41, err := d.ReadInt()
+			rv50, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.X = int(rv41)
+			v.X = int(rv50)
 		}
 	case "y":
 		{
-			rv42, err := d.ReadFloat64()
+			rv51, err := d.ReadFloat64()
 			if err != nil {
 				return err
 			}
-			v.Y = rv42
+			v.Y = rv51
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -686,7 +739,7 @@ func (v *Sample) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_Sample byte
-var qdfFieldHdrs_Sample = [][]byte{qdfFieldHdr_name_27, qdfFieldHdr_age_43, qdfFieldHdr_active_44, qdfFieldHdr_score_45, qdfFieldHdr_tags_46, qdfFieldHdr_meta_47, qdfFieldHdr_inner_48, qdfFieldHdr_when_49, qdfFieldHdr_buf_50, qdfFieldHdr_opt_51, qdfFieldHdr_counts_52}
+var qdfFieldHdrs_Sample = [][]byte{qdfFieldHdr_name_27, qdfFieldHdr_age_52, qdfFieldHdr_active_53, qdfFieldHdr_score_54, qdfFieldHdr_tags_55, qdfFieldHdr_meta_56, qdfFieldHdr_inner_57, qdfFieldHdr_when_58, qdfFieldHdr_buf_59, qdfFieldHdr_opt_60, qdfFieldHdr_counts_61}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -700,17 +753,17 @@ func (v *Sample) EncodeQDF(e *qdf.Encoder) error {
 		e.WriteNil()
 	} else {
 		e.WriteArrayHeader(len(v.Tags))
-		for i53 := range v.Tags {
-			e.WriteString(string(v.Tags[i53]))
+		for i62 := range v.Tags {
+			e.WriteString(string(v.Tags[i62]))
 		}
 	}
 	if v.Meta == nil {
 		e.WriteNil()
 	} else {
 		e.WriteMapHeader(len(v.Meta))
-		for k54, vv55 := range v.Meta {
-			e.WriteString(string(k54))
-			e.WriteString(string(vv55))
+		for k63, vv64 := range v.Meta {
+			e.WriteString(string(k63))
+			e.WriteString(string(vv64))
 		}
 	}
 	if err := qdf.EncodeNested(e, &v.Inner); err != nil {
@@ -733,8 +786,8 @@ func (v *Sample) EncodeQDF(e *qdf.Encoder) error {
 		}
 	}
 	e.WriteArrayHeader(3)
-	for i56 := range v.Counts {
-		e.WriteInt(int64(v.Counts[i56]))
+	for i65 := range v.Counts {
+		e.WriteInt(int64(v.Counts[i65]))
 	}
 	return nil
 }
@@ -770,35 +823,35 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "name":
 		{
-			rv57, err := d.ReadString()
+			rv66, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv57
+			v.Name = rv66
 		}
 	case "age":
 		{
-			rv58, err := d.ReadInt()
+			rv67, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.Age = int(rv58)
+			v.Age = int(rv67)
 		}
 	case "active":
 		{
-			rv59, err := d.ReadBool()
+			rv68, err := d.ReadBool()
 			if err != nil {
 				return err
 			}
-			v.Active = rv59
+			v.Active = rv68
 		}
 	case "score":
 		{
-			rv60, err := d.ReadFloat64()
+			rv69, err := d.ReadFloat64()
 			if err != nil {
 				return err
 			}
-			v.Score = rv60
+			v.Score = rv69
 		}
 	case "tags":
 		{
@@ -809,21 +862,21 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Tags = nil
 			} else {
-				n61, err := d.ReadArrayHeader()
+				n70, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n61, 1); err != nil {
+				if err := d.CheckLength(n70, 1); err != nil {
 					return err
 				}
-				v.Tags = make([]string, n61)
-				for i62 := range n61 {
+				v.Tags = make([]string, n70)
+				for i71 := range n70 {
 					{
-						rv63, err := d.ReadString()
+						rv72, err := d.ReadString()
 						if err != nil {
 							return err
 						}
-						v.Tags[i62] = rv63
+						v.Tags[i71] = rv72
 					}
 				}
 			}
@@ -837,30 +890,30 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Meta = nil
 			} else {
-				n64, err := d.ReadMapHeader()
+				n73, err := d.ReadMapHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n64, 1); err != nil {
+				if err := d.CheckLength(n73, 1); err != nil {
 					return err
 				}
-				v.Meta = make(map[string]string, n64)
-				for range n64 {
-					var k65 string
-					var vv66 string
-					kb67, err := d.ReadStringBytes()
+				v.Meta = make(map[string]string, n73)
+				for range n73 {
+					var k74 string
+					var vv75 string
+					kb76, err := d.ReadStringBytes()
 					if err != nil {
 						return err
 					}
-					k65 = string(d.InternKey(kb67))
+					k74 = string(d.InternKey(kb76))
 					{
-						rv68, err := d.ReadString()
+						rv77, err := d.ReadString()
 						if err != nil {
 							return err
 						}
-						vv66 = rv68
+						vv75 = rv77
 					}
-					v.Meta[k65] = vv66
+					v.Meta[k74] = vv75
 				}
 			}
 		}
@@ -870,11 +923,11 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 		}
 	case "when":
 		{
-			sec69, nsec70, err := d.ReadTimestamp()
+			sec78, nsec79, err := d.ReadTimestamp()
 			if err != nil {
 				return err
 			}
-			v.When = time.Unix(sec69, int64(nsec70)).UTC()
+			v.When = time.Unix(sec78, int64(nsec79)).UTC()
 		}
 	case "buf":
 		{
@@ -909,20 +962,20 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 		}
 	case "counts":
 		{
-			n71, err := d.ReadArrayHeader()
+			n80, err := d.ReadArrayHeader()
 			if err != nil {
 				return err
 			}
-			if n71 != 3 {
+			if n80 != 3 {
 				return qdf.ErrTypeMismatch
 			}
-			for i72 := range 3 {
+			for i81 := range 3 {
 				{
-					rv73, err := d.ReadInt()
+					rv82, err := d.ReadInt()
 					if err != nil {
 						return err
 					}
-					v.Counts[i72] = int32(rv73)
+					v.Counts[i81] = int32(rv82)
 				}
 			}
 		}

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -16,30 +16,46 @@ var (
 	qdfFieldHdr_ptr_4      = []byte{0x83, 0x70, 0x74, 0x72}
 	qdfFieldHdr_tail_5     = []byte{0x84, 0x74, 0x61, 0x69, 0x6c}
 	qdfFieldHdr_ts_17      = []byte{0x82, 0x74, 0x73}
-	qdfFieldHdr_value_18   = []byte{0x85, 0x76, 0x61, 0x6c, 0x75, 0x65}
-	qdfFieldHdr_count_19   = []byte{0x85, 0x63, 0x6f, 0x75, 0x6e, 0x74}
-	qdfFieldHdr_ok_20      = []byte{0x82, 0x6f, 0x6b}
-	qdfFieldHdr_ratio_21   = []byte{0x85, 0x72, 0x61, 0x74, 0x69, 0x6f}
-	qdfFieldHdr_name_27    = []byte{0x84, 0x6e, 0x61, 0x6d, 0x65}
-	qdfFieldHdr_metrics_28 = []byte{0x87, 0x6d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73}
-	qdfFieldHdr_x_48       = []byte{0x81, 0x78}
-	qdfFieldHdr_y_49       = []byte{0x81, 0x79}
-	qdfFieldHdr_age_52     = []byte{0x83, 0x61, 0x67, 0x65}
-	qdfFieldHdr_active_53  = []byte{0x86, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65}
-	qdfFieldHdr_score_54   = []byte{0x85, 0x73, 0x63, 0x6f, 0x72, 0x65}
-	qdfFieldHdr_tags_55    = []byte{0x84, 0x74, 0x61, 0x67, 0x73}
-	qdfFieldHdr_meta_56    = []byte{0x84, 0x6d, 0x65, 0x74, 0x61}
-	qdfFieldHdr_inner_57   = []byte{0x85, 0x69, 0x6e, 0x6e, 0x65, 0x72}
-	qdfFieldHdr_when_58    = []byte{0x84, 0x77, 0x68, 0x65, 0x6e}
-	qdfFieldHdr_buf_59     = []byte{0x83, 0x62, 0x75, 0x66}
-	qdfFieldHdr_opt_60     = []byte{0x83, 0x6f, 0x70, 0x74}
-	qdfFieldHdr_counts_61  = []byte{0x86, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73}
+	qdfFieldHdr_level_18   = []byte{0x85, 0x6c, 0x65, 0x76, 0x65, 0x6c}
+	qdfFieldHdr_code_19    = []byte{0x84, 0x63, 0x6f, 0x64, 0x65}
+	qdfFieldHdr_msg_20     = []byte{0x83, 0x6d, 0x73, 0x67}
+	qdfFieldHdr_source_26  = []byte{0x86, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65}
+	qdfFieldHdr_events_27  = []byte{0x86, 0x65, 0x76, 0x65, 0x6e, 0x74, 0x73}
+	qdfFieldHdr_value_50   = []byte{0x85, 0x76, 0x61, 0x6c, 0x75, 0x65}
+	qdfFieldHdr_count_51   = []byte{0x85, 0x63, 0x6f, 0x75, 0x6e, 0x74}
+	qdfFieldHdr_ok_52      = []byte{0x82, 0x6f, 0x6b}
+	qdfFieldHdr_ratio_53   = []byte{0x85, 0x72, 0x61, 0x74, 0x69, 0x6f}
+	qdfFieldHdr_name_59    = []byte{0x84, 0x6e, 0x61, 0x6d, 0x65}
+	qdfFieldHdr_metrics_60 = []byte{0x87, 0x6d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73}
+	qdfFieldHdr_first_80   = []byte{0x85, 0x66, 0x69, 0x72, 0x73, 0x74}
+	qdfFieldHdr_last_81    = []byte{0x84, 0x6c, 0x61, 0x73, 0x74}
+	qdfFieldHdr_names_84   = []byte{0x85, 0x6e, 0x61, 0x6d, 0x65, 0x73}
+	qdfFieldHdr_id_100     = []byte{0x82, 0x69, 0x64}
+	qdfFieldHdr_inner_101  = []byte{0x85, 0x69, 0x6e, 0x6e, 0x65, 0x72}
+	qdfFieldHdr_tags_102   = []byte{0x84, 0x74, 0x61, 0x67, 0x73}
+	qdfFieldHdr_x_112      = []byte{0x81, 0x78}
+	qdfFieldHdr_y_113      = []byte{0x81, 0x79}
+	qdfFieldHdr_rows_116   = []byte{0x84, 0x72, 0x6f, 0x77, 0x73}
+	qdfFieldHdr_age_139    = []byte{0x83, 0x61, 0x67, 0x65}
+	qdfFieldHdr_active_140 = []byte{0x86, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65}
+	qdfFieldHdr_score_141  = []byte{0x85, 0x73, 0x63, 0x6f, 0x72, 0x65}
+	qdfFieldHdr_meta_142   = []byte{0x84, 0x6d, 0x65, 0x74, 0x61}
+	qdfFieldHdr_when_143   = []byte{0x84, 0x77, 0x68, 0x65, 0x6e}
+	qdfFieldHdr_buf_144    = []byte{0x83, 0x62, 0x75, 0x66}
+	qdfFieldHdr_opt_145    = []byte{0x83, 0x6f, 0x70, 0x74}
+	qdfFieldHdr_counts_146 = []byte{0x86, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73}
 )
 
 // Columnar shape descriptors: per element-type column names and kind
 // bytes for the monomorphized tagColStruct transpose path.
+var qdfColNames_GenEvent = []string{"ts", "level", "code", "msg"}
+var qdfColKinds_GenEvent = []byte{0x05, 0x04, 0x00, 0x04}
 var qdfColNames_GenMetric = []string{"ts", "value", "count", "ok", "ratio"}
 var qdfColKinds_GenMetric = []byte{0x00, 0x02, 0x01, 0x03, 0x06}
+var qdfColNames_GenName = []string{"first", "last"}
+var qdfColKinds_GenName = []byte{0x04, 0x04}
+var qdfHybNames_GenRow = []string{"id", "name", "inner", "tags"}
+var qdfHybKinds_GenRow = []byte{0x00, 0x04, 0xff, 0xff}
 
 // MarshalQDF appends a qdf-encoded representation of v to dst and returns
 // the extended slice.
@@ -236,6 +252,357 @@ func (v *Edge) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, er
 
 // MarshalQDF appends a qdf-encoded representation of v to dst and returns
 // the extended slice.
+func (v *GenEvent) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenEvent byte
+var qdfFieldHdrs_GenEvent = [][]byte{qdfFieldHdr_ts_17, qdfFieldHdr_level_18, qdfFieldHdr_code_19, qdfFieldHdr_msg_20}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenEvent) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenEvent, qdfFieldHdrs_GenEvent)
+	{
+		_t := (v.TS).UTC()
+		e.WriteTimestamp(_t.Unix(), uint32(_t.Nanosecond()))
+	}
+	e.WriteString(string(v.Level))
+	e.WriteInt(int64(v.Code))
+	e.WriteString(string(v.Msg))
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenEvent) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenEvent) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "ts":
+		{
+			sec21, nsec22, err := d.ReadTimestamp()
+			if err != nil {
+				return err
+			}
+			v.TS = time.Unix(sec21, int64(nsec22)).UTC()
+		}
+	case "level":
+		{
+			rv23, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Level = rv23
+		}
+	case "code":
+		{
+			rv24, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v.Code = int32(rv24)
+		}
+	case "msg":
+		{
+			rv25, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Msg = rv25
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenEvent) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenEvent) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenEvent) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
+func (v *GenEventLog) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenEventLog byte
+var qdfFieldHdrs_GenEventLog = [][]byte{qdfFieldHdr_source_26, qdfFieldHdr_events_27}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenEventLog) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenEventLog, qdfFieldHdrs_GenEventLog)
+	e.WriteString(string(v.Source))
+	if v.Events == nil {
+		e.WriteNil()
+	} else if len(v.Events) >= 16 { // columnarMinElems
+		col28 := v.Events
+		e.WriteColStructHeader(len(col28), qdfColNames_GenEvent, qdfColKinds_GenEvent)
+		sec30 := e.ScratchInt(len(col28))
+		ns31 := e.ScratchUint(len(col28))
+		for i := range col28 {
+			t32 := col28[i].TS.UTC()
+			sec30[i] = t32.Unix()
+			ns31[i] = uint64(t32.Nanosecond())
+		}
+		if err := e.WriteTimeColumn(sec30, ns31); err != nil {
+			return err
+		}
+		c33 := e.ScratchString(len(col28))
+		for i := range col28 {
+			c33[i] = string(col28[i].Level)
+		}
+		e.WriteStringColumn(c33)
+		c34 := e.ScratchInt(len(col28))
+		for i := range col28 {
+			c34[i] = int64(col28[i].Code)
+		}
+		if err := e.WriteIntColumn(c34); err != nil {
+			return err
+		}
+		c35 := e.ScratchString(len(col28))
+		for i := range col28 {
+			c35[i] = string(col28[i].Msg)
+		}
+		e.WriteStringColumn(c35)
+	} else {
+		e.WriteArrayHeader(len(v.Events))
+		for i36 := range v.Events {
+			if err := qdf.EncodeNested(e, &v.Events[i36]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenEventLog) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenEventLog) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "source":
+		{
+			rv37, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Source = rv37
+		}
+	case "events":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Events = nil
+			} else if d.PeekColStruct() {
+				n38, names39, kinds40, err := d.ReadColStructHeader()
+				if err != nil {
+					return err
+				}
+				_ = kinds40
+				v.Events = make([]GenEvent, n38)
+				for ci41 := range names39 {
+					switch names39[ci41] {
+					case "ts":
+						sec43, ns44, err := d.ReadTimeColumn(n38)
+						if err != nil {
+							return err
+						}
+						for i := range sec43 {
+							v.Events[i].TS = time.Unix(sec43[i], int64(ns44[i])).UTC()
+						}
+					case "level":
+						col45, err := d.ReadStringColumn(n38)
+						if err != nil {
+							return err
+						}
+						for i := range col45 {
+							v.Events[i].Level = string(col45[i])
+						}
+					case "code":
+						col46, err := d.ReadIntColumn(n38)
+						if err != nil {
+							return err
+						}
+						for i := range col46 {
+							v.Events[i].Code = int32(col46[i])
+						}
+					case "msg":
+						col47, err := d.ReadStringColumn(n38)
+						if err != nil {
+							return err
+						}
+						for i := range col47 {
+							v.Events[i].Msg = string(col47[i])
+						}
+					default:
+						return qdf.ErrTypeMismatch
+					}
+				}
+			} else {
+				n48, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n48, 1); err != nil {
+					return err
+				}
+				v.Events = make([]GenEvent, n48)
+				for i49 := range n48 {
+					if err := qdf.DecodeNested(d, &v.Events[i49]); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenEventLog) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenEventLog) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenEventLog) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
 func (v *GenMetric) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
@@ -251,7 +618,7 @@ func (v *GenMetric) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenMetric byte
-var qdfFieldHdrs_GenMetric = [][]byte{qdfFieldHdr_ts_17, qdfFieldHdr_value_18, qdfFieldHdr_count_19, qdfFieldHdr_ok_20, qdfFieldHdr_ratio_21}
+var qdfFieldHdrs_GenMetric = [][]byte{qdfFieldHdr_ts_17, qdfFieldHdr_value_50, qdfFieldHdr_count_51, qdfFieldHdr_ok_52, qdfFieldHdr_ratio_53}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -296,43 +663,43 @@ func (v *GenMetric) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "ts":
 		{
-			rv22, err := d.ReadInt()
+			rv54, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.TS = int64(rv22)
+			v.TS = int64(rv54)
 		}
 	case "value":
 		{
-			rv23, err := d.ReadFloat64()
+			rv55, err := d.ReadFloat64()
 			if err != nil {
 				return err
 			}
-			v.Value = rv23
+			v.Value = rv55
 		}
 	case "count":
 		{
-			rv24, err := d.ReadUint()
+			rv56, err := d.ReadUint()
 			if err != nil {
 				return err
 			}
-			v.Count = uint32(rv24)
+			v.Count = uint32(rv56)
 		}
 	case "ok":
 		{
-			rv25, err := d.ReadBool()
+			rv57, err := d.ReadBool()
 			if err != nil {
 				return err
 			}
-			v.OK = rv25
+			v.OK = rv57
 		}
 	case "ratio":
 		{
-			rv26, err := d.ReadFloat32()
+			rv58, err := d.ReadFloat32()
 			if err != nil {
 				return err
 			}
-			v.Ratio = rv26
+			v.Ratio = rv58
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -393,7 +760,7 @@ func (v *GenMetricBatch) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_GenMetricBatch byte
-var qdfFieldHdrs_GenMetricBatch = [][]byte{qdfFieldHdr_name_27, qdfFieldHdr_metrics_28}
+var qdfFieldHdrs_GenMetricBatch = [][]byte{qdfFieldHdr_name_59, qdfFieldHdr_metrics_60}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -403,47 +770,47 @@ func (v *GenMetricBatch) EncodeQDF(e *qdf.Encoder) error {
 	if v.Metrics == nil {
 		e.WriteNil()
 	} else if len(v.Metrics) >= 16 { // columnarMinElems
-		col29 := v.Metrics
-		e.WriteColStructHeader(len(col29), qdfColNames_GenMetric, qdfColKinds_GenMetric)
-		c30 := e.ScratchInt(len(col29))
-		for i := range col29 {
-			c30[i] = int64(col29[i].TS)
+		col61 := v.Metrics
+		e.WriteColStructHeader(len(col61), qdfColNames_GenMetric, qdfColKinds_GenMetric)
+		c62 := e.ScratchInt(len(col61))
+		for i := range col61 {
+			c62[i] = int64(col61[i].TS)
 		}
-		if err := e.WriteIntColumn(c30); err != nil {
+		if err := e.WriteIntColumn(c62); err != nil {
 			return err
 		}
-		c31 := e.ScratchFloat64(len(col29))
-		for i := range col29 {
-			c31[i] = float64(col29[i].Value)
+		c63 := e.ScratchFloat64(len(col61))
+		for i := range col61 {
+			c63[i] = float64(col61[i].Value)
 		}
-		if err := e.WriteFloat64Column(c31); err != nil {
+		if err := e.WriteFloat64Column(c63); err != nil {
 			return err
 		}
-		c32 := e.ScratchUint(len(col29))
-		for i := range col29 {
-			c32[i] = uint64(col29[i].Count)
+		c64 := e.ScratchUint(len(col61))
+		for i := range col61 {
+			c64[i] = uint64(col61[i].Count)
 		}
-		if err := e.WriteUintColumn(c32); err != nil {
+		if err := e.WriteUintColumn(c64); err != nil {
 			return err
 		}
-		c33 := e.ScratchBool(len(col29))
-		for i := range col29 {
-			c33[i] = col29[i].OK
+		c65 := e.ScratchBool(len(col61))
+		for i := range col61 {
+			c65[i] = col61[i].OK
 		}
-		if err := e.WriteBoolColumn(c33); err != nil {
+		if err := e.WriteBoolColumn(c65); err != nil {
 			return err
 		}
-		c34 := e.ScratchFloat32(len(col29))
-		for i := range col29 {
-			c34[i] = float32(col29[i].Ratio)
+		c66 := e.ScratchFloat32(len(col61))
+		for i := range col61 {
+			c66[i] = float32(col61[i].Ratio)
 		}
-		if err := e.WriteFloat32Column(c34); err != nil {
+		if err := e.WriteFloat32Column(c66); err != nil {
 			return err
 		}
 	} else {
 		e.WriteArrayHeader(len(v.Metrics))
-		for i35 := range v.Metrics {
-			if err := qdf.EncodeNested(e, &v.Metrics[i35]); err != nil {
+		for i67 := range v.Metrics {
+			if err := qdf.EncodeNested(e, &v.Metrics[i67]); err != nil {
 				return err
 			}
 		}
@@ -482,11 +849,11 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "name":
 		{
-			rv36, err := d.ReadString()
+			rv68, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv36
+			v.Name = rv68
 		}
 	case "metrics":
 		{
@@ -497,69 +864,69 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Metrics = nil
 			} else if d.PeekColStruct() {
-				n37, names38, kinds39, err := d.ReadColStructHeader()
+				n69, names70, kinds71, err := d.ReadColStructHeader()
 				if err != nil {
 					return err
 				}
-				_ = kinds39
-				v.Metrics = make([]GenMetric, n37)
-				for ci40 := range names38 {
-					switch names38[ci40] {
+				_ = kinds71
+				v.Metrics = make([]GenMetric, n69)
+				for ci72 := range names70 {
+					switch names70[ci72] {
 					case "ts":
-						col41, err := d.ReadIntColumn(n37)
+						col73, err := d.ReadIntColumn(n69)
 						if err != nil {
 							return err
 						}
-						for i := range col41 {
-							v.Metrics[i].TS = int64(col41[i])
+						for i := range col73 {
+							v.Metrics[i].TS = int64(col73[i])
 						}
 					case "value":
-						col42, err := d.ReadFloat64Column(n37)
+						col74, err := d.ReadFloat64Column(n69)
 						if err != nil {
 							return err
 						}
-						for i := range col42 {
-							v.Metrics[i].Value = float64(col42[i])
+						for i := range col74 {
+							v.Metrics[i].Value = float64(col74[i])
 						}
 					case "count":
-						col43, err := d.ReadUintColumn(n37)
+						col75, err := d.ReadUintColumn(n69)
 						if err != nil {
 							return err
 						}
-						for i := range col43 {
-							v.Metrics[i].Count = uint32(col43[i])
+						for i := range col75 {
+							v.Metrics[i].Count = uint32(col75[i])
 						}
 					case "ok":
-						col44, err := d.ReadBoolColumn(n37)
+						col76, err := d.ReadBoolColumn(n69)
 						if err != nil {
 							return err
 						}
-						for i := range col44 {
-							v.Metrics[i].OK = col44[i]
+						for i := range col76 {
+							v.Metrics[i].OK = col76[i]
 						}
 					case "ratio":
-						col45, err := d.ReadFloat32Column(n37)
+						col77, err := d.ReadFloat32Column(n69)
 						if err != nil {
 							return err
 						}
-						for i := range col45 {
-							v.Metrics[i].Ratio = float32(col45[i])
+						for i := range col77 {
+							v.Metrics[i].Ratio = float32(col77[i])
 						}
 					default:
 						return qdf.ErrTypeMismatch
 					}
 				}
 			} else {
-				n46, err := d.ReadArrayHeader()
+				n78, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n46, 1); err != nil {
+				if err := d.CheckLength(n78, 1); err != nil {
 					return err
 				}
-				v.Metrics = make([]GenMetric, n46)
-				for i47 := range n46 {
-					if err := qdf.DecodeNested(d, &v.Metrics[i47]); err != nil {
+				v.Metrics = make([]GenMetric, n78)
+				for i79 := range n78 {
+					if err := qdf.DecodeNested(d, &v.Metrics[i79]); err != nil {
 						return err
 					}
 				}
@@ -609,6 +976,822 @@ func (v *GenMetricBatch) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena
 
 // MarshalQDF appends a qdf-encoded representation of v to dst and returns
 // the extended slice.
+func (v *GenName) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenName byte
+var qdfFieldHdrs_GenName = [][]byte{qdfFieldHdr_first_80, qdfFieldHdr_last_81}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenName) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenName, qdfFieldHdrs_GenName)
+	e.WriteString(string(v.First))
+	e.WriteString(string(v.Last))
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenName) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenName) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "first":
+		{
+			rv82, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.First = rv82
+		}
+	case "last":
+		{
+			rv83, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Last = rv83
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenName) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenName) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenName) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
+func (v *GenNameList) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenNameList byte
+var qdfFieldHdrs_GenNameList = [][]byte{qdfFieldHdr_names_84}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenNameList) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenNameList, qdfFieldHdrs_GenNameList)
+	if v.Names == nil {
+		e.WriteNil()
+	} else if len(v.Names) >= 16 { // columnarMinElems
+		col85 := v.Names
+		ben86 := false
+		pb87 := e.ScratchString(min(len(col85), 32))
+		for i := range pb87 {
+			pb87[i] = string(col85[i].First)
+		}
+		if qdf.StringColumnsBeneficial(pb87) {
+			ben86 = true
+		}
+		for i := range pb87 {
+			pb87[i] = string(col85[i].Last)
+		}
+		if qdf.StringColumnsBeneficial(pb87) {
+			ben86 = true
+		}
+		if ben86 {
+			e.WriteColStructHeader(len(col85), qdfColNames_GenName, qdfColKinds_GenName)
+			c88 := e.ScratchString(len(col85))
+			for i := range col85 {
+				c88[i] = string(col85[i].First)
+			}
+			e.WriteStringColumn(c88)
+			c89 := e.ScratchString(len(col85))
+			for i := range col85 {
+				c89[i] = string(col85[i].Last)
+			}
+			e.WriteStringColumn(c89)
+		} else {
+			e.WriteArrayHeader(len(col85))
+			for i90 := range col85 {
+				if err := qdf.EncodeNested(e, &col85[i90]); err != nil {
+					return err
+				}
+			}
+		}
+	} else {
+		e.WriteArrayHeader(len(v.Names))
+		for i91 := range v.Names {
+			if err := qdf.EncodeNested(e, &v.Names[i91]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenNameList) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenNameList) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "names":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Names = nil
+			} else if d.PeekColStruct() {
+				n92, names93, kinds94, err := d.ReadColStructHeader()
+				if err != nil {
+					return err
+				}
+				_ = kinds94
+				v.Names = make([]GenName, n92)
+				for ci95 := range names93 {
+					switch names93[ci95] {
+					case "first":
+						col96, err := d.ReadStringColumn(n92)
+						if err != nil {
+							return err
+						}
+						for i := range col96 {
+							v.Names[i].First = string(col96[i])
+						}
+					case "last":
+						col97, err := d.ReadStringColumn(n92)
+						if err != nil {
+							return err
+						}
+						for i := range col97 {
+							v.Names[i].Last = string(col97[i])
+						}
+					default:
+						return qdf.ErrTypeMismatch
+					}
+				}
+			} else {
+				n98, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n98, 1); err != nil {
+					return err
+				}
+				v.Names = make([]GenName, n98)
+				for i99 := range n98 {
+					if err := qdf.DecodeNested(d, &v.Names[i99]); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenNameList) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenNameList) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenNameList) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
+func (v *GenRow) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenRow byte
+var qdfFieldHdrs_GenRow = [][]byte{qdfFieldHdr_id_100, qdfFieldHdr_name_59, qdfFieldHdr_inner_101, qdfFieldHdr_tags_102}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenRow) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenRow, qdfFieldHdrs_GenRow)
+	e.WriteInt(int64(v.ID))
+	e.WriteString(string(v.Name))
+	if err := qdf.EncodeNested(e, &v.Inner); err != nil {
+		return err
+	}
+	if v.Tags == nil {
+		e.WriteNil()
+	} else {
+		e.WriteMapHeader(len(v.Tags))
+		for k103, vv104 := range v.Tags {
+			e.WriteString(string(k103))
+			e.WriteInt(int64(vv104))
+		}
+	}
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenRow) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenRow) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "id":
+		{
+			rv105, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v.ID = int64(rv105)
+		}
+	case "name":
+		{
+			rv106, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Name = rv106
+		}
+	case "inner":
+		if err := qdf.DecodeNested(d, &v.Inner); err != nil {
+			return err
+		}
+	case "tags":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Tags = nil
+			} else {
+				n107, err := d.ReadMapHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n107, 1); err != nil {
+					return err
+				}
+				v.Tags = make(map[string]int, n107)
+				for range n107 {
+					var k108 string
+					var vv109 int
+					kb110, err := d.ReadStringBytes()
+					if err != nil {
+						return err
+					}
+					k108 = string(d.InternKey(kb110))
+					{
+						rv111, err := d.ReadInt()
+						if err != nil {
+							return err
+						}
+						vv109 = int(rv111)
+					}
+					v.Tags[k108] = vv109
+				}
+			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenRow) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenRow) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenRow) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
+func (v *GenRowInner) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenRowInner byte
+var qdfFieldHdrs_GenRowInner = [][]byte{qdfFieldHdr_x_112, qdfFieldHdr_y_113}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenRowInner) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenRowInner, qdfFieldHdrs_GenRowInner)
+	e.WriteInt(int64(v.X))
+	e.WriteString(string(v.Y))
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenRowInner) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenRowInner) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "x":
+		{
+			rv114, err := d.ReadInt()
+			if err != nil {
+				return err
+			}
+			v.X = int(rv114)
+		}
+	case "y":
+		{
+			rv115, err := d.ReadString()
+			if err != nil {
+				return err
+			}
+			v.Y = rv115
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenRowInner) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenRowInner) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenRowInner) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
+func (v *GenRowSet) MarshalQDF(dst []byte) ([]byte, error) {
+	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
+	if hadHeader {
+		e.MarkHeaderWritten()
+	} else {
+		e.EnsureHeader()
+	}
+	if err := v.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+var qdfShapeTok_GenRowSet byte
+var qdfFieldHdrs_GenRowSet = [][]byte{qdfFieldHdr_rows_116}
+
+// EncodeQDF writes v's fields into e. It lets a parent thread one encoder
+// through nested values instead of allocating an encoder per value.
+func (v *GenRowSet) EncodeQDF(e *qdf.Encoder) error {
+	e.StructShape(&qdfShapeTok_GenRowSet, qdfFieldHdrs_GenRowSet)
+	if v.Rows == nil {
+		e.WriteNil()
+	} else if len(v.Rows) >= 16 { // columnarMinElems
+		col117 := v.Rows
+		e.WriteHybridColStructHeader(len(col117), qdfHybNames_GenRow, qdfHybKinds_GenRow)
+		c118 := e.ScratchInt(len(col117))
+		for i := range col117 {
+			c118[i] = int64(col117[i].ID)
+		}
+		if err := e.WriteIntColumn(c118); err != nil {
+			return err
+		}
+		c119 := e.ScratchString(len(col117))
+		for i := range col117 {
+			c119[i] = string(col117[i].Name)
+		}
+		e.WriteStringColumn(c119)
+		for i120 := range col117 {
+			if err := qdf.EncodeNested(e, &col117[i120].Inner); err != nil {
+				return err
+			}
+			if col117[i120].Tags == nil {
+				e.WriteNil()
+			} else {
+				e.WriteMapHeader(len(col117[i120].Tags))
+				for k121, vv122 := range col117[i120].Tags {
+					e.WriteString(string(k121))
+					e.WriteInt(int64(vv122))
+				}
+			}
+		}
+	} else {
+		e.WriteArrayHeader(len(v.Rows))
+		for i123 := range v.Rows {
+			if err := qdf.EncodeNested(e, &v.Rows[i123]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// DecodeQDF reads v's fields from the shared decoder d, advancing it. It lets
+// a parent thread one decoder through nested values (see qdf.DecodeNested).
+func (v *GenRowSet) DecodeQDF(d *qdf.Decoder) error {
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		return err
+	}
+	if shaped {
+		for _, name := range names {
+			if err := v.decodeQDFField(d, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for range plainN {
+		kb, err := d.ReadStringBytes()
+		if err != nil {
+			return err
+		}
+		if err := v.decodeQDFField(d, string(kb)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *GenRowSet) decodeQDFField(d *qdf.Decoder, name string) error {
+	switch name {
+	case "rows":
+		{
+			isNil, err := d.IsNil()
+			if err != nil {
+				return err
+			}
+			if isNil {
+				v.Rows = nil
+			} else if d.PeekHybridColStruct() {
+				n124, names125, kinds126, err := d.ReadHybridColStructHeader()
+				if err != nil {
+					return err
+				}
+				_ = names125
+				_ = kinds126
+				v.Rows = make([]GenRow, n124)
+				col127, err := d.ReadIntColumn(n124)
+				if err != nil {
+					return err
+				}
+				for i := range col127 {
+					v.Rows[i].ID = int64(col127[i])
+				}
+				col128, err := d.ReadStringColumn(n124)
+				if err != nil {
+					return err
+				}
+				for i := range col128 {
+					v.Rows[i].Name = string(col128[i])
+				}
+				d.ClearColMaxLen()
+				for i129 := range v.Rows {
+					if err := qdf.DecodeNested(d, &v.Rows[i129].Inner); err != nil {
+						return err
+					}
+					{
+						isNil, err := d.IsNil()
+						if err != nil {
+							return err
+						}
+						if isNil {
+							v.Rows[i129].Tags = nil
+						} else {
+							n130, err := d.ReadMapHeader()
+							if err != nil {
+								return err
+							}
+							if err := d.CheckLength(n130, 1); err != nil {
+								return err
+							}
+							v.Rows[i129].Tags = make(map[string]int, n130)
+							for range n130 {
+								var k131 string
+								var vv132 int
+								kb133, err := d.ReadStringBytes()
+								if err != nil {
+									return err
+								}
+								k131 = string(d.InternKey(kb133))
+								{
+									rv134, err := d.ReadInt()
+									if err != nil {
+										return err
+									}
+									vv132 = int(rv134)
+								}
+								v.Rows[i129].Tags[k131] = vv132
+							}
+						}
+					}
+				}
+			} else {
+				n135, err := d.ReadArrayHeader()
+				if err != nil {
+					return err
+				}
+				if err := d.CheckLength(n135, 1); err != nil {
+					return err
+				}
+				v.Rows = make([]GenRow, n135)
+				for i136 := range n135 {
+					if err := qdf.DecodeNested(d, &v.Rows[i136]); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	default:
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalQDF decodes a qdf payload into v and returns the number of
+// bytes consumed.
+func (v *GenRowSet) UnmarshalQDF(src []byte) (int, error) {
+	return v.UnmarshalQDFArena(src, false, nil)
+}
+
+// UnmarshalQDFOpts decodes like UnmarshalQDF; when noCopy is true the decoded
+// string and []byte fields alias src instead of copying. The aliases are valid
+// only while src stays alive and is not modified (see qdf.WithNoCopy).
+func (v *GenRowSet) UnmarshalQDFOpts(src []byte, noCopy bool) (int, error) {
+	return v.UnmarshalQDFArena(src, noCopy, nil)
+}
+
+// UnmarshalQDFArena decodes like UnmarshalQDFOpts; when a is non-nil the copied
+// string fields are packed into the arena instead of one allocation each (see
+// qdf.WithArena). The decoded strings then alias the arena's memory.
+func (v *GenRowSet) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, error) {
+	d := qdf.NewDecoderOnBuf(src)
+	if noCopy {
+		d.SetNoCopy(true)
+	}
+	if a != nil {
+		d.SetArena(a)
+	}
+	hasHeader := len(src) >= 5 && src[0] == qdf.Magic0 && src[1] == qdf.Magic1 && src[2] == qdf.Magic2
+	if !hasHeader {
+		d.MarkHeaderRead()
+	}
+	if err := v.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return d.Pos(), nil
+}
+
+// MarshalQDF appends a qdf-encoded representation of v to dst and returns
+// the extended slice.
 func (v *Inner) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
@@ -624,7 +1807,7 @@ func (v *Inner) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_Inner byte
-var qdfFieldHdrs_Inner = [][]byte{qdfFieldHdr_x_48, qdfFieldHdr_y_49}
+var qdfFieldHdrs_Inner = [][]byte{qdfFieldHdr_x_112, qdfFieldHdr_y_113}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -666,19 +1849,19 @@ func (v *Inner) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "x":
 		{
-			rv50, err := d.ReadInt()
+			rv137, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.X = int(rv50)
+			v.X = int(rv137)
 		}
 	case "y":
 		{
-			rv51, err := d.ReadFloat64()
+			rv138, err := d.ReadFloat64()
 			if err != nil {
 				return err
 			}
-			v.Y = rv51
+			v.Y = rv138
 		}
 	default:
 		if err := d.Skip(); err != nil {
@@ -739,7 +1922,7 @@ func (v *Sample) MarshalQDF(dst []byte) ([]byte, error) {
 }
 
 var qdfShapeTok_Sample byte
-var qdfFieldHdrs_Sample = [][]byte{qdfFieldHdr_name_27, qdfFieldHdr_age_52, qdfFieldHdr_active_53, qdfFieldHdr_score_54, qdfFieldHdr_tags_55, qdfFieldHdr_meta_56, qdfFieldHdr_inner_57, qdfFieldHdr_when_58, qdfFieldHdr_buf_59, qdfFieldHdr_opt_60, qdfFieldHdr_counts_61}
+var qdfFieldHdrs_Sample = [][]byte{qdfFieldHdr_name_59, qdfFieldHdr_age_139, qdfFieldHdr_active_140, qdfFieldHdr_score_141, qdfFieldHdr_tags_102, qdfFieldHdr_meta_142, qdfFieldHdr_inner_101, qdfFieldHdr_when_143, qdfFieldHdr_buf_144, qdfFieldHdr_opt_145, qdfFieldHdr_counts_146}
 
 // EncodeQDF writes v's fields into e. It lets a parent thread one encoder
 // through nested values instead of allocating an encoder per value.
@@ -753,17 +1936,17 @@ func (v *Sample) EncodeQDF(e *qdf.Encoder) error {
 		e.WriteNil()
 	} else {
 		e.WriteArrayHeader(len(v.Tags))
-		for i62 := range v.Tags {
-			e.WriteString(string(v.Tags[i62]))
+		for i147 := range v.Tags {
+			e.WriteString(string(v.Tags[i147]))
 		}
 	}
 	if v.Meta == nil {
 		e.WriteNil()
 	} else {
 		e.WriteMapHeader(len(v.Meta))
-		for k63, vv64 := range v.Meta {
-			e.WriteString(string(k63))
-			e.WriteString(string(vv64))
+		for k148, vv149 := range v.Meta {
+			e.WriteString(string(k148))
+			e.WriteString(string(vv149))
 		}
 	}
 	if err := qdf.EncodeNested(e, &v.Inner); err != nil {
@@ -786,8 +1969,8 @@ func (v *Sample) EncodeQDF(e *qdf.Encoder) error {
 		}
 	}
 	e.WriteArrayHeader(3)
-	for i65 := range v.Counts {
-		e.WriteInt(int64(v.Counts[i65]))
+	for i150 := range v.Counts {
+		e.WriteInt(int64(v.Counts[i150]))
 	}
 	return nil
 }
@@ -823,35 +2006,35 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 	switch name {
 	case "name":
 		{
-			rv66, err := d.ReadString()
+			rv151, err := d.ReadString()
 			if err != nil {
 				return err
 			}
-			v.Name = rv66
+			v.Name = rv151
 		}
 	case "age":
 		{
-			rv67, err := d.ReadInt()
+			rv152, err := d.ReadInt()
 			if err != nil {
 				return err
 			}
-			v.Age = int(rv67)
+			v.Age = int(rv152)
 		}
 	case "active":
 		{
-			rv68, err := d.ReadBool()
+			rv153, err := d.ReadBool()
 			if err != nil {
 				return err
 			}
-			v.Active = rv68
+			v.Active = rv153
 		}
 	case "score":
 		{
-			rv69, err := d.ReadFloat64()
+			rv154, err := d.ReadFloat64()
 			if err != nil {
 				return err
 			}
-			v.Score = rv69
+			v.Score = rv154
 		}
 	case "tags":
 		{
@@ -862,21 +2045,21 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Tags = nil
 			} else {
-				n70, err := d.ReadArrayHeader()
+				n155, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n70, 1); err != nil {
+				if err := d.CheckLength(n155, 1); err != nil {
 					return err
 				}
-				v.Tags = make([]string, n70)
-				for i71 := range n70 {
+				v.Tags = make([]string, n155)
+				for i156 := range n155 {
 					{
-						rv72, err := d.ReadString()
+						rv157, err := d.ReadString()
 						if err != nil {
 							return err
 						}
-						v.Tags[i71] = rv72
+						v.Tags[i156] = rv157
 					}
 				}
 			}
@@ -890,30 +2073,30 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 			if isNil {
 				v.Meta = nil
 			} else {
-				n73, err := d.ReadMapHeader()
+				n158, err := d.ReadMapHeader()
 				if err != nil {
 					return err
 				}
-				if err := d.CheckLength(n73, 1); err != nil {
+				if err := d.CheckLength(n158, 1); err != nil {
 					return err
 				}
-				v.Meta = make(map[string]string, n73)
-				for range n73 {
-					var k74 string
-					var vv75 string
-					kb76, err := d.ReadStringBytes()
+				v.Meta = make(map[string]string, n158)
+				for range n158 {
+					var k159 string
+					var vv160 string
+					kb161, err := d.ReadStringBytes()
 					if err != nil {
 						return err
 					}
-					k74 = string(d.InternKey(kb76))
+					k159 = string(d.InternKey(kb161))
 					{
-						rv77, err := d.ReadString()
+						rv162, err := d.ReadString()
 						if err != nil {
 							return err
 						}
-						vv75 = rv77
+						vv160 = rv162
 					}
-					v.Meta[k74] = vv75
+					v.Meta[k159] = vv160
 				}
 			}
 		}
@@ -923,11 +2106,11 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 		}
 	case "when":
 		{
-			sec78, nsec79, err := d.ReadTimestamp()
+			sec163, nsec164, err := d.ReadTimestamp()
 			if err != nil {
 				return err
 			}
-			v.When = time.Unix(sec78, int64(nsec79)).UTC()
+			v.When = time.Unix(sec163, int64(nsec164)).UTC()
 		}
 	case "buf":
 		{
@@ -962,20 +2145,20 @@ func (v *Sample) decodeQDFField(d *qdf.Decoder, name string) error {
 		}
 	case "counts":
 		{
-			n80, err := d.ReadArrayHeader()
+			n165, err := d.ReadArrayHeader()
 			if err != nil {
 				return err
 			}
-			if n80 != 3 {
+			if n165 != 3 {
 				return qdf.ErrTypeMismatch
 			}
-			for i81 := range 3 {
+			for i166 := range 3 {
 				{
-					rv82, err := d.ReadInt()
+					rv167, err := d.ReadInt()
 					if err != nil {
 						return err
 					}
-					v.Counts[i81] = int32(rv82)
+					v.Counts[i166] = int32(rv167)
 				}
 			}
 		}

--- a/internal/codegen_test/types.go
+++ b/internal/codegen_test/types.go
@@ -62,3 +62,52 @@ type GenMetricBatch struct {
 	Name    string      `qdf:"name"`
 	Metrics []GenMetric `qdf:"metrics"`
 }
+
+// --- Phase 2b columnar codegen fixtures: string / time / hybrid columns ---
+
+// GenEvent mixes a time.Time, string, and numeric column — a pure columnar
+// element (every field eligible; numeric/time present so no probe).
+type GenEvent struct {
+	TS    time.Time `qdf:"ts"`
+	Level string    `qdf:"level"`
+	Code  int32     `qdf:"code"`
+	Msg   string    `qdf:"msg"`
+}
+
+// GenEventLog wraps an event slice (the columnar-eligible field).
+type GenEventLog struct {
+	Source string     `qdf:"source"`
+	Events []GenEvent `qdf:"events"`
+}
+
+// GenRowInner is a nested struct used as a residual (non-columnar) field.
+type GenRowInner struct {
+	X int    `qdf:"x"`
+	Y string `qdf:"y"`
+}
+
+// GenRow exercises the HYBRID frame: scalar + string columns plus a residual
+// nested struct and a residual map.
+type GenRow struct {
+	ID    int64          `qdf:"id"`
+	Name  string         `qdf:"name"`
+	Inner GenRowInner    `qdf:"inner"`
+	Tags  map[string]int `qdf:"tags"`
+}
+
+// GenRowSet wraps a hybrid-element slice.
+type GenRowSet struct {
+	Rows []GenRow `qdf:"rows"`
+}
+
+// GenName is a string-only element: the cardinality probe decides columnar vs
+// row-major at encode time.
+type GenName struct {
+	First string `qdf:"first"`
+	Last  string `qdf:"last"`
+}
+
+// GenNameList wraps a string-only-element slice.
+type GenNameList struct {
+	Names []GenName `qdf:"names"`
+}

--- a/internal/codegen_test/types.go
+++ b/internal/codegen_test/types.go
@@ -111,3 +111,29 @@ type GenName struct {
 type GenNameList struct {
 	Names []GenName `qdf:"names"`
 }
+
+// --- Phase 2d fixtures: []byte columns + nullable (*T) columns ---
+
+// GenBlobRow exercises a []byte column (routed through the string column codec).
+type GenBlobRow struct {
+	ID   int64  `qdf:"id"`
+	Data []byte `qdf:"data"`
+}
+
+// GenBlobSet wraps a []byte-column-bearing slice.
+type GenBlobSet struct {
+	Rows []GenBlobRow `qdf:"rows"`
+}
+
+// GenOpt exercises nullable scalar/string columns (presence bitmap + dense).
+type GenOpt struct {
+	A *int32   `qdf:"a"`
+	B *string  `qdf:"b"`
+	C *bool    `qdf:"c"`
+	D *float64 `qdf:"d"`
+}
+
+// GenOptSet wraps a nullable-column slice.
+type GenOptSet struct {
+	Rows []GenOpt `qdf:"rows"`
+}

--- a/internal/codegen_test/types.go
+++ b/internal/codegen_test/types.go
@@ -45,3 +45,20 @@ type Edge struct {
 	Ptr    *Label        `qdf:"ptr"`
 	Tail   int           `qdf:"tail"`
 }
+
+// GenMetric is an all-scalar struct: the columnar-eligible element shape that
+// triggers the monomorphized transpose path in generated encode/decode.
+type GenMetric struct {
+	TS    int64   `qdf:"ts"`
+	Value float64 `qdf:"value"`
+	Count uint32  `qdf:"count"`
+	OK    bool    `qdf:"ok"`
+	Ratio float32 `qdf:"ratio"`
+}
+
+// GenMetricBatch carries a slice of the scalar element — the field that
+// triggers columnar codegen.
+type GenMetricBatch struct {
+	Name    string      `qdf:"name"`
+	Metrics []GenMetric `qdf:"metrics"`
+}

--- a/internal/codegen_test/types.go
+++ b/internal/codegen_test/types.go
@@ -137,3 +137,12 @@ type GenOpt struct {
 type GenOptSet struct {
 	Rows []GenOpt `qdf:"rows"`
 }
+
+// GenTrailed places fields AFTER the columnar []struct field, exercising the
+// colMaxLen reset (a sibling decoded on the shared decoder must not inherit the
+// columnar length bound).
+type GenTrailed struct {
+	Rows []GenMetric `qdf:"rows"`
+	Note string      `qdf:"note"`
+	Tail []int64     `qdf:"tail"`
+}

--- a/nullable_col.go
+++ b/nullable_col.go
@@ -44,7 +44,13 @@ func (e *Encoder) writeStringColumn(strs []string) {
 	// keeps the interning per-value form, which the gates model correctly — so
 	// its wire is unchanged (const/raw-forced are codegen-only; the decoders
 	// still read them for cross-path interop).
-	if !e.opts.Has(OptDense) {
+	//
+	// An EMPTY column (len==0, e.g. an all-nil nullable string column's dense
+	// part) must emit NOTHING, exactly as the plain loop below does and as the
+	// reflect/Dense path does: writeStringColumnRawForced would otherwise lay
+	// down a tagColStrRaw block that ReadStringColumn(0) skips (its block-tag
+	// dispatch is guarded by n>0), desyncing the decode cursor.
+	if !e.opts.Has(OptDense) && len(strs) > 0 {
 		if e.tryWriteStringColumnConst(strs) {
 			return
 		}

--- a/nullable_col.go
+++ b/nullable_col.go
@@ -33,6 +33,24 @@ func (e *Encoder) writeStringColumn(strs []string) {
 	if e.tryWriteStringColumnRaw(strs) {
 		return
 	}
+	// Without OptDense (the codegen/Fast path) the per-value fallback below does
+	// NOT intern: WriteString emits every occurrence inline, so the dict/raw
+	// never-larger gates — which model the per-value cost as the Dense interned
+	// form (distinct once + 1-byte state refs) — under-estimate it and decline,
+	// leaving the column wire-bloated and decoding to n string allocations.
+	// Mode-aware fallback: a single-distinct column collapses to one value
+	// (tagColStrConst), any other column materializes in ONE slab allocation
+	// (tagColStrRaw, wire-neutral + a tiny header). The reflect path (OptDense)
+	// keeps the interning per-value form, which the gates model correctly — so
+	// its wire is unchanged (const/raw-forced are codegen-only; the decoders
+	// still read them for cross-path interop).
+	if !e.opts.Has(OptDense) {
+		if e.tryWriteStringColumnConst(strs) {
+			return
+		}
+		e.writeStringColumnRawForced(strs)
+		return
+	}
 	for _, v := range strs {
 		e.WriteString(v)
 	}

--- a/qpack_strdict.go
+++ b/qpack_strdict.go
@@ -125,6 +125,9 @@ func (e *Encoder) tryWriteStringColumnDict(strs []string) bool {
 // writeStringColumn: a tagColStrDict dictionary block, a tagColStrFSST block,
 // or n per-value strings.
 func (d *Decoder) readStringColumn(n int) ([]string, error) {
+	if n > 0 && d.i < len(d.buf) && d.buf[d.i] == tagColStrConst {
+		return d.readStringColumnConst(n)
+	}
 	// FSST allocates its own output slab+slice, so dispatch before the per-value
 	// make to avoid a dead []string allocation on the FSST path.
 	if n > 0 && d.i < len(d.buf) && d.buf[d.i] == tagColStrFSST {

--- a/state.go
+++ b/state.go
@@ -996,6 +996,7 @@ type decState struct {
 	colScratchF64  []float64
 	colScratchBool []bool
 	colScratchF32  []float32 // codegen columnar float32 scatter scratch
+	colScratchStr  []string  // codegen columnar plain string scatter scratch
 
 	// deltaColRows is reused storage for a sparse column's decoded ascending row
 	// indices during a tagColSlicePatch apply (delta_columnar.go).
@@ -1094,6 +1095,9 @@ func (d *decState) reset() {
 	}
 	if cap(d.colScratchF32) > maxRetainedColScratch {
 		d.colScratchF32 = nil
+	}
+	if cap(d.colScratchStr) > maxRetainedColScratch {
+		d.colScratchStr = nil
 	}
 	if cap(d.colLenScratch) > maxRetainedColScratch {
 		d.colLenScratch = nil

--- a/state.go
+++ b/state.go
@@ -198,7 +198,8 @@ type encState struct {
 	colScratchU64  []uint64
 	colScratchF64  []float64
 	colScratchBool []bool
-	colScratchStr  []string // gathered string column values
+	colScratchF32  []float32 // codegen columnar float32 gather scratch
+	colScratchStr  []string  // gathered string column values
 	// Canonical map-key sort scratch (OptCanonical), reused across maps; adaptive
 	// retention (dropped when oversized in the encoder pool reset, like
 	// colScratch*). Pointer-free numeric scratch needs no clear; canonKeysStr
@@ -482,6 +483,9 @@ func (e *encState) reset() {
 	// memory. sync.Pool's GC eviction reclaims it when the encoder goes idle.
 	if cap(e.colScratchI64) > maxRetainedColScratch {
 		e.colScratchI64, e.colScratchU64, e.colScratchF64, e.colScratchBool = nil, nil, nil, nil
+	}
+	if cap(e.colScratchF32) > maxRetainedColScratch {
+		e.colScratchF32 = nil
 	}
 	// Column-diff scratch (delta_columnar.go): same row-scaled hard-ceiling
 	// retention as colScratch* (pointer-free, no clear needed).
@@ -991,6 +995,7 @@ type decState struct {
 	colScratchU64  []uint64
 	colScratchF64  []float64
 	colScratchBool []bool
+	colScratchF32  []float32 // codegen columnar float32 scatter scratch
 
 	// deltaColRows is reused storage for a sparse column's decoded ascending row
 	// indices during a tagColSlicePatch apply (delta_columnar.go).
@@ -1086,6 +1091,9 @@ func (d *decState) reset() {
 	// streak), reclaimed when idle by sync.Pool GC.
 	if cap(d.colScratchI64) > maxRetainedColScratch {
 		d.colScratchI64, d.colScratchU64, d.colScratchF64, d.colScratchBool = nil, nil, nil, nil
+	}
+	if cap(d.colScratchF32) > maxRetainedColScratch {
+		d.colScratchF32 = nil
 	}
 	if cap(d.colLenScratch) > maxRetainedColScratch {
 		d.colLenScratch = nil

--- a/wire.go
+++ b/wire.go
@@ -232,7 +232,28 @@ const (
 	// one allocation. A decoder that does not implement it sees an unknown tag →
 	// ErrBadTag.
 	tagColStrRaw = 0xF8
+
+	// tagColStrConst is a single-distinct (constant) string column inside a
+	// tagColStruct payload: every row holds the SAME string. The dict codec
+	// rejects this (it requires count >= 2 for a bounded index body) and the
+	// per-value form stores the value n times (Dense state-repeats it, but the
+	// codegen/Fast path does not), so a constant column is both wire-bloated and
+	// decodes to n allocations there. tagColStrConst stores the value once plus
+	// the row count; the decoder fills n shares of the single owned string (one
+	// allocation). Chosen automatically when every value is identical. Wire:
+	//   0xF9, varuint(len), len bytes, varuint(n)
+	// n is checked against the columnar header's row count, which bounds it; a
+	// decoder that does not implement it sees an unknown tag → ErrBadTag.
+	tagColStrConst = 0xF9
 )
+
+// isStringColumnBlockTag reports whether b begins a self-describing string
+// column block (dict / FSST / raw / const) rather than a per-value plain run.
+// The columnar decoders peek this to choose the block reader (readStringColumn)
+// over a ReadString loop.
+func isStringColumnBlockTag(b byte) bool {
+	return b == tagColStrDict || b == tagColStrFSST || b == tagColStrRaw || b == tagColStrConst
+}
 
 // Varint (ULEB128) helpers. Used for state-table IDs and intern-payload
 // lengths. The encoder always appends; the decoder returns the consumed


### PR DESCRIPTION
A code-generated type that implements `Marshaler`/`Unmarshaler` cannot use the
reflect columnar path (a custom-codec element returns early in `descBuild`, so a
`[]GenStruct` field always encoded **row-major**, one self-describing record per
element). For numeric data that costs ~12× wire vs the columnar layout reflect
gives a plain type (`[]gpm` 74008 B vs `[]pm` 6079 B, 2000 rows). This PR makes
`qdfgen` emit a **reflection-free, monomorphized columnar transpose** for
eligible `[]struct` fields, recovering the columnar win for generated types and
beating reflect on CPU.

## Headline results (Go 1.26, MetricHost = 2000 all-scalar rows, OptBalanced)

| metric | reflect columnar | **codegen columnar** | bare `[]GenMetric` (row-major) |
|---|---|---|---|
| wire_B | 24342 | **24340** (≈ reflect) | 46014 (1.9×) |
| encode ns/op | 82405 | **73268** (faster) | — |
| encode allocs | 3 | **3** | — |
| decode ns/op | 50724 | 53132 | — |
| decode allocs | 22 | **12** | — |

Codegen columnar **ties reflect on wire** and **beats it on encode CPU** at equal
allocs (no reflection, no plan lookup, compile-time field offsets). A bare
`[]GenMetric` stays row-major (a `Marshaler` element disables reflect columnar),
so the win lives on a `[]scalar-struct` **field** of a generated wrapper.

## Eligibility / framing

- Per `[]NamedStruct` field, `gen.go` builds a `colElemPlan` from `go/types`
  (zero reflection in the generated code). Eligible columns: scalar
  `int*/uint*/float*/bool`, `string`, `time.Time`, `[]byte`, and pointers to
  scalar/string (`*T` → **nullable** column). Residual fields (nested struct,
  map, non-byte slice, `*struct`, `*time.Time`, interface) go to a row-major
  block in a **hybrid** frame.
- **Pure** frame `tagColStruct` (0xEF) when all fields eligible; **hybrid**
  `tagHybridColStruct` (0xF7) when some are residual. Byte-identical layout to
  the reflect `encodeColumnar`/`encodeHybridColumnar` (shared `colShapeFor`/
  `hybridShapeFor` id space) → cross-path interop holds.
- Runtime gate: `len >= columnarMinElems` (16), else row-major fallback; `nil`
  slice → `WriteNil` (preserves nil-vs-empty).
- Kind bytes match `classifyColKind`: int0 uint1 float64 2 bool3 string4 time5
  float32 6, nullable `|0x80`, residual `0xFF`.

## Column types

- **Numeric** — gathered via static field access into a **pooled** Encoder
  scratch (`ScratchInt`/`Uint`/`Float64`/`Float32`/`Bool`) and written through
  the adaptive pickers (`encodeSliceInt64` … → FOR/Delta/RLE/Dict/PFOR). Zero
  per-column allocation; decode reuses the decoder's pooled scratch.
- **String** — reuses the Balanced string-column picker (dict / FSST / raw-slab /
  plain), exposed as `WriteStringColumn`/`ReadStringColumn`. A **string-only**
  element runs a runtime cardinality probe (`StringColumnsBeneficial`, mirrors
  the reflect `columnarProbe`) so high-cardinality strings stay row-major; any
  numeric/time column makes columnar unconditional.
- **time.Time** — sec (`[]int64`, Delta+FOR) + nsec (`[]uint64`) sub-columns,
  `.UTC()`-normalized, matching the reflect `colKindTime` wire.
- **[]byte** — routed through a **nullable** column (presence bit = field != nil)
  so `nil` and empty `[]byte{}` stay distinct; values travel as a zero-copy
  `unsafe.String` byte view.
- **nullable (`*T`)** — presence bitmap (1 bit/row) + dense column of present
  values (`ScratchMask`/`WriteColNullMask`/`ReadColNullMask`).

## Mode-aware string compression (codegen runs `Fast`)

Codegen `MarshalQDF` uses `Fast` mode (no Dense interning) to stay wire-identical
to `OptSpeed` (enforced by `TestCodegen_MatchesOptSpeed`/`…_EmbeddedWireParity`).
The string-column never-larger gates model the per-value fallback as the *Dense
interned* form, so under `Fast` they under-estimate, decline, and leave a string
column wire-bloated + decoding to `n` allocations. Mode-aware fix (gated on
`!OptDense`, so the reflect/Dense path is byte-unchanged):

- single-distinct (all-identical) column → new **`tagColStrConst`** (0xF9): value
  stored once + count, decode fills `n` shares of one owned string (1 alloc).
- any other column dict/raw declined → `writeStringColumnRawForced`: one-slab
  decode (1 alloc), wire-neutral + a tiny header.

Measured (GenEventLog, 2000 all-identical string col): decode **2029 → 25** allocs,
wire **52073 → 14087**; realistic multi-distinct columns dict-code (35 allocs).

## Generator performance

`gen.go` string assembly moved off `fmt.Sprintf`/`strings.Join` to direct buffer
appends (`fresh`/`colNamesVar`/`colKindsVar`/`writeHexByteLiteral`); generated
output is **byte-identical** (`TestGenerate` diff). Micro-bench of one columnar
kinds var-decl: **590 → 216 ns, 9 → 1 allocs**. (The remaining `fmt.Fprintf`
line-emits are build-time and kept for readability + `go vet` printf checks.)

## Bugs found by adversarial agent review (3 rounds, 11 agents) — fixed + regressed

1. **HIGH** — an all-nil `*string` nullable column (present=0, empty dense) emitted
   a `tagColStrRaw` block that `ReadStringColumn(0)` skips (n>0 dispatch guard),
   desyncing the decode cursor. Fixed: the `!OptDense` fallback emits nothing for
   an empty column.
2. **MED** — pure-columnar decode never reset `d.colMaxLen` (set by the header),
   unlike the hybrid path / the reflect `defer`. On the shared threaded decoder a
   sibling `colLenOK`-gated codec could then be wrongly length-bounded. Fixed:
   emit `d.ClearColMaxLen()` at the end of the pure decode.
3. **codegen** — a `[]byte` column routed through the plain string codec collapsed
   nil and empty `[]byte` to `""` → nil decoded to a non-nil empty slice. Fixed:
   `[]byte` now travels as a nullable column.

Perf from the review: `ReadColStructHeader`/`ReadHybridColStructHeader` returned a
`make`+copy `kinds []byte` every decode that generated code discards → now a
zero-copy `unsafe` alias of the cached `[]colKind` (−1 alloc/decode).

Hostile-input decode proven safe: **4.7M+ fuzz execs** across
`FuzzRoundTrip_AllModesAgree`, `FuzzDecoder_NeverPanics`, and a purpose-built
`FuzzGenDecodersNeverPanic` (mangled bytes straight into the generated decoders) —
0 crashers / OOM / panics.

## Known limitation (documented, not a correctness bug)

The **reflect** columnar `[]byte` path (`n >= 16`) collapses a nil `[]byte` and an
empty `[]byte{}` to nil — a plain string column carries no presence bit, kept that
way so it stays wire-compatible with a string column for the `string<->[]byte`
schema interchange (`TestColumnarStringIntoByteField`). Adding a presence bit
collides with that interchange (on the wire a nullable `[]byte` 0x84 becomes
indistinguishable from `*string` and incompatible with a plain string column
0x04), so it is documented as inherent columnar lossiness (same class as
int→int64 widening / time monotonic-clock stripping). Bytes are always correct;
only the nil-vs-empty distinction is lost, only in reflect-columnar. The **codegen**
path has no such interchange and keeps nil vs empty distinct. Row-major (any size,
both paths) preserves it.

## Tests / quality gate

- Round-trip across the gate boundary (sizes 0/1/8/15/16/17/256/257) for every
  column type + frame (pure / hybrid / string-only-probe / nullable / []byte /
  fields-after-columnar), generated **and** reflect decode, asserting agreement.
- `go test ./...` (main + nested `cmd/qdfgen` module), `-race`, `golangci-lint
  run ./...` = **0 issues** on both modules, fuzz clean.
- New exposed API: `Encoder.WriteColStructHeader`/`WriteHybridColStructHeader`/
  `Write{Int,Uint,Float64,Float32,Bool,String,Time}Column`/`WriteColNullMask`/
  `Scratch{Int,Uint,Float64,Float32,Bool,String,Mask}`; `Decoder.Peek*`/`Read*`
  counterparts + `ReadColNullMask`/`ClearColMaxLen`; `tagColStrConst` codec.