### PR TITLE
feat(stream): cross-stream reuse (`Reset`) + arena decode (`SetArena`); zero-dep library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
             go.sum
             bench/go.sum
             cmd/qdfgen/go.sum
+            cmd/qdf-bench/go.sum
             internal/codegen_test/go.sum
 
       # Cache the Go build cache separately. setup-go already caches the
@@ -88,6 +89,14 @@ jobs:
         working-directory: cmd/qdfgen
         run: go build ./...
 
+      - name: build qdf-bench
+        working-directory: cmd/qdf-bench
+        run: |
+          # Its own module (msgpack baseline lives here, not in the qdf library).
+          # Build + vet only; the full data-driven matrix runs in qdf-bench-matrix.yml.
+          go build .
+          go vet .
+
       - name: codegen test (two-phase)
         working-directory: internal/codegen_test
         run: |
@@ -113,6 +122,8 @@ jobs:
             working-directory: bench
           - module: qdfgen
             working-directory: cmd/qdfgen
+          - module: qdf-bench
+            working-directory: cmd/qdf-bench
     steps:
       - uses: actions/checkout@v6
 
@@ -124,6 +135,7 @@ jobs:
             go.sum
             bench/go.sum
             cmd/qdfgen/go.sum
+            cmd/qdf-bench/go.sum
             internal/codegen_test/go.sum
 
       - name: golangci-lint (${{ matrix.module }})

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -33,6 +33,8 @@ jobs:
             working-directory: bench
           - module: qdfgen
             working-directory: cmd/qdfgen
+          - module: qdf-bench
+            working-directory: cmd/qdf-bench
           - module: codegen_test
             working-directory: internal/codegen_test
     steps:
@@ -46,6 +48,7 @@ jobs:
             go.sum
             bench/go.sum
             cmd/qdfgen/go.sum
+            cmd/qdf-bench/go.sum
             internal/codegen_test/go.sum
 
       - name: install govulncheck

--- a/README.md
+++ b/README.md
@@ -490,8 +490,13 @@ Each message is length-framed (a `uvarint` byte-count precedes its body;
 the 5-byte header is written once up front), so a message of any size
 round-trips — even across a reader that delivers one byte at a time — and
 `io.EOF` cleanly marks the end. Struct tags and all Dense/codec options
-work exactly as in one-shot `Marshal`, and `dec.SetNoCopy(true)` gives
-zero-copy decode whose aliases stay valid for the stream's lifetime. The
+work exactly as in one-shot `Marshal`. Decode-side allocation has two
+levers: `dec.SetNoCopy(true)` aliases the window (zero copies, values valid
+for the stream's lifetime), and `dec.SetArena(a)` bump-packs string bodies
+into a caller-owned arena (one amortized copy, values valid as long as the
+arena — `Reset` it per batch). To reuse one encoder/decoder across
+independent streams (pay the intern-table construction once), `Reset` them
+between streams; pair with the arena to bound a long stream's memory. The
 encoder reuses one pooled buffer (allocation-free steady state); target a
 `*bytes.Buffer` to collect into a `[]byte`. The three whole-batch
 features — `OptColumnIndex`, `Where`/`Select` pushdown, and `OptRANS` —

--- a/cmd/qdf-bench/README.md
+++ b/cmd/qdf-bench/README.md
@@ -154,6 +154,20 @@ encoder and decodes it back, per value: qdf `StreamEncoder` / `StreamDecoder`
 vs `encoding/json` and msgpack `NewEncoder` / `NewDecoder`, for both the typed
 and map representations. qdf streams the `summaryBundle` options.
 
+Each codec constructs ONE encoder/decoder and `Reset`s it per batch (so the
+heavy per-stream construction — qdf's intern table — is paid once, outside the
+timed loop, matching real streaming; json builds fresh since its constructor is
+cheap and stateless). A `dec` column reports qdf's stream decode mode:
+
+- `copy` — every string copied to the heap (default).
+- `nocopy` — `StreamDecoder.SetNoCopy`: strings alias the window (zero copies).
+- `arena` — `StreamDecoder.SetArena` with the arena `Reset` per batch: string
+  bodies bump-pack into the arena (fewer alloc events; values' lifetime is the
+  arena, not the window).
+
+`ser_*` and `wire_B` are identical across a repr's three qdf decode rows (same
+encode). json/msgpack have a single mode (`-`).
+
 ## Profiling
 
 ```sh

--- a/cmd/qdf-bench/go.mod
+++ b/cmd/qdf-bench/go.mod
@@ -1,0 +1,16 @@
+module github.com/alex60217101990/qdf/cmd/qdf-bench
+
+go 1.26
+
+require (
+	github.com/alex60217101990/qdf v0.0.0
+	github.com/vmihailenco/msgpack/v5 v5.4.1
+)
+
+require (
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
+)
+
+replace github.com/alex60217101990/qdf => ../../

--- a/cmd/qdf-bench/go.sum
+++ b/cmd/qdf-bench/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmd/qdf-bench/run.sh
+++ b/cmd/qdf-bench/run.sh
@@ -30,7 +30,10 @@ combos=("" "qdf_reflect2" "qdf_simd" "qdf_reflect2 qdf_simd")
 
 for tags in "${combos[@]}"; do
 	bin="$TMP/qdf-bench"
-	CGO_ENABLED=0 "$GO" build -tags "$tags" -o "$bin" ./cmd/qdf-bench
+	# cmd/qdf-bench is its own module (keeps the msgpack baseline out of the qdf
+	# library's go.mod); build from inside it. The qdf build tags still apply to
+	# the qdf dependency, resolved via the module's replace => ../../ directive.
+	( cd "$REPO_ROOT/cmd/qdf-bench" && CGO_ENABLED=0 "$GO" build -tags "$tags" -o "$bin" . )
 	if [[ -n "$DP" ]]; then
 		"$bin" -datapath "$DP" "$@"
 	else

--- a/cmd/qdf-bench/streaming.go
+++ b/cmd/qdf-bench/streaming.go
@@ -25,6 +25,13 @@ type streamCase struct {
 	n           int
 	encodeBatch func(w io.Writer) error
 	decodeBatch func(r io.Reader) error
+	// cleanup releases the persistent encoder/decoder (returned to a pool) after
+	// the case is measured. A streaming codec constructs ONE encoder/decoder and
+	// the batch closures Reset it per call, so the heavy per-stream construction
+	// (e.g. qdf's intern table) is paid once, outside the timed loop — matching
+	// real streaming use and keeping the per-message figures comparable. nil if
+	// the codec has nothing to release.
+	cleanup func()
 }
 
 // streamStat is the per-value result of a streaming batch.
@@ -82,6 +89,9 @@ func benchStream(iters int, sc streamCase) streamStat {
 		decOnce()
 	}
 	st.deserNs, st.deserB, st.deserAllocs = streamRounds(iters, decOnce, sc.n)
+	if sc.cleanup != nil {
+		sc.cleanup()
+	}
 	return st
 }
 
@@ -121,54 +131,73 @@ func streamRounds(iters int, fn func(), n int) (nsPerVal int64, bPerVal, allocsP
 func streamCases(typed []*Info, dyn []map[string]any) []streamCase {
 	nt, nm := len(typed), len(dyn)
 	opts := bundleOpts(summaryBundle)
+
+	// qdf: one StreamEncoder/Decoder per case, Reset between batches. The heavy
+	// per-stream construction (intern table) is paid once at NewStream*, outside
+	// the timed loop — so the measured figures are the per-message cost, the same
+	// basis as msgpack (whose encoder/decoder also reset over a reused buffer).
+	qeT := qdf.NewStreamEncoderWith(io.Discard, opts)
+	qdT := qdf.NewStreamDecoder(nil)
+	qeM := qdf.NewStreamEncoderWith(io.Discard, opts)
+	qdM := qdf.NewStreamDecoder(nil)
+	meT := msgpack.NewEncoder(io.Discard)
+	mdT := msgpack.NewDecoder(nil)
+	meM := msgpack.NewEncoder(io.Discard)
+	mdM := msgpack.NewDecoder(nil)
+
 	return []streamCase{
 		{
 			codec: "qdf", repr: "typed", n: nt,
 			encodeBatch: func(w io.Writer) error {
-				e := qdf.NewStreamEncoderWith(w, opts)
+				qeT.Reset(w)
 				for _, p := range typed {
-					if err := e.Encode(*p); err != nil {
+					if err := qeT.Encode(*p); err != nil {
 						return err
 					}
 				}
-				return e.Close()
+				return qeT.Flush()
 			},
 			decodeBatch: func(r io.Reader) error {
-				d := qdf.NewStreamDecoder(r)
+				qdT.Reset(r)
 				for range nt {
 					var out Info
-					if err := d.Decode(&out); err != nil {
+					if err := qdT.Decode(&out); err != nil {
 						return err
 					}
 					decInfo = out
 				}
 				return nil
 			},
+			cleanup: func() { qeT.Close(); qdT.Close() },
 		},
 		{
 			codec: "qdf", repr: "map", n: nm,
 			encodeBatch: func(w io.Writer) error {
-				e := qdf.NewStreamEncoderWith(w, opts)
+				qeM.Reset(w)
 				for _, v := range dyn {
-					if err := e.Encode(v); err != nil {
+					if err := qeM.Encode(v); err != nil {
 						return err
 					}
 				}
-				return e.Close()
+				return qeM.Flush()
 			},
 			decodeBatch: func(r io.Reader) error {
-				d := qdf.NewStreamDecoder(r)
+				qdM.Reset(r)
 				for range nm {
 					var out map[string]any
-					if err := d.Decode(&out); err != nil {
+					if err := qdM.Decode(&out); err != nil {
 						return err
 					}
 					decMap = out
 				}
 				return nil
 			},
+			cleanup: func() { qeM.Close(); qdM.Close() },
 		},
 		{
+			// json's Encoder/Decoder have no Reset; NewEncoder/NewDecoder are
+			// cheap (no cross-message state), so constructing per batch adds no
+			// measurable bias.
 			codec: "json", repr: "typed", n: nt,
 			encodeBatch: func(w io.Writer) error {
 				e := json.NewEncoder(w)
@@ -217,19 +246,19 @@ func streamCases(typed []*Info, dyn []map[string]any) []streamCase {
 		{
 			codec: "msgpack", repr: "typed", n: nt,
 			encodeBatch: func(w io.Writer) error {
-				e := msgpack.NewEncoder(w)
+				meT.Reset(w)
 				for _, p := range typed {
-					if err := e.Encode(*p); err != nil {
+					if err := meT.Encode(*p); err != nil {
 						return err
 					}
 				}
 				return nil
 			},
 			decodeBatch: func(r io.Reader) error {
-				d := msgpack.NewDecoder(r)
+				mdT.Reset(r)
 				for range nt {
 					var out Info
-					if err := d.Decode(&out); err != nil {
+					if err := mdT.Decode(&out); err != nil {
 						return err
 					}
 					decInfo = out
@@ -240,19 +269,19 @@ func streamCases(typed []*Info, dyn []map[string]any) []streamCase {
 		{
 			codec: "msgpack", repr: "map", n: nm,
 			encodeBatch: func(w io.Writer) error {
-				e := msgpack.NewEncoder(w)
+				meM.Reset(w)
 				for _, v := range dyn {
-					if err := e.Encode(v); err != nil {
+					if err := meM.Encode(v); err != nil {
 						return err
 					}
 				}
 				return nil
 			},
 			decodeBatch: func(r io.Reader) error {
-				d := msgpack.NewDecoder(r)
+				mdM.Reset(r)
 				for range nm {
 					var out map[string]any
-					if err := d.Decode(&out); err != nil {
+					if err := mdM.Decode(&out); err != nil {
 						return err
 					}
 					decMap = out

--- a/cmd/qdf-bench/streaming.go
+++ b/cmd/qdf-bench/streaming.go
@@ -22,6 +22,7 @@ import (
 type streamCase struct {
 	codec       string
 	repr        string
+	dec         string // decode mode label: copy / nocopy / arena (qdf), "-" otherwise
 	n           int
 	encodeBatch func(w io.Writer) error
 	decodeBatch func(r io.Reader) error
@@ -124,81 +125,111 @@ func streamRounds(iters int, fn func(), n int) (nsPerVal int64, bPerVal, allocsP
 	return
 }
 
-// streamCases builds the streaming matrix: qdf (typed + map), encoding/json
-// (typed + map), and msgpack (typed + map). qdf streams with summaryBundle so
-// it is comparable to the headline diff. json and msgpack use their standard
-// streaming encoder/decoder over the same values.
+// streamCases builds the streaming matrix: qdf (typed + map, each in the three
+// decode modes copy / nocopy / arena), encoding/json (typed + map), and msgpack
+// (typed + map). Every codec constructs ONE encoder/decoder and the batch
+// closures Reset it between batches, so the heavy per-stream construction (qdf's
+// intern table) is paid once, outside the timed loop — the figures are the
+// per-message cost, the same basis as msgpack (whose codec also resets over a
+// reused buffer). json's Encoder/Decoder have no Reset but are cheap + stateless,
+// so constructing per batch adds no measurable bias.
+//
+// The qdf decode modes exercise the StreamDecoder allocation levers: copy (one
+// heap string per value), nocopy (SetNoCopy — values alias the window, zero
+// copies), arena (SetArena — string bodies bump into a per-batch-Reset arena).
 func streamCases(typed []*Info, dyn []map[string]any) []streamCase {
 	nt, nm := len(typed), len(dyn)
 	opts := bundleOpts(summaryBundle)
 
-	// qdf: one StreamEncoder/Decoder per case, Reset between batches. The heavy
-	// per-stream construction (intern table) is paid once at NewStream*, outside
-	// the timed loop — so the measured figures are the per-message cost, the same
-	// basis as msgpack (whose encoder/decoder also reset over a reused buffer).
-	qeT := qdf.NewStreamEncoderWith(io.Discard, opts)
-	qdT := qdf.NewStreamDecoder(nil)
-	qeM := qdf.NewStreamEncoderWith(io.Discard, opts)
-	qdM := qdf.NewStreamDecoder(nil)
-	meT := msgpack.NewEncoder(io.Discard)
-	mdT := msgpack.NewDecoder(nil)
-	meM := msgpack.NewEncoder(io.Discard)
-	mdM := msgpack.NewDecoder(nil)
+	// configDec applies a qdf decode mode to a StreamDecoder, returning the arena
+	// (non-nil only for "arena") so the decode loop can Reset it per batch.
+	configDec := func(d *qdf.StreamDecoder, mode string) *qdf.Arena {
+		switch mode {
+		case "nocopy":
+			d.SetNoCopy(true)
+		case "arena":
+			a := qdf.NewArena()
+			d.SetArena(a)
+			return a
+		}
+		return nil
+	}
 
-	return []streamCase{
-		{
-			codec: "qdf", repr: "typed", n: nt,
+	qdfTyped := func(mode string) streamCase {
+		qe := qdf.NewStreamEncoderWith(io.Discard, opts)
+		qd := qdf.NewStreamDecoder(nil)
+		ar := configDec(qd, mode)
+		return streamCase{
+			codec: "qdf", repr: "typed", dec: mode, n: nt,
 			encodeBatch: func(w io.Writer) error {
-				qeT.Reset(w)
+				qe.Reset(w)
 				for _, p := range typed {
-					if err := qeT.Encode(*p); err != nil {
+					if err := qe.Encode(*p); err != nil {
 						return err
 					}
 				}
-				return qeT.Flush()
+				return qe.Flush()
 			},
 			decodeBatch: func(r io.Reader) error {
-				qdT.Reset(r)
+				if ar != nil {
+					ar.Reset() // reuse the arena's blocks for this batch (prior values are dead)
+				}
+				qd.Reset(r)
 				for range nt {
 					var out Info
-					if err := qdT.Decode(&out); err != nil {
+					if err := qd.Decode(&out); err != nil {
 						return err
 					}
 					decInfo = out
 				}
 				return nil
 			},
-			cleanup: func() { qeT.Close(); qdT.Close() },
-		},
-		{
-			codec: "qdf", repr: "map", n: nm,
+			cleanup: func() { qe.Close(); qd.Close() },
+		}
+	}
+	qdfMap := func(mode string) streamCase {
+		qe := qdf.NewStreamEncoderWith(io.Discard, opts)
+		qd := qdf.NewStreamDecoder(nil)
+		ar := configDec(qd, mode)
+		return streamCase{
+			codec: "qdf", repr: "map", dec: mode, n: nm,
 			encodeBatch: func(w io.Writer) error {
-				qeM.Reset(w)
+				qe.Reset(w)
 				for _, v := range dyn {
-					if err := qeM.Encode(v); err != nil {
+					if err := qe.Encode(v); err != nil {
 						return err
 					}
 				}
-				return qeM.Flush()
+				return qe.Flush()
 			},
 			decodeBatch: func(r io.Reader) error {
-				qdM.Reset(r)
+				if ar != nil {
+					ar.Reset()
+				}
+				qd.Reset(r)
 				for range nm {
 					var out map[string]any
-					if err := qdM.Decode(&out); err != nil {
+					if err := qd.Decode(&out); err != nil {
 						return err
 					}
 					decMap = out
 				}
 				return nil
 			},
-			cleanup: func() { qeM.Close(); qdM.Close() },
-		},
+			cleanup: func() { qe.Close(); qd.Close() },
+		}
+	}
+
+	meT := msgpack.NewEncoder(io.Discard)
+	mdT := msgpack.NewDecoder(nil)
+	meM := msgpack.NewEncoder(io.Discard)
+	mdM := msgpack.NewDecoder(nil)
+
+	return []streamCase{
+		qdfTyped("copy"), qdfTyped("nocopy"), qdfTyped("arena"),
+		qdfMap("copy"), qdfMap("nocopy"), qdfMap("arena"),
 		{
-			// json's Encoder/Decoder have no Reset; NewEncoder/NewDecoder are
-			// cheap (no cross-message state), so constructing per batch adds no
-			// measurable bias.
-			codec: "json", repr: "typed", n: nt,
+			codec: "json", repr: "typed", dec: "-", n: nt,
 			encodeBatch: func(w io.Writer) error {
 				e := json.NewEncoder(w)
 				for _, p := range typed {
@@ -221,7 +252,7 @@ func streamCases(typed []*Info, dyn []map[string]any) []streamCase {
 			},
 		},
 		{
-			codec: "json", repr: "map", n: nm,
+			codec: "json", repr: "map", dec: "-", n: nm,
 			encodeBatch: func(w io.Writer) error {
 				e := json.NewEncoder(w)
 				for _, v := range dyn {
@@ -244,7 +275,7 @@ func streamCases(typed []*Info, dyn []map[string]any) []streamCase {
 			},
 		},
 		{
-			codec: "msgpack", repr: "typed", n: nt,
+			codec: "msgpack", repr: "typed", dec: "-", n: nt,
 			encodeBatch: func(w io.Writer) error {
 				meT.Reset(w)
 				for _, p := range typed {
@@ -267,7 +298,7 @@ func streamCases(typed []*Info, dyn []map[string]any) []streamCase {
 			},
 		},
 		{
-			codec: "msgpack", repr: "map", n: nm,
+			codec: "msgpack", repr: "map", dec: "-", n: nm,
 			encodeBatch: func(w io.Writer) error {
 				meM.Reset(w)
 				for _, v := range dyn {
@@ -297,13 +328,15 @@ func streamCases(typed []*Info, dyn []map[string]any) []streamCase {
 func printStreaming(iters int, typed []*Info, dyn []map[string]any) {
 	fmt.Printf("\n=== STREAMING: encode then decode the whole batch through each codec's\n" +
 		"    streaming Encoder/Decoder (qdf StreamEncoder/Decoder, json/msgpack\n" +
-		"    NewEncoder/NewDecoder). Per-value figures. ===\n")
+		"    NewEncoder/NewDecoder). Per-value figures. The 'dec' column is qdf's\n" +
+		"    stream decode mode — copy / nocopy (SetNoCopy) / arena (SetArena, the\n" +
+		"    arena Reset per batch); json/msgpack have one mode ('-'). ===\n")
 	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
-	fmt.Fprintln(w, "codec\trepr\tser_ns\tser_B\tser_alloc\tdeser_ns\tdeser_B\tdeser_alloc\twire_B")
+	fmt.Fprintln(w, "codec\trepr\tdec\tser_ns\tser_B\tser_alloc\tdeser_ns\tdeser_B\tdeser_alloc\twire_B")
 	for _, sc := range streamCases(typed, dyn) {
 		s := benchStream(iters, sc)
-		fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
-			sc.codec, sc.repr,
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+			sc.codec, sc.repr, sc.dec,
 			s.serNs, s.serB, s.serAllocs,
 			s.deserNs, s.deserB, s.deserAllocs, s.wirePerVal)
 	}

--- a/docs/ARENA.md
+++ b/docs/ARENA.md
@@ -156,6 +156,39 @@ d.SetArena(a)
 // ... typed Read* / generated UnmarshalQDFArena ...
 ```
 
+### Pattern 4 — arena over a `StreamDecoder` (bounded long-stream decode)
+
+`StreamDecoder.SetArena` is the streaming twin of `WithArena`: decoded string
+bodies bump into the arena instead of one heap allocation each. It complements
+`SetNoCopy` — `nocopy` aliases the window (zero copies, but a value lives only as
+long as the window, which only grows), while the arena copies once into a
+lifetime you control. The bounded-memory pattern partitions the stream into
+envelopes: reuse the decoder with `Reset` (caps the growing window — its backing
+is reused, not re-grown) and `Reset` the arena per envelope (caps the values):
+
+```go
+a := qdf.NewArena()
+d := qdf.NewStreamDecoder(nil)
+d.SetArena(a)                        // preserved across Reset
+defer d.Close()
+for _, envelope := range envelopes {
+    a.Reset()                        // ⚠ invalidates the previous envelope's values
+    d.Reset(envelope)                // reuse window backing + dense state
+    for {
+        var ev Event
+        if err := d.Decode(&ev); err == io.EOF {
+            break
+        } else if err != nil {
+            return err
+        }
+        process(ev)                  // ev's strings live in `a` until the next a.Reset()
+    }
+}
+```
+
+`SetArena` is ignored while `SetNoCopy(true)` is set (no-copy already avoids the
+copy). The arena bounds the decoded *values*; `Reset` bounds the read *window*.
+
 ---
 
 ## Safety / lifetime contract

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1081,9 +1081,17 @@ State (intern table, shape table, predictors) persists across
 event log shares one intern table; the second event onwards trades
 its keys for state-refs.
 
-`StreamDecoder` is symmetric. Reset semantics are unchanged: when
-the stream encoder is returned to its pool (`Close`), the state
-shrinks via the same watermark logic.
+`StreamDecoder` is symmetric.
+
+**Reusing one encoder/decoder across streams.** `StreamEncoder.Reset(w)` /
+`StreamDecoder.Reset(r)` rewind the instance for a NEW, independent stream while
+reusing its grown intern/shape table and window buffer — so the heavy per-stream
+construction (the intern table) is paid once, not per stream. The configured
+`Options` (and `SetNoCopy`/`SetArena`) are preserved; the cross-message state is
+cleared so the new stream starts fresh and stays independent. This is the
+streaming counterpart of the `Marshal` encoder pool: construct one
+`StreamEncoder`/`StreamDecoder`, `Reset` it per batch. (`Close` still returns the
+buffer to the pool and shrinks the state via the watermark logic.)
 
 **Framing.** The 5-byte header is written once, before the first
 message. Each message is then length-delimited: a `uvarint` byte-count
@@ -1099,10 +1107,24 @@ has no per-message length prefix.)
 **What the stream supports vs the one-shot API.** Struct tags
 (`qdf:"..."`) and all Dense/codec features behave identically — pass any
 `Options` to `NewStreamEncoderWith`, and the intern/shape/predictor
-tables span the whole stream. Decode-side **zero-copy** works too:
-`StreamDecoder.SetNoCopy(true)` aliases the input buffer, and because the
-window is never compacted the aliases stay valid for the stream's
-lifetime.
+tables span the whole stream.
+
+Decode-side **alloc reduction** has two levers that trade copies for lifetime:
+
+- `StreamDecoder.SetNoCopy(true)` — decoded strings alias the window buffer
+  (zero copies). Safe for the stream's lifetime because the window is never
+  compacted, but a value lives only as long as the window — i.e. until `Close`
+  (or a `Reset`), and the window only ever grows.
+- `StreamDecoder.SetArena(a)` — string bodies bump into a caller-owned `Arena`
+  (one amortized-to-zero copy). The decoded values then live as long as the
+  `Arena`, independent of the window — `Reset` the arena once a batch's values
+  are dead to reuse its blocks, or drop it.
+
+**Bounding a long stream's memory.** The window grows monotonically, so total
+footprint tracks stream length. To bound it, partition the stream into envelopes
+and reuse the decoder across them with `Reset` (caps the window — its high-water
+backing is reused, not re-grown); pair with `SetArena` to also cap the decoded
+values. See [ARENA.md](ARENA.md).
 
 Three whole-payload features are **not** part of streaming, by design —
 they operate on a single complete message/batch, which is the opposite

--- a/encoder.go
+++ b/encoder.go
@@ -280,6 +280,26 @@ func NewEncoderOnBuf(buf []byte, mode Mode) *Encoder {
 // next caller — apply the desired options explicitly via applyOpts /
 // SetQPack after Reset.
 func (e *Encoder) Reset() {
+	e.resetForReuse()
+	e.opts = OptSpeed
+	e.mode = Fast
+	e.qpack = false
+	e.gorillaFloat = false
+	e.rans = false
+	e.colIndex = false
+	e.fsst = false
+	e.pairPred = false
+	e.mtf = false
+	e.fsstDict = nil
+}
+
+// resetForReuse clears the per-message / per-stream encoder state — the output
+// buffer, frame header flag, dense intern/shape state, and the row-scaled
+// scratch — while KEEPING the configured options/mode/codec flags. Encoder.Reset
+// layers the option reset on top (a pooled encoder is reconfigured per acquire);
+// StreamEncoder.Reset calls this directly so one encoder + its grown intern table
+// is reused across independent streams without a fresh newEncState allocation.
+func (e *Encoder) resetForReuse() {
 	e.buf = e.buf[:0]
 	e.customFramed = false
 	// Row-scaled ALP staging scratch: retain across batches, drop only past the
@@ -301,19 +321,8 @@ func (e *Encoder) Reset() {
 	if e.maxDepth == 0 {
 		e.maxDepth = DefaultMaxDepth
 	}
-	e.opts = OptSpeed
-	e.mode = Fast
-	e.qpack = false
-	e.gorillaFloat = false
-	e.rans = false
-	e.colIndex = false
-	e.fsst = false
-	e.pairPred = false
-	e.mtf = false
-	e.fsstDict = nil
-	// Drop any PreIntern entries — they reference caller-supplied
-	// backing pointers that are not safe to assume valid across a
-	// pool recycle.
+	// Drop any PreIntern entries — they reference caller-supplied backing
+	// pointers that are not safe to assume valid across a pool / stream recycle.
 	if e.preIntern != nil {
 		e.preIntern = e.preIntern[:0]
 	}

--- a/example_stream_test.go
+++ b/example_stream_test.go
@@ -82,3 +82,78 @@ func ExampleStreamDecoder_SetNoCopy() {
 	// auth
 	// auth
 }
+
+// ExampleStreamEncoder_Reset reuses ONE StreamEncoder across two independent
+// streams via Reset, instead of constructing a fresh one per stream. The heavy
+// per-stream construction (the intern table) is paid once; Reset clears the
+// cross-message state so each stream stays independent, while keeping the
+// configured Options and the grown buffers for reuse.
+func ExampleStreamEncoder_Reset() {
+	type Event struct {
+		Service string `qdf:"service"`
+		Status  int    `qdf:"status"`
+	}
+
+	enc := qdf.NewStreamEncoderWith(nil, qdf.OptBalanced)
+	defer enc.Close() //nolint:errcheck // example
+
+	encodeBatch := func(evs []Event) []byte {
+		var sink bytes.Buffer
+		enc.Reset(&sink) // new independent stream, reuse encoder + intern table
+		for _, e := range evs {
+			_ = enc.Encode(e)
+		}
+		_ = enc.Flush()
+		return append([]byte(nil), sink.Bytes()...)
+	}
+
+	a := encodeBatch([]Event{{"billing", 200}, {"billing", 500}})
+	b := encodeBatch([]Event{{"auth", 200}})
+
+	dec := qdf.NewStreamDecoder(nil)
+	defer dec.Close() //nolint:errcheck // example
+	for _, stream := range [][]byte{a, b} {
+		dec.Reset(bytes.NewReader(stream)) // reuse decoder + window across streams
+		var ev Event
+		for dec.Decode(&ev) == nil {
+			fmt.Println(ev.Service, ev.Status)
+		}
+	}
+	// Output:
+	// billing 200
+	// billing 500
+	// auth 200
+}
+
+// ExampleStreamDecoder_SetArena decodes a stream with string bodies bump-packed
+// into a caller-owned Arena instead of one heap allocation per value. The arena
+// is Reset per envelope so its blocks are reused; the decoder is Reset alongside
+// to cap the read window. Together they bound a long stream's memory.
+func ExampleStreamDecoder_SetArena() {
+	type Event struct {
+		Service string `qdf:"service"`
+	}
+
+	var sink bytes.Buffer
+	enc := qdf.NewStreamEncoderWith(&sink, qdf.OptBalanced)
+	_ = enc.Encode(Event{Service: "billing"})
+	_ = enc.Encode(Event{Service: "auth"})
+	_ = enc.Flush()
+	_ = enc.Close()
+	stream := sink.Bytes()
+
+	a := qdf.NewArena()
+	dec := qdf.NewStreamDecoder(nil)
+	dec.SetArena(a)   // copied string bodies live in the arena, not the heap
+	defer dec.Close() //nolint:errcheck // example
+
+	a.Reset()
+	dec.Reset(bytes.NewReader(stream))
+	var ev Event
+	for dec.Decode(&ev) == nil {
+		fmt.Println(ev.Service)
+	}
+	// Output:
+	// billing
+	// auth
+}

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,5 @@ go 1.26
 
 require (
 	github.com/modern-go/reflect2 v1.0.2
-	github.com/vmihailenco/msgpack/v5 v5.4.1
 	golang.org/x/sys v0.45.0
 )
-
-require github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,16 +1,4 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
-github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
-github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
-github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/stream.go
+++ b/stream.go
@@ -171,7 +171,11 @@ func (s *StreamEncoder) Reset(w io.Writer) {
 // The decoder grows its window buffer as needed. State-table entries
 // alias the buffer, so the window is never compacted during a stream;
 // total memory tracks the stream length. For unbounded streams partition
-// into envelopes and create a fresh StreamDecoder per envelope.
+// into envelopes: decode one envelope, then Reset this decoder for the next
+// (Reset reuses the decoder, its dense state, and the window backing — only the
+// contents are cleared, so the window's high-water memory is reused, not
+// re-grown, and the per-envelope footprint stays bounded). Pair Reset with
+// SetArena to also bound the decoded-value memory across envelopes.
 type StreamDecoder struct {
 	r   io.Reader
 	dec *Decoder
@@ -213,6 +217,40 @@ func NewStreamDecoder(r io.Reader) *StreamDecoder {
 func (s *StreamDecoder) SetNoCopy(v bool) {
 	if s.dec != nil {
 		s.dec.noCopy = v
+	}
+}
+
+// SetArena directs Decode to pack copied string / []byte-as-string bodies into
+// the caller-owned Arena (bump-allocated, amortized to ~zero alloc) instead of
+// one heap allocation per value. It is the streaming counterpart of
+// Unmarshal(..., WithArena(a)).
+//
+// Why both this AND SetNoCopy: they trade off lifetime vs copies.
+//
+//   - SetNoCopy aliases the window: zero copies, but a decoded value lives only
+//     as long as the window — i.e. until Close (or until a Reset for a new
+//     stream). The window only ever grows (it is never compacted mid-stream), so
+//     for a long stream its memory tracks the whole stream length.
+//   - SetArena copies once into the arena: the decoded values then live as long
+//     as the Arena (independent of the window), and you control that — keep the
+//     arena across batches, Reset it once a batch's values are dead to reuse its
+//     blocks for the next batch at zero allocation, or drop it and let the GC
+//     free it. This is the right choice when you process a stream in batches and
+//     want each batch's decoded memory released without holding the growing
+//     window, or when values must outlive a Reset/new stream.
+//
+// SetArena is ignored while SetNoCopy(true) is set (no-copy already avoids the
+// copy the arena would pack). The setting is preserved across Reset; pass nil to
+// clear it. Arena strings ALIAS the arena — see Arena for the use-after-free
+// contract around Arena.Reset. No-op after Close. One Arena per goroutine.
+//
+// Memory note: SetArena bounds the DECODED-VALUE memory (via Arena.Reset), not
+// the read WINDOW. To bound a long stream's total footprint, partition it into
+// envelopes and reuse this decoder across them with Reset (see Reset) — that is
+// what caps the window; the arena caps the values.
+func (s *StreamDecoder) SetArena(a *Arena) {
+	if s.dec != nil {
+		s.dec.arena = a
 	}
 }
 

--- a/stream.go
+++ b/stream.go
@@ -145,6 +145,26 @@ func (s *StreamEncoder) Close() error {
 	return nil
 }
 
+// Reset prepares the encoder to write a NEW, independent stream to w, reusing
+// the encoder, its grown intern / shape state, and the scratch buffer instead
+// of allocating a fresh one. The configured Options (Dense, codecs) are kept;
+// the cross-message state is cleared so the new stream's back-references start
+// from scratch and the next Encode re-emits the one-per-stream header. A no-op
+// after Close.
+//
+// This is the streaming counterpart of the encoder pool behind Marshal: rather
+// than construct (and re-allocate the intern table for) a StreamEncoder per
+// independent batch, construct one and Reset it between batches — the heavy
+// newEncState() is paid once.
+func (s *StreamEncoder) Reset(w io.Writer) {
+	if s.enc == nil {
+		return // closed: the buffer was returned to the pool
+	}
+	s.enc.resetForReuse()
+	s.w = w
+	s.broken = false
+}
+
 // StreamDecoder reads a sequence of values from an io.Reader. The intern
 // table is preserved across Decode calls to match StreamEncoder.
 //
@@ -334,6 +354,29 @@ func (s *StreamDecoder) fill(need int, boundary bool) error {
 		}
 	}
 	return nil
+}
+
+// Reset prepares the decoder to read a NEW, independent stream from r, reusing
+// the decoder, its dense state, and the window buffer instead of allocating a
+// fresh one. The noCopy setting is preserved; the cross-message state is cleared
+// so the new stream is decoded from scratch. A no-op after Close.
+func (s *StreamDecoder) Reset(r io.Reader) {
+	if s.dec == nil {
+		return // closed: the buffer was returned to the pool
+	}
+	s.dec.buf = (*s.buf)[:0]
+	s.dec.i = 0
+	s.dec.depth = 0
+	s.dec.headerRead = false
+	s.dec.mode = Fast
+	s.dec.colIndex = false
+	s.dec.colMaxLen = 0
+	clear(s.dec.mapFreeList)
+	if s.dec.state != nil {
+		s.dec.state.reset()
+	}
+	s.r = r
+	s.broken = false
 }
 
 // Close releases the scratch buffer to the pool. The underlying reader

--- a/stream_test.go
+++ b/stream_test.go
@@ -152,3 +152,62 @@ func TestStreamEncoderReset(t *testing.T) {
 		t.Fatalf("Reset reuse should be low-alloc, got %.1f (newEncState leaking per batch?)", allocs)
 	}
 }
+
+// TestStreamDecoderArena verifies StreamDecoder.SetArena: decoded string bodies
+// bump into the caller's arena, values round-trip, the arena is reused across
+// batches via the envelope pattern (arena.Reset + decoder.Reset), and the arena
+// setting survives Reset.
+func TestStreamDecoderArena(t *testing.T) {
+	type rec struct {
+		Name string `qdf:"name"`
+		Tag  string `qdf:"tag"`
+	}
+	batch := []rec{{"alpha", "x"}, {"beta", "y"}, {"alpha", "z"}, {"gamma", "x"}}
+
+	var w bytes.Buffer
+	enc := NewStreamEncoderWith(&w, OptBalanced)
+	for _, r := range batch {
+		if err := enc.Encode(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+	buf := append([]byte(nil), w.Bytes()...)
+
+	a := NewArena()
+	d := NewStreamDecoder(bytes.NewReader(buf))
+	d.SetArena(a)
+	defer d.Close()
+
+	decodeAll := func() []rec {
+		out := make([]rec, 0, len(batch))
+		for range batch {
+			var r rec
+			if err := d.Decode(&r); err != nil {
+				t.Fatal(err)
+			}
+			out = append(out, r)
+		}
+		return out
+	}
+	got := decodeAll()
+	for i := range batch {
+		if got[i] != batch[i] {
+			t.Fatalf("arena decode [%d]=%v, want %v", i, got[i], batch[i])
+		}
+	}
+
+	// Envelope reuse: Reset the arena (prior values dead) + the decoder, decode
+	// again — the arena setting is preserved across Reset, and the result is
+	// correct (no stale aliasing).
+	a.Reset()
+	d.Reset(bytes.NewReader(buf))
+	got2 := decodeAll()
+	for i := range batch {
+		if got2[i] != batch[i] {
+			t.Fatalf("after envelope reset [%d]=%v, want %v", i, got2[i], batch[i])
+		}
+	}
+}

--- a/stream_test.go
+++ b/stream_test.go
@@ -76,3 +76,79 @@ func TestStream_DenseSharesInternTable(t *testing.T) {
 		t.Fatalf("expected stream encoding to be smaller than concatenated solo encodings (shared intern wins)")
 	}
 }
+
+// TestStreamEncoderReset verifies one StreamEncoder (and StreamDecoder) reused
+// across independent streams via Reset: each batch round-trips correctly, the
+// reused encoder does not leak a fresh newEncState per batch, and the cleared
+// cross-message state keeps the streams independent.
+func TestStreamEncoderReset(t *testing.T) {
+	type rec struct {
+		Name string `qdf:"name"`
+		N    int    `qdf:"n"`
+	}
+	batchA := []rec{{"alpha", 1}, {"alpha", 2}, {"beta", 3}}
+	batchB := []rec{{"gamma", 10}, {"gamma", 11}}
+
+	enc := NewStreamEncoderWith(nil, OptBalanced)
+	defer enc.Close()
+	dec := NewStreamDecoder(nil)
+	defer dec.Close()
+
+	encodeBatch := func(b []rec) []byte {
+		var w bytes.Buffer
+		enc.Reset(&w)
+		for _, r := range b {
+			if err := enc.Encode(r); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := enc.Flush(); err != nil {
+			t.Fatal(err)
+		}
+		return append([]byte(nil), w.Bytes()...)
+	}
+	decodeBatch := func(buf []byte, n int) []rec {
+		dec.Reset(bytes.NewReader(buf))
+		out := make([]rec, 0, n)
+		for range n {
+			var r rec
+			if err := dec.Decode(&r); err != nil {
+				t.Fatal(err)
+			}
+			out = append(out, r)
+		}
+		return out
+	}
+
+	bufA := encodeBatch(batchA)
+	bufB := encodeBatch(batchB) // same encoder, Reset between batches
+
+	gotA := decodeBatch(bufA, len(batchA))
+	gotB := decodeBatch(bufB, len(batchB))
+	gotA2 := decodeBatch(bufA, len(batchA)) // decode A again after B: decoder Reset must fully clear
+
+	for i := range batchA {
+		if gotA[i] != batchA[i] || gotA2[i] != batchA[i] {
+			t.Fatalf("batchA[%d]: got %v / %v, want %v", i, gotA[i], gotA2[i], batchA[i])
+		}
+	}
+	for i := range batchB {
+		if gotB[i] != batchB[i] {
+			t.Fatalf("batchB[%d]: got %v, want %v", i, gotB[i], batchB[i])
+		}
+	}
+
+	// Reuse keeps the per-batch encode allocation-light (no fresh newEncState).
+	var w bytes.Buffer
+	allocs := testing.AllocsPerRun(50, func() {
+		w.Reset()
+		enc.Reset(&w)
+		for _, r := range batchA {
+			_ = enc.Encode(r)
+		}
+		_ = enc.Flush()
+	})
+	if allocs > 12 {
+		t.Fatalf("Reset reuse should be low-alloc, got %.1f (newEncState leaking per batch?)", allocs)
+	}
+}


### PR DESCRIPTION
Two streaming improvements + a dependency-hygiene change:

1. **`StreamEncoder.Reset` / `StreamDecoder.Reset`** — reuse one
   encoder/decoder (and its interned state) across independent streams, so the
   heavy per-stream construction (the intern table) is paid once.
2. **`StreamDecoder.SetArena`** — back streamed string decode with a reusable
   arena (bounded-memory long-stream decode via the envelope pattern).
3. **`cmd/qdf-bench` is now its own Go module** — the `msgpack` benchmark
   baseline is out of the qdf library's `go.mod`. The library builds with
   **zero external dependencies** by default.

## Streaming reuse — `Reset`

`StreamEncoder.Reset(w)` / `StreamDecoder.Reset(r)` re-point an existing codec
at a new `io.Writer`/`io.Reader` while keeping its allocated buffers, intern
table, and options. The encoder's reset body was factored out of
`Encoder.Reset()` into a shared `resetForReuse()` so the stream and one-shot
paths reset identically; the decoder reset clears the per-stream parse state
(buffer/cursor/depth/headerRead/mode/colIndex/colMaxLen/mapFreeList/intern
state) but **keeps** the configured `noCopy` flag and arena.

This matches real streaming: construct once, `Reset` per stream/batch, so the
intern-table construction lands outside the hot loop. The `cmd/qdf-bench`
streaming section was reworked to do exactly this (it previously constructed a
fresh encoder per batch, which charged the per-stream construction to every
timed iteration and inflated qdf's streaming numbers).

## Arena decode — `SetArena` + the envelope pattern

`StreamDecoder.SetArena(a *Arena)` forwards an arena to the underlying decoder:
decoded string bodies bump-pack into the arena instead of each landing on the
heap (fewer alloc events → less GC pressure). The values' lifetime becomes the
arena's, not the window's.

Combined with `Reset`, this gives **bounded-memory** decode of an unbounded
stream — the *envelope pattern* (documented in `docs/ARENA.md` Pattern 4):
decode a batch into the arena, consume it, `arena.Reset()` + `StreamDecoder`
keeps going. `SetNoCopy` (alias the window, zero copies) is the other
decode-mode lever; the trade is spelled out in the docs (nocopy can't free the
window buffer; an arena can be reset on your schedule).

## Benchmark: streaming decode modes

`cmd/qdf-bench` streaming now constructs ONE encoder/decoder per codec and
`Reset`s per batch (json stays fresh — its constructor is cheap/stateless), and
reports a `dec` column for qdf's three decode modes: `copy` (default), `nocopy`
(`SetNoCopy`), `arena` (`SetArena`, arena `Reset` per batch). `ser_*` and
`wire_B` are identical across a repr's three qdf decode rows (same encode).

## Zero external dependencies by default

`vmihailenco/msgpack/v5` (+ its `tagparser/v2` transitive) only existed for the
bench baseline. It is moved into a new nested module
`cmd/qdf-bench/go.mod` (`replace github.com/alex60217101990/qdf => ../../`),
mirroring the existing `bench/` and `cmd/qdfgen/` nested-module pattern. After
`go mod tidy`, the library's `go.mod` requires only `modern-go/reflect2` and
`golang.org/x/sys` — and **both are build-tag-gated** (`qdf_reflect2`,
`qdf_simd`), so `go list -deps .` on the default build is free of external
packages. CI (`ci.yml`, `govulncheck.yml`) gains the `qdf-bench` module in the
build/vet/lint/scan matrices + cache paths; `run.sh` builds from inside the
module.

## API added

- `StreamEncoder.Reset(w io.Writer)`
- `StreamDecoder.Reset(r io.Reader)`
- `StreamDecoder.SetArena(a *Arena)`
- (internal) `Encoder.resetForReuse()` extracted from `Encoder.Reset()`.
