### PR TITLE
ci: harden workflows per OpenSSF Scorecard (pin SHAs + least-privilege)

### DIFF
--- a/.github/workflows/bench-trend.yml
+++ b/.github/workflows/bench-trend.yml
@@ -7,9 +7,10 @@ on:
     branches: [main]
 
 # contents:write — push history to gh-pages. pull-requests:write — post the alert comment.
+# Least-privilege default; the bench job elevates the writes it needs
+# (contents: push history to gh-pages; pull-requests: post the alert comment).
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: bench-trend-${{ github.workflow }}-${{ github.ref }}
@@ -19,10 +20,13 @@ jobs:
   bench:
     name: bench-trend
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -31,7 +35,7 @@ jobs:
             bench/go.sum
 
       - name: Restore build cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/go-build
           key: gocache-benchtrend-${{ runner.os }}-${{ hashFiles('**/go.sum', '**/*.go') }}
@@ -74,7 +78,7 @@ jobs:
       # --- main: append to history + publish the trend dashboard ---
       - name: store benchmark result (push to gh-pages)
         if: github.event_name == 'push'
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1
         with:
           name: qdf Go Benchmarks
           tool: go
@@ -106,7 +110,7 @@ jobs:
       # --- PR: comment-only regression alert, never push, never fail ---
       - name: compare benchmark result (PR alert)
         if: github.event_name == 'pull_request' && steps.ghpages.outputs.exists == 'true'
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1
         with:
           name: qdf Go Benchmarks
           tool: go
@@ -136,7 +140,7 @@ jobs:
       # sequenced. keep_files:true preserves dev/bench/ that the action wrote.
       - name: publish landing + coverage to gh-pages
         if: github.event_name == 'push'
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,9 +24,9 @@ jobs:
     name: bench
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -36,7 +36,7 @@ jobs:
             internal/codegen_test/go.sum
 
       - name: Restore build cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/go-build
           key: gocache-bench-${{ runner.os }}-${{ hashFiles('**/go.sum', '**/*.go') }}
@@ -81,7 +81,7 @@ jobs:
           go test -bench=. -benchmem -benchtime="${BENCH_TIME}" -run=^$ -timeout=10m | tee bench_codegen.txt
 
       - name: upload bench artefacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: bench-results-${{ github.sha }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
         # but this is the canonical Linux arm64 runner).
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         id: setup-go
         with:
           go-version-file: go.mod
@@ -48,7 +48,7 @@ jobs:
       # module download cache (~/go/pkg/mod), but the build cache makes
       # the biggest difference on incremental runs.
       - name: Restore build cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cache/go-build
@@ -70,7 +70,7 @@ jobs:
 
       - name: upload coverage
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: ./coverage.out
           flags: unittests-${{ matrix.os }}
@@ -125,9 +125,9 @@ jobs:
           - module: qdf-bench
             working-directory: cmd/qdf-bench
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -139,7 +139,7 @@ jobs:
             internal/codegen_test/go.sum
 
       - name: golangci-lint (${{ matrix.module }})
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
           version: latest
           working-directory: ${{ matrix.working-directory }}
@@ -150,9 +150,9 @@ jobs:
     name: fuzz (30s smoke)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         id: setup-go
         with:
           go-version-file: go.mod
@@ -160,7 +160,7 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Restore build cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/go-build
           key: gocache-fuzz-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('**/go.sum', '**/*.go') }}
@@ -170,7 +170,7 @@ jobs:
       # Persist the fuzz corpus between runs so newly discovered inputs
       # accumulate across CI builds. Restore is best-effort.
       - name: Restore fuzz corpus
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: testdata/fuzz
           key: fuzz-corpus-${{ github.sha }}
@@ -203,9 +203,9 @@ jobs:
     name: codegen drift (protobuf/flatbuffers)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -213,7 +213,7 @@ jobs:
 
       - name: Cache protoc + flatc binaries
         id: codegen-tools
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.codegen-tools/bin
           key: codegen-tools-protoc34.1-flatc25.12.19

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,10 +8,9 @@ on:
   schedule:
     - cron: "23 5 * * 1"
 
+# Least-privilege default; the analyze job elevates only what CodeQL needs.
 permissions:
   contents: read
-  security-events: write
-  actions: read
 
 concurrency:
   group: codeql-${{ github.ref }}
@@ -21,10 +20,14 @@ jobs:
   analyze:
     name: analyze (go)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload the SARIF results
+      actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -35,15 +38,15 @@ jobs:
             internal/codegen_test/go.sum
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: go
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:go"

--- a/.github/workflows/dependabot-auto-tidy.yml
+++ b/.github/workflows/dependabot-auto-tidy.yml
@@ -27,8 +27,10 @@ on:
       - "**/go.mod"
       - "**/go.sum"
 
+# Least-privilege default; the tidy job elevates contents to write so it can
+# push the tidy commit back to the Dependabot PR branch.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: dependabot-auto-tidy-${{ github.event.pull_request.number }}
@@ -38,18 +40,20 @@ jobs:
   tidy:
     name: go mod tidy (all modules)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: >-
       github.actor == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           # Default GITHUB_TOKEN (write, via pull_request_target) so the tidy
           # commit can be pushed back to the PR branch.
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/fuzz-extended.yml
+++ b/.github/workflows/fuzz-extended.yml
@@ -23,16 +23,16 @@ jobs:
       matrix:
         target: [FuzzDecoder_NeverPanics, FuzzRoundTrip_StringSlice]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
 
       - name: Restore build cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/go-build
           key: gocache-fuzz-${{ runner.os }}-${{ hashFiles('**/go.sum', '**/*.go') }}
@@ -40,7 +40,7 @@ jobs:
             gocache-fuzz-${{ runner.os }}-
 
       - name: Restore fuzz corpus
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: testdata/fuzz/${{ matrix.target }}
           key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload new corpus on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
           path: testdata/fuzz/${{ matrix.target }}

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -38,9 +38,9 @@ jobs:
           - module: codegen_test
             working-directory: internal/codegen_test
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -16,9 +16,9 @@ on:
   pull_request_target:
     types: [opened, edited, reopened]
 
+# Least-privilege default; the label job elevates the writes it needs.
 permissions:
-  pull-requests: write
-  issues: write
+  contents: read
 
 concurrency:
   group: pr-label-${{ github.event.pull_request.number }}
@@ -28,8 +28,11 @@ jobs:
   label:
     name: label from title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             // Conventional Commit type -> label name, color (6-hex, no '#'),

--- a/.github/workflows/qdf-bench-matrix.yml
+++ b/.github/workflows/qdf-bench-matrix.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -38,7 +38,7 @@ jobs:
             go.sum
 
       - name: Restore build cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/go-build
           key: gocache-qdfbench-${{ runner.os }}-${{ hashFiles('**/go.sum', '**/*.go') }}
@@ -60,7 +60,7 @@ jobs:
           } 2>&1 | tee qdf-bench-matrix.txt
 
       - name: Upload benchmark output
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: qdf-bench-matrix-${{ github.sha }}
           path: qdf-bench-matrix.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,9 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+# Least-privilege default; the release job elevates contents to write.
 permissions:
-  contents: write # create the GitHub release and (on dispatch) push the tag
+  contents: read
 
 env:
   GOEXPERIMENT: simd
@@ -28,12 +29,14 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub release and (on dispatch) push the tag
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0 # full history + tags for --generate-notes
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,25 +25,25 @@ jobs:
       actions: read
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: run scorecard
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: scorecard-results
           path: results.sarif
           retention-days: 30
 
       - name: upload sarif to code-scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Addresses the OpenSSF Scorecard alerts on the Actions workflows.

## Pinned dependencies (50 alerts — `PinnedDependenciesID`)
Every `uses:` is now pinned to a full commit SHA with a `# vX` comment. A retagged or compromised action tag can no longer silently change a workflow; Dependabot keeps the SHAs current via the version comment. The two stray `actions/setup-go@v5` uses are unified onto v6 (already used everywhere else).

## Least-privilege tokens (4 high alerts — `TokenPermissionsID`)
Top-level `permissions:` now defaults to `contents: read` for every workflow; the specific write scope is elevated only on the job that needs it:

| workflow | job elevation |
|----------|---------------|
| release | `contents: write` |
| dependabot-auto-tidy | `contents: write` |
| bench-trend | `contents: write`, `pull-requests: write` |
| codeql | `security-events: write`, `actions: read` |
| pr-label | `pull-requests: write`, `issues: write` |

## Not covered here
- `DangerousWorkflowID` (critical, dependabot-auto-tidy `pull_request_target` head checkout) — separate decision (the job is already gated to `dependabot[bot]` on a same-repo branch and only runs `go mod tidy`, which never executes PR code).
- `BranchProtectionID`, `CodeReviewID`, `MaintainedID`, `CIIBestPracticesID` — repo settings / time, not workflow code.

`actionlint` clean.