### PR TITLE
fix(delta): audit-4 — never-larger wire-state leaks + qdfgen nested-struct diagnostic

### DIFF
--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -760,6 +760,9 @@ func (g *gen) emitEncodeNamed(w io.Writer, expr string, n *types.Named, indent s
 		// encoder allocated). expr is always addressable (a struct field,
 		// slice/array element, map range var, or pointer deref), so take its
 		// address directly — EncodeQDF only reads the receiver.
+		if !g.canEncodeNested(n) {
+			return g.nestedStructErr(n, "encode")
+		}
 		fmt.Fprintf(w, "%sif err := qdf.EncodeNested(e, &%s); err != nil {\n%s\treturn err\n%s}\n", indent, expr, indent, indent)
 		return nil
 	case *types.Slice, *types.Array, *types.Map, *types.Pointer:
@@ -779,6 +782,9 @@ func (g *gen) emitEncodePointer(w io.Writer, expr string, p *types.Pointer, inde
 		fmt.Fprintf(w, "%s\t{ _t := (*%s).UTC(); e.WriteTimestamp(_t.Unix(), uint32(_t.Nanosecond())) }\n", indent, expr)
 	} else if named, ok := elem.(*types.Named); ok {
 		if _, isStruct := named.Underlying().(*types.Struct); isStruct {
+			if !g.canEncodeNested(named) {
+				return g.nestedStructErr(named, "encode")
+			}
 			fmt.Fprintf(w, "%s\tif err := qdf.EncodeNested(e, %s); err != nil {\n%s\t\treturn err\n%s\t}\n", indent, expr, indent, indent)
 		} else {
 			if err := g.emitEncodeValue(w, "(*"+expr+")", named.Underlying(), indent+"\t"); err != nil {
@@ -921,6 +927,29 @@ func hasMethod(t types.Type, name string) bool {
 		}
 	}
 	return false
+}
+
+// nestedStructErr reports a nested struct that qdfgen would emit a
+// qdf.EncodeNested/DecodeNested call against but that implements neither codec
+// side: it is not a -type target (so no codec is generated for it) and carries
+// no hand-written MarshalQDF/UnmarshalQDF. Without this check the generated file
+// fails to compile with an opaque "does not implement qdf.Marshaler" error far
+// from its cause; here we name the missing -type entry instead.
+func (g *gen) nestedStructErr(n *types.Named, dir string) error {
+	return fmt.Errorf("%s: nested struct type %q is neither a -type target nor a type with a hand-written %s codec; add %q to the -type list (or give it a codec)",
+		dir, n.Obj().Name(), map[string]string{"encode": "MarshalQDF", "decode": "UnmarshalQDF"}[dir], n.Obj().Name())
+}
+
+// canEncodeNested reports whether a nested named struct will satisfy qdf.Marshaler
+// in the generated code — either qdfgen generates its codec (it is a target) or it
+// already has a hand-written one.
+func (g *gen) canEncodeNested(n *types.Named) bool {
+	return g.targets[n.Obj().Name()] || hasMethod(n, "MarshalQDF")
+}
+
+// canDecodeNested is canEncodeNested's decode-side mirror (qdf.Unmarshaler).
+func (g *gen) canDecodeNested(n *types.Named) bool {
+	return g.targets[n.Obj().Name()] || hasMethod(n, "UnmarshalQDF")
 }
 
 // classifyColField maps a struct field to its columnar column descriptor, or
@@ -1481,6 +1510,9 @@ func (g *gen) emitDecodeNamed(w io.Writer, lhs string, n *types.Named, indent st
 	case *types.Struct:
 		// Nested struct: thread the shared decoder (no new decoder; the nested
 		// DecodeQDF inherits d's noCopy / arena).
+		if !g.canDecodeNested(n) {
+			return g.nestedStructErr(n, "decode")
+		}
 		fmt.Fprintf(w, "%sif err := qdf.DecodeNested(d, &%s); err != nil {\n%s\treturn err\n%s}\n", indent, lhs, indent, indent)
 		return nil
 	case *types.Slice, *types.Array, *types.Map, *types.Pointer:
@@ -1507,6 +1539,9 @@ func (g *gen) emitDecodePointer(w io.Writer, lhs string, p *types.Pointer, inden
 		fmt.Fprintf(w, "%s\t\t%s = &t\n", indent, lhs)
 	} else if named, ok := elem.(*types.Named); ok {
 		if _, isStruct := named.Underlying().(*types.Struct); isStruct {
+			if !g.canDecodeNested(named) {
+				return g.nestedStructErr(named, "decode")
+			}
 			fmt.Fprintf(w, "%s\t\t%s = new(%s)\n", indent, lhs, g.typeRef(named))
 			fmt.Fprintf(w, "%s\t\tif err := qdf.DecodeNested(d, %s); err != nil {\n%s\t\t\treturn err\n%s\t\t}\n", indent, lhs, indent, indent)
 		} else {

--- a/cmd/qdfgen/gen/gen_columnar_test.go
+++ b/cmd/qdfgen/gen/gen_columnar_test.go
@@ -13,15 +13,15 @@ import (
 // diverging from the reflect path (mirrors reflect commit 9c6f524). A plain
 // all-scalar element must still be columnar-transposed (guard must not over-fire).
 func TestColumnarSkipsCustomCodecElem(t *testing.T) {
-	gen := func(t *testing.T, typeName string) string {
+	gen := func(t *testing.T, types ...string) string {
 		t.Helper()
 		out := filepath.Join(t.TempDir(), "out.go")
 		err := Generate([]string{"./testdata/customcodec"}, Options{
-			Types:   []string{typeName},
+			Types:   types,
 			OutFile: out,
 		})
 		if err != nil {
-			t.Fatalf("Generate(%s): %v", typeName, err)
+			t.Fatalf("Generate(%v): %v", types, err)
 		}
 		b, err := os.ReadFile(out)
 		if err != nil {
@@ -41,7 +41,9 @@ func TestColumnarSkipsCustomCodecElem(t *testing.T) {
 	})
 
 	t.Run("plain_elem_is_columnar", func(t *testing.T) {
-		src := gen(t, "PlainHolder")
+		// PlainElem must also be a target: the columnar field's row-major fallback
+		// (len < columnarMinElems) encodes each element via EncodeNested.
+		src := gen(t, "PlainHolder", "PlainElem")
 		if !strings.Contains(src, "WriteColStructHeader") {
 			t.Fatalf("PlainHolder should columnar-transpose its plain all-scalar element:\n%s", src)
 		}
@@ -53,7 +55,10 @@ func TestColumnarSkipsCustomCodecElem(t *testing.T) {
 	// (*B, not *byte) and `[]B([]byte(...))` (an illegal conversion) — neither
 	// compiles. It must fall through to the generic per-element encoder.
 	t.Run("defined_byte_elem_slice_not_bytes_column", func(t *testing.T) {
-		src := gen(t, "NamedByteHolder")
+		// NamedByteElem is a nested struct, so it must itself be a target (else
+		// qdfgen now rejects the row-major EncodeNested against a non-generated
+		// type — see TestNestedNonTargetStructErrors).
+		src := gen(t, "NamedByteHolder", "NamedByteElem")
 		// The broken Bytes-column emit dereferences the field via unsafe.SliceData;
 		// the generic row-major path uses WriteArrayHeader instead.
 		if strings.Contains(src, "unsafe.SliceData(") && strings.Contains(src, ".Data") {

--- a/cmd/qdfgen/gen/gen_nested_nontarget_test.go
+++ b/cmd/qdfgen/gen/gen_nested_nontarget_test.go
@@ -1,0 +1,29 @@
+package gen
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNestedNonTargetStructErrors pins the audit-4 diagnostic: a target struct
+// referencing a nested struct that is neither a -type target nor a custom-codec
+// type must fail generation with a clear, actionable error naming the missing
+// type — not emit an EncodeNested/DecodeNested call that fails to compile later.
+func TestNestedNonTargetStructErrors(t *testing.T) {
+	for _, typeName := range []string{"Parent", "PtrParent"} {
+		t.Run(typeName, func(t *testing.T) {
+			out := filepath.Join(t.TempDir(), "out.go")
+			err := Generate([]string{"./testdata/nestednontarget"}, Options{
+				Types:   []string{typeName},
+				OutFile: out,
+			})
+			if err == nil {
+				t.Fatalf("%s: Generate succeeded; want a nested-struct diagnostic", typeName)
+			}
+			if !strings.Contains(err.Error(), "Inner") || !strings.Contains(err.Error(), "-type") {
+				t.Fatalf("%s: error %q must name the missing type Inner and the -type fix", typeName, err)
+			}
+		})
+	}
+}

--- a/cmd/qdfgen/gen/testdata/nestednontarget/types.go
+++ b/cmd/qdfgen/gen/testdata/nestednontarget/types.go
@@ -1,0 +1,22 @@
+// Package nestednontarget is a generator fixture: a target struct that
+// references a nested struct which is neither a -type target nor a custom-codec
+// type. qdfgen must reject this at generation time with a clear diagnostic
+// instead of emitting an EncodeNested/DecodeNested call that fails to compile.
+package nestednontarget
+
+// Inner has no hand-written codec and is not passed as a -type target.
+type Inner struct {
+	X int64
+}
+
+// Parent is the generated target; its Inner field forces the nested-struct path.
+type Parent struct {
+	Name  string
+	Inner Inner
+}
+
+// PtrParent exercises the pointer-to-nested-struct path.
+type PtrParent struct {
+	Name  string
+	Inner *Inner
+}

--- a/delta_audit4_test.go
+++ b/delta_audit4_test.go
@@ -1,0 +1,162 @@
+package qdf
+
+import (
+	"maps"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+// TestColDiffInternLeakAcrossField is the audit-4 RED repro for the columnar
+// never-larger intern leak: diffColumnar builds a positional baseline under
+// normal Dense interning, then (when the column body wins) discards those bytes
+// but leaves the assigned intern ids live in enc.state. A later field that
+// reuses one of those string values emits a state-ref to an id whose
+// tagInternStr definition lived only in the discarded positional bytes, so the
+// decoder hits ErrUnknownStateID — a valid Diff produces an undecodable patch.
+//
+// The struct places a columnar []struct with a changing string column BEFORE a
+// map field whose value reuses one of the column's strings ("green").
+func TestColDiffInternLeakAcrossField(t *testing.T) {
+	type colE struct {
+		N int32
+		S string
+	}
+	type colR struct {
+		Cols []colE
+		M    map[int32]string
+	}
+	palette := []string{"red", "green", "blue"}
+	const n = 32
+
+	mkOld := func() colR {
+		r := colR{Cols: make([]colE, n), M: map[int32]string{1: "x"}}
+		for i := range n {
+			r.Cols[i] = colE{int32(i), palette[i%3]}
+		}
+		return r
+	}
+	mkNew := func() colR {
+		r := colR{Cols: make([]colE, n), M: map[int32]string{1: "green"}}
+		for i := range n {
+			r.Cols[i] = colE{int32(i), palette[(i+1)%3]}
+		}
+		return r
+	}
+
+	for _, opt := range []Options{OptBalanced, OptCompression, OptDense | OptBalanced} {
+		old, nw := mkOld(), mkNew()
+		patch, err := Diff(old, nw, opt)
+		if err != nil {
+			t.Fatalf("opt %v: Diff: %v", opt, err)
+		}
+		base := colR{Cols: slices.Clone(old.Cols), M: maps.Clone(old.M)}
+		if err := Apply(&base, patch); err != nil {
+			t.Fatalf("opt %v: Apply rejected a valid patch: %v", opt, err)
+		}
+		if !reflect.DeepEqual(base, nw) {
+			t.Fatalf("opt %v: round-trip mismatch\n got %+v\nwant %+v", opt, base, nw)
+		}
+	}
+}
+
+// a4InnerTok is the stable per-type shape token (as qdfgen emits per type).
+var a4InnerTok byte
+
+// a4Inner is a hand-rolled EncoderMarshaler/DecoderUnmarshaler (the shape a
+// qdfgen-generated struct takes) that uses Encoder.StructShape — the one
+// wire-state id-assigning site the keyed never-larger trial failed to gate.
+type a4Inner struct{ W int64 }
+
+func (n a4Inner) EncodeQDF(e *Encoder) error {
+	e.StructShape(&a4InnerTok, [][]byte{append([]byte{tagFixstr | 1}, 'W')})
+	e.WriteInt(n.W)
+	return nil
+}
+
+func (n a4Inner) MarshalQDF(dst []byte) ([]byte, error) {
+	e := NewEncoderOnBuf(dst, Fast)
+	e.EnsureHeader()
+	if err := n.EncodeQDF(e); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+func (n *a4Inner) DecodeQDF(d *Decoder) error {
+	if _, _, _, err := d.ReadStructHeader(); err != nil {
+		return err
+	}
+	w, err := d.ReadInt()
+	if err != nil {
+		return err
+	}
+	n.W = w
+	return nil
+}
+
+func (n *a4Inner) UnmarshalQDF(src []byte) (int, error) {
+	d := NewDecoderOnBuf(src)
+	if err := d.readHeader(); err != nil {
+		return 0, err
+	}
+	if err := n.DecodeQDF(d); err != nil {
+		return 0, err
+	}
+	return len(src), nil
+}
+
+// TestKeyedStructShapeNoLeak is the audit-4 RED repro for the keyed never-larger
+// trial leaking a StructShape id: a keyed-slice element whose Sub field is an
+// EncoderMarshaler using StructShape. During diffKeyedSlice's suspended trial,
+// the discarded positional candidate binds the shape token; the kept keyed
+// candidate then emits an id-only tagMapShape reference whose declaration lived
+// only in the discarded bytes, so Apply of a valid Diff hits ErrUnknownStateID.
+func TestKeyedStructShapeNoLeak(t *testing.T) {
+	type a4Elem struct {
+		K   string  `qdf:"id,key"`
+		Sub a4Inner `qdf:"sub"`
+	}
+	type a4Holder struct {
+		Items []a4Elem `qdf:"items"`
+		// P and Q sit AFTER the keyed slice and share a4Inner's shape token, so
+		// the first declares the shape and the second references it by id. If the
+		// trial leaves the shape counter mis-based, that post-slice ref desyncs.
+		P a4Inner `qdf:"p"`
+		Q a4Inner `qdf:"q"`
+	}
+
+	// 30 keyed elements rotated by one (so a positional diff re-encodes every
+	// row, but a keyed diff only re-encodes the few genuinely changed rows and
+	// wins the never-larger trial), with two rows changing their Sub.W. The
+	// re-encoded rows drive Encoder.StructShape during the suspended trial.
+	const m = 200
+	key := func(i int) string { return string(rune('A'+i%26)) + string(rune('0'+i/26)) }
+	oldItems := make([]a4Elem, m)
+	for i := range m {
+		oldItems[i] = a4Elem{key(i), a4Inner{int64(i)}}
+	}
+	newItems := make([]a4Elem, m)
+	for i := range m {
+		src := (i + 1) % m // rotate by one
+		newItems[i] = oldItems[src]
+	}
+	newItems[3].Sub.W = 9990
+	newItems[7].Sub.W = 9991
+	old := a4Holder{Items: oldItems, P: a4Inner{100}, Q: a4Inner{100}}
+	nw := a4Holder{Items: newItems, P: a4Inner{200}, Q: a4Inner{200}}
+
+	for _, opt := range []Options{OptBalanced, OptCompression, OptDense | OptBalanced} {
+		patch, err := Diff(old, nw, opt)
+		if err != nil {
+			t.Fatalf("opt %v: Diff: %v", opt, err)
+		}
+		base := a4Holder{Items: slices.Clone(old.Items), P: old.P, Q: old.Q}
+		if err := Apply(&base, patch); err != nil {
+			t.Fatalf("opt %v: Apply rejected a valid patch: %v", opt, err)
+		}
+		if !reflect.DeepEqual(base, nw) {
+			t.Fatalf("opt %v: round-trip mismatch\n got %+v\nwant %+v", opt, base, nw)
+		}
+	}
+}

--- a/delta_columnar.go
+++ b/delta_columnar.go
@@ -100,12 +100,27 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 	st.deltaColBitmap = newChangedBitmap(st.deltaColBitmap, n)
 	markChangedRows(st.deltaColBitmap, plan, stride, oldData, newData, n, elem.pod)
 
+	// Never-larger trial: build a positional baseline (the size-comparison
+	// alternative) and the column body, keep the smaller. Suspend interning for
+	// the whole trial so the DISCARDED candidate cannot leak intern ids whose
+	// wire definitions are thrown away with it — a later state-ref to such an id
+	// dangles (ErrUnknownStateID). This is the same trap diffKeyedSlice guards
+	// against; the column string body is already wire-stateless
+	// (writeStringColumnStateless), but the positional baseline interned
+	// normally and, when the column body won, left orphaned ids in enc.state.
+	// Under suspension the only intern substate a body mutates is lastID, which
+	// is captured after the positional build and restored if positional wins.
+	prevSuspended := enc.stateSuspended
+	enc.stateSuspended = true
+	defer func() { enc.stateSuspended = prevSuspended }()
+
 	// Build the positional body into enc.buf first (the comparison baseline).
 	posStart := len(enc.buf)
 	if err := diffElemsPositional(enc, elem, stride, oldData, n, newData, n, depth); err != nil {
 		return false, err
 	}
 	posLen := len(enc.buf) - posStart
+	posEndLastID := st.lastID
 
 	body := st.deltaColBuf[:0]
 	body = append(body, tagColSlicePatch)
@@ -128,6 +143,7 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 			// positional body already in enc.buf handles the whole slice.
 			enc.buf = savedBuf
 			st.deltaColBuf = body[:0]
+			st.lastID = posEndLastID // positional wins; track its kept bytes
 			return true, nil
 		}
 		nChanged++
@@ -176,9 +192,13 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 	if len(body) < posLen {
 		enc.buf = enc.buf[:posStart]
 		enc.buf = append(enc.buf, body...)
+		// Column body wins; st.lastID already reflects the column build.
+	} else {
+		// Positional wins; restore lastID to its post-positional value so it
+		// tracks the bytes the decoder will actually read.
+		st.lastID = posEndLastID
 	}
-	// Otherwise the positional body already sits in enc.buf and wins. Either
-	// way exactly one body remains and the slice is handled.
+	// Either way exactly one body remains and the slice is handled.
 	return true, nil
 }
 

--- a/delta_keyed.go
+++ b/delta_keyed.go
@@ -93,14 +93,24 @@ func diffKeyedSlice(enc *Encoder, td, elem *typeDesc, oldP, newP unsafe.Pointer,
 	enc.stateSuspended = true
 	defer func() { enc.stateSuspended = prevSuspended }()
 
+	// shapeStart anchors the shape-id counter: a suspended StructShape (a
+	// qdfgen EncoderMarshaler element field) emits a fresh declaration and
+	// advances shapeCount per emit, so the discarded candidate's declarations
+	// must be re-based off the counter or a later shape ref desyncs.
+	shapeStart := uint32(0)
+	if enc.state != nil {
+		shapeStart = enc.state.shapeCount
+	}
+
 	posStart := len(enc.buf)
 	if err := diffSlice(enc, td, oldP, newP, depth); err != nil {
 		return err
 	}
 	posLen := len(enc.buf) - posStart
-	posEndLastID, haveLast := uint32(0), enc.state != nil
+	posEndLastID, shapeAfterPos, haveLast := uint32(0), shapeStart, enc.state != nil
 	if haveLast {
 		posEndLastID = enc.state.lastID
+		shapeAfterPos = enc.state.shapeCount
 	}
 
 	// Build the keyed body APPENDED after the positional one, using enc.buf
@@ -116,12 +126,19 @@ func diffKeyedSlice(enc *Encoder, td, elem *typeDesc, oldP, newP unsafe.Pointer,
 		// reflects the keyed build (emitted last), matching the kept body.
 		copy(enc.buf[posStart:], enc.buf[keyedStart:])
 		enc.buf = enc.buf[:posStart+keyedLen]
+		// Keyed wins: only its declarations reach the decoder, so drop the
+		// discarded positional candidate's from the shape counter.
+		if haveLast {
+			enc.state.shapeCount = shapeStart + (enc.state.shapeCount - shapeAfterPos)
+		}
 	} else {
-		// Positional wins; drop the trailing keyed body and restore lastID to
-		// its post-positional value so it tracks the bytes the decoder will read.
+		// Positional wins; drop the trailing keyed body and restore lastID and
+		// the shape counter to their post-positional values so they track the
+		// bytes the decoder will read.
 		enc.buf = enc.buf[:keyedStart]
 		if haveLast {
 			enc.state.lastID = posEndLastID
+			enc.state.shapeCount = shapeAfterPos
 		}
 	}
 	return nil

--- a/delta_test.go
+++ b/delta_test.go
@@ -175,18 +175,24 @@ func TestDiffApplyFlatStruct(t *testing.T) {
 }
 
 func TestApplyArena(t *testing.T) {
+	// Tags ([]string) keeps the element row-major (a slice field disqualifies the
+	// columnar transpose), so the string fields decode through the per-field
+	// (row-major) path — the path the decode arena batches. An all-scalar element
+	// would transpose to columnar and decode its string column as one bulk blob,
+	// which is already few-alloc and bypasses the arena.
 	type Row struct {
 		ID    int
 		Name  string
 		Email string
 		Note  string
+		Tags  []string
 	}
 	const n = 500
 	old := make([]Row, n)
 	neu := make([]Row, n)
 	for i := range n {
-		old[i] = Row{ID: i, Name: "old-name-padding", Email: "old@example.invalid", Note: "old note body text here"}
-		neu[i] = Row{ID: i, Name: "new-name-padding-changed", Email: "new@example.invalid", Note: "new note body text here changed"}
+		old[i] = Row{ID: i, Name: "old-name-padding", Email: "old@example.invalid", Note: "old note body text here", Tags: []string{"t"}}
+		neu[i] = Row{ID: i, Name: "new-name-padding-changed", Email: "new@example.invalid", Note: "new note body text here changed", Tags: []string{"t"}}
 	}
 	patch, err := Diff(old, neu, OptBalanced)
 	if err != nil {

--- a/encoder.go
+++ b/encoder.go
@@ -927,6 +927,23 @@ func (e *Encoder) StructShape(token *byte, fieldHdrs [][]byte) {
 		e.state = newEncState()
 	}
 	st := e.state
+	if e.stateSuspended {
+		// Inside a never-larger trial (diffKeyedSlice / diffColumnar): emit a
+		// self-contained declaration every time and never bind or reference a
+		// token. A bound id whose declaration is thrown away with the losing
+		// candidate would dangle (ErrUnknownStateID) — the same leak the trial
+		// suspends interning to avoid. Still advance the shape counter so it
+		// tracks the decoder (which registers a shape per declaration it reads);
+		// the trial re-bases the counter for the discarded candidate.
+		st.shapeDeclareEnc()
+		e.buf = append(e.buf, tagMapShape)
+		e.buf = appendUvarint(e.buf, 0) // 0 ⇒ declaration follows
+		e.buf = appendUvarint(e.buf, uint64(len(fieldHdrs)))
+		for _, h := range fieldHdrs {
+			e.buf = append(e.buf, h...)
+		}
+		return
+	}
 	if id := st.shapeForToken(token); id != 0 {
 		e.buf = append(e.buf, tagMapShape)
 		e.buf = appendUvarint(e.buf, uint64(id))


### PR DESCRIPTION
Fourth full-codebase agent audit. Eight finder agents (by bug-class / new-code target) each adversarially verified, then every surviving finding RED-verified by hand with a concrete repro that fails on the prior code. Three real findings; four areas confirmed clean.

## HIGH — `diffColumnar` positional baseline leaked intern ids
`diffColumnar` built its positional comparison baseline under normal Dense interning, then discarded those bytes when the column body won — but kept the assigned intern ids in `enc.state`. A later field reusing one of those strings emitted a state-ref to an id whose `tagInternStr` definition was gone, so `Apply` rejected a valid `Diff` with `ErrUnknownStateID`.

Fix: suspend interning for the whole columnar trial (mirroring `diffKeyedSlice`). The column string body is already wire-stateless; the only intern substate a suspended body mutates is `lastID`, captured after the positional build and restored if positional wins. Repro: `TestColDiffInternLeakAcrossField`.

## HIGH — `Encoder.StructShape` not gated under a suspended trial
`StructShape` (the qdfgen `EncoderMarshaler` wire path) was the one id-assigning site the keyed never-larger trial failed to gate. The discarded positional candidate bound the shape token; the kept keyed candidate emitted an id-only `tagMapShape` reference whose declaration was discarded → `ErrUnknownStateID`.

Fix: under `stateSuspended`, `StructShape` emits a self-contained declaration every time and never binds/references a token; it still advances the shape counter (the decoder registers a shape per declaration it reads), and `diffKeyedSlice` re-bases `shapeCount` for the discarded candidate alongside `lastID`. Repro: `TestKeyedStructShapeNoLeak` (also exercises a post-slice shape reference the counter re-base must keep in sync).

## LOW — qdfgen emitted non-compiling code for a nested non-target struct
A struct field whose type was a nested struct that is neither a `-type` target nor a custom-codec type was emitted as `qdf.EncodeNested`/`DecodeNested` against a type implementing neither interface → opaque compile failure. Now rejected at generation time with a diagnostic naming the missing type, at all four nested-struct emit sites. Repro: `TestNestedNonTargetStructErrors`. (Surfaced two `gen_columnar_test` fixtures that referenced element structs without listing them as targets — string-only assertions never compiled the output; fixed.)

## Clean (swept, no findings)
streaming intern-arena retention; integer narrowing / count×width overflow; reused-scratch under-fill; columnar query / 3VL predicate eval.

## Gate
`go test` + `-race` (full); 7 fuzz oracles (ColDiffString/ColDiff/KeyedSlice/DiffApply/ApplyKeyedHostile/ColDiffApply/BaselineApply); `codegen_test` (both phases); qdfgen + bench suites; `golangci-lint` v2 = 0 issues (main + qdfgen); gofmt/vet clean. Generated output byte-identical for valid types.

Note: suspending the columnar positional baseline costs cross-body string interning on the rare positional-wins path (the same accepted trade as the keyed picker) — correctness over a marginal wire-size optimization.