### PR TITLE
fix(delta): audit-5 — close two residuals of the suspend invariant

### DIFF
--- a/delta_audit5_test.go
+++ b/delta_audit5_test.go
@@ -1,0 +1,124 @@
+package qdf
+
+import (
+	"maps"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+// TestKeyedMapShapeNoLeak is the audit-5 RED repro for the residual of the
+// audit-4 suspension fix: mapStringShapeOrder (the OptMapShape declaring site)
+// was the one shape site left ungated on stateSuspended. During diffKeyedSlice's
+// suspended never-larger trial, a re-encoded element's map[string]V field
+// declares/binds a key-set shape on enc.state; the keyed-win re-base fixes only
+// shapeCount, never the map-shape binding, so a later sibling map that reuses the
+// key-set emits a tagMapShape reference whose declaration lived only in the
+// discarded/trial bytes — Apply of a valid Diff fails with ErrUnknownStateID.
+func TestKeyedMapShapeNoLeak(t *testing.T) {
+	type msElem struct {
+		K string            `qdf:"id,key"`
+		M map[string]string `qdf:"m"`
+	}
+	type msHolder struct {
+		Items []msElem          `qdf:"items"`
+		Tail  map[string]string `qdf:"tail"`
+	}
+
+	const base = 60
+	key := func(i int) string { return string(rune('a'+i%26)) + string(rune('0'+i/26)) }
+
+	mkOld := func() msHolder {
+		items := make([]msElem, base)
+		for i := range base {
+			items[i] = msElem{key(i), map[string]string{"a": "x", "b": "y"}}
+		}
+		return msHolder{Items: items, Tail: map[string]string{"p": "0", "q": "2", "r": "3"}}
+	}
+	mkNew := func() msHolder {
+		// rotate by one, then append 5 new-key elements whose M uses the {p,q,r}
+		// key-set that Tail also uses.
+		items := make([]msElem, base, base+5)
+		for i := range base {
+			items[i] = msElem{key((i + 1) % base), map[string]string{"a": "x", "b": "y"}}
+		}
+		for i := range 5 {
+			items = append(items, msElem{"NEW" + string(rune('0'+i)),
+				map[string]string{"p": "1", "q": "2", "r": "3"}})
+		}
+		return msHolder{Items: items, Tail: map[string]string{"p": "9", "q": "2", "r": "3"}}
+	}
+
+	for _, opt := range []Options{OptMapShape | OptDense, OptBalanced | OptMapShape, OptCompression | OptMapShape} {
+		old, nw := mkOld(), mkNew()
+		patch, err := Diff(old, nw, opt)
+		if err != nil {
+			t.Fatalf("opt %v: Diff: %v", opt, err)
+		}
+		base := msHolder{Items: slices.Clone(old.Items), Tail: maps.Clone(old.Tail)}
+		if err := Apply(&base, patch); err != nil {
+			t.Fatalf("opt %v: Apply rejected a valid patch: %v", opt, err)
+		}
+		if !reflect.DeepEqual(base, nw) {
+			t.Fatalf("opt %v: round-trip mismatch", opt)
+		}
+	}
+}
+
+// TestColWinLastIDNoPairCorruption is the audit-5 RED probe for the columnar
+// column-win lastID divergence: after a column body wins the never-larger trial,
+// the encoder left lastID at the (suspended) positional-build value while the
+// decoder, reading the wire-stateless column body, keeps its pre-slice lastID.
+// The two then disagree on the Markov-1 pair predictor, which under OptBalanced
+// can make a later interned value resolve to the WRONG string with no error.
+// Randomized over many orderings to hit the specific pre/post sequence.
+func TestColWinLastIDNoPairCorruption(t *testing.T) {
+	type colRow struct {
+		N int32  `qdf:"n"`
+		S string `qdf:"s"`
+	}
+	type doc struct {
+		Pre  []string `qdf:"pre"`
+		Cols []colRow `qdf:"cols"`
+		Post []string `qdf:"post"`
+	}
+	alpha := []string{"red", "green", "blue", "amber", "violet", "cyan", "gray"}
+	rng := func(seed uint64) func(int) int {
+		s := seed
+		return func(n int) int { s = s*6364136223846793005 + 1442695040888963407; return int((s >> 33) % uint64(n)) }
+	}
+	mkStrs := func(r func(int) int, n int) []string {
+		out := make([]string, n)
+		for i := range out {
+			out[i] = alpha[r(len(alpha))]
+		}
+		return out
+	}
+	mkCols := func(r func(int) int, n int) []colRow {
+		out := make([]colRow, n)
+		for i := range out {
+			out[i] = colRow{int32(r(1000)), alpha[r(len(alpha))]}
+		}
+		return out
+	}
+	for seed := uint64(1); seed <= 4000; seed++ {
+		r := rng(seed)
+		old := doc{Pre: mkStrs(r, 12), Cols: mkCols(r, 20), Post: mkStrs(r, 12)}
+		r2 := rng(seed * 2654435761)
+		nw := doc{Pre: mkStrs(r2, 12), Cols: mkCols(r2, 20), Post: mkStrs(r2, 12)}
+		patch, err := Diff(old, nw, OptBalanced)
+		if err != nil {
+			t.Fatalf("seed %d: Diff: %v", seed, err)
+		}
+		base := old
+		base.Pre = slices.Clone(old.Pre)
+		base.Cols = slices.Clone(old.Cols)
+		base.Post = slices.Clone(old.Post)
+		if err := Apply(&base, patch); err != nil {
+			t.Fatalf("seed %d: Apply: %v", seed, err)
+		}
+		if !reflect.DeepEqual(base, nw) {
+			t.Fatalf("seed %d: round-trip mismatch (lastID/pair desync)\n got %+v\nwant %+v", seed, base, nw)
+		}
+	}
+}

--- a/delta_columnar.go
+++ b/delta_columnar.go
@@ -114,6 +114,13 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 	enc.stateSuspended = true
 	defer func() { enc.stateSuspended = prevSuspended }()
 
+	// preTrialLastID is the intern lastID the decoder reaches when the column
+	// body wins: that body is wire-stateless (no inline strings, no state-refs),
+	// so a decoder reading it never touches lastID and stays at its pre-slice
+	// value. The encoder must end there too, or the two diverge and a later
+	// pair/repeat state-ref desyncs (the keyed picker keeps the same invariant).
+	preTrialLastID := st.lastID
+
 	// Build the positional body into enc.buf first (the comparison baseline).
 	posStart := len(enc.buf)
 	if err := diffElemsPositional(enc, elem, stride, oldData, n, newData, n, depth); err != nil {
@@ -192,7 +199,12 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 	if len(body) < posLen {
 		enc.buf = enc.buf[:posStart]
 		enc.buf = append(enc.buf, body...)
-		// Column body wins; st.lastID already reflects the column build.
+		// Column body wins. It is wire-stateless, so a decoder leaves lastID at
+		// its pre-slice value — restore the encoder to match (the positional
+		// build may have moved lastID, e.g. to lruInvalidID on a changed string
+		// column). Without this the encoder/decoder lastID + pair predictor
+		// diverge after the slice.
+		st.lastID = preTrialLastID
 	} else {
 		// Positional wins; restore lastID to its post-positional value so it
 		// tracks the bytes the decoder will actually read.

--- a/map_shape.go
+++ b/map_shape.go
@@ -29,6 +29,30 @@ func mapStringShapeOrder[V any](e *Encoder, m map[string]V) []string {
 	n := len(m)
 	st := e.state
 
+	if e.stateSuspended {
+		// Inside a never-larger trial (diffKeyedSlice / diffColumnar): emit a
+		// self-contained id-0 declaration every time and never bind/reuse a
+		// map-shape id — a bound id whose declaration is thrown away with the
+		// losing candidate would dangle (ErrUnknownStateID), the same leak the
+		// trial suspends interning to avoid. Mirrors Encoder.StructShape under
+		// suspension: advance shapeCount (the decoder registers a shape per
+		// declaration it reads; the trial re-bases the counter for the discarded
+		// candidate) but touch no mapShapes / lastMapShapeID binding.
+		keys := make([]string, 0, n)
+		for k := range m {
+			keys = append(keys, k)
+		}
+		slices.Sort(keys)
+		st.shapeDeclareEnc()
+		e.buf = append(e.buf, tagMapShape)
+		e.buf = appendUvarint(e.buf, 0)
+		e.buf = appendUvarint(e.buf, uint64(n))
+		for _, k := range keys {
+			e.WriteString(k)
+		}
+		return keys
+	}
+
 	// Fast path: a run of homogeneous rows reuses the previous shape. Verify
 	// membership directly (len + every bound key present) — no set-hash, no
 	// registry scan. Exact, so collision-proof.


### PR DESCRIPTION
Fifth full-codebase agent audit (8 finder agents, each adversarially verified; every surviving finding RED-verified by hand). Two findings, both residuals of the audit-4 never-larger suspension fix; six areas confirmed clean.

## HIGH — `mapStringShapeOrder` ungated under suspension
`OptMapShape`'s key-set declaring site was the one shape site audit-4 did not make suspension-aware (StructShape, the reflect struct-shape and reflect map-shape paths were all gated). During `diffKeyedSlice`'s suspended never-larger trial, a re-encoded element's `map[string]V` field declared and **bound** a key-set shape on `enc.state`; the keyed-win re-base fixes only `shapeCount`, never the map-shape binding, so a later sibling map reusing that key-set emitted a `tagMapShape` reference whose declaration lived only in the discarded trial bytes → `Apply` of a valid `Diff` failed with `ErrUnknownStateID`.

Fix: a suspended fast-path in `mapStringShapeOrder` that emits a self-contained id-0 declaration every time and binds nothing, mirroring `Encoder.StructShape`. RED-verified with `TestKeyedMapShapeNoLeak` (fails on prior code across `OptMapShape|OptDense`, `OptBalanced|OptMapShape`, `OptCompression|OptMapShape`).

## LOW — `diffColumnar` column-win leaves `lastID` diverged
On the column-win path the encoder left `lastID` at the post-positional value (`lruInvalidID` when a string column changed under suspension), while a decoder reading the wire-stateless column body keeps its pre-slice `lastID` — a proven encoder/decoder state divergence that the keyed picker already guards against. Restore `lastID` to the pre-trial value on column-win.

I could not weaponize this into observable corruption (4000 randomized + 4000 + a targeted deterministic attempt all pass — the encoder stays conservative when `lastID` is invalid), so it is filed LOW, but the divergence is real and the fix restores the documented suspend invariant ("a suspended body mutates only `lastID`, captured and restored").

## Clean (swept, no findings)
shapeCount re-base math (exact for nested trials, pre-bound tokens, mixed StructShape+reflect bodies); columnar suspend interactions; qdfgen nested-struct guards (no false-positive/negative); pool-reuse of `stateSuspended`+`shapeCount` across an errored Diff; integer-narrowing / scratch-underfill; concurrency.

## Gate
`go test` + `-race` (full); gofmt; `go vet`; `golangci-lint` v2 = 0; fuzz (ColDiff/ColDiffString/KeyedSlice/DiffApply); `codegen_test` (both phases) + qdfgen. The transient `FuzzDiffApplyOracle` failure was an environmental OOM from four back-to-back fuzz runs — clean standalone.