### PR TITLE
test(delta): fix flaky TestRegisterIdMatchesDiffBaseFP under -race

### DIFF
--- a/delta_baseline_test.go
+++ b/delta_baseline_test.go
@@ -185,6 +185,9 @@ func TestRegisterIdMatchesDiffBaseFP(t *testing.T) {
 	if got := r.Len(); got != 1 {
 		t.Fatalf("Len() = %d, want 1", got)
 	}
+	// The registry holds v only through a weak.Pointer; keep it reachable
+	// across Len() or -race GC may reclaim it and Len() prunes to 0.
+	runtime.KeepAlive(v)
 }
 
 func TestBaselineApplyHappyPath(t *testing.T) {


### PR DESCRIPTION
## Problem

CI hit a flaky failure under `-race`:

```
--- FAIL: TestRegisterIdMatchesDiffBaseFP (0.00s)
    delta_baseline_test.go:186: Len() = 0, want 1
```

## Root cause

`BaselineRegistry` holds a registered value only through a `weak.Pointer`, and `Len()` prunes entries whose weak value has been collected. In the test, the last use of `v` was the `Diff(v, ...)` call several statements before the `Len() == 1` assertion. In that gap `v` is dead, so under `-race` (aggressive GC) the runtime could reclaim it and `Len()` pruned the entry to 0.

Not a logic bug — the registry's documented contract is *"the CALLER must keep v reachable for it to remain resolvable."* The test simply violated it; every other test in the file already calls `runtime.KeepAlive`.

## Fix

Add `runtime.KeepAlive(v)` after the assertion, matching the file's convention.

## Verification

`GOGC=1 go test -race -run TestRegisterIdMatchesDiffBaseFP -count=50` — 50/50 green (was intermittently failing).