### PR TITLE
feat(codegen): intern-aware columnar gate — match reflect after alpha/hybrid

### DIFF
--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -1172,7 +1172,15 @@ func (g *gen) emitEncodeColumnarSlice(w io.Writer, expr string, elem types.Type,
 			fmt.Fprintf(w, "%s\t%s := make([]string, min(len(%s), 32))\n", indent, pb, s)
 			fmt.Fprintf(w, "%s\tfor i := range %s { %s[i] = string(%s[i].%s) }\n", indent, pb, pb, s, c.Access)
 		}
-		fmt.Fprintf(w, "%s\t%s := qdf.StringColumnsBeneficial(%s)\n", indent, ben, strings.Join(pbs, ", "))
+		// A hybrid string-only element (residual map/slice fields, no numeric
+		// column) uses the intern-aware gate so codegen flips it into the columnar
+		// form — and alpha-packs a restricted-alphabet ID column — exactly when
+		// reflect does; a pure string-only element keeps the plain gate.
+		benFn := "StringColumnsBeneficial"
+		if plan.hybrid() {
+			benFn = "StringColumnsBeneficialHybrid"
+		}
+		fmt.Fprintf(w, "%s\t%s := qdf.%s(%s)\n", indent, ben, benFn, strings.Join(pbs, ", "))
 		fmt.Fprintf(w, "%s\tif %s {\n", indent, ben)
 		if err := g.emitEncodeColumnarFrame(w, s, plan, indent+"\t\t"); err != nil {
 			return err

--- a/cmd/qdfgen/gen/gen_internaware_test.go
+++ b/cmd/qdfgen/gen/gen_internaware_test.go
@@ -1,0 +1,44 @@
+package gen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestColumnarGate_InternAwareForHybrid pins that the generated columnar gate for
+// a string-only element matches the reflect probe: a HYBRID string-only element
+// (residual fields, no numeric) uses StringColumnsBeneficialHybrid (intern-aware
+// + alpha), while a PURE string-only element keeps the plain StringColumnsBeneficial.
+func TestColumnarGate_InternAwareForHybrid(t *testing.T) {
+	gen := func(t *testing.T, types ...string) string {
+		t.Helper()
+		out := filepath.Join(t.TempDir(), "out.go")
+		if err := Generate([]string{"./testdata/internaware"}, Options{Types: types, OutFile: out}); err != nil {
+			t.Fatalf("Generate(%v): %v", types, err)
+		}
+		b, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("read output: %v", err)
+		}
+		return string(b)
+	}
+
+	t.Run("hybrid_string_only_uses_intern_aware_gate", func(t *testing.T) {
+		src := gen(t, "HybridStrHolder", "HybridStrElem")
+		if !strings.Contains(src, "StringColumnsBeneficialHybrid(") {
+			t.Fatalf("hybrid string-only element must gate columnar via StringColumnsBeneficialHybrid:\n%s", src)
+		}
+	})
+
+	t.Run("pure_string_only_uses_plain_gate", func(t *testing.T) {
+		src := gen(t, "PureStrHolder", "PureStrElem")
+		if strings.Contains(src, "StringColumnsBeneficialHybrid(") {
+			t.Fatalf("pure string-only element must NOT use the intern-aware gate:\n%s", src)
+		}
+		if !strings.Contains(src, "StringColumnsBeneficial(") {
+			t.Fatalf("pure string-only element must gate columnar via StringColumnsBeneficial:\n%s", src)
+		}
+	})
+}

--- a/cmd/qdfgen/gen/testdata/internaware/types.go
+++ b/cmd/qdfgen/gen/testdata/internaware/types.go
@@ -1,0 +1,28 @@
+package internaware
+
+// HybridStrElem is a string-ONLY element with a residual map field (no numeric,
+// no time): a HYBRID string-only element. Its columnar gate in generated code
+// must be the intern-aware StringColumnsBeneficialHybrid so it flips into the
+// columnar form (and alpha-packs a restricted-alphabet ID) exactly when reflect
+// does.
+type HybridStrElem struct {
+	Span string            `qdf:"span"`
+	Tags map[string]string `qdf:"tags"`
+}
+
+// HybridStrHolder holds a slice of the hybrid element so the columnar transpose
+// fires on the field.
+type HybridStrHolder struct {
+	Items []HybridStrElem `qdf:"items"`
+}
+
+// PureStrElem is a string-ONLY element with NO residual: a PURE string-only
+// element. Its gate must remain the plain StringColumnsBeneficial.
+type PureStrElem struct {
+	A string `qdf:"a"`
+	B string `qdf:"b"`
+}
+
+type PureStrHolder struct {
+	Items []PureStrElem `qdf:"items"`
+}

--- a/colcodegen.go
+++ b/colcodegen.go
@@ -454,13 +454,21 @@ func (d *Decoder) ReadHybridColStructHeader() (int, []string, []byte, error) {
 func (d *Decoder) ClearColMaxLen() { d.colMaxLen = 0 }
 
 // stringColumnsBeneficial samples the given string columns and reports whether a
-// dictionary string column would beat plain per-value row-major encoding by the
-// columnar min-gain threshold. Reflection-free; reuses bitsForDistinct and the
-// same estimate the reflect columnarProbe uses for colKindString. Generated
-// code calls this only for string-ONLY elements (any numeric/time column makes
-// columnar unconditionally beneficial), so a high-cardinality string struct
-// (e.g. unique names) stays row-major exactly as the reflect probe decides.
-func stringColumnsBeneficial(cols ...[]string) bool {
+// columnar string column would beat plain per-value row-major encoding by the
+// min-gain threshold. Reflection-free; it mirrors the reflect columnarProbe's
+// colKindString branch byte-for-byte so the generated code makes the SAME
+// columnar-vs-row-major decision as reflect.
+//
+// internAware selects the model the reflect probe uses for the element kind:
+//   - false (a PURE string-only element): per-value / dict estimate, gain 10 —
+//     identical to columnarProbe with internAware=false.
+//   - true (a HYBRID string-only element, i.e. residual map/slice fields with no
+//     numeric column): additionally credits Dense intern dedup in the row-major
+//     baseline (a repeat costs 1 byte) AND alpha-packing on a restricted-alphabet
+//     high-cardinality column, with the wider gain 30 — identical to
+//     columnarProbe with internAware=true. Without this a hybrid hex-ID element
+//     would stay row-major in codegen while reflect goes columnar + alpha.
+func stringColumnsBeneficial(internAware bool, cols ...[]string) bool {
 	if len(cols) == 0 || len(cols[0]) == 0 {
 		return false
 	}
@@ -469,9 +477,12 @@ func stringColumnsBeneficial(cols ...[]string) bool {
 	for _, strs := range cols {
 		var seen [columnarProbeSample]string
 		nseen := 0
-		var tableBytes, perValue int
+		var tableBytes, perValue, sampleChars int
 		prev := ""
 		first := true
+		var alphaSeen [256]bool
+		alphaCount := 0
+		alphaOK := internAware
 		for i := range sample {
 			s := strs[i]
 			fresh := true
@@ -491,19 +502,58 @@ func stringColumnsBeneficial(cols ...[]string) bool {
 			} else {
 				perValue += 2 + len(s)
 			}
-			rowBytes += 2 + len(s)
+			if internAware && !fresh {
+				rowBytes += 1
+			} else {
+				rowBytes += 2 + len(s)
+			}
 			prev = s
 			first = false
+			if alphaOK {
+				sampleChars += len(s)
+				for k := 0; k < len(s); k++ {
+					if !alphaSeen[s[k]] {
+						if alphaCount >= qpackStrAlphaMaxAlphabet {
+							alphaOK = false
+							break
+						}
+						alphaSeen[s[k]] = true
+						alphaCount++
+					}
+				}
+			}
 		}
 		dictBytes := tableBytes + (sample*bitsForDistinct(nseen)+7)/8
-		colBytes += min(perValue, dictBytes)
+		best := min(perValue, dictBytes)
+		if alphaOK && alphaCount >= 2 &&
+			nseen*100 >= sample*alphaMinDistinctPct &&
+			sampleChars >= sample*alphaProbeMinAvgLen {
+			alphaEst := alphaCount + sample + (sampleChars*bitsForDistinct(alphaCount)+7)/8
+			if alphaEst < best {
+				best = alphaEst
+			}
+		}
+		colBytes += best
 	}
 	if rowBytes == 0 {
 		return false
 	}
-	return colBytes*100 <= rowBytes*(100-columnarMinGainPct)
+	gain := columnarMinGainPct
+	if internAware {
+		gain = columnarMinGainPctInternAware
+	}
+	return colBytes*100 <= rowBytes*(100-gain)
 }
 
-// StringColumnsBeneficial is the exported entry generated code calls to gate a
-// string-only element's columnar encode (see stringColumnsBeneficial).
-func StringColumnsBeneficial(cols ...[]string) bool { return stringColumnsBeneficial(cols...) }
+// StringColumnsBeneficial gates a PURE string-only element's columnar encode in
+// generated code (mirrors columnarProbe with internAware=false).
+func StringColumnsBeneficial(cols ...[]string) bool { return stringColumnsBeneficial(false, cols...) }
+
+// StringColumnsBeneficialHybrid gates a HYBRID (residual-bearing) string-only
+// element's columnar encode in generated code (mirrors columnarProbe with
+// internAware=true: intern-credited baseline + alpha-packing estimate + the
+// wider gain), so codegen flips such an element into the columnar form exactly
+// when reflect does.
+func StringColumnsBeneficialHybrid(cols ...[]string) bool {
+	return stringColumnsBeneficial(true, cols...)
+}

--- a/colcodegen_internaware_test.go
+++ b/colcodegen_internaware_test.go
@@ -1,0 +1,83 @@
+package qdf
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+)
+
+// hybridHexRec is a string-only HYBRID element whose string columns are ALL
+// high-cardinality restricted-alphabet (hex) IDs + a residual map, NO numeric
+// and NO low-card enum column. This is exactly the case the OLD codegen gate
+// (StringColumnsBeneficial) declines (dict/per-value ≈ raw) but the intern-aware
+// reflect path accepts (alpha-packs the hex) — the divergence the hybrid gate
+// closes.
+type hybridHexRec struct {
+	Span   string            `qdf:"span"`
+	Parent string            `qdf:"parent"`
+	Tags   map[string]string `qdf:"tags"`
+}
+
+func mkHybridHexRecs(n int) []hybridHexRec {
+	r := rand.New(rand.NewSource(7))
+	hex := func(ln int) string {
+		const h = "0123456789abcdef"
+		b := make([]byte, ln)
+		for j := range b {
+			b[j] = h[r.Intn(16)]
+		}
+		return string(b)
+	}
+	out := make([]hybridHexRec, n)
+	for i := range out {
+		out[i] = hybridHexRec{Span: hex(16), Parent: hex(16), Tags: map[string]string{"k": "v"}}
+	}
+	return out
+}
+
+func hasByte(b []byte, x byte) bool { return bytes.IndexByte(b, x) >= 0 }
+
+// TestCodegenGate_MatchesReflectInternAware: for a hybrid hex-only element the
+// reflect path flips it into a columnar (hybrid) frame and alpha-packs the IDs;
+// the NEW codegen gate (StringColumnsBeneficialHybrid) agrees, while the OLD gate
+// (StringColumnsBeneficial) would have kept codegen row-major — the divergence.
+func TestCodegenGate_MatchesReflectInternAware(t *testing.T) {
+	recs := mkHybridHexRecs(2000)
+	b, err := Marshal(recs, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasByte(b, tagHybridColStruct) {
+		t.Fatalf("reflect did not emit a hybrid columnar frame for the hybrid hex element (wire=%d)", len(b))
+	}
+	spans := make([]string, len(recs))
+	parents := make([]string, len(recs))
+	for i, r := range recs {
+		spans[i] = r.Span
+		parents[i] = r.Parent
+	}
+	if !StringColumnsBeneficialHybrid(spans, parents) {
+		t.Fatalf("codegen hybrid gate declined columnar where reflect accepted it (divergence)")
+	}
+	if StringColumnsBeneficial(spans, parents) {
+		t.Fatalf("expected the plain gate to decline (the gap the hybrid gate closes); it accepted")
+	}
+}
+
+// TestCodegenGate_ConservativeStaysRowMajor: a hybrid element whose string column
+// does NOT compress (full-alphabet high-card) must be declined by the hybrid gate
+// too, so codegen and reflect both keep it row-major.
+func TestCodegenGate_ConservativeStaysRowMajor(t *testing.T) {
+	r := rand.New(rand.NewSource(9))
+	cols := make([]string, 2000)
+	for i := range cols {
+		b := make([]byte, 24)
+		for j := range b {
+			b[j] = byte(32 + r.Intn(95))
+		}
+		cols[i] = string(b)
+	}
+	if StringColumnsBeneficialHybrid(cols) {
+		t.Fatalf("hybrid gate accepted an incompressible full-alphabet column (would bloat)")
+	}
+}

--- a/colcodegen_test.go
+++ b/colcodegen_test.go
@@ -224,14 +224,14 @@ func TestStringColumnsBeneficial(t *testing.T) {
 	for i := range lowCard {
 		lowCard[i] = []string{"GET", "POST", "PUT"}[i%3]
 	}
-	if !stringColumnsBeneficial(lowCard) {
+	if !stringColumnsBeneficial(false, lowCard) {
 		t.Fatal("low-cardinality string column should be columnar-beneficial")
 	}
 	highCard := make([]string, 64)
 	for i := range highCard {
 		highCard[i] = "unique-value-" + string(rune('a'+i%26)) + string(rune('0'+i%10)) + string(rune('A'+(i*7)%26))
 	}
-	if stringColumnsBeneficial(highCard) {
+	if stringColumnsBeneficial(false, highCard) {
 		t.Fatal("high-cardinality string column should stay row-major")
 	}
 }


### PR DESCRIPTION
## What

After the **alphabet-packed codec** + **intern-aware Balanced-hybrid probe** landed in the reflect path, the **codegen (qdfgen) columnar decision diverged**. A generated `[]struct` field whose element is a **hybrid string-only** struct (string columns + residual map/slice, *no numeric/time*) gated its columnar encode through `StringColumnsBeneficial` — a copy of the **old** `columnarProbe` string estimate (plain per-value/dict model, gain 10, no alpha credit). The reflect path now flips such an element into a columnar frame and **alpha-packs** a restricted-alphabet ID column.

Result: for a hybrid hex-ID element **codegen stayed row-major while reflect went columnar+alpha** — different wire and a missed win.

## Fix

Sync the codegen gate with the reflect probe byte-for-byte:
- `stringColumnsBeneficial` gains an `internAware` parameter mirroring `columnarProbe`'s `colKindString` branch (intern-credited rowBytes, alpha-packing estimate, wider gain 30).
- New `StringColumnsBeneficialHybrid` (internAware=true) for **hybrid** string-only elements; `StringColumnsBeneficial` (internAware=false) stays for **pure** string-only elements.
- `gen.go` emits the hybrid gate when `plan.hybrid()`, else the plain gate.

## Consistency audit (codegen vs reflect after alpha/intern-aware/SIMD)

| aspect | status |
|---|---|
| DECODE alpha + AVX2/NEON (`ReadStringColumn`→`readStringColumn`) | ✅ already consistent |
| ENCODE alpha codec (`WriteStringColumn`→`writeStringColumn`) | ✅ already consistent (alpha is mode-independent) |
| ENCODE columnar **decision** for hybrid string-only | ✅ **fixed here** |
| codegen Fast-mode value-intern/MTF (Phase 2c) | ⚠️ pre-existing, documented separate follow-up — not alpha-related |

Pure-string-only and mixed (numeric-bearing) elements are **unchanged** — verified by regenerating the `cmd/qdf-bench` fixtures **byte-identical**.