### PR TITLE
perf(encode): adaptive arena retention for streaming intern

### DIFF
--- a/internal/internarena/arena.go
+++ b/internal/internarena/arena.go
@@ -134,6 +134,21 @@ func (a *Arena) BytesUsed() int {
 	return total
 }
 
+// ResidentBytes is the total capacity the arena currently keeps resident
+// across every slab it holds — independent of the bump cursor, so it counts
+// memory retained past a Reset() (the spike chunks an adaptive caller chooses
+// to keep warm). Distinct from BytesUsed, which reports only the volume handed
+// out below the live cursor. Used for retention tuning and tests.
+//
+//go:nosplit
+func (a *Arena) ResidentBytes() int {
+	total := 0
+	for _, c := range a.chunks {
+		total += cap(c)
+	}
+	return total
+}
+
 // Put copies s into the arena and returns the assigned id. Caller
 // guarantees len(s) <= MaxStringLen; longer payloads must take the
 // fallback path.

--- a/state.go
+++ b/state.go
@@ -256,6 +256,15 @@ type encState struct {
 	// adaptive-retention policy in reset(). Cold — touched once per reset.
 	retainStreak uint8
 
+	// arenaSmallStreak is the arena's own analogue of retainStreak, driven by
+	// the byte volume interned per message (internarena.DefaultRetainBytes)
+	// rather than the intern-id count (maxRetainedIDs). The two signals diverge:
+	// a batch can intern < maxRetainedIDs distinct keys yet still push the arena
+	// past its byte cap (long keys), so reusing retainStreak would shed the
+	// arena's spike slabs every steady batch in that band. Cold — touched once
+	// per reset. Packs into the same word as the two flags above (no size cost).
+	arenaSmallStreak uint8
+
 	// arena owns the byte storage that backs every intern key the
 	// encoder allocates — accessed only on intern miss, kept at the
 	// end so the hot fields above share earlier cache lines.
@@ -427,7 +436,37 @@ func (e *encState) reset() {
 		clear(e.internTable)
 	}
 	e.internLoad = 0
-	e.arena.Reset() // Arena has its own watermark, see internarena.
+	// Adaptive arena retention. The default Reset() soft cap (256 KiB) drops the
+	// spike slabs a high-cardinality AD/log batch just grew, forcing a full arena
+	// regrow every batch — the dominant streaming-encode allocation (~181 KB/value
+	// measured on high-card AD data, where each per-batch StreamEncoder.Reset
+	// sheds and the next batch rebuilds the slabs). While a steady large-volume
+	// workload keeps filling the arena past the cap, retain every slab —
+	// ResetWithLimit(0) rolls the cursor back to chunks[0] and keeps the spike
+	// chunks so the next same-shaped batch reuses them in place. Resident memory
+	// stays bounded by the single-batch peak (the cursor resets each batch and
+	// grow() walks the existing slabs before allocating).
+	//
+	// The trigger is the arena's OWN per-message byte demand (BytesUsed, the
+	// volume interned THIS batch, measured before the cursor rolls back), not the
+	// intern-id streak above: a batch can intern fewer than maxRetainedIDs keys
+	// yet still exceed the byte cap with long keys, so the id-based `release`
+	// would shed the arena's slabs every steady batch in that band. Only after
+	// retainReleaseStreak consecutive sub-cap batches (burst genuinely subsided)
+	// do we fall back to the default cap and shed the spike memory, so a
+	// one-shot/bursty pool encoder still bounds its resident set. The intern
+	// table was already cleared above, dropping every aliased slot.key, so
+	// rolling the cursor back is safe at any retain limit.
+	if e.arena.BytesUsed() > internarena.DefaultRetainBytes {
+		e.arenaSmallStreak = 0
+	} else if e.arenaSmallStreak < retainReleaseStreak {
+		e.arenaSmallStreak++
+	}
+	if e.arenaSmallStreak >= retainReleaseStreak {
+		e.arena.Reset() // default 256 KiB soft cap — burst subsided, shrink.
+	} else {
+		e.arena.ResetWithLimit(0) // large-volume streak: keep slabs warm.
+	}
 
 	e.lastID = lruInvalidID
 	e.lruHead = lruInvalidID

--- a/stream_arena_retain_bench_test.go
+++ b/stream_arena_retain_bench_test.go
@@ -1,0 +1,65 @@
+package qdf
+
+import (
+	"io"
+	"strconv"
+	"testing"
+)
+
+// adRow is a small high-cardinality record: every batch carries distinct,
+// long-ish string keys/values (host names, SIDs, paths) — the AD/telemetry
+// shape where first-occurrence interning dominates encode allocation.
+type adRow struct {
+	Host    string
+	SID     string
+	Path    string
+	Service string
+	Value   int64
+}
+
+func makeADBatch(n, batchSeed int) []adRow {
+	rows := make([]adRow, n)
+	for i := range n {
+		k := strconv.Itoa(batchSeed*1_000_000 + i)
+		rows[i] = adRow{
+			Host:    "WIN-DC-" + k + ".corp.internal.example.com",
+			SID:     "S-1-5-21-3623811015-3361044348-30300820-" + k,
+			Path:    "C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\" + k,
+			Service: "telemetry-collector-shard-" + k,
+			Value:   int64(i),
+		}
+	}
+	return rows
+}
+
+// BenchmarkStreamEncodeADRetain streams many same-shaped high-cardinality
+// batches through one reused StreamEncoder, resetting per batch (the
+// qdf-bench / per-request pattern). Reports encode allocation per value. With
+// adaptive arena retention the spike slabs survive the per-batch Reset, so a
+// steady stream stops paying a full arena regrow every batch.
+func BenchmarkStreamEncodeADRetain(b *testing.B) {
+	const rowsPerBatch = 4000 // ~400 KiB interned/batch: past the 256 KiB cap.
+
+	// Distinct batches so keys never repeat across batches (worst case for
+	// interning — every batch is a fresh first-occurrence wave).
+	batches := make([][]adRow, 16)
+	for i := range batches {
+		batches[i] = makeADBatch(rowsPerBatch, i+1)
+	}
+
+	enc := NewStreamEncoder(io.Discard, Dense)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		batch := batches[i%len(batches)]
+		enc.Reset(io.Discard)
+		for j := range batch {
+			if err := enc.Encode(batch[j]); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(rowsPerBatch), "rows/batch")
+}

--- a/stream_arena_retain_test.go
+++ b/stream_arena_retain_test.go
@@ -1,0 +1,113 @@
+package qdf
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/alex60217101990/qdf/internal/internarena"
+)
+
+// internBatch drives n distinct large keys through the encoder intern table,
+// growing the arena past the default soft cap, then resets once. Returns the
+// arena bytes resident *after* the reset — i.e. what the adaptive policy chose
+// to keep warm for the next batch.
+func internBatch(e *encState, n int) int {
+	for i := range n {
+		// ~100-byte distinct keys: n=5000 => ~500 KiB, well past the 256 KiB
+		// DefaultRetainBytes cap, so the spike chunks are what's at stake.
+		key := "host-" + strconv.Itoa(i) + "-region-eu-west-1-az-1-service-telemetry-collector-shard"
+		e.lookupOrAssign(key)
+	}
+	e.reset()
+	return e.arena.ResidentBytes()
+}
+
+// TestStreamArenaRetainAcrossLargeBatches proves the adaptive arena retention:
+// while a steady high-cardinality (streaming-shaped) workload keeps
+// retainStreak pinned at 0, the encoder keeps its grown arena slabs resident
+// across reset() so the next same-shaped batch reuses them instead of
+// regrowing — the streaming-encode allocation lever. Once the burst subsides
+// (retainReleaseStreak consecutive small batches), the arena falls back to the
+// default soft cap and sheds the spike memory.
+func TestStreamArenaRetainAcrossLargeBatches(t *testing.T) {
+	const bigN = 5000 // > maxRetainedIDs (4096) => retainStreak stays 0.
+
+	e := newEncState()
+
+	// First large batch grows the arena; reset retains it (release == false).
+	resident := internBatch(e, bigN)
+	if resident <= internarena.DefaultRetainBytes {
+		t.Fatalf("after first large batch: arena resident=%d, want > DefaultRetainBytes=%d (spike chunks should be retained, not dropped)",
+			resident, internarena.DefaultRetainBytes)
+	}
+	peak := resident
+
+	// Steady large batches must keep the arena resident — no per-batch
+	// drop-and-regrow. Resident stays at the single-batch peak (cursor rolls
+	// to 0 each reset and reuses the same slabs), never shedding.
+	for b := range 5 {
+		resident = internBatch(e, bigN)
+		if resident < peak {
+			t.Fatalf("steady large batch %d: arena resident=%d dropped below peak=%d; spike chunks were shed mid-stream (regrow alloc)",
+				b, resident, peak)
+		}
+	}
+
+	// Burst subsides: retainReleaseStreak consecutive SMALL batches must drive
+	// release and shrink the arena back under the default soft cap.
+	var small int
+	for b := range retainReleaseStreak {
+		small = internBatch(e, 4) // tiny load => streak advances toward release.
+		_ = b
+	}
+	if small > internarena.DefaultRetainBytes {
+		t.Fatalf("after %d small batches: arena resident=%d, want <= DefaultRetainBytes=%d (burst subsided, spike memory should be released)",
+			retainReleaseStreak, small, internarena.DefaultRetainBytes)
+	}
+}
+
+// TestStreamArenaRetainWireIdentical locks the invariant that adaptive arena
+// retention is a memory-only optimization: the encoded bytes for a fixed batch
+// must be byte-identical whether or not the prior batch left spike slabs warm.
+// Encoding the same batch on a fresh stream and after a large warm-up batch (so
+// the arena is retained) must produce the same wire output — intern ids come
+// from internLoad (reset to 0 each batch), independent of slab layout.
+func TestStreamArenaRetainWireIdentical(t *testing.T) {
+	type row struct {
+		Name string
+		ID   string
+		N    int64
+	}
+	batch := make([]row, 64)
+	for i := range batch {
+		k := strconv.Itoa(i)
+		batch[i] = row{Name: "service-instance-" + k + ".prod.internal", ID: "uuid-" + k, N: int64(i)}
+	}
+
+	encodeBatch := func(warmup bool) []byte {
+		var buf bytes.Buffer
+		enc := NewStreamEncoder(&buf, Dense)
+		if warmup {
+			// Large prior batch grows + retains the arena slabs, then reset.
+			enc.Reset(&buf)
+			for i := range 6000 {
+				_ = enc.Encode(row{Name: "warm-" + strconv.Itoa(i) + "-padding-to-grow-the-arena-past-cap", ID: strconv.Itoa(i), N: int64(i)})
+			}
+			buf.Reset()
+		}
+		enc.Reset(&buf)
+		for i := range batch {
+			if err := enc.Encode(batch[i]); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return append([]byte(nil), buf.Bytes()...)
+	}
+
+	cold := encodeBatch(false)
+	warm := encodeBatch(true)
+	if !bytes.Equal(cold, warm) {
+		t.Fatalf("wire output differs with arena retention: cold=%d bytes, warm=%d bytes — retention must not affect encoding", len(cold), len(warm))
+	}
+}


### PR DESCRIPTION
A steady high-cardinality streaming encode (`StreamEncoder` re-used across
same-shaped batches, the per-request / `cmd/qdf-bench` pattern) was reallocating
the entire string-intern arena on **every batch**. Dense/Balanced interns every
distinct string into the encoder's bump arena; AD/log/telemetry batches intern
several MB of unique keys (SIDs, DACLs, paths, service names — all distinct), and
each per-batch `StreamEncoder.Reset` ran the arena's default `ResetWithLimit(256 KiB)`,
which **drops the spike slabs** the batch just grew. The next batch then regrew
them from scratch — the dominant streaming-encode allocation (~181 KB/value
measured on real adalanche AD data).

This is a memory-retention change only. Interning is unchanged, so the **wire is
byte-identical** (intern ids come from `internLoad`, reset to 0 per batch,
independent of slab layout). Interning is what buys qdf its ~2.6–3× smaller wire
(streaming wire ≈163 KB vs msgpack ≈500 KB), so the fix keeps the arena warm
instead of killing the feature.

## The change

`encState.reset()` now keeps the grown arena slabs resident across reset while a
steady workload keeps filling them, falling back to the default soft cap only
once a burst genuinely subsides:

```go
if e.arena.BytesUsed() > internarena.DefaultRetainBytes {
    e.arenaSmallStreak = 0
} else if e.arenaSmallStreak < retainReleaseStreak {
    e.arenaSmallStreak++
}
if e.arenaSmallStreak >= retainReleaseStreak {
    e.arena.Reset()           // burst subsided → shrink to the 256 KiB cap
} else {
    e.arena.ResetWithLimit(0) // large-volume streak → keep slabs warm for reuse
}
```

### Why a separate byte-streak, not the existing id-based `release`

The encoder already has an adaptive-retention streak (`retainStreak`) for its
table backings, keyed on the **intern-id count** (`maxRetainedIDs` = 4096). That
signal misfires for the arena: a batch can intern *fewer than* 4096 distinct keys
yet still blow past the **256 KiB byte cap** with long keys (SIDs, file paths). If
the arena reused the id-based `release`, it would shed its slabs every steady
batch in that band (256 KiB–4096 ids) — defeating the fix. So the arena gets its
own streak driven by its true per-message **byte** demand (`BytesUsed()`).

Resident memory stays bounded by the single-batch peak: the cursor rolls back to
`chunks[0]` each reset and `grow()` reuses the existing slabs before allocating.
A one-shot / bursty pool encoder still releases its spike memory after
`retainReleaseStreak` (8) consecutive sub-cap batches, so the reason the 256 KiB
cap exists (no unbounded pin across pooled reuse) is preserved.

New `internarena.Arena.ResidentBytes()` (sum of capacity across all slabs)
supports retention tuning and the tests. New `encState.arenaSmallStreak uint8`
packs free into the existing cold-flag word (no struct growth; fieldalignment
clean).

## Measured (benchstat)

i7-9750H, `Dense`, 4000 distinct-key rows/batch, per-batch `Reset` (n=8):

```
                        │   old    │           new            │
                        │   B/op   │   B/op      vs base       │
StreamEncodeADRetain      1703 KiB    707 KiB   -58.46% (p=0.000)

                        │  sec/op  │  sec/op     vs base       │
StreamEncodeADRetain      2.377m      2.168m     -8.77% (p=0.005)

                        │ allocs/op│ allocs/op   vs base       │
StreamEncodeADRetain      8.008k      8.001k      ~ (wire unchanged)
```

`allocs/op` is flat because the regrow was a few *huge* allocations, not many —
the byte volume is what collapses.

## Quality gate (all green)

- `go test ./...` — full suite + all `internal/*` packages.
- `-race` — 3/3 clean repeated runs of the package. (One earlier single failure
  was a known flaky `AllocsPerRun`-based test under `-race`, not reproduced, and
  unrelated to this change — alloc budgets are intentionally not measured under
  `-race`.)
- `golangci-lint run ./...` — 0 issues (matched toolchain GOROOT).
- Fuzz — `FuzzRoundTrip_StringSlice` / `FuzzRoundTrip_StructTriad` /
  `FuzzRoundTrip_AllModesAgree`, ~1.35M execs, clean.

## Tests added

- `TestStreamArenaRetainAcrossLargeBatches` — proves the arena retains slabs
  during a steady large streak and shrinks after `retainReleaseStreak` small
  batches (via `Arena.ResidentBytes()`). RED-verified: without the fix the arena
  resident drops to 4096 B after the first large batch.
- `TestStreamArenaRetainWireIdentical` — locks the memory-only invariant: a fixed
  batch encodes byte-identically whether or not a prior large batch left the
  arena warm.
- `BenchmarkStreamEncodeADRetain` — the benchstat scenario above.

## Scope

Encode-side streaming arena only. The decode-side arena (`SetArena`) is a
separate, already-shipped feature and is untouched. No wire-format or public-API
changes.