### PR TITLE
fix(delta): never-larger picker for keyed slices via state-suspended trial

### DIFF
--- a/delta_keyed.go
+++ b/delta_keyed.go
@@ -75,6 +75,63 @@ func diffKeyedSlice(enc *Encoder, td, elem *typeDesc, oldP, newP unsafe.Pointer,
 		return diffSlice(enc, td, oldP, newP, depth)
 	}
 
+	// Never-larger picker (docs/DELTA.md:86). The keyed patch wins big on a
+	// reorder (preserved elements cost nothing) but LOSES on high key turnover:
+	// the new-order key list plus the full per-op replaces expand past — and on
+	// full rotation even past a full re-encode — the positional alternative. So
+	// build both bodies and keep the smaller, mirroring diffColumnar.
+	//
+	// Building a discarded candidate would normally leak intern definitions
+	// (ids whose wire defs are thrown away → a later state-ref dangles), the
+	// trap diffColumnar dodges via a wire-stateless string column. A keyed
+	// element diff recurses through arbitrary value codecs, so that trick does
+	// not generalise; instead suspend interning for the whole trial. Both
+	// candidates and the kept winner are then wire-stateless, the size compare
+	// is exact, and the only intern substate a suspended body mutates is lastID
+	// (captured after the positional build, restored if positional wins).
+	prevSuspended := enc.stateSuspended
+	enc.stateSuspended = true
+	defer func() { enc.stateSuspended = prevSuspended }()
+
+	posStart := len(enc.buf)
+	if err := diffSlice(enc, td, oldP, newP, depth); err != nil {
+		return err
+	}
+	posLen := len(enc.buf) - posStart
+	posEndLastID, haveLast := uint32(0), enc.state != nil
+	if haveLast {
+		posEndLastID = enc.state.lastID
+	}
+
+	// Build the keyed body APPENDED after the positional one, using enc.buf
+	// itself as scratch (no extra allocation): keep whichever is smaller.
+	keyedStart := len(enc.buf)
+	if err := encodeKeyedSlicePatch(enc, elem, oh, nh, stride, lookup, oldKeyAt, newKeyAt, depth); err != nil {
+		return err
+	}
+	keyedLen := len(enc.buf) - keyedStart
+
+	if keyedLen < posLen {
+		// Shift the keyed body down over the positional one. lastID already
+		// reflects the keyed build (emitted last), matching the kept body.
+		copy(enc.buf[posStart:], enc.buf[keyedStart:])
+		enc.buf = enc.buf[:posStart+keyedLen]
+	} else {
+		// Positional wins; drop the trailing keyed body and restore lastID to
+		// its post-positional value so it tracks the bytes the decoder will read.
+		enc.buf = enc.buf[:keyedStart]
+		if haveLast {
+			enc.state.lastID = posEndLastID
+		}
+	}
+	return nil
+}
+
+// encodeKeyedSlicePatch writes a tagKeyedSlicePatch body: an optional new-order
+// key list (when the key sequence changed) followed by the per-key ops. Factored
+// out of diffKeyedSlice so the never-larger picker can build it as one candidate.
+func encodeKeyedSlicePatch(enc *Encoder, elem *typeDesc, oh, nh *sliceHeader, stride uintptr,
+	lookup keyLookup, oldKeyAt, newKeyAt func(int) string, depth int) error {
 	orderChanged := oh.Len != nh.Len
 	if !orderChanged {
 		for i := range nh.Len {

--- a/delta_keyed_neverlarger_test.go
+++ b/delta_keyed_neverlarger_test.go
@@ -1,0 +1,173 @@
+package qdf
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// keyedRec / plainRec are the same struct with and without the ,key tag. Diffing
+// plainRec forces the positional differ (diffSlice), giving the exact alternative
+// the keyed never-larger picker must never exceed.
+type keyedRec struct {
+	ID  string `qdf:"id,key"`
+	Val string `qdf:"v"`
+}
+
+type plainRec struct {
+	ID  string `qdf:"id"`
+	Val string `qdf:"v"`
+}
+
+func mkKeyed(idPrefix string, n int) []keyedRec {
+	s := make([]keyedRec, n)
+	for i := range s {
+		s[i] = keyedRec{
+			ID:  fmt.Sprintf("%s-key-%06d", idPrefix, i),
+			Val: fmt.Sprintf("payload-value-%06d-some-longer-text", i),
+		}
+	}
+	return s
+}
+
+func asPlain(k []keyedRec) []plainRec {
+	p := make([]plainRec, len(k))
+	for i := range k {
+		p[i] = plainRec{ID: k[i].ID, Val: k[i].Val}
+	}
+	return p
+}
+
+// keyedShapes returns the spread of change shapes the never-larger picker must
+// hold the contract across — full key rotation (the audit-3 +29% breach), pure
+// reorder (where keyed wins big), value-only change, and partial rotation.
+func keyedShapes(n int) map[string][]keyedRec {
+	return map[string][]keyedRec{
+		"full-rotation": mkKeyed("new", n),
+		"reorder-only": func() []keyedRec {
+			s := mkKeyed("old", n)
+			for i := 0; i < n/2; i++ {
+				s[i], s[n-1-i] = s[n-1-i], s[i]
+			}
+			return s
+		}(),
+		"value-only": func() []keyedRec {
+			s := mkKeyed("old", n)
+			for i := range s {
+				s[i].Val = "changed-" + s[i].Val
+			}
+			return s
+		}(),
+		"half-rotation": func() []keyedRec {
+			s := mkKeyed("old", n)
+			for i := 0; i < n/2; i++ {
+				s[i].ID = fmt.Sprintf("new-key-%06d", i)
+			}
+			return s
+		}(),
+	}
+}
+
+// TestKeyedNeverLarger asserts the docs/DELTA.md never-larger contract: the keyed
+// slice patch must never exceed the positional alternative, NOR a full re-encode,
+// for any change shape — and must round-trip exactly. Audit-3 found a +29% breach
+// vs positional on full rotation (keyed patch even exceeded a full re-encode); the
+// never-larger picker added in this change closes it.
+func TestKeyedNeverLarger(t *testing.T) {
+	old := mkKeyed("old", 100)
+	oldPlain := asPlain(old)
+
+	for _, opts := range []Options{OptBalanced, OptCompression, OptSpeed} {
+		for name, neu := range keyedShapes(100) {
+			keyedPatch, err := Diff(old, neu, opts)
+			if err != nil {
+				t.Fatalf("opts=%d %s: Diff keyed: %v", opts, name, err)
+			}
+			posPatch, err := Diff(oldPlain, asPlain(neu), opts)
+			if err != nil {
+				t.Fatalf("opts=%d %s: Diff positional: %v", opts, name, err)
+			}
+			full, err := Marshal(neu, opts)
+			if err != nil {
+				t.Fatalf("opts=%d %s: Marshal: %v", opts, name, err)
+			}
+			t.Logf("opts=%d %-14s keyed=%d positional=%d full=%d", opts, name, len(keyedPatch), len(posPatch), len(full))
+
+			// The documented contract (docs/DELTA.md:124): the keyed patch is never
+			// larger than the alternative representation — the positional differ.
+			if len(keyedPatch) > len(posPatch) {
+				t.Errorf("opts=%d %s: keyed patch %d > positional %d (breaches never-larger)",
+					opts, name, len(keyedPatch), len(posPatch))
+			}
+			// The keyed patch must not exceed a full re-encode either, EXCEPT under a
+			// heavy-codec tier where the positional alternative also loses to a full
+			// rANS re-encode (a slice-level whole-replace fallback, not the keyed
+			// contract). Only flag a keyed-introduced regression.
+			if len(keyedPatch) > len(full) && len(posPatch) <= len(full) {
+				t.Errorf("opts=%d %s: keyed patch %d > full re-encode %d (positional %d stayed under)",
+					opts, name, len(keyedPatch), len(full), len(posPatch))
+			}
+
+			// Round-trip exact.
+			base := append([]keyedRec(nil), old...)
+			if err := Apply(&base, keyedPatch); err != nil {
+				t.Fatalf("opts=%d %s: Apply: %v", opts, name, err)
+			}
+			if !reflect.DeepEqual(base, neu) {
+				t.Fatalf("opts=%d %s: round-trip mismatch", opts, name)
+			}
+		}
+	}
+}
+
+// TestKeyedNeverLargerNoInternLeak guards the trap the suspend-during-trial design
+// exists for: a discarded never-larger candidate must not leak a shared-state id
+// (intern string OR struct/map shape) whose wire definition is thrown away. The
+// struct here places a keyed slice BEFORE fields whose values recur as interned
+// strings AND a shaped map; if the trial leaked an id, decoding the later content
+// would dangle (ErrUnknownStateID) or corrupt.
+func TestKeyedNeverLargerNoInternLeak(t *testing.T) {
+	type Item struct {
+		ID   string `qdf:"id,key"`
+		Note string `qdf:"note"`
+	}
+	type Doc struct {
+		Items []Item            `qdf:"items"`
+		Tags  []string          `qdf:"tags"`
+		Meta  map[string]string `qdf:"meta"`
+	}
+
+	// Strings long enough to be interned (>= minIntern) that recur across the
+	// keyed slice and the later fields.
+	old := Doc{
+		Items: []Item{{"alpha-key", "shared-note-payload"}, {"beta-key", "another-note-value"}},
+		Tags:  []string{"shared-note-payload", "tag-recurring-value"},
+		Meta:  map[string]string{"k1": "another-note-value", "k2": "tag-recurring-value"},
+	}
+	neu := Doc{
+		// Reorder + value change + new key → exercises the keyed orderChanged path.
+		Items: []Item{{"beta-key", "another-note-value"}, {"alpha-key", "shared-note-payload"}, {"gamma-key", "tag-recurring-value"}},
+		Tags:  []string{"tag-recurring-value", "shared-note-payload", "fresh-tag-payload"},
+		Meta:  map[string]string{"k1": "shared-note-payload", "k2": "fresh-tag-payload", "k3": "another-note-value"},
+	}
+
+	for _, opts := range []Options{OptBalanced, OptCompression, OptSpeed} {
+		patch, err := Diff(old, neu, opts)
+		if err != nil {
+			t.Fatalf("opts=%d Diff: %v", opts, err)
+		}
+		base := old
+		base.Items = append([]Item(nil), old.Items...)
+		base.Tags = append([]string(nil), old.Tags...)
+		base.Meta = map[string]string{}
+		for k, v := range old.Meta {
+			base.Meta[k] = v
+		}
+		if err := Apply(&base, patch); err != nil {
+			t.Fatalf("opts=%d Apply: %v", opts, err)
+		}
+		if !reflect.DeepEqual(base, neu) {
+			t.Fatalf("opts=%d: round-trip mismatch\n got %+v\nwant %+v", opts, base, neu)
+		}
+	}
+}

--- a/delta_keyed_test.go
+++ b/delta_keyed_test.go
@@ -113,11 +113,18 @@ func TestKeyedPatchUsesKeyedTag(t *testing.T) {
 		ID  string `qdf:"id,key"`
 		Val int
 	}
-	old := []E{{"a", 1}}
-	neu := []E{{"a", 2}}
+	// A pure reorder is the case the keyed differ wins decisively: preserved
+	// elements cost nothing, so the keyed patch (a new-order key list) beats the
+	// positional alternative (which re-replaces every shifted element). The
+	// never-larger picker must therefore keep the tagKeyedSlicePatch body here.
+	// (On a one-element value change the positional body is smaller — an index
+	// beats a key — so the picker correctly declines the keyed tag; that path is
+	// exercised by the round-trip matrix elsewhere.)
+	old := []E{{"a", 1}, {"b", 2}, {"c", 3}, {"d", 4}}
+	neu := []E{{"d", 4}, {"c", 3}, {"b", 2}, {"a", 1}}
 	patch, _ := Diff(old, neu, OptBalanced)
 	if !containsByte(patch, tagKeyedSlicePatch) {
-		t.Fatal("keyed type must emit tagKeyedSlicePatch")
+		t.Fatal("a reorder must keep the tagKeyedSlicePatch body (keyed beats positional)")
 	}
 }
 

--- a/encoder.go
+++ b/encoder.go
@@ -193,6 +193,20 @@ type Encoder struct {
 	// keyIdxBusy marks keyIdx as borrowed by an in-progress keyed-slice diff so a
 	// nested keyed slice routes to a fresh local map instead of clobbering it.
 	keyIdxBusy bool
+
+	// stateSuspended turns off every wire-stateful encoding — string/[]byte
+	// interning, struct-shape interning, map-shape interning — for the duration
+	// of a keyed-slice delta's never-larger trial (delta_keyed.go). A keyed patch
+	// is compared against the positional alternative by building both bodies and
+	// keeping the smaller; a stateful DISCARDED body leaks shared-state ids whose
+	// wire definitions are thrown away, so a later reference into the kept wire
+	// dangles (ErrUnknownStateID). Suspending makes both candidate bodies — and
+	// the emitted winner — wire-stateless, so the trial is pollution-free, the
+	// size comparison is exact, and the kept body is self-consistent. The only
+	// substate a suspended body mutates is lastID (the inline-string reset, which
+	// the decoder mirrors). Saved/restored across nested keyed slices so
+	// re-entrancy keeps the outer suspension.
+	stateSuspended bool
 }
 
 // applyOpts mirrors the options bitmask onto the cached mode / qpack
@@ -584,7 +598,7 @@ func (e *Encoder) WriteString(s string) {
 	e.writeHeader()
 	st := e.state
 	dense := e.opts.Has(OptDense)
-	if dense && st != nil && len(s) >= e.minIntern && int(st.internLoad) < e.maxStateEntries {
+	if dense && !e.stateSuspended && st != nil && len(s) >= e.minIntern && int(st.internLoad) < e.maxStateEntries {
 		// PreIntern identity fast path: if the caller registered
 		// this exact backing pointer + length via Encoder.PreIntern,
 		// the cached id (after first sight on the wire) lets us
@@ -812,7 +826,7 @@ func (e *Encoder) WriteBytes(b []byte) {
 	e.writeHeader()
 	st := e.state
 	dense := e.opts.Has(OptDense)
-	if dense && st != nil && len(b) >= e.minIntern && int(st.internLoad) < e.maxStateEntries {
+	if dense && !e.stateSuspended && st != nil && len(b) >= e.minIntern && int(st.internLoad) < e.maxStateEntries {
 		key := unsafestr.String(b)
 		id, ok := st.lookupOrAssign(key)
 		if ok {

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -222,7 +222,7 @@ func encodeSlice(elem *typeDesc, stride uintptr, colPlan *columnarPlan) func(*En
 		// OptCompression). Without FSST a hybrid plan falls through to row-major,
 		// byte-identical to today (no regression). Intern-aware Balanced hybrid is
 		// a follow-up.
-		if colPlan != nil && n >= columnarMinElems && e.state != nil &&
+		if colPlan != nil && n >= columnarMinElems && e.state != nil && !e.stateSuspended &&
 			e.opts.Has(OptDense) && e.opts.Has(OptShapeIntern) {
 			pure := colPlan.residual == nil
 			if (pure || e.fsst) && columnarProbe(colPlan, hdr.Data, n, e.fsst, e.fsstDict) {
@@ -474,7 +474,7 @@ func encodeMap(t reflect.Type, k, v *typeDesc) func(*Encoder, unsafe.Pointer) er
 		if n > 0 && e.opts.Has(OptCanonical) {
 			return e.encodeMapCanonical(rv, keyType, valType, k, v)
 		}
-		if stringKey && n > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+		if stringKey && n > 0 && e.state != nil && !e.stateSuspended && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 			return e.encodeStringMapShaped(rv, keyType, valType, v)
 		}
 		e.WriteMapHeader(n)
@@ -1013,7 +1013,7 @@ func encodeStruct(td *typeDesc) func(*Encoder, unsafe.Pointer) error {
 		// falls back to the tagMap8/16/32 encoding so the rest of the
 		// state stack (intern + Markov / MTF / Pair) still applies
 		// per-field.
-		if e.opts.Has(OptDense) && e.state != nil && e.opts.Has(OptShapeIntern) {
+		if e.opts.Has(OptDense) && e.state != nil && !e.stateSuspended && e.opts.Has(OptShapeIntern) {
 			if id := e.state.shapeForType(td); id != 0 {
 				e.buf = append(e.buf, tagMapShape)
 				e.buf = appendUvarint(e.buf, uint64(id))
@@ -1075,7 +1075,7 @@ func encodeStruct(td *typeDesc) func(*Encoder, unsafe.Pointer) error {
 			pairOn := e.pairPred
 			for i := range fields {
 				f := &fields[i]
-				if len(f.name) >= e.minIntern && int(st.internLoad) < e.maxStateEntries {
+				if len(f.name) >= e.minIntern && !e.stateSuspended && int(st.internLoad) < e.maxStateEntries {
 					if id, ok := st.lookupOrAssign(f.name); ok {
 						if st.lastID == id {
 							e.buf = append(e.buf, tagStateRepeat)


### PR DESCRIPTION
`diffKeyedSlice` emitted a `tagKeyedSlicePatch` body unconditionally, with no size
comparison against the positional alternative — the one delta location missing the
never-larger picker that `diffColumnar` already has. On high key turnover the
keyed patch (new-order key list + full per-op replaces) expands past the
positional diff, breaching the documented contract (docs/DELTA.md:124, *"the
format picks per case and guarantees the result is never larger than the
alternative"*). The fix adds the picker, solving the intern/shape-leak trap that
makes a naive build-both approach corrupt the wire.

## The bug (reproduced, RED)

A 100-element `[]struct{ ID string \`qdf:"id,key"\`; Val string }` across change
shapes, `Diff(old, new, OptBalanced)`:

| shape          | keyed (before) | positional | full re-encode |
|----------------|---------------:|-----------:|---------------:|
| full-rotation  | **6133**       | 1531       | 5714           |
| value-only     | **6825**       | 4631       | 6514           |

The keyed patch exceeded both the positional alternative **and a full re-encode** —
broader than the audit-3 note recorded (which only flagged full-rotation vs
positional; value-only also breaches). Correctness was never affected (round-trips
fine); only wire size regressed.

## The fix

Mirror `diffColumnar`: build the positional body and the keyed body, keep the
smaller. The keyed body is appended **after** the positional one using `enc.buf`
itself as scratch (no extra allocation); the winner is kept via a copy-down.

The trap a naive build-both falls into: a **discarded** candidate that interned a
string or declared a struct/map **shape** leaks a shared-state id whose wire
definition is thrown away, so a later reference into the kept wire dangles
(`ErrUnknownStateID`). `diffColumnar` dodges this with a wire-stateless string
column, but a keyed *element* diff recurses through arbitrary value codecs, so that
trick does not generalise. Instead a new `Encoder.stateSuspended` flag turns off
**every** wire-stateful encoding for the duration of the trial — string/[]byte
interning, struct-shape interning, map-shape interning. Both candidates and the
emitted winner are then wire-stateless: the trial is pollution-free, the size
comparison is exact, and the kept body is self-consistent. The only intern
substate a suspended body mutates is `lastID` (the inline-string reset the decoder
mirrors); it is captured after the positional build and restored if positional
wins. The flag is saved/restored across nested keyed slices so re-entrancy keeps
the outer suspension.

Suspension is gated at every state-id-assigning site reachable from a keyed
element diff: `WriteString` / `WriteBytes` intern branches, the reflect
struct-shape path, the reflect non-shape struct field-name intern (the subtle one —
it interns names directly via `lookupOrAssign`, not through `WriteString`), the
reflect map-shape path, and the columnar full-encode path.

## Result

| shape          | keyed (after) | positional | verdict                        |
|----------------|--------------:|-----------:|--------------------------------|
| full-rotation  | 1531          | 1531       | ties positional                |
| reorder-only   | 1526          | 5337       | keyed wins big (preserved rows)|
| value-only     | 4631          | 4631       | ties positional                |
| half-rotation  | 1075          | 1125       | keyed wins                     |

`keyed <= positional` now holds strictly across **all** change shapes and **all**
option tiers (OptBalanced / OptCompression / OptSpeed). Where a heavy-codec tier
lets a full rANS re-encode beat the structural patch, that is a slice-level
whole-replace concern shared by the positional differ — not the keyed contract —
and the regression test only flags a *keyed-introduced* full-exceed.