### PR TITLE
docs: fix mermaid diagrams rendering as raw code in the article

### DIFF
--- a/docs/ARTICLE.md
+++ b/docs/ARTICLE.md
@@ -127,11 +127,11 @@ cheapest of four back-references:
 ```mermaid
 stateDiagram-v2
     [*] --> Inline: never seen
-    Inline --> Interned: 0xE0 declare (assign id N)
-    Interned --> Repeat: value == last  →  0xE8 (1 byte)
-    Interned --> Pair: "follows last"   →  0xEA rank (Markov-1)
-    Interned --> MTF: recent            →  0xE9 rank
-    Interned --> ById: fallback         →  0xE1 id
+    Inline --> Interned: 0xE0 declare, assign id N
+    Interned --> Repeat: value == last, 0xE8 (1 byte)
+    Interned --> Pair: follows last, 0xEA rank (Markov-1)
+    Interned --> MTF: recent, 0xE9 rank
+    Interned --> ById: fallback, 0xE1 id
 ```
 
 Encoder and decoder keep mirrored state: an id table, an LRU chain (move-to-front), and
@@ -153,9 +153,7 @@ Field names written once across a `[]Service`, no schema declared.
 
 ```mermaid
 flowchart TD
-    S["[]int64 / []uint64 / []float64"] --> P{probe once:
-min/max, deltas,
-runs, distinct, outliers}
+    S["[]int64 / []uint64 / []float64"] --> P{"probe once: min/max,<br/>deltas, runs, distinct, outliers"}
     P -->|tight range| FOR[Frame-of-Reference]
     P -->|monotonic| DFOR[Delta + FOR]
     P -->|few runs| RLE[Run-Length]
@@ -163,7 +161,7 @@ runs, distinct, outliers}
     P -->|tight + outliers| PFOR[Patched FOR]
     P -->|smooth floats| GOR[Gorilla XOR]
     P -->|decimal floats| ALP[ALP]
-    FOR & DFOR & RLE & DICT & PFOR & GOR & ALP --> K{< raw-LE?}
+    FOR & DFOR & RLE & DICT & PFOR & GOR & ALP --> K{"smaller than raw-LE?"}
     K -->|yes| W[write codec frame]
     K -->|no| R[write raw]
 ```
@@ -409,15 +407,10 @@ but not perfect.
 
 ```mermaid
 flowchart TD
-    Q1{Wire size matters?} -->|no, latency is king| SPEED[OptSpeed]
-    Q1 -->|yes| Q2{Can you spend
-encode CPU for
-smaller wire?}
-    Q2 -->|no — default| BAL[OptBalanced]
-    Q2 -->|yes — archive/cold| COMP[OptCompression]
-    SPEED -.tiny RPC, hot loop.-> SPEED
-    BAL -.telemetry, logs, APIs.-> BAL
-    COMP -.cold storage, egress.-> COMP
+    Q1{"Wire size matters?"} -->|no, latency is king| SPEED["OptSpeed<br/>(tiny RPC, hot loop)"]
+    Q1 -->|yes| Q2{"Can you spend encode CPU<br/>for smaller wire?"}
+    Q2 -->|no, default| BAL["OptBalanced<br/>(telemetry, logs, APIs)"]
+    Q2 -->|yes, archive/cold| COMP["OptCompression<br/>(cold storage, egress)"]
 ```
 
 - **`OptSpeed`** (= `0`, "Fast"): no codecs, no interning. Largest wire, lowest CPU,
@@ -469,18 +462,10 @@ string/`[]byte` copies handed back to you. qdf gives you four strategies:
 
 ```mermaid
 flowchart TD
-    D{Does the decoded value
-outlive the input buffer?} -->|no, and buffer is stable| NC[WithNoCopy
-zero copies, alias buffer]
-    D -->|yes| C{Many small strings
-per message?}
-    C -->|yes| AR[WithArena
-one slab per epoch]
+    D{"Decoded value outlives<br/>the input buffer?"} -->|no, buffer is stable| NC["WithNoCopy<br/>(zero copies, alias buffer)"]
+    D -->|yes| C{"Many small strings<br/>per message?"}
+    C -->|yes| AR["WithArena<br/>(one slab per epoch)"]
     C -->|no| CP[default copy]
-    NC -.request handler,
-buffer not recycled.-> NC
-    AR -.batch decode,
-request-scoped.-> AR
 ```
 
 - **default (copy)** — each string/`[]byte` is its own allocation. Safe, simplest, but

--- a/docs/article.html
+++ b/docs/article.html
@@ -67,26 +67,23 @@
   mermaid.initialize({ startOnLoad: false, theme: dark ? 'dark' : 'default',
                        securityLevel: 'strict' });
 
-  // Emit mermaid fences as <pre class="mermaid"> with RAW (un-escaped) text so
-  // mermaid can read them; everything else uses marked's default rendering.
-  marked.use({
-    renderer: {
-      code(token) {
-        if (token.lang === 'mermaid') {
-          return '<pre class="mermaid">' + token.text + '</pre>';
-        }
-        return false; // default renderer
-      },
-    },
-  });
-
   const el = document.getElementById('content');
   try {
     const res = await fetch('ARTICLE.md', { cache: 'no-cache' });
     if (!res.ok) throw new Error('HTTP ' + res.status);
-    const md = await res.text();
-    el.innerHTML = marked.parse(md);
-    await mermaid.run({ querySelector: 'pre.mermaid' });
+    el.innerHTML = marked.parse(await res.text());
+
+    // Promote ```mermaid fenced blocks (rendered by marked as
+    // <pre><code class="language-mermaid">) into <pre class="mermaid"> holding
+    // the RAW (un-escaped, via textContent) diagram source, then let mermaid
+    // render them. Robust across marked renderer-API versions.
+    el.querySelectorAll('code.language-mermaid').forEach((c) => {
+      const pre = document.createElement('pre');
+      pre.className = 'mermaid';
+      pre.textContent = c.textContent;
+      (c.closest('pre') || c).replaceWith(pre);
+    });
+    await mermaid.run({ querySelector: 'pre.mermaid', suppressErrors: true });
     document.title = (el.querySelector('h1')?.textContent || document.title).trim();
   } catch (e) {
     el.innerHTML = '<p>Could not render the article (' + e.message +


### PR DESCRIPTION
The published article rendered its mermaid diagrams as raw code blocks. Two causes:

1. **Render path** — `article.html` relied on a marked v12 renderer override to emit `<pre class="mermaid">`; it didn't fire, so `mermaid.run()` had nothing to render. Replaced with a version-robust DOM post-process: promote every `<code class="language-mermaid">` to `<pre class="mermaid">` (raw `textContent`), then `mermaid.run({ suppressErrors: true })`.

2. **Diagram syntax** — node labels used raw newlines inside `{...}`/`[...]`, which mermaid can't parse. Quoted the labels, used `<br/>` for line breaks, dropped the self-loop pseudo-note edges, and avoided a bare `<` in a decision label.

After merge the `pages-article` workflow republishes; the diagrams (codec picker, dense state machine, profile + decode decision trees) then render.