### PR TITLE
fix: second full-codebase audit — 8 fixes across reflect, codegen, decode, columnar

### DIFF
--- a/canon_busy_test.go
+++ b/canon_busy_test.go
@@ -1,0 +1,24 @@
+package qdf
+
+import "testing"
+
+// A canonical (OptCanonical) map encode that errors mid-loop on an `any` value
+// must still release the canonKeysBusy re-entrancy latch — otherwise a pooled
+// encoder is pinned to the fresh-allocation fallback forever. The generated
+// fast paths now release via defer (matching the reflect path). Regression for
+// the maps_fast_generated canonical-encode error path.
+func TestCanonKeysBusyReleasedOnError(t *testing.T) {
+	e := NewEncoderWith(OptCanonical | OptDense)
+	// chan has no codec → encodeReflect errors inside the sorted-key loop.
+	if err := e.EncodeValue(map[string]any{"k": make(chan int)}); err == nil {
+		t.Fatal("expected an error encoding a chan map value")
+	}
+	if e.state != nil && e.state.canonKeysBusy {
+		t.Fatal("canonKeysBusy leaked true after a mid-loop error return")
+	}
+	// A subsequent canonical map encode must still succeed (and reuse the pooled
+	// scratch, not be wedged on the busy latch).
+	if err := e.EncodeValue(map[string]any{"b": 2, "a": 1}); err != nil {
+		t.Fatalf("follow-up canonical encode failed: %v", err)
+	}
+}

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -912,7 +912,15 @@ func (g *gen) classifyColField(wireName, access string, ft types.Type) (colColum
 	// the presence bit (nil → absent, empty/non-nil → present "") to preserve
 	// the nil-vs-empty distinction (a plain string column would collapse them).
 	if sl, ok := ft.Underlying().(*types.Slice); ok {
-		if eb, ok := sl.Elem().Underlying().(*types.Basic); ok && eb.Kind() == types.Uint8 {
+		// Require the element to be *exactly* byte/uint8 — match elem directly,
+		// not its Underlying. A defined byte-element slice (`type B byte; []B`)
+		// cannot be expressed as []byte: the columnar Bytes emit would generate
+		// `unsafe.SliceData([]B)` (*B, not *byte) and `[]B([]byte(...))` (an
+		// illegal slice conversion), neither of which compiles. The row-major
+		// path (emitEncodeSlice) already gates on `elem.(*types.Basic)` for the
+		// same reason and falls through to the generic per-element encoder, which
+		// handles defined byte elements correctly; mirror that here.
+		if eb, ok := sl.Elem().(*types.Basic); ok && eb.Kind() == types.Uint8 {
 			return colColumn{WireName: wireName, Access: access, KindByte: 4 | 0x80, GoType: g.typeExprFromType(ft), ColAPI: "Bytes", Nullable: true}, true
 		}
 		return colColumn{}, false

--- a/cmd/qdfgen/gen/gen_columnar_test.go
+++ b/cmd/qdfgen/gen/gen_columnar_test.go
@@ -46,4 +46,21 @@ func TestColumnarSkipsCustomCodecElem(t *testing.T) {
 			t.Fatalf("PlainHolder should columnar-transpose its plain all-scalar element:\n%s", src)
 		}
 	})
+
+	// A []struct element with a defined-byte-element slice field (`type B byte;
+	// []B`) must NOT classify that field as a columnar Bytes column: the Bytes
+	// emit assumes a literal []byte and would generate `unsafe.SliceData([]B)`
+	// (*B, not *byte) and `[]B([]byte(...))` (an illegal conversion) — neither
+	// compiles. It must fall through to the generic per-element encoder.
+	t.Run("defined_byte_elem_slice_not_bytes_column", func(t *testing.T) {
+		src := gen(t, "NamedByteHolder")
+		// The broken Bytes-column emit dereferences the field via unsafe.SliceData;
+		// the generic row-major path uses WriteArrayHeader instead.
+		if strings.Contains(src, "unsafe.SliceData(") && strings.Contains(src, ".Data") {
+			t.Fatalf("[]NamedByte field was emitted as a Bytes column (non-compiling):\n%s", src)
+		}
+		if !strings.Contains(src, "WriteArrayHeader") {
+			t.Fatalf("[]NamedByte field should encode via the generic per-element path (WriteArrayHeader):\n%s", src)
+		}
+	})
 }

--- a/cmd/qdfgen/gen/testdata/customcodec/types.go
+++ b/cmd/qdfgen/gen/testdata/customcodec/types.go
@@ -37,3 +37,21 @@ type PlainElem struct {
 type PlainHolder struct {
 	Items []PlainElem
 }
+
+// NamedByte is a defined byte element type. A slice of it ([]NamedByte) must NOT
+// be columnar-transposed as a Bytes column — that emit assumes a literal []byte
+// and would generate non-compiling code (unsafe.SliceData → *NamedByte, and an
+// illegal []NamedByte([]byte(...)) conversion). It must fall through to the
+// generic row-major per-element encoder instead.
+type NamedByte byte
+
+// NamedByteElem mixes a scalar column with a defined-byte-element slice.
+type NamedByteElem struct {
+	ID   int64
+	Data []NamedByte
+}
+
+// NamedByteHolder slices the element with the defined-byte-element field.
+type NamedByteHolder struct {
+	Rows []NamedByteElem
+}

--- a/colcodegen.go
+++ b/colcodegen.go
@@ -177,6 +177,13 @@ func (d *Decoder) ReadColNullMask(n int) ([]byte, int, error) {
 	for _, b := range mask {
 		present += bits.OnesCount8(b)
 	}
+	// Reject set padding bits (positions [n%8, 8) of the last byte): a hostile
+	// mask can set one while under-filling in-range bits, keeping present<=n yet
+	// silently dropping trailing dense values in the scatter loop. Mirrors the
+	// reflect sibling readNullableMask.
+	if n&7 != 0 && mask[mb-1]>>uint(n&7) != 0 {
+		return nil, 0, ErrInvalidLength
+	}
 	if present > n {
 		return nil, 0, ErrInvalidLength
 	}

--- a/decoder.go
+++ b/decoder.go
@@ -316,8 +316,11 @@ func (d *Decoder) readHeaderSlow() error {
 		}
 		// Bound the allocation: reject a hostile origLen that dwarfs the
 		// input. rANS shrinks at best modestly, so a real origLen stays
-		// within a small factor of the compressed size.
-		if origLen > uint64(len(d.buf))*64+(1<<20) {
+		// within a small factor of the compressed size. The second clause
+		// rejects anything past the int range so the int(origLen) narrowing
+		// below cannot truncate a multi-GiB length on a 32-bit build and decode
+		// a silently short/wrong body.
+		if origLen > uint64(len(d.buf))*64+(1<<20) || origLen > uint64(int(^uint(0)>>1)) {
 			return ErrInvalidLength
 		}
 		body, err := rans.Decode(rest[k:], int(origLen))

--- a/decoder_read.go
+++ b/decoder_read.go
@@ -269,11 +269,15 @@ func (d *Decoder) readStringBytes() ([]byte, error) {
 		if d.i+4 > len(d.buf) {
 			return nil, ErrShortBuffer
 		}
-		n := int(readU32(d.buf[d.i:]))
+		n64 := uint64(readU32(d.buf[d.i:]))
 		d.i += 4
-		if d.i+n > len(d.buf) {
+		// Compare in uint64 before narrowing: on a 32-bit int a length near
+		// 2^32 would become negative and slip past a `d.i+n > len` check, then
+		// panic the slice with high < low. Mirrors the tagInternStr guard below.
+		if n64 > uint64(len(d.buf)-d.i) {
 			return nil, ErrShortBuffer
 		}
+		n := int(n64)
 		out := d.buf[d.i : d.i+n]
 		d.i += n
 		if invalidateLast {

--- a/internal/internarena/arena.go
+++ b/internal/internarena/arena.go
@@ -105,6 +105,14 @@ type Arena struct {
 	// cur is the index of the chunk the cursor lives in. Reset()
 	// rolls this back to 0.
 	cur int
+
+	// putBytes accumulates the payload bytes stored via Put since the last
+	// Reset — an O(1) running counter so callers can read the current cycle's
+	// intern volume without the O(chunks) BytesUsed walk (which also over-counts
+	// the full capacity of any chunk grow() skipped because a payload did not
+	// fit). The adaptive-retention trigger in encState.reset reads this once per
+	// message; ResetWithLimit zeroes it.
+	putBytes int
 }
 
 // MaxStringLen is the largest single payload the arena can store.
@@ -172,11 +180,21 @@ func (a *Arena) Put(s string) uint32 {
 		copy(full[a.off:a.off+n], s)
 	}
 	a.off += n
+	a.putBytes += int(n)
 
 	id := uint32(len(a.locs))
 	a.locs = append(a.locs, pack(uint16(a.cur), offset, uint16(n)))
 	return id
 }
+
+// BytesPut is the payload volume stored via Put since the last Reset, in O(1)
+// (a running counter, no chunk walk). This is the exact per-cycle intern demand
+// — unlike BytesUsed it never counts a skipped chunk's capacity — so it is the
+// signal the adaptive-retention policy uses to decide whether to keep the grown
+// slabs warm across a Reset.
+//
+//go:nosplit
+func (a *Arena) BytesPut() int { return a.putBytes }
 
 // Get returns the bytes for id. The slice aliases the chunk the
 // payload lives in — caller MUST NOT retain it across a Reset() or
@@ -212,6 +230,7 @@ func (a *Arena) Reset() { a.ResetWithLimit(DefaultRetainBytes) }
 // call.
 func (a *Arena) ResetWithLimit(retainBytes int) {
 	a.locs = a.locs[:0]
+	a.putBytes = 0
 	if len(a.chunks) == 0 {
 		a.off = 0
 		a.end = 0

--- a/internal/internarena/arena_test.go
+++ b/internal/internarena/arena_test.go
@@ -160,6 +160,43 @@ func TestArena_BytesUsedAccounting(t *testing.T) {
 	}
 }
 
+// BytesPut is an O(1) running counter of payload bytes stored since the last
+// Reset, used as the adaptive-retention trigger. It must equal the exact sum of
+// Put lengths, zero after Reset, and — unlike BytesUsed — must NOT count the
+// capacity of a chunk that grow() skipped because a payload did not fit.
+func TestArena_BytesPut(t *testing.T) {
+	a := &Arena{}
+	total := 0
+	for i := range 200 {
+		s := fmt.Sprintf("entry-%05d", i)
+		a.Put(s)
+		total += len(s)
+	}
+	if got := a.BytesPut(); got != total {
+		t.Fatalf("BytesPut=%d want=%d", got, total)
+	}
+	a.Reset()
+	if got := a.BytesPut(); got != 0 {
+		t.Fatalf("BytesPut after Reset=%d want=0", got)
+	}
+
+	// Skipped-chunk case: a fresh arena's chunk[0] is 4 KiB; a single payload
+	// larger than that forces grow() to walk past (skip) chunk[0] and allocate a
+	// big chunk. BytesPut must report ONLY the real payload, while BytesUsed
+	// over-counts the skipped chunk[0]'s full capacity.
+	a2 := &Arena{}
+	a2.Put("warm") // lands in chunk[0] (4 KiB)
+	a2.Reset()     // retains chunk[0]; cursor back to 0
+	big := make([]byte, 10*1024)
+	a2.Put(string(big)) // 10 KiB: skips 4 KiB chunk[0], allocates a bigger one
+	if got := a2.BytesPut(); got != len(big) {
+		t.Fatalf("BytesPut with skipped chunk=%d want=%d (must not count skipped capacity)", got, len(big))
+	}
+	if a2.BytesUsed() <= a2.BytesPut() {
+		t.Fatalf("expected BytesUsed (%d) to over-count vs BytesPut (%d) when a chunk was skipped", a2.BytesUsed(), a2.BytesPut())
+	}
+}
+
 // Randomised round-trip: fuzz-style coverage that mixed lengths /
 // orderings cannot corrupt loc indexing across chunk growth.
 func TestArena_RandomRoundTrip(t *testing.T) {

--- a/internal/mapsgen/main.go
+++ b/internal/mapsgen/main.go
@@ -353,7 +353,12 @@ func emitCanonicalEncode(buf *bytes.Buffer, p pair) {
 		fmt.Fprintf(buf, "\t\tfor k := range m {\n\t\t\tkeys = append(keys, k)\n\t\t}\n")
 	}
 	fmt.Fprintf(buf, "\t\tslices.Sort(keys)\n")
-	fmt.Fprintf(buf, "\t\tif canonPooled {\n\t\t\te.state.%s = keys\n\t\t\te.state.canonKeysBusy = true\n\t\t}\n", scratchField)
+	// Release the re-entrancy latch via defer so it clears on EVERY exit —
+	// including a mid-loop `return err` from a value write (the *Any pairs).
+	// An inline post-loop release leaks busy=true on the error path, pinning a
+	// pooled encoder to the fresh-allocation fallback forever. Mirrors the
+	// reflect path's `defer e.canonKeysRelease(pooled)`.
+	fmt.Fprintf(buf, "\t\tif canonPooled {\n\t\t\te.state.%s = keys\n\t\t\te.state.canonKeysBusy = true\n\t\t\tdefer func() { e.state.canonKeysBusy = false }()\n\t\t}\n", scratchField)
 	fmt.Fprintf(buf, "\t\tfor _, sk := range keys {\n")
 	if needCast {
 		fmt.Fprintf(buf, "\t\t\tk := %s(sk)\n", p.K.goType)
@@ -364,7 +369,6 @@ func emitCanonicalEncode(buf *bytes.Buffer, p pair) {
 	fmt.Fprintf(buf, "\t\t\t%s\n", indent(indent(p.K.writeBlock("k"))))
 	fmt.Fprintf(buf, "\t\t\t%s\n", indent(indent(p.V.writeBlock("v"))))
 	fmt.Fprintf(buf, "\t\t}\n")
-	fmt.Fprintf(buf, "\t\tif canonPooled {\n\t\t\te.state.canonKeysBusy = false\n\t\t}\n")
 	fmt.Fprintf(buf, "\t\treturn nil\n\t}\n")
 }
 

--- a/internal/mapsgen/main.go
+++ b/internal/mapsgen/main.go
@@ -97,10 +97,32 @@ var kindBool = kind{
 }
 
 var kindBytes = kind{
-	suffix:     "Bytes",
-	goType:     "[]byte",
-	writeBlock: func(v string) string { return fmt.Sprintf("e.WriteBytes(%s)", v) },
-	readBlock:  mkReadValue("d.ReadBytes()", "[]byte"),
+	suffix: "Bytes",
+	goType: "[]byte",
+	// A nil []byte value travels as tagNil, distinct from an empty []byte —
+	// matching the reflect encoder so the nil-vs-empty distinction round-trips.
+	writeBlock: func(v string) string {
+		return fmt.Sprintf(`if %[1]s == nil {
+e.WriteNil()
+} else {
+e.WriteBytes(%[1]s)
+}`, v)
+	},
+	readBlock: func(v string) string {
+		return fmt.Sprintf(`var %[1]s []byte
+%[1]sTag, err := d.peekTag()
+if err != nil {
+return err
+}
+if %[1]sTag != tagNil {
+%[1]s, err = d.ReadBytes()
+if err != nil {
+return err
+}
+} else {
+d.i++
+}`, v)
+	},
 }
 
 var kindFloat32 = kind{
@@ -156,27 +178,44 @@ var kindStringSlice = kind{
 	suffix: "StringSlice",
 	goType: "[]string",
 	writeBlock: func(v string) string {
-		return fmt.Sprintf(`e.WriteArrayHeader(len(%s))
-for _, sv := range %s {
+		// A nil slice value travels as tagNil (WriteNil), distinct from an empty
+		// slice (header 0) — matching the reflect encoder's encodeNilSlice so the
+		// fast path and reflect path emit identical wire and the nil-vs-empty
+		// distinction survives the round-trip.
+		return fmt.Sprintf(`if %[1]s == nil {
+e.WriteNil()
+} else {
+e.WriteArrayHeader(len(%[1]s))
+for _, sv := range %[1]s {
 e.WriteString(sv)
-}`, v, v)
+}
+}`, v)
 	},
 	readBlock: func(v string) string {
-		return fmt.Sprintf(`hdrN, err := d.ReadArrayHeader()
+		return fmt.Sprintf(`var %[1]s []string
+%[1]sTag, err := d.peekTag()
+if err != nil {
+return err
+}
+if %[1]sTag != tagNil {
+hdrN, err := d.ReadArrayHeader()
 if err != nil {
 return err
 }
 if err := d.CheckLength(hdrN, 1); err != nil {
 return err
 }
-%s := make([]string, hdrN)
+%[1]s = make([]string, hdrN)
 for i := range hdrN {
 sv, err := d.ReadString()
 if err != nil {
 return err
 }
-%s[i] = sv
-}`, v, v)
+%[1]s[i] = sv
+}
+} else {
+d.i++
+}`, v)
 	},
 }
 

--- a/map_slice_value_nil_test.go
+++ b/map_slice_value_nil_test.go
@@ -1,0 +1,52 @@
+package qdf
+
+import "testing"
+
+// A nil slice/[]byte value inside a generated map fast path must round-trip as
+// nil (tagNil), not collapse to an empty slice — matching the reflect encoder so
+// the nil-vs-empty distinction is preserved and the two paths emit identical
+// wire. Regression for the mapsgen kindStringSlice / kindBytes writeBlock.
+func TestMapSliceValueNilPreserved(t *testing.T) {
+	opts := []Options{OptSpeed, OptBalanced, OptCompression, OptCanonical | OptDense}
+	for _, opt := range opts {
+		// map[string][]string
+		m1 := map[string][]string{"nilv": nil, "empty": {}, "full": {"x", "y"}}
+		b1, err := Marshal(m1, opt)
+		if err != nil {
+			t.Fatalf("opt=%v marshal []string: %v", opt, err)
+		}
+		var o1 map[string][]string
+		if err := Unmarshal(b1, &o1); err != nil {
+			t.Fatalf("opt=%v unmarshal []string: %v", opt, err)
+		}
+		if o1["nilv"] != nil {
+			t.Errorf("opt=%v []string nil value -> %#v, want nil", opt, o1["nilv"])
+		}
+		if o1["empty"] == nil || len(o1["empty"]) != 0 {
+			t.Errorf("opt=%v []string empty value -> %#v, want empty non-nil", opt, o1["empty"])
+		}
+		if len(o1["full"]) != 2 || o1["full"][0] != "x" || o1["full"][1] != "y" {
+			t.Errorf("opt=%v []string full value lost -> %#v", opt, o1["full"])
+		}
+
+		// map[string][]byte
+		m2 := map[string][]byte{"nilv": nil, "empty": {}, "full": {1, 2, 3}}
+		b2, err := Marshal(m2, opt)
+		if err != nil {
+			t.Fatalf("opt=%v marshal []byte: %v", opt, err)
+		}
+		var o2 map[string][]byte
+		if err := Unmarshal(b2, &o2); err != nil {
+			t.Fatalf("opt=%v unmarshal []byte: %v", opt, err)
+		}
+		if o2["nilv"] != nil {
+			t.Errorf("opt=%v []byte nil value -> %#v, want nil", opt, o2["nilv"])
+		}
+		if o2["empty"] == nil || len(o2["empty"]) != 0 {
+			t.Errorf("opt=%v []byte empty value -> %#v, want empty non-nil", opt, o2["empty"])
+		}
+		if len(o2["full"]) != 3 {
+			t.Errorf("opt=%v []byte full value lost -> %#v", opt, o2["full"])
+		}
+	}
+}

--- a/maps_fast_generated.go
+++ b/maps_fast_generated.go
@@ -41,15 +41,13 @@ func encodeMapStringString(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteString(v)
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -142,15 +140,13 @@ func encodeMapStringBool(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteBool(v)
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -243,15 +239,13 @@ func encodeMapStringInt8(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteInt(int64(v))
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -346,15 +340,13 @@ func encodeMapStringInt16(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteInt(int64(v))
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -449,15 +441,13 @@ func encodeMapStringInt32(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteInt(int64(v))
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -552,15 +542,13 @@ func encodeMapStringInt(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteInt(int64(v))
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -655,15 +643,13 @@ func encodeMapStringInt64(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteInt(int64(v))
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -756,15 +742,13 @@ func encodeMapStringUint8(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteUint(uint64(v))
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -859,15 +843,13 @@ func encodeMapStringUint16(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteUint(uint64(v))
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -962,15 +944,13 @@ func encodeMapStringUint32(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteUint(uint64(v))
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -1065,15 +1045,13 @@ func encodeMapStringUint(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteUint(uint64(v))
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -1168,15 +1146,13 @@ func encodeMapStringUint64(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteUint(uint64(v))
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -1269,15 +1245,13 @@ func encodeMapStringFloat32(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteFloat32(v)
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -1370,15 +1344,13 @@ func encodeMapStringFloat64(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteFloat64(v)
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -1471,15 +1443,13 @@ func encodeMapStringBytes(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
 			e.WriteBytes(v)
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -1575,6 +1545,7 @@ func encodeMapStringStringSlice(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
@@ -1584,9 +1555,6 @@ func encodeMapStringStringSlice(e *Encoder, p unsafe.Pointer) error {
 			for _, sv := range v {
 				e.WriteString(sv)
 			}
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -1706,6 +1674,7 @@ func encodeMapStringAny(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysStr = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
@@ -1714,9 +1683,6 @@ func encodeMapStringAny(e *Encoder, p unsafe.Pointer) error {
 			if err := encodeReflect(e, v); err != nil {
 				return err
 			}
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -1804,15 +1770,13 @@ func encodeMapIntString(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysI64 = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := int(sk)
 			v := m[k]
 			e.WriteInt(int64(k))
 			e.WriteString(v)
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -1882,15 +1846,13 @@ func encodeMapIntInt(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysI64 = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := int(sk)
 			v := m[k]
 			e.WriteInt(int64(k))
 			e.WriteInt(int64(v))
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -1961,15 +1923,13 @@ func encodeMapIntInt64(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysI64 = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := int(sk)
 			v := m[k]
 			e.WriteInt(int64(k))
 			e.WriteInt(int64(v))
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -2039,6 +1999,7 @@ func encodeMapIntAny(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysI64 = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := int(sk)
@@ -2047,9 +2008,6 @@ func encodeMapIntAny(e *Encoder, p unsafe.Pointer) error {
 			if err := encodeReflect(e, v); err != nil {
 				return err
 			}
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -2121,15 +2079,13 @@ func encodeMapInt64String(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysI64 = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteInt(int64(k))
 			e.WriteString(v)
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -2198,15 +2154,13 @@ func encodeMapInt64Int64(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysI64 = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteInt(int64(k))
 			e.WriteInt(int64(v))
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -2275,6 +2229,7 @@ func encodeMapInt64Any(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysI64 = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
@@ -2283,9 +2238,6 @@ func encodeMapInt64Any(e *Encoder, p unsafe.Pointer) error {
 			if err := encodeReflect(e, v); err != nil {
 				return err
 			}
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -2356,15 +2308,13 @@ func encodeMapUint64String(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysU64 = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteUint(uint64(k))
 			e.WriteString(v)
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -2433,15 +2383,13 @@ func encodeMapUint64Uint64(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysU64 = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
 			v := m[k]
 			e.WriteUint(uint64(k))
 			e.WriteUint(uint64(v))
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}
@@ -2510,6 +2458,7 @@ func encodeMapUint64Any(e *Encoder, p unsafe.Pointer) error {
 		if canonPooled {
 			e.state.canonKeysU64 = keys
 			e.state.canonKeysBusy = true
+			defer func() { e.state.canonKeysBusy = false }()
 		}
 		for _, sk := range keys {
 			k := sk
@@ -2518,9 +2467,6 @@ func encodeMapUint64Any(e *Encoder, p unsafe.Pointer) error {
 			if err := encodeReflect(e, v); err != nil {
 				return err
 			}
-		}
-		if canonPooled {
-			e.state.canonKeysBusy = false
 		}
 		return nil
 	}

--- a/maps_fast_generated.go
+++ b/maps_fast_generated.go
@@ -1422,7 +1422,11 @@ func encodeMapStringBytes(e *Encoder, p unsafe.Pointer) error {
 	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
-			e.WriteBytes(v)
+			if v == nil {
+				e.WriteNil()
+			} else {
+				e.WriteBytes(v)
+			}
 		}
 		return nil
 	}
@@ -1449,13 +1453,21 @@ func encodeMapStringBytes(e *Encoder, p unsafe.Pointer) error {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
-			e.WriteBytes(v)
+			if v == nil {
+				e.WriteNil()
+			} else {
+				e.WriteBytes(v)
+			}
 		}
 		return nil
 	}
 	for k, v := range m {
 		e.WriteString(k)
-		e.WriteBytes(v)
+		if v == nil {
+			e.WriteNil()
+		} else {
+			e.WriteBytes(v)
+		}
 	}
 	return nil
 }
@@ -1477,9 +1489,18 @@ func decodeMapStringBytes(d *Decoder, p unsafe.Pointer) error {
 		}
 		m := reuseOrMakeMap[string, []byte](d, p, len(names))
 		for _, k := range names {
-			v, err := d.ReadBytes()
+			var v []byte
+			vTag, err := d.peekTag()
 			if err != nil {
 				return err
+			}
+			if vTag != tagNil {
+				v, err = d.ReadBytes()
+				if err != nil {
+					return err
+				}
+			} else {
+				d.i++
 			}
 			m[k] = v
 		}
@@ -1500,9 +1521,18 @@ func decodeMapStringBytes(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		k := d.keyCache.Make(kb)
-		v, err := d.ReadBytes()
+		var v []byte
+		vTag, err := d.peekTag()
 		if err != nil {
 			return err
+		}
+		if vTag != tagNil {
+			v, err = d.ReadBytes()
+			if err != nil {
+				return err
+			}
+		} else {
+			d.i++
 		}
 		m[k] = v
 	}
@@ -1521,9 +1551,13 @@ func encodeMapStringStringSlice(e *Encoder, p unsafe.Pointer) error {
 	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
-			e.WriteArrayHeader(len(v))
-			for _, sv := range v {
-				e.WriteString(sv)
+			if v == nil {
+				e.WriteNil()
+			} else {
+				e.WriteArrayHeader(len(v))
+				for _, sv := range v {
+					e.WriteString(sv)
+				}
 			}
 		}
 		return nil
@@ -1551,18 +1585,26 @@ func encodeMapStringStringSlice(e *Encoder, p unsafe.Pointer) error {
 			k := sk
 			v := m[k]
 			e.WriteString(k)
-			e.WriteArrayHeader(len(v))
-			for _, sv := range v {
-				e.WriteString(sv)
+			if v == nil {
+				e.WriteNil()
+			} else {
+				e.WriteArrayHeader(len(v))
+				for _, sv := range v {
+					e.WriteString(sv)
+				}
 			}
 		}
 		return nil
 	}
 	for k, v := range m {
 		e.WriteString(k)
-		e.WriteArrayHeader(len(v))
-		for _, sv := range v {
-			e.WriteString(sv)
+		if v == nil {
+			e.WriteNil()
+		} else {
+			e.WriteArrayHeader(len(v))
+			for _, sv := range v {
+				e.WriteString(sv)
+			}
 		}
 	}
 	return nil
@@ -1585,20 +1627,29 @@ func decodeMapStringStringSlice(d *Decoder, p unsafe.Pointer) error {
 		}
 		m := reuseOrMakeMap[string, []string](d, p, len(names))
 		for _, k := range names {
-			hdrN, err := d.ReadArrayHeader()
+			var v []string
+			vTag, err := d.peekTag()
 			if err != nil {
 				return err
 			}
-			if err := d.CheckLength(hdrN, 1); err != nil {
-				return err
-			}
-			v := make([]string, hdrN)
-			for i := range hdrN {
-				sv, err := d.ReadString()
+			if vTag != tagNil {
+				hdrN, err := d.ReadArrayHeader()
 				if err != nil {
 					return err
 				}
-				v[i] = sv
+				if err := d.CheckLength(hdrN, 1); err != nil {
+					return err
+				}
+				v = make([]string, hdrN)
+				for i := range hdrN {
+					sv, err := d.ReadString()
+					if err != nil {
+						return err
+					}
+					v[i] = sv
+				}
+			} else {
+				d.i++
 			}
 			m[k] = v
 		}
@@ -1619,20 +1670,29 @@ func decodeMapStringStringSlice(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		k := d.keyCache.Make(kb)
-		hdrN, err := d.ReadArrayHeader()
+		var v []string
+		vTag, err := d.peekTag()
 		if err != nil {
 			return err
 		}
-		if err := d.CheckLength(hdrN, 1); err != nil {
-			return err
-		}
-		v := make([]string, hdrN)
-		for i := range hdrN {
-			sv, err := d.ReadString()
+		if vTag != tagNil {
+			hdrN, err := d.ReadArrayHeader()
 			if err != nil {
 				return err
 			}
-			v[i] = sv
+			if err := d.CheckLength(hdrN, 1); err != nil {
+				return err
+			}
+			v = make([]string, hdrN)
+			for i := range hdrN {
+				sv, err := d.ReadString()
+				if err != nil {
+					return err
+				}
+				v[i] = sv
+			}
+		} else {
+			d.i++
 		}
 		m[k] = v
 	}

--- a/nullable_col.go
+++ b/nullable_col.go
@@ -260,12 +260,16 @@ func (d *Decoder) readNullableMask(n int) (mask []byte, present int, err error) 
 	for _, b := range mask {
 		present += bits.OnesCount8(b)
 	}
-	// Reject a mangled bitmap whose padding bits (indices >= n in the last
-	// byte) are set: present must never exceed n. A valid encoder only sets
-	// bits for present rows in [0,n), so this never triggers on good input.
-	// Mirrors the codegen sibling ReadColNullMask; without it the string
-	// path would read `present` dense values but the scatter loop consumes
-	// only the in-range set bits, desyncing the cursor for the next frame.
+	// Reject a mangled bitmap. A valid encoder only sets bits for present rows
+	// in [0,n), so the last byte's padding bits (positions [n%8, 8)) are always
+	// zero. A hostile mask can set a padding bit while under-filling the in-range
+	// bits, keeping the popcount <= n (so the present>n check alone passes) yet
+	// making the scatter loop — which consumes only in-range set bits — drop the
+	// trailing dense value(s) silently. Reject any set padding bit so the frame
+	// errors instead. Mirrors the codegen sibling ReadColNullMask.
+	if n&7 != 0 && mask[maskBytes-1]>>uint(n&7) != 0 {
+		return nil, 0, ErrInvalidLength
+	}
 	if present > n {
 		return nil, 0, ErrInvalidLength
 	}

--- a/reflect_desc.go
+++ b/reflect_desc.go
@@ -381,7 +381,18 @@ func appendStructFields(out []fieldDesc, t reflect.Type, base uintptr, ctx *buil
 		// such a field loses data on round-trip. Pointer-typed
 		// embedded fields fall through to the regular field path so
 		// they encode as a pointer-to-struct value.
-		if sf.Anonymous && sf.Type.Kind() == reflect.Struct {
+		//
+		// EXCEPT a type that carries its own value codec — time.Time or
+		// any Marshaler/Unmarshaler — must NOT be flattened: its fields
+		// are unexported (time.Time) or its wire form is opaque, so
+		// flattening yields zero fields and drops the value on round-trip.
+		// Fall through to the regular field path so fillDesc applies the
+		// type's own codec as one named field (matches encoding/json,
+		// which never flattens an embedded time.Time / Marshaler).
+		if sf.Anonymous && sf.Type.Kind() == reflect.Struct &&
+			sf.Type != reflect.TypeFor[time.Time]() &&
+			!reflect.PointerTo(sf.Type).Implements(reflect.TypeFor[Marshaler]()) &&
+			!reflect.PointerTo(sf.Type).Implements(reflect.TypeFor[Unmarshaler]()) {
 			// Tag "-" on the embedded field itself opts the whole
 			// nested layout out — matches encoding/json.
 			if tag, ok := sf.Tag.Lookup("qdf"); ok && tag == "-" {

--- a/reflect_embed_test.go
+++ b/reflect_embed_test.go
@@ -1,0 +1,63 @@
+package qdf
+
+import (
+	"testing"
+	"time"
+)
+
+// An embedded type that carries its own value codec (time.Time, or a Marshaler)
+// must round-trip as a single value field, NOT be structurally flattened into
+// zero fields and dropped. Regression for the appendStructFields flatten guard.
+
+type embeddedTime struct {
+	time.Time
+	Name string
+}
+
+func TestEmbeddedTimeRoundTrip(t *testing.T) {
+	in := embeddedTime{Time: time.Unix(1700000000, 0).UTC(), Name: "host-1"}
+	for _, opt := range []Options{OptSpeed, OptBalanced, OptCompression} {
+		b, err := Marshal(in, opt)
+		if err != nil {
+			t.Fatalf("opt=%v marshal: %v", opt, err)
+		}
+		var out embeddedTime
+		if err := Unmarshal(b, &out); err != nil {
+			t.Fatalf("opt=%v unmarshal: %v", opt, err)
+		}
+		if !out.Equal(in.Time) {
+			t.Fatalf("opt=%v embedded time lost: got %v want %v", opt, out.Time, in.Time)
+		}
+		if out.Name != in.Name {
+			t.Fatalf("opt=%v name: got %q want %q", opt, out.Name, in.Name)
+		}
+	}
+}
+
+// A plain embedded struct (no own codec) must STILL flatten its exported fields
+// into the parent — the documented encoding/json idiom. Guards against the time/
+// Marshaler exclusion over-firing.
+type plainInner struct {
+	A int
+	B string
+}
+
+type embeddedPlain struct {
+	plainInner
+	C bool
+}
+
+func TestEmbeddedPlainStillFlattens(t *testing.T) {
+	in := embeddedPlain{plainInner: plainInner{A: 7, B: "ok"}, C: true}
+	b, err := Marshal(in, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out embeddedPlain
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.A != 7 || out.B != "ok" || out.C != true {
+		t.Fatalf("flattened embedded struct round-trip: got %+v want %+v", out, in)
+	}
+}

--- a/state.go
+++ b/state.go
@@ -447,17 +447,20 @@ func (e *encState) reset() {
 	// stays bounded by the single-batch peak (the cursor resets each batch and
 	// grow() walks the existing slabs before allocating).
 	//
-	// The trigger is the arena's OWN per-message byte demand (BytesUsed, the
-	// volume interned THIS batch, measured before the cursor rolls back), not the
-	// intern-id streak above: a batch can intern fewer than maxRetainedIDs keys
-	// yet still exceed the byte cap with long keys, so the id-based `release`
-	// would shed the arena's slabs every steady batch in that band. Only after
-	// retainReleaseStreak consecutive sub-cap batches (burst genuinely subsided)
-	// do we fall back to the default cap and shed the spike memory, so a
-	// one-shot/bursty pool encoder still bounds its resident set. The intern
-	// table was already cleared above, dropping every aliased slot.key, so
-	// rolling the cursor back is safe at any retain limit.
-	if e.arena.BytesUsed() > internarena.DefaultRetainBytes {
+	// The trigger is the arena's OWN per-message byte demand (BytesPut, the
+	// payload volume interned THIS batch — an O(1) counter, read before the
+	// cursor rolls back), not the intern-id streak above: a batch can intern
+	// fewer than maxRetainedIDs keys yet still exceed the byte cap with long
+	// keys, so the id-based `release` would shed the arena's slabs every steady
+	// batch in that band. Only after retainReleaseStreak consecutive sub-cap
+	// batches (burst genuinely subsided) do we fall back to the default cap and
+	// shed the spike memory, so a one-shot/bursty pool encoder still bounds its
+	// resident set. Under a sustained streak the resident set is bounded by the
+	// streak-window peak (plus doubling slack), reclaimed by the sub-cap shed and
+	// sync.Pool's GC eviction. The intern table was already cleared above,
+	// dropping every aliased slot.key, so rolling the cursor back is safe at any
+	// retain limit.
+	if e.arena.BytesPut() > internarena.DefaultRetainBytes {
 		e.arenaSmallStreak = 0
 	} else if e.arenaSmallStreak < retainReleaseStreak {
 		e.arenaSmallStreak++


### PR DESCRIPTION
A second exhaustive, file-by-file audit of the whole library — a follow-up to the
first full audit. Every core subsystem was re-read line by line (wire/encode,
decode, reflect, columnar, qpack int/float/string, entropy, slices/maps, delta,
query, canonical, stream, bitpack/SIMD, and both code generators). Every finding
was reproduced from a clean tree (RED), fixed, and pinned with a permanent
regression test; agent false-positives and speculative micro-opts were filtered
out (measure-first). No public-API changes.

Quality gate (all green): `go test ./...` + `-race` on the main module and the
nested `cmd/qdfgen` / `internal/codegen_test` modules; `golangci-lint run ./...`
= 0 issues on both modules; `go generate` idempotent; fuzz
(`FuzzRoundTrip_AllModesAgree` / `_StringSlice` / `_StructTriad` /
`_MapStringInt` / `FuzzCanonicalStable` / `FuzzDecoder_NeverPanics`) clean.

## HIGH — data loss / non-compiling output

1. **Embedded `time.Time` / Marshaler dropped on round-trip** (`reflect_desc.go`).
   `appendStructFields` flattened *any* anonymous embedded struct by promoting its
   exported fields. A type carrying its own value codec — `time.Time`, or any
   `Marshaler`/`Unmarshaler` — has only unexported fields (`time.Time`) or an
   opaque wire form, so flattening promoted **zero** fields and silently dropped
   the value (an embedded `time.Time` came back as the zero time). Now excluded
   from the flatten branch so the type's own codec applies as one named field —
   matching `encoding/json`. Both directions (encode/decode share the descriptor).

2. **`[]NamedByte` columnar codegen emitted non-compiling code** (`cmd/qdfgen`).
   `classifyColField` gated the columnar `[]byte` ("Bytes") column on the
   element's *underlying* kind, so a defined byte-element slice (`type B byte;
   []B`) passed. The emit then generated `unsafe.SliceData([]B)` (`*B`, not the
   `*byte` `unsafe.String` wants) and an illegal `[]B([]byte(...))` conversion —
   `qdfgen` produced a file that would not build. The gate now matches the element
   type exactly (mirroring the row-major path), so such a field falls through to
   the generic per-element encoder. Literal `[]byte` and defined *slice* types
   (`type Data []byte`) still take the columnar path.

## MED — latent state leak

3. **`canonKeysBusy` re-entrancy latch leaked on the error path** (`internal/mapsgen`).
   The generated `OptCanonical` map-encode released the latch inline *after* the
   value loop; for `any`-valued maps a mid-loop `return err` skipped the release,
   leaving `busy=true` and pinning a pooled encoder to the fresh-allocation
   fallback forever. Now released via `defer` on every exit (matching the reflect
   path). Regenerated `maps_fast_generated.go`.

## Correctness / semantics

4. **Preserve nil-vs-empty for slice/`[]byte` map values** (`internal/mapsgen`).
   The generated `map[string][]string` / `map[string][]byte` fast paths encoded a
   nil value the same as an empty one, so nil round-tripped back as an empty
   slice and the wire diverged from the reflect path (which emits `tagNil`). Now
   emits `tagNil` for nil and decodes it back to nil, matching reflect; empty
   values still travel as a header-0 array / empty bin.

5. **Reject set padding bits in a nullable presence mask** (`nullable_col.go`,
   `colcodegen.go`). A hostile mask could set a padding bit while under-filling
   the in-range bits, passing the `present>n` check yet silently dropping a
   trailing dense value in the scatter loop. Now rejects any set padding bit
   (which a valid encoder never sets).

## Hardening (32-bit) / performance

6. **`tagStr32`/`tagBin32` length 32-bit narrowing guard** (`decoder_read.go`) —
   a length near 2^32 became a negative `int` on a 32-bit build, slipped past the
   bound, and panicked the slice. Mirrors the existing `tagInternStr` uint64
   guard. No-op on 64-bit.

7. **rANS `origLen` past the int range rejected** (`decoder.go`) — same 32-bit
   narrowing class on the FlagRANS path; reject before `int(origLen)`.

8. **O(1) `Arena.BytesPut` counter for the retention trigger** (`internal/internarena`).
   `encState.reset()` drove the adaptive arena-retention decision off
   `Arena.BytesUsed`, an O(len(chunks)) walk that the streaming-retain change
   itself made run over every retained chunk per batch — and `BytesUsed`
   over-counted a chunk `grow()` skipped. Added an O(1) running counter
   (`BytesPut`, the exact per-cycle intern volume) and use it for the trigger.
   `BytesUsed` is unchanged. No behavior change.