### PR TITLE
fix(decode): audit-6 — columnar memory-amplification DoS

### DIFF
--- a/cmd/qdf-bench/types_qdf_gen.go
+++ b/cmd/qdf-bench/types_qdf_gen.go
@@ -5,6 +5,7 @@ package main
 import (
 	"github.com/alex60217101990/qdf"
 	"slices"
+	"unsafe"
 )
 
 // Pre-encoded field-name headers (fixstr / strN). Lets the hot path
@@ -273,6 +274,9 @@ func (v *GenHost) decodeQDFField(d *qdf.Decoder, name string) error {
 				if !slices.Equal(names32, qdfHybNames_GenService) || !slices.Equal(kinds33, qdfHybKinds_GenService) {
 					return qdf.ErrTypeMismatch
 				}
+				if err := qdf.CheckColumnarBytes(n31, unsafe.Sizeof(*new(GenService))); err != nil {
+					return err
+				}
 				v.Services = make([]GenService, n31)
 				col34, err := d.ReadStringColumn(n31)
 				if err != nil {
@@ -419,6 +423,9 @@ func (v *GenHost) decodeQDFField(d *qdf.Decoder, name string) error {
 				}
 				if !slices.Equal(names53, qdfHybNames_GenTask) || !slices.Equal(kinds54, qdfHybKinds_GenTask) {
 					return qdf.ErrTypeMismatch
+				}
+				if err := qdf.CheckColumnarBytes(n52, unsafe.Sizeof(*new(GenTask))); err != nil {
+					return err
 				}
 				v.Tasks = make([]GenTask, n52)
 				col55, err := d.ReadStringColumn(n52)
@@ -827,6 +834,9 @@ func (v *GenMetricHost) decodeQDFField(d *qdf.Decoder, name string) error {
 			} else if d.PeekColStruct() {
 				n89, names90, kinds91, err := d.ReadColStructHeader()
 				if err != nil {
+					return err
+				}
+				if err := qdf.CheckColumnarBytes(n89, unsafe.Sizeof(*new(GenMetric))); err != nil {
 					return err
 				}
 				v.Metrics = make([]GenMetric, n89)

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -1640,6 +1640,9 @@ func (g *gen) emitDecodeColumnarBody(w io.Writer, lhs string, elem types.Type, p
 	idxVar := g.fresh("ci")
 	fmt.Fprintf(w, "%s%s, %s, %s, err := d.ReadColStructHeader()\n", indent, nVar, namesVar, kindsVar)
 	fmt.Fprintf(w, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
+	g.imports["unsafe"] = ""
+	fmt.Fprintf(w, "%sif err := qdf.CheckColumnarBytes(%s, unsafe.Sizeof(*new(%s))); err != nil {\n%s\treturn err\n%s}\n",
+		indent, nVar, g.typeExprFromType(elem), indent, indent)
 	fmt.Fprintf(w, "%s%s = make([]%s, %s)\n", indent, lhs, g.typeExprFromType(elem), nVar)
 	fmt.Fprintf(w, "%sfor %s := range %s {\n", indent, idxVar, namesVar)
 	fmt.Fprintf(w, "%s\tswitch %s[%s] {\n", indent, namesVar, idxVar)
@@ -1769,6 +1772,9 @@ func (g *gen) emitDecodeHybridBody(w io.Writer, lhs string, elem types.Type, pla
 	g.imports["slices"] = ""
 	fmt.Fprintf(w, "%sif !slices.Equal(%s, %s) || !slices.Equal(%s, %s) {\n%s\treturn qdf.ErrTypeMismatch\n%s}\n",
 		indent, namesVar, nv, kindsVar, kv, indent, indent)
+	g.imports["unsafe"] = ""
+	fmt.Fprintf(w, "%sif err := qdf.CheckColumnarBytes(%s, unsafe.Sizeof(*new(%s))); err != nil {\n%s\treturn err\n%s}\n",
+		indent, nVar, g.typeExprFromType(elem), indent, indent)
 	fmt.Fprintf(w, "%s%s = make([]%s, %s)\n", indent, lhs, g.typeExprFromType(elem), nVar)
 	for _, c := range plan.Columns {
 		g.emitDecodeColumnScatter(w, lhs, nVar, c, indent)

--- a/columnar.go
+++ b/columnar.go
@@ -163,6 +163,31 @@ func checkColumnarN(n int) error {
 	return nil
 }
 
+// maxColumnarBytes caps the OUTPUT allocation of a columnar struct decode. The
+// element-count ceiling (maxColumnarElems) does NOT bound the n*elemSize output
+// slice: a constant / RLE / zero-width column compresses many rows into a few
+// wire bytes, so a hostile header can claim maxColumnarElems rows of a wide
+// struct and amplify a ~1 KB input into a multi-GB allocation. This byte ceiling
+// caps that amplification before the slice is made; callers with larger batches
+// shard or stream.
+const maxColumnarBytes = 256 << 20
+
+// checkColumnarBytes rejects a columnar output whose total size (n elements of
+// elemSize bytes) exceeds maxColumnarBytes — the byte-bounded companion to
+// checkColumnarN's element-count ceiling. n must already be >= 0 (checkColumnarN).
+func checkColumnarBytes(n int, elemSize uintptr) error {
+	if uint64(n)*uint64(elemSize) > maxColumnarBytes {
+		return ErrInvalidLength
+	}
+	return nil
+}
+
+// CheckColumnarBytes is the exported guard cmd/qdfgen-generated columnar
+// decoders call after ReadColStructHeader / ReadHybridColStructHeader, before
+// allocating the row slice, to reject the same memory-amplification a hostile
+// row count would cause on the reflect path. elemSize is unsafe.Sizeof(row).
+func CheckColumnarBytes(n int, elemSize uintptr) error { return checkColumnarBytes(n, elemSize) }
+
 // buildColumnarPlan classifies a struct's fields into columnar-eligible columns
 // and (hybrid) residual fields. Called once at fillDesc time; the result is
 // cached so the hot path never reflects.
@@ -1314,6 +1339,11 @@ func decodeColumnarQuery(d *Decoder, t reflect.Type, plan *columnarPlan, p unsaf
 		return err
 	}
 	n, sh, colLens := cs.n, cs.sh, cs.colLens
+	// Bound by bytes before runQueryColumns materialises n-element column
+	// scratch (memory amplification from a compressed column count).
+	if err := checkColumnarBytes(n, t.Elem().Size()); err != nil {
+		return err
+	}
 	d.colMaxLen = n
 	defer func() { d.colMaxLen = 0 }()
 
@@ -1429,6 +1459,12 @@ func decodeColumnar(d *Decoder, t reflect.Type, plan *columnarPlan, p unsafe.Poi
 	// claimed length so a constant/zero-width codec cannot allocate past n.
 	d.colMaxLen = n
 	defer func() { d.colMaxLen = 0 }()
+
+	// Bound the output by bytes, not just element count: a compressed column
+	// can claim maxColumnarElems rows from a tiny input (memory amplification).
+	if err := checkColumnarBytes(n, t.Elem().Size()); err != nil {
+		return err
+	}
 
 	// Reuse the caller's backing when the row struct is pointer-free and the
 	// pre-sized slice has cap >= n (decode into a pooled slice), else fresh.
@@ -1557,6 +1593,11 @@ func decodeHybridColumnar(d *Decoder, t reflect.Type, plan *columnarPlan, p unsa
 	// Bound every eligible column codec's claimed length to n.
 	d.colMaxLen = n
 	defer func() { d.colMaxLen = 0 }()
+
+	// Bound the output by bytes, not just element count (memory amplification).
+	if err := checkColumnarBytes(n, t.Elem().Size()); err != nil {
+		return err
+	}
 
 	base := reuseOrMakeSlice(t, n, p, t.Elem().Size(), noPointers(t.Elem()))
 

--- a/columnar_dos_test.go
+++ b/columnar_dos_test.go
@@ -1,0 +1,49 @@
+package qdf
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestColumnarDecodeMemoryAmplification is the audit-6 RED repro for the
+// columnar memory-amplification DoS: a tagColStruct header claims a struct
+// count up to maxColumnarElems (1<<24), and decodeColumnar allocates the output
+// slice as count*elemSize BEFORE reading the (constant/RLE-compressible) column
+// bodies. A tiny hostile input then forces a multi-hundred-MB / multi-GB
+// allocation. The count ceiling bounds elements, never bytes.
+func TestColumnarDecodeMemoryAmplification(t *testing.T) {
+	type dosRow struct {
+		A int64 `qdf:"a"`
+		B int64 `qdf:"b"`
+		C int64 `qdf:"c"`
+		D int64 `qdf:"d"`
+		E int64 `qdf:"e"`
+	}
+	// 64 all-scalar rows → the columnar probe fires (tagColStruct, 0xEF) under
+	// OptBalanced. Keep the values small so 0xEF only appears as the frame tag.
+	rows := make([]dosRow, 64)
+	for i := range rows {
+		rows[i] = dosRow{A: int64(i)}
+	}
+	buf, err := Marshal(rows, OptBalanced)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if buf[5] != tagColStruct {
+		t.Fatalf("expected tagColStruct (0x%02x) at buf[5], got 0x%02x — payload not columnar", tagColStruct, buf[5])
+	}
+
+	// Splice the 1-byte struct count (64 = 0x40) with a count whose
+	// count*stride (stride 40 B) exceeds a sane byte ceiling: 8<<20 * 40 ≈ 335 MB.
+	const evilN = 8 << 20
+	evil := append([]byte{}, buf[:6]...) // header(5) + tagColStruct(1)
+	evil = appendUvarint(evil, uint64(evilN))
+	evil = append(evil, buf[7:]...) // rest after the original 1-byte count
+
+	var out []dosRow
+	derr := Unmarshal(evil, &out)
+	// A tiny hostile input must be rejected, not amplified into a giant slice.
+	if !errors.Is(derr, ErrInvalidLength) {
+		t.Fatalf("hostile columnar count not rejected: err=%v, len(out)=%d (memory-amplification DoS)", derr, len(out))
+	}
+}

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -491,6 +491,9 @@ func (v *GenBlobSet) decodeQDFField(d *qdf.Decoder, name string) error {
 				if err != nil {
 					return err
 				}
+				if err := qdf.CheckColumnarBytes(n27, unsafe.Sizeof(*new(GenBlobRow))); err != nil {
+					return err
+				}
 				v.Rows = make([]GenBlobRow, n27)
 				for ci30 := range names28 {
 					switch names28[ci30] {
@@ -840,6 +843,9 @@ func (v *GenEventLog) decodeQDFField(d *qdf.Decoder, name string) error {
 			} else if d.PeekColStruct() {
 				n60, names61, kinds62, err := d.ReadColStructHeader()
 				if err != nil {
+					return err
+				}
+				if err := qdf.CheckColumnarBytes(n60, unsafe.Sizeof(*new(GenEvent))); err != nil {
 					return err
 				}
 				v.Events = make([]GenEvent, n60)
@@ -1219,6 +1225,9 @@ func (v *GenMetricBatch) decodeQDFField(d *qdf.Decoder, name string) error {
 				if err != nil {
 					return err
 				}
+				if err := qdf.CheckColumnarBytes(n91, unsafe.Sizeof(*new(GenMetric))); err != nil {
+					return err
+				}
 				v.Metrics = make([]GenMetric, n91)
 				for ci94 := range names92 {
 					switch names92[ci94] {
@@ -1562,6 +1571,9 @@ func (v *GenNameList) decodeQDFField(d *qdf.Decoder, name string) error {
 			} else if d.PeekColStruct() {
 				n115, names116, kinds117, err := d.ReadColStructHeader()
 				if err != nil {
+					return err
+				}
+				if err := qdf.CheckColumnarBytes(n115, unsafe.Sizeof(*new(GenName))); err != nil {
 					return err
 				}
 				v.Names = make([]GenName, n115)
@@ -2091,6 +2103,9 @@ func (v *GenOptSet) decodeQDFField(d *qdf.Decoder, name string) error {
 			} else if d.PeekColStruct() {
 				n148, names149, kinds150, err := d.ReadColStructHeader()
 				if err != nil {
+					return err
+				}
+				if err := qdf.CheckColumnarBytes(n148, unsafe.Sizeof(*new(GenOpt))); err != nil {
 					return err
 				}
 				v.Rows = make([]GenOpt, n148)
@@ -2639,6 +2654,9 @@ func (v *GenRowSet) decodeQDFField(d *qdf.Decoder, name string) error {
 				if !slices.Equal(names197, qdfHybNames_GenRow) || !slices.Equal(kinds198, qdfHybKinds_GenRow) {
 					return qdf.ErrTypeMismatch
 				}
+				if err := qdf.CheckColumnarBytes(n196, unsafe.Sizeof(*new(GenRow))); err != nil {
+					return err
+				}
 				v.Rows = make([]GenRow, n196)
 				col199, err := d.ReadIntColumn(n196)
 				if err != nil {
@@ -2876,6 +2894,9 @@ func (v *GenTrailed) decodeQDFField(d *qdf.Decoder, name string) error {
 			} else if d.PeekColStruct() {
 				n218, names219, kinds220, err := d.ReadColStructHeader()
 				if err != nil {
+					return err
+				}
+				if err := qdf.CheckColumnarBytes(n218, unsafe.Sizeof(*new(GenMetric))); err != nil {
 					return err
 				}
 				v.Rows = make([]GenMetric, n218)


### PR DESCRIPTION
Sixth full-codebase agent audit, re-targeted at the non-delta subsystems (numeric/float/string codecs, columnar query, SIMD bitpack, hostile decode, streaming, nullable columns). 8 finder agents, each adversarially verified; the surviving finding RED-verified by hand. One finding; seven areas confirmed clean.

## HIGH — columnar decode memory amplification (DoS)
A `tagColStruct` / `tagHybridColStruct` header may claim up to `maxColumnarElems` (1<<24) rows, and the columnar decoders allocate the output slice as `count * elemSize` **before** reading any column body. The element-count ceiling does not bound that allocation — a constant / RLE / zero-width column legitimately expands a few wire bytes to `n` elements, so a ~1 KB hostile header amplifies into a multi-hundred-MB / multi-GB allocation. Measured: a **1.1 KB input materialized 8.4M structs (~335 MB)**; a wider struct scales to several GB.

Fix: add `maxColumnarBytes` (256 MiB) + `checkColumnarBytes(n, elemSize)` and reject before each output allocation on the reflect path (`decodeColumnar`, `decodeColumnarQuery` — before `runQueryColumns` materializes per-column scratch — and `decodeHybridColumnar`). Export `CheckColumnarBytes` and emit the same guard from `cmd/qdfgen` after `ReadColStructHeader`/`ReadHybridColStructHeader`; regenerate the `codegen_test` and `qdf-bench` fixtures. A legitimate batch is orders of magnitude under the ceiling; callers with larger batches shard or stream (already documented). RED-verified with `TestColumnarDecodeMemoryAmplification`.

## Clean (swept, no findings)
integer QPack codecs (FOR/Delta/RLE/Dict/PFOR inverse + never-larger + hostile bounds); float codecs (Gorilla/ALP bit-exact incl NaN/-0.0/Inf via Float bits); FSST + rANS (never-larger, origLen bound, truncated/corrupt → clean error); columnar query 3VL (And/Or/Not over nullable vs a Kleene oracle, colVals field selection, OptColumnIndex skip, matchedIndices); SIMD bitpack scalar/SIMD parity for all widths 1..56 (200k+ differential; arm64 NEON WORD-opcode read-audited); streaming (cross-message intern across window grow, truncated-read latch, Reset) + canonical determinism; nullable columns (presence mask padding/popcount, all-nil/all-present, byte-boundary n).

## Gate
`go test` + `-race` (full); gofmt; `golangci-lint` v2 = 0 (main + qdfgen); `FuzzDecoder_NeverPanics`; `codegen_test` (both phases) + `qdfgen` build/lint; `qdf-bench` regenerated, build + vet. All green.

(Note: the agents left a few untracked throwaway probe `*_test.go` files in the tree during the run; removed.)