### PR TITLE
fix(qdfgen): validate columnar wire shape in the generated decoder

### DIFF
--- a/cmd/qdf-bench/types_qdf_gen.go
+++ b/cmd/qdf-bench/types_qdf_gen.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"github.com/alex60217101990/qdf"
+	"slices"
 )
 
 // Pre-encoded field-name headers (fixstr / strN). Lets the hot path
@@ -269,8 +270,9 @@ func (v *GenHost) decodeQDFField(d *qdf.Decoder, name string) error {
 				if err != nil {
 					return err
 				}
-				_ = names32
-				_ = kinds33
+				if !slices.Equal(names32, qdfHybNames_GenService) || !slices.Equal(kinds33, qdfHybKinds_GenService) {
+					return qdf.ErrTypeMismatch
+				}
 				v.Services = make([]GenService, n31)
 				col34, err := d.ReadStringColumn(n31)
 				if err != nil {
@@ -415,8 +417,9 @@ func (v *GenHost) decodeQDFField(d *qdf.Decoder, name string) error {
 				if err != nil {
 					return err
 				}
-				_ = names53
-				_ = kinds54
+				if !slices.Equal(names53, qdfHybNames_GenTask) || !slices.Equal(kinds54, qdfHybKinds_GenTask) {
+					return qdf.ErrTypeMismatch
+				}
 				v.Tasks = make([]GenTask, n52)
 				col55, err := d.ReadStringColumn(n52)
 				if err != nil {
@@ -826,11 +829,13 @@ func (v *GenMetricHost) decodeQDFField(d *qdf.Decoder, name string) error {
 				if err != nil {
 					return err
 				}
-				_ = kinds91
 				v.Metrics = make([]GenMetric, n89)
 				for ci92 := range names90 {
 					switch names90[ci92] {
 					case "ts":
+						if kinds91[ci92] != 0x00 {
+							return qdf.ErrTypeMismatch
+						}
 						col93, err := d.ReadIntColumn(n89)
 						if err != nil {
 							return err
@@ -839,6 +844,9 @@ func (v *GenMetricHost) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Metrics[i].TS = int64(col93[i])
 						}
 					case "cpu":
+						if kinds91[ci92] != 0x02 {
+							return qdf.ErrTypeMismatch
+						}
 						col94, err := d.ReadFloat64Column(n89)
 						if err != nil {
 							return err
@@ -847,6 +855,9 @@ func (v *GenMetricHost) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Metrics[i].CPU = float64(col94[i])
 						}
 					case "mem":
+						if kinds91[ci92] != 0x01 {
+							return qdf.ErrTypeMismatch
+						}
 						col95, err := d.ReadUintColumn(n89)
 						if err != nil {
 							return err
@@ -855,6 +866,9 @@ func (v *GenMetricHost) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Metrics[i].Mem = uint64(col95[i])
 						}
 					case "errors":
+						if kinds91[ci92] != 0x01 {
+							return qdf.ErrTypeMismatch
+						}
 						col96, err := d.ReadUintColumn(n89)
 						if err != nil {
 							return err
@@ -863,6 +877,9 @@ func (v *GenMetricHost) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Metrics[i].Errors = uint32(col96[i])
 						}
 					case "up":
+						if kinds91[ci92] != 0x03 {
+							return qdf.ErrTypeMismatch
+						}
 						col97, err := d.ReadBoolColumn(n89)
 						if err != nil {
 							return err
@@ -874,6 +891,7 @@ func (v *GenMetricHost) decodeQDFField(d *qdf.Decoder, name string) error {
 						return qdf.ErrTypeMismatch
 					}
 				}
+				d.ClearColMaxLen()
 			} else {
 				n98, err := d.ReadArrayHeader()
 				if err != nil {

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -1566,12 +1566,17 @@ func (g *gen) emitDecodeColumnarBody(w io.Writer, lhs string, elem types.Type, p
 	idxVar := g.fresh("ci")
 	fmt.Fprintf(w, "%s%s, %s, %s, err := d.ReadColStructHeader()\n", indent, nVar, namesVar, kindsVar)
 	fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
-	fmt.Fprintf(w, "%s_ = %s\n", indent, kindsVar)
 	fmt.Fprintf(w, "%s%s = make([]%s, %s)\n", indent, lhs, g.typeExprFromType(elem), nVar)
 	fmt.Fprintf(w, "%sfor %s := range %s {\n", indent, idxVar, namesVar)
 	fmt.Fprintf(w, "%s\tswitch %s[%s] {\n", indent, namesVar, idxVar)
 	for _, c := range plan.Columns {
 		fmt.Fprintf(w, "%s\tcase %s:\n", indent, strconv.Quote(c.WireName))
+		// Reject a wire column whose name matches but whose kind differs from the
+		// generated field's — mirrors decodeColumnar's `sh.kinds[c] != col.kind`
+		// guard so a mismatched/corrupt frame fails cleanly instead of decoding
+		// the wrong column reader over the body.
+		fmt.Fprintf(w, "%s\t\tif %s[%s] != 0x%02x {\n%s\t\t\treturn qdf.ErrTypeMismatch\n%s\t\t}\n",
+			indent, kindsVar, idxVar, c.KindByte, indent, indent)
 		g.emitDecodeColumnScatter(w, lhs, nVar, c, indent+"\t\t")
 	}
 	fmt.Fprintf(w, "%s\tdefault:\n%s\t\treturn qdf.ErrTypeMismatch\n", indent, indent)
@@ -1678,7 +1683,18 @@ func (g *gen) emitDecodeHybridBody(w io.Writer, lhs string, elem types.Type, pla
 	kindsVar := g.fresh("kinds")
 	fmt.Fprintf(w, "%s%s, %s, %s, err := d.ReadHybridColStructHeader()\n", indent, nVar, namesVar, kindsVar)
 	fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
-	fmt.Fprintf(w, "%s_ = %s\n%s_ = %s\n", indent, namesVar, indent, kindsVar)
+	// The hybrid body is decoded POSITIONALLY (wire order == declaration order),
+	// so validate the wire shape matches this type's generated layout exactly
+	// before scattering. A frame from a different/evolved schema (added, removed,
+	// reordered, or kind-changed columns) fails cleanly with ErrTypeMismatch
+	// instead of mis-scattering silently. Schema evolution is the reflect path's
+	// job; the generated decoder requires the exact schema it was generated for.
+	id := sanitizeIdent(plan.ElemType)
+	nv := g.colNamesVar("qdfHybNames_"+id, plan.HybridNames)
+	kv := g.colKindsVar("qdfHybKinds_"+id, plan.HybridKinds)
+	g.imports["slices"] = ""
+	fmt.Fprintf(w, "%sif !slices.Equal(%s, %s) || !slices.Equal(%s, %s) {\n%s\treturn qdf.ErrTypeMismatch\n%s}\n",
+		indent, namesVar, nv, kindsVar, kv, indent, indent)
 	fmt.Fprintf(w, "%s%s = make([]%s, %s)\n", indent, lhs, g.typeExprFromType(elem), nVar)
 	for _, c := range plan.Columns {
 		g.emitDecodeColumnScatter(w, lhs, nVar, c, indent)

--- a/internal/codegen_test/codegen_hybrid_shape_test.go
+++ b/internal/codegen_test/codegen_hybrid_shape_test.go
@@ -1,0 +1,34 @@
+package cgsample
+
+import (
+	"bytes"
+	"testing"
+)
+
+// Encode a hybrid batch, then corrupt a column name in the hybrid shape header.
+// The hybrid body is decoded POSITIONALLY, so without a shape-validation guard
+// the decoder ignores the names and silently accepts the malformed frame. The
+// slices.Equal(names/kinds, expected) guard must reject it.
+func TestHybridShapeMismatchRejected(t *testing.T) {
+	var set GenRowSet
+	for i := 0; i < 32; i++ {
+		set.Rows = append(set.Rows, GenRow{ID: int64(i), Name: "r", Inner: GenRowInner{}, Tags: map[string]int{"a": i}})
+	}
+	m := any(&set).(interface{ MarshalQDF([]byte) ([]byte, error) })
+	b, err := m.MarshalQDF(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx := bytes.Index(b, []byte("inner")) // residual column name in the hybrid shape
+	if idx < 0 {
+		t.Fatal("'inner' column name not found in hybrid frame")
+	}
+	corrupt := append([]byte(nil), b...)
+	corrupt[idx] = 'x' // "inner" -> "xnner": wire shape no longer matches expected
+
+	var out GenRowSet
+	um := any(&out).(interface{ UnmarshalQDF([]byte) (int, error) })
+	if _, derr := um.UnmarshalQDF(corrupt); derr == nil {
+		t.Fatalf("decode of shape-corrupted hybrid frame returned nil error — malformed frame silently accepted")
+	}
+}

--- a/internal/codegen_test/codegen_kindcheck_test.go
+++ b/internal/codegen_test/codegen_kindcheck_test.go
@@ -1,0 +1,40 @@
+package cgsample
+
+import (
+	"bytes"
+	"testing"
+)
+
+// Encode a valid columnar batch, then flip the "value" column's kind byte in the
+// header (f64=0x02 → int=0x00). The pure-columnar decoder switches on NAME, so
+// without a kind check it ignores the corrupt kind byte and silently ACCEPTS the
+// malformed frame. The kind check must reject it.
+func TestColumnarKindByteFlipRejected(t *testing.T) {
+	var batch GenMetricBatch
+	batch.Name = "host"
+	for i := 0; i < 32; i++ {
+		batch.Metrics = append(batch.Metrics, GenMetric{TS: int64(i), Value: float64(i) + 0.5, Count: uint32(i), OK: i%2 == 0, Ratio: float32(i)})
+	}
+	m := any(&batch).(interface{ MarshalQDF([]byte) ([]byte, error) })
+	b, err := m.MarshalQDF(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Locate the "value" column name in the header, flip the kind byte right after.
+	idx := bytes.Index(b, []byte("value"))
+	if idx < 0 {
+		t.Fatal("value column name not found in frame")
+	}
+	kindPos := idx + len("value")
+	if b[kindPos] != 0x02 { // f64 kind
+		t.Fatalf("expected f64 kind 0x02 after 'value', got 0x%02x", b[kindPos])
+	}
+	corrupt := append([]byte(nil), b...)
+	corrupt[kindPos] = 0x00 // claim int
+
+	var out GenMetricBatch
+	um := any(&out).(interface{ UnmarshalQDF([]byte) (int, error) })
+	if _, derr := um.UnmarshalQDF(corrupt); derr == nil {
+		t.Fatalf("decode of kind-flipped frame returned nil error — malformed frame silently accepted")
+	}
+}

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -4,6 +4,7 @@ package cgsample
 
 import (
 	"github.com/alex60217101990/qdf"
+	"slices"
 	"time"
 	"unsafe"
 )
@@ -488,11 +489,13 @@ func (v *GenBlobSet) decodeQDFField(d *qdf.Decoder, name string) error {
 				if err != nil {
 					return err
 				}
-				_ = kinds29
 				v.Rows = make([]GenBlobRow, n27)
 				for ci30 := range names28 {
 					switch names28[ci30] {
 					case "id":
+						if kinds29[ci30] != 0x00 {
+							return qdf.ErrTypeMismatch
+						}
 						col31, err := d.ReadIntColumn(n27)
 						if err != nil {
 							return err
@@ -501,6 +504,9 @@ func (v *GenBlobSet) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Rows[i].ID = int64(col31[i])
 						}
 					case "data":
+						if kinds29[ci30] != 0x84 {
+							return qdf.ErrTypeMismatch
+						}
 						mask32, present33, err := d.ReadColNullMask(n27)
 						if err != nil {
 							return err
@@ -834,11 +840,13 @@ func (v *GenEventLog) decodeQDFField(d *qdf.Decoder, name string) error {
 				if err != nil {
 					return err
 				}
-				_ = kinds62
 				v.Events = make([]GenEvent, n60)
 				for ci63 := range names61 {
 					switch names61[ci63] {
 					case "ts":
+						if kinds62[ci63] != 0x05 {
+							return qdf.ErrTypeMismatch
+						}
 						sec65, ns66, err := d.ReadTimeColumn(n60)
 						if err != nil {
 							return err
@@ -847,6 +855,9 @@ func (v *GenEventLog) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Events[i].TS = time.Unix(sec65[i], int64(ns66[i])).UTC()
 						}
 					case "level":
+						if kinds62[ci63] != 0x04 {
+							return qdf.ErrTypeMismatch
+						}
 						col67, err := d.ReadStringColumn(n60)
 						if err != nil {
 							return err
@@ -855,6 +866,9 @@ func (v *GenEventLog) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Events[i].Level = string(col67[i])
 						}
 					case "code":
+						if kinds62[ci63] != 0x00 {
+							return qdf.ErrTypeMismatch
+						}
 						col68, err := d.ReadIntColumn(n60)
 						if err != nil {
 							return err
@@ -863,6 +877,9 @@ func (v *GenEventLog) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Events[i].Code = int32(col68[i])
 						}
 					case "msg":
+						if kinds62[ci63] != 0x04 {
+							return qdf.ErrTypeMismatch
+						}
 						col69, err := d.ReadStringColumn(n60)
 						if err != nil {
 							return err
@@ -1200,11 +1217,13 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 				if err != nil {
 					return err
 				}
-				_ = kinds93
 				v.Metrics = make([]GenMetric, n91)
 				for ci94 := range names92 {
 					switch names92[ci94] {
 					case "ts":
+						if kinds93[ci94] != 0x00 {
+							return qdf.ErrTypeMismatch
+						}
 						col95, err := d.ReadIntColumn(n91)
 						if err != nil {
 							return err
@@ -1213,6 +1232,9 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Metrics[i].TS = int64(col95[i])
 						}
 					case "value":
+						if kinds93[ci94] != 0x02 {
+							return qdf.ErrTypeMismatch
+						}
 						col96, err := d.ReadFloat64Column(n91)
 						if err != nil {
 							return err
@@ -1221,6 +1243,9 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Metrics[i].Value = float64(col96[i])
 						}
 					case "count":
+						if kinds93[ci94] != 0x01 {
+							return qdf.ErrTypeMismatch
+						}
 						col97, err := d.ReadUintColumn(n91)
 						if err != nil {
 							return err
@@ -1229,6 +1254,9 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Metrics[i].Count = uint32(col97[i])
 						}
 					case "ok":
+						if kinds93[ci94] != 0x03 {
+							return qdf.ErrTypeMismatch
+						}
 						col98, err := d.ReadBoolColumn(n91)
 						if err != nil {
 							return err
@@ -1237,6 +1265,9 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Metrics[i].OK = col98[i]
 						}
 					case "ratio":
+						if kinds93[ci94] != 0x06 {
+							return qdf.ErrTypeMismatch
+						}
 						col99, err := d.ReadFloat32Column(n91)
 						if err != nil {
 							return err
@@ -1531,11 +1562,13 @@ func (v *GenNameList) decodeQDFField(d *qdf.Decoder, name string) error {
 				if err != nil {
 					return err
 				}
-				_ = kinds117
 				v.Names = make([]GenName, n115)
 				for ci118 := range names116 {
 					switch names116[ci118] {
 					case "first":
+						if kinds117[ci118] != 0x04 {
+							return qdf.ErrTypeMismatch
+						}
 						col119, err := d.ReadStringColumn(n115)
 						if err != nil {
 							return err
@@ -1544,6 +1577,9 @@ func (v *GenNameList) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Names[i].First = string(col119[i])
 						}
 					case "last":
+						if kinds117[ci118] != 0x04 {
+							return qdf.ErrTypeMismatch
+						}
 						col120, err := d.ReadStringColumn(n115)
 						if err != nil {
 							return err
@@ -1942,11 +1978,13 @@ func (v *GenOptSet) decodeQDFField(d *qdf.Decoder, name string) error {
 				if err != nil {
 					return err
 				}
-				_ = kinds147
 				v.Rows = make([]GenOpt, n145)
 				for ci148 := range names146 {
 					switch names146[ci148] {
 					case "a":
+						if kinds147[ci148] != 0x80 {
+							return qdf.ErrTypeMismatch
+						}
 						mask149, present150, err := d.ReadColNullMask(n145)
 						if err != nil {
 							return err
@@ -1966,6 +2004,9 @@ func (v *GenOptSet) decodeQDFField(d *qdf.Decoder, name string) error {
 							}
 						}
 					case "b":
+						if kinds147[ci148] != 0x84 {
+							return qdf.ErrTypeMismatch
+						}
 						mask154, present155, err := d.ReadColNullMask(n145)
 						if err != nil {
 							return err
@@ -1985,6 +2026,9 @@ func (v *GenOptSet) decodeQDFField(d *qdf.Decoder, name string) error {
 							}
 						}
 					case "c":
+						if kinds147[ci148] != 0x83 {
+							return qdf.ErrTypeMismatch
+						}
 						mask159, present160, err := d.ReadColNullMask(n145)
 						if err != nil {
 							return err
@@ -2004,6 +2048,9 @@ func (v *GenOptSet) decodeQDFField(d *qdf.Decoder, name string) error {
 							}
 						}
 					case "d":
+						if kinds147[ci148] != 0x82 {
+							return qdf.ErrTypeMismatch
+						}
 						mask164, present165, err := d.ReadColNullMask(n145)
 						if err != nil {
 							return err
@@ -2474,8 +2521,9 @@ func (v *GenRowSet) decodeQDFField(d *qdf.Decoder, name string) error {
 				if err != nil {
 					return err
 				}
-				_ = names194
-				_ = kinds195
+				if !slices.Equal(names194, qdfHybNames_GenRow) || !slices.Equal(kinds195, qdfHybKinds_GenRow) {
+					return qdf.ErrTypeMismatch
+				}
 				v.Rows = make([]GenRow, n193)
 				col196, err := d.ReadIntColumn(n193)
 				if err != nil {
@@ -2715,11 +2763,13 @@ func (v *GenTrailed) decodeQDFField(d *qdf.Decoder, name string) error {
 				if err != nil {
 					return err
 				}
-				_ = kinds217
 				v.Rows = make([]GenMetric, n215)
 				for ci218 := range names216 {
 					switch names216[ci218] {
 					case "ts":
+						if kinds217[ci218] != 0x00 {
+							return qdf.ErrTypeMismatch
+						}
 						col219, err := d.ReadIntColumn(n215)
 						if err != nil {
 							return err
@@ -2728,6 +2778,9 @@ func (v *GenTrailed) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Rows[i].TS = int64(col219[i])
 						}
 					case "value":
+						if kinds217[ci218] != 0x02 {
+							return qdf.ErrTypeMismatch
+						}
 						col220, err := d.ReadFloat64Column(n215)
 						if err != nil {
 							return err
@@ -2736,6 +2789,9 @@ func (v *GenTrailed) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Rows[i].Value = float64(col220[i])
 						}
 					case "count":
+						if kinds217[ci218] != 0x01 {
+							return qdf.ErrTypeMismatch
+						}
 						col221, err := d.ReadUintColumn(n215)
 						if err != nil {
 							return err
@@ -2744,6 +2800,9 @@ func (v *GenTrailed) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Rows[i].Count = uint32(col221[i])
 						}
 					case "ok":
+						if kinds217[ci218] != 0x03 {
+							return qdf.ErrTypeMismatch
+						}
 						col222, err := d.ReadBoolColumn(n215)
 						if err != nil {
 							return err
@@ -2752,6 +2811,9 @@ func (v *GenTrailed) decodeQDFField(d *qdf.Decoder, name string) error {
 							v.Rows[i].OK = col222[i]
 						}
 					case "ratio":
+						if kinds217[ci218] != 0x06 {
+							return qdf.ErrTypeMismatch
+						}
 						col223, err := d.ReadFloat32Column(n215)
 						if err != nil {
 							return err


### PR DESCRIPTION
The two remaining codegen-decoder robustness gaps noted by the second full audit
(A12[2], A12[3]). The generated columnar decoders trusted the wire shape instead
of validating it, so a corrupt or schema-mismatched frame was decoded with the
wrong reader — or silently accepted — instead of being rejected.

## The gaps

1. **Pure-columnar decoder ignored the kind bytes.** `emitDecodeColumnarBody`
   switched on the column NAME and discarded the kinds (`_ = kinds`). The column
   reader is therefore picked by name, not kind, so a frame whose column matched
   by name but carried a different kind was decoded with the wrong reader, and a
   frame with a corrupt kind byte was **silently accepted**.

2. **Hybrid decoder read positionally and ignored the shape.** `emitDecodeHybridBody`
   read the eligible columns in declaration order and discarded the names/kinds
   entirely. A frame from a different/evolved schema (added, removed, reordered,
   or kind-changed columns) was mis-scattered or silently accepted.

## The fix

Both generated decoders now validate the wire shape before scattering, mirroring
the reflect path's `sh.kinds[c] != col.kind` guard:

- Pure path: each name-matched column checks `kinds[ci] != <field KindByte>` →
  `ErrTypeMismatch`.
- Hybrid path: the whole `(names, kinds)` sequence is checked against the
  generated layout via `slices.Equal(...)` → `ErrTypeMismatch`.

The generated decoder requires the exact schema it was generated for — it fails
clean instead of decoding silently wrong. Schema evolution (skipping unknown
columns, tolerating reorders) remains the reflect path's job; this is a
documented codegen contract, not a regression (self-roundtrip and reflect↔codegen
interop for the same type are unaffected).

Regenerated the `internal/codegen_test` and `cmd/qdf-bench` fixtures.