### PR TITLE
fix(rans): worst-case encode buffer overflow + feat(qpack): ALP float32 codec

### DIFF
--- a/alp_float32_test.go
+++ b/alp_float32_test.go
@@ -60,7 +60,7 @@ func TestALPFloat32Fires(t *testing.T) {
 // bit-exactly via the exception list.
 func TestALPFloat32Exceptions(t *testing.T) {
 	r := rand.New(rand.NewSource(5))
-	for iter := 0; iter < 200; iter++ {
+	for iter := range 200 {
 		n := 16 + r.Intn(300)
 		v := make([]float32, n)
 		for i := range v {

--- a/alp_float32_test.go
+++ b/alp_float32_test.go
@@ -1,0 +1,99 @@
+package qdf
+
+import (
+	"math"
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+type alp32row struct {
+	V []float32 `qdf:"v"`
+}
+
+// TestALPFloat32Fires: a quantized float32 column compresses via ALP under
+// OptCompression (well below raw 4 bytes/val) and round-trips bit-exactly.
+func TestALPFloat32Fires(t *testing.T) {
+	n := 2000
+	v := make([]float32, n)
+	for i := range v {
+		// float32-nearest-to-decimal (e.g. a sensor/price value stored as float32):
+		// v = round-to-f32(k/10). round(v*10) == k and f32(k/10) == v, so it packs
+		// as an integer mantissa with no exceptions. (Computing it as f32*f32, e.g.
+		// float32(i)*0.1, would NOT match the f64 reconstruction and falls to the
+		// exception path — that is float-arithmetic noise, not clean decimal data.)
+		v[i] = float32(float64(2050+i) / 10)
+	}
+	in := alp32row{V: v}
+	// OptBalanced|OptGorillaFloat enables ALP but NOT the whole-body rANS pass, so
+	// the wire reflects the column codec directly: ALP must fire (Gorilla declines
+	// on decimal data) and the body collapses to ~ceil(log2 range) bits/value.
+	b, err := Marshal(in, OptBalanced|OptGorillaFloat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := 2 + uvarintLen(uint64(n)) + n*4
+	hasALP := false
+	for i := 0; i+1 < len(b); i++ {
+		if b[i] == tagPackALP && b[i+1] == qpackKindFloat32 {
+			hasALP = true
+			break
+		}
+	}
+	if !hasALP {
+		t.Fatalf("ALP float32 did not fire (no tagPackALP/kindFloat32); wire=%d raw=%d", len(b), raw)
+	}
+	if len(b)*2 >= raw { // ALP ~11 bits/val vs raw 32 → well under half
+		t.Fatalf("ALP float32 wire %d not << raw %d", len(b), raw)
+	}
+	var out alp32row
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip mismatch")
+	}
+	t.Logf("wire=%d raw=%d (%.1f bits/val)", len(b), raw, float64(len(b)*8)/float64(n))
+}
+
+// TestALPFloat32Exceptions: NaN / ±Inf / -0.0 / irrational values round-trip
+// bit-exactly via the exception list.
+func TestALPFloat32Exceptions(t *testing.T) {
+	r := rand.New(rand.NewSource(5))
+	for iter := 0; iter < 200; iter++ {
+		n := 16 + r.Intn(300)
+		v := make([]float32, n)
+		for i := range v {
+			switch r.Intn(8) {
+			case 0:
+				v[i] = float32(math.NaN())
+			case 1:
+				v[i] = float32(math.Inf(1))
+			case 2:
+				v[i] = float32(math.Inf(-1))
+			case 3:
+				v[i] = float32(math.Copysign(0, -1)) // -0.0
+			case 4:
+				v[i] = math.Float32frombits(r.Uint32()) // arbitrary bits
+			default:
+				v[i] = float32(r.Intn(100000)) * 0.01 // decimal
+			}
+		}
+		in := alp32row{V: v}
+		for _, opt := range []Options{OptBalanced, OptCompression, OptBalanced | OptGorillaFloat} {
+			b, err := Marshal(in, opt)
+			if err != nil {
+				t.Fatalf("iter %d opt %d: %v", iter, opt, err)
+			}
+			var out alp32row
+			if err := Unmarshal(b, &out); err != nil {
+				t.Fatalf("iter %d opt %d: %v", iter, opt, err)
+			}
+			for i := range v {
+				if math.Float32bits(out.V[i]) != math.Float32bits(v[i]) {
+					t.Fatalf("iter %d opt %d [%d]: bits %x != %x", iter, opt, i, math.Float32bits(out.V[i]), math.Float32bits(v[i]))
+				}
+			}
+		}
+	}
+}

--- a/decoder_skip.go
+++ b/decoder_skip.go
@@ -362,7 +362,12 @@ func (d *Decoder) Skip() error {
 		if d.i >= len(d.buf) {
 			return ErrShortBuffer
 		}
-		if d.buf[d.i] != qpackKindFloat64 {
+		excValBytes := 8 // float64 exception value width
+		switch d.buf[d.i] {
+		case qpackKindFloat64:
+		case qpackKindFloat32:
+			excValBytes = 4
+		default:
 			return ErrTypeMismatch
 		}
 		d.i++ // kind
@@ -415,10 +420,10 @@ func (d *Decoder) Skip() error {
 				return ErrInvalidLength
 			}
 			d.i += nr
-			if d.i+8 > len(d.buf) {
+			if d.i+excValBytes > len(d.buf) {
 				return ErrShortBuffer
 			}
-			d.i += 8
+			d.i += excValBytes
 		}
 		return nil
 	case tagPackDeltaFor:

--- a/frontcoding_test.go
+++ b/frontcoding_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -151,11 +152,11 @@ func TestFrontCodedRoundTripOracle(t *testing.T) {
 		card := 1 + r(260)
 		pool := make([]string, card)
 		for i := range pool {
-			suf := ""
+			var suf strings.Builder
 			for j := 0; j < r(6); j++ {
-				suf += string(rune('a' + r(26)))
+				suf.WriteString(string(rune('a' + r(26))))
 			}
-			pool[i] = pfx + suf
+			pool[i] = pfx + suf.String()
 			switch {
 			case r(20) == 0:
 				pool[i] = pfx // prefix-of-another / dup

--- a/internal/bitpack/hex4_test.go
+++ b/internal/bitpack/hex4_test.go
@@ -7,7 +7,7 @@ import (
 
 // hex4Ref is an independent byte-at-a-time reference for DecodeHex4.
 func hex4Ref(dst, src []byte, lut *[16]byte) {
-	for k := 0; k < len(dst); k++ {
+	for k := range dst {
 		b := src[k>>1]
 		if k&1 == 0 {
 			dst[k] = lut[b&0x0f]

--- a/internal/rans/rans.go
+++ b/internal/rans/rans.go
@@ -14,6 +14,14 @@ const (
 	scaleBits = 12
 	scale     = 1 << scaleBits // 4096; frequencies are normalized to sum to this
 	ransByteL = 1 << 23        // renormalization lower bound
+	// maxRenormBytesPerSym bounds the renorm bytes a single symbol can emit: the
+	// state lives in [ransByteL, ransByteL<<8) = [2^23, 2^31) and a freq-1 symbol
+	// has xMax = (ransByteL>>scaleBits)<<8 = 2^19, so the `for x >= xMax { x>>=8 }`
+	// renorm runs at most ceil((31-19)/8) = 2 times. Output buffers are sized as
+	// len*maxRenormBytesPerSym + state + slack so the backward writer never
+	// underflows, even when a (sub)stream's local byte distribution is skewed
+	// against the frequency table it is encoded under.
+	maxRenormBytesPerSym = 2
 )
 
 // Format tags for the leading byte of a rANS blob.
@@ -107,7 +115,14 @@ func buildSlot(cum *[257]uint32, slot *[scale]byte) {
 // encodeStream rANS-encodes src and returns the stream: 4-byte little-endian
 // final state followed by the renormalization bytes in decode order.
 func encodeStream(src []byte, freq *[256]uint32, cum *[257]uint32) []byte {
-	size := len(src) + 16
+	// Worst-case output: each symbol emits at most maxRenormBytesPerSym renorm
+	// bytes (a freq-1 symbol over the scale=2^12 table renormalizes a state in
+	// [2^23, 2^31) down past xMax=2^19, i.e. two >>8 steps), plus the 4-byte final
+	// state. len(src)+16 under-sizes this when a stream is dominated by globally-
+	// rare bytes — most visible in the interleaved path, where a substream sees a
+	// local distribution skewed against the SHARED table (see encodeStreamStrided-
+	// Into). Size for the proven bound so the backward writer can never underflow.
+	size := len(src)*maxRenormBytesPerSym + 16
 	buf := make([]byte, size)
 	pos := size
 	x := uint32(ransByteL)

--- a/internal/rans/rans_interleaved.go
+++ b/internal/rans/rans_interleaved.go
@@ -3,8 +3,9 @@ package rans
 import "encoding/binary"
 
 // encodeStreamStridedInto rANS-encodes the substream src[k], src[k+n], … into
-// the caller-provided buf (which must have len >= m+16, where m is the element
-// count) and returns buf[pos:] = [4-byte LE final state][renorm bytes]. Writing
+// the caller-provided buf (which must have len >= m*maxRenormBytesPerSym+16,
+// where m is the element count) and returns buf[pos:] = [4-byte LE final state]
+// [renorm bytes]. Writing
 // into a caller buffer lets appendInterleaved place all N substreams in one
 // allocation, avoiding the per-substream make() (and its size-class rounding).
 func encodeStreamStridedInto(buf, src []byte, k, n int, freq *[256]uint32, cum *[257]uint32) []byte {
@@ -43,17 +44,22 @@ func appendInterleaved(dst, src []byte, freq *[256]uint32, cum *[257]uint32, n i
 	var subsArr [maxInterleaveN][]byte
 	states := statesArr[:n]
 	subs := subsArr[:n]
-	// One allocation for every substream's output. Region k spans m_k+16 bytes
-	// (the encodeStream worst case); the regions sum to len(src)+n*16.
-	scratch := make([]byte, len(src)+n*16)
+	// One allocation for every substream's output. Each substream is encoded under
+	// the SHARED freq table, so its local distribution can be skewed against that
+	// table and emit up to maxRenormBytesPerSym bytes per symbol — region k must
+	// span m_k*maxRenormBytesPerSym+16 bytes (NOT m_k+16, which assumes <=1 byte/
+	// symbol and underflows the backward writer on rare-byte-heavy substreams). The
+	// regions sum to len(src)*maxRenormBytesPerSym + n*16.
+	scratch := make([]byte, len(src)*maxRenormBytesPerSym+n*16)
 	off := 0
 	for k := range n {
 		m := max((len(src)-k+n-1)/n, 0)
-		region := scratch[off : off+m+16]
+		sz := m*maxRenormBytesPerSym + 16
+		region := scratch[off : off+sz]
 		blob := encodeStreamStridedInto(region, src, k, n, freq, cum) // [4-byte state][bytes]; always >= 4 bytes
 		states[k] = binary.LittleEndian.Uint32(blob[:4])
 		subs[k] = blob[4:]
-		off += m + 16
+		off += sz
 	}
 	var s4 [4]byte
 	for k := range n {

--- a/internal/rans/rans_test.go
+++ b/internal/rans/rans_test.go
@@ -44,6 +44,7 @@ func FuzzRoundTrip(f *testing.F) {
 	f.Add(bytes.Repeat([]byte{1, 2, 3}, 100))
 	f.Add(bytes.Repeat([]byte{1, 2, 3}, 5000))                // ≥ interleaveMinBytes → interleaved path
 	f.Add(bytes.Repeat([]byte("the quick brown fox "), 1000)) // skewed, large → interleaved
+	f.Add(adversarialRareSubstream(8000))                     // rare-byte substream → worst-case region
 	f.Fuzz(func(t *testing.T, src []byte) {
 		enc := Encode(nil, src)
 		got, err := Decode(enc, len(src))
@@ -81,6 +82,45 @@ func TestRoundTrip_Basic(t *testing.T) {
 		}
 		if !bytes.Equal(got, src) {
 			t.Fatalf("case %d: round-trip mismatch\n got=%v\nwant=%v", i, got, src)
+		}
+	}
+}
+
+// adversarialRareSubstream builds a stream whose interleaved substream 0 is
+// dominated by globally-rare bytes: every position is 0x00 (huge frequency)
+// except positions ≡0 mod interleaveN, which cycle through 1..255 (each a low,
+// often freq-1 symbol). Encoded under the SHARED freq table, substream 0 emits
+// ~maxRenormBytesPerSym bytes/symbol — overflowing the old m+16 region.
+func adversarialRareSubstream(nElems int) []byte {
+	src := make([]byte, nElems)
+	r := byte(1)
+	for i := range src {
+		if i%4 == 0 {
+			src[i] = r
+			r++
+			if r == 0 {
+				r = 1
+			}
+		}
+	}
+	return src
+}
+
+// TestEncode_AdversarialSubstreamNoOverflow is a regression for the interleaved
+// rANS encode buffer underflow: a substream skewed against the shared frequency
+// table emits up to 2 bytes/symbol, which the old len(src)+16 region under-sized
+// → index-out-of-range panic. Encode must now size for the worst case and the
+// stream must round-trip.
+func TestEncode_AdversarialSubstreamNoOverflow(t *testing.T) {
+	for _, n := range []int{2000, 5000, 9000, 40000} {
+		src := adversarialRareSubstream(n)
+		enc := Encode(nil, src) // must not panic
+		got, err := Decode(enc, len(src))
+		if err != nil {
+			t.Fatalf("n=%d decode err: %v", n, err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatalf("n=%d round-trip mismatch", n)
 		}
 	}
 }

--- a/qpack_alp.go
+++ b/qpack_alp.go
@@ -185,6 +185,239 @@ func (e *Encoder) writePackedALPFloat64Slice(s []float64, plan alpFloatPlan) {
 	e.buf = out
 }
 
+// --- float32 ALP (qpackKindFloat32) ---
+//
+// Identical scheme to the float64 path: integer mantissas I = round(v * 10^d)
+// FOR-bit-packed, plus an exception list for any value that does not reconstruct
+// bit-for-bit. The mantissa is computed in float64 (exact for the integers ALP
+// targets) and the round-trip is checked against the float32 bits; exception
+// values are stored as 4-byte float32 patterns, not 8. The 23-bit float32
+// mantissa makes the typical FOR width narrower than float64.
+
+// alpMantissaF32 returns the integer mantissa round(v*10^d) (pe=10^d) and whether
+// it reconstructs v bit-for-bit as a float32 (ie=10^-d) — i.e. whether the value
+// packs as a mantissa or falls to the exception list. The mantissa is computed
+// through float64 so it stays exact for values needing more than float32's 24-bit
+// significand (a float32-only round would mis-round those into extra exceptions).
+// Bit comparison (not ==) keeps -0.0/NaN/±Inf as exceptions. Centralises the one
+// float32↔float64↔int64 chain the score / pack / exception passes all share.
+func alpMantissaF32(v float32, pe, ie float64) (mant int64, exact bool) {
+	I := int64(math.RoundToEven(float64(v) * pe))
+	return I, math.Float32bits(float32(float64(I)*ie)) == math.Float32bits(v)
+}
+
+// alpScoreExpF32 evaluates one effective exponent d over s (float32 bit-exact
+// round-trip). Mirrors alpScoreExp.
+func alpScoreExpF32(s []float32, d int) (forMin int64, width uint8, exc int) {
+	pe := alpPow10[d]
+	ie := alpInv10[d]
+	mn := int64(math.MaxInt64)
+	mx := int64(math.MinInt64)
+	for _, v := range s {
+		I, ok := alpMantissaF32(v, pe, ie)
+		if !ok {
+			exc++
+			continue
+		}
+		if I < mn {
+			mn = I
+		}
+		if I > mx {
+			mx = I
+		}
+	}
+	if mn > mx {
+		return 0, 0, exc
+	}
+	return mn, uint8(bits.Len64(uint64(mx - mn))), exc
+}
+
+// alpChooseExpF32 samples ~32 values to pick the cheapest effective exponent.
+func alpChooseExpF32(s []float32) int {
+	const sampleN = 32
+	sample := s
+	if len(s) > sampleN {
+		sample = make([]float32, 0, sampleN)
+		step := len(s) / sampleN
+		for i := 0; i < len(s); i += step {
+			sample = append(sample, s[i])
+		}
+	}
+	bestD, bestCost := 0, math.MaxInt64
+	for d := 0; d <= alpMaxExpSearch; d++ {
+		_, w, exc := alpScoreExpF32(sample, d)
+		cost := (int(w)*len(sample)+7)/8 + exc*6 // exc value is 4 bytes here
+		if cost < bestCost {
+			bestCost, bestD = cost, d
+		}
+	}
+	return bestD
+}
+
+// alpPlanFloat32 chooses the exponent, scores the block, and returns a
+// conservative upper bound on the encoded size (exception value = 4 bytes).
+func alpPlanFloat32(s []float32) (plan alpFloatPlan, estBytes int, ok bool) {
+	n := len(s)
+	if n == 0 {
+		return alpFloatPlan{}, 2 + 1, true
+	}
+	if n > alpMaxElems {
+		return alpFloatPlan{}, 0, false
+	}
+	d := alpChooseExpF32(s)
+	forMin, width, exc := alpScoreExpF32(s, d)
+	if width > qpackForMaxBits {
+		return alpFloatPlan{}, 0, false
+	}
+	if exc >= n {
+		return alpFloatPlan{}, 0, false
+	}
+	plan = alpFloatPlan{d: d, forMin: forMin, width: width, exc: exc}
+	body := (int(width)*n + 7) / 8
+	estBytes = 2 + uvarintLen(uint64(n)) + 1 + uvarintLen(zigzagEncode64(forMin)) +
+		1 + body + uvarintLen(uint64(exc)) + exc*(5+4)
+	return plan, estBytes, true
+}
+
+// writePackedALPFloat32Slice emits s under ALP using a pre-computed plan.
+func (e *Encoder) writePackedALPFloat32Slice(s []float32, plan alpFloatPlan) {
+	e.writeHeader()
+	n := len(s)
+	out := slices.Grow(e.buf, 2+10+1+10+1+(int(plan.width)*n+7)/8+10+plan.exc*(5+4))
+	out = append(out, tagPackALP, qpackKindFloat32)
+	out = appendUvarint(out, uint64(n))
+	if n == 0 {
+		e.buf = out
+		return
+	}
+	out = append(out, byte(plan.d))
+	out = appendUvarint(out, zigzagEncode64(plan.forMin))
+	out = append(out, plan.width)
+
+	pe := alpPow10[plan.d]
+	ie := alpInv10[plan.d]
+
+	if plan.width > 0 {
+		if cap(e.alpScratch) < n {
+			e.alpScratch = make([]uint64, n)
+		}
+		packed := e.alpScratch[:n]
+		clear(packed) // exception slots stay 0 (never written in the loop)
+		for i, v := range s {
+			if I, ok := alpMantissaF32(v, pe, ie); ok {
+				packed[i] = uint64(I - plan.forMin)
+			}
+		}
+		bodyBytes := (int(plan.width)*n + 7) / 8
+		base := len(out)
+		out = append(out, make([]byte, bodyBytes)...)
+		bitpack.Pack(out[base:], packed, int(plan.width))
+	}
+
+	out = appendUvarint(out, uint64(plan.exc))
+	for i, v := range s {
+		if _, ok := alpMantissaF32(v, pe, ie); !ok {
+			out = appendUvarint(out, uint64(i))
+			out = appendU32(out, math.Float32bits(v))
+		}
+	}
+	e.buf = out
+}
+
+// readPackedALPFloat32Slice decodes a float32 ALP payload. The cursor (d.i) must
+// point at the kind byte. Bounds mirror readPackedALPFloat64Slice; exception
+// values are 4 bytes.
+func (d *Decoder) readPackedALPFloat32Slice() ([]float32, error) {
+	if d.i >= len(d.buf) {
+		return nil, ErrShortBuffer
+	}
+	if d.buf[d.i] != qpackKindFloat32 {
+		return nil, ErrTypeMismatch
+	}
+	d.i++
+	n64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, ErrInvalidLength
+	}
+	d.i += nr
+	if n64 == 0 {
+		return []float32{}, nil
+	}
+	if n64 > alpMaxElems {
+		return nil, ErrInvalidLength
+	}
+	if d.i >= len(d.buf) {
+		return nil, ErrShortBuffer
+	}
+	expD := int(d.buf[d.i])
+	d.i++
+	if expD > alpMaxExp {
+		return nil, ErrBadTag
+	}
+	fm64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, ErrInvalidLength
+	}
+	d.i += nr
+	forMin := zigzagDecode64(fm64)
+	if d.i >= len(d.buf) {
+		return nil, ErrShortBuffer
+	}
+	width := int(d.buf[d.i])
+	d.i++
+	if width > qpackForMaxBits {
+		return nil, ErrBadTag
+	}
+	rem := uint64(len(d.buf) - d.i)
+	if width > 0 && n64 > rem*8/uint64(width) {
+		return nil, ErrShortBuffer
+	}
+	n := int(n64)
+	ie := alpInv10[expD]
+	out := make([]float32, n)
+	if width > 0 {
+		bodyBytes := int((n64*uint64(width) + 7) / 8)
+		if cap(d.deltaScratch) < n {
+			d.deltaScratch = make([]uint64, n)
+		}
+		packed := d.deltaScratch[:n]
+		bitpack.Unpack(packed, d.buf[d.i:d.i+bodyBytes], width)
+		d.i += bodyBytes
+		for i := range out {
+			out[i] = float32(float64(int64(packed[i])+forMin) * ie)
+		}
+	} else {
+		fv := float32(float64(forMin) * ie)
+		for i := range out {
+			out[i] = fv
+		}
+	}
+	excN, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, ErrInvalidLength
+	}
+	d.i += nr
+	if excN > n64 {
+		return nil, ErrInvalidLength
+	}
+	for range excN {
+		pos64, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return nil, ErrInvalidLength
+		}
+		d.i += nr
+		if pos64 >= n64 {
+			return nil, ErrInvalidLength
+		}
+		if d.i+4 > len(d.buf) {
+			return nil, ErrShortBuffer
+		}
+		out[pos64] = math.Float32frombits(readU32(d.buf[d.i:]))
+		d.i += 4
+	}
+	return out, nil
+}
+
 // readPackedALPFloat64Slice decodes an ALP payload. The cursor (d.i) must point
 // at the kind byte (the caller consumed the tag). Bounds-checked against hostile
 // input: width capped at 56, body size validated overflow-safe, exception

--- a/qpack_strdict.go
+++ b/qpack_strdict.go
@@ -195,7 +195,7 @@ func dictSampleHighCard(strs []string) bool {
 	sampleN := min(len(strs), qpackStrDictSampleN)
 	var seen [qpackStrDictSampleN]string
 	distinct := 0
-	for i := 0; i < sampleN; i++ {
+	for i := range sampleN {
 		s := strs[i]
 		fresh := true
 		for j := 0; j < distinct; j++ {

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -772,28 +772,35 @@ func encodeSliceFloat32(e *Encoder, p unsafe.Pointer) error {
 		s = e.canonicalFloat32Slice(s)
 	}
 	if e.qpack {
-		// Mirror encodeSliceFloat64's Gorilla branch (float32 has no ALP). The
-		// projection from pickF32Codec is only a hint, so emit Gorilla for real,
-		// measure it, and keep it solely when it actually beat raw — a true
-		// never-larger gate. The rollback re-emits raw only on the rare lose case,
-		// so the common smooth-data path encodes Gorilla once.
+		// Under OptCompression both Gorilla and ALP are enabled. Pick the smallest
+		// of {raw-LE, Gorilla projection, ALP estimate}. ALP's estimate is a
+		// conservative upper bound, so it is chosen only when it strictly beats both
+		// alternatives — pure-smooth floats keep Gorilla, quantized/decimal floats
+		// take ALP, and nothing grows the wire. Mirrors encodeSliceFloat64.
 		if e.gorillaFloat {
+			rawExact := 2 + uvarintLen(uint64(len(s))) + len(s)*4
+			plan, alpEst, alpOK := alpPlanFloat32(s) // safe upper bound
+			alpWins := alpOK && alpEst < rawExact
 			if gorCodec, _ := pickF32Codec(s); gorCodec == qpackGorilla {
-				rawExact := 2 + uvarintLen(uint64(len(s))) + len(s)*4
 				start := len(e.buf)
 				hdrBefore, flagBefore := e.headerOut, e.headerFlagAt
 				e.writePackedGorillaFloat32Slice(s)
-				if len(e.buf)-start < rawExact {
+				gorActual := len(e.buf) - start
+				if gorActual < rawExact && (!alpWins || alpEst >= gorActual) {
 					return nil
 				}
 				// Gorilla did not win — roll back. writePackedGorilla* may have
 				// emitted the stream header on a top-level first write; truncating to
 				// start drops it, and writeHeader's headerOut latch would then
-				// suppress the raw fallback's header and produce a headerless,
-				// undecodable stream. Restore the pre-attempt header state so the raw
-				// fallback re-emits the header when it was rolled away.
+				// suppress the fallback's header and produce a headerless, undecodable
+				// stream. Restore the pre-attempt header state so the raw/ALP fallback
+				// re-emits the header when it was rolled away.
 				e.buf = e.buf[:start]
 				e.headerOut, e.headerFlagAt = hdrBefore, flagBefore
+			}
+			if alpWins {
+				e.writePackedALPFloat32Slice(s, plan)
+				return nil
 			}
 		}
 		e.writePackedFloat32Slice(s)
@@ -818,6 +825,15 @@ func decodeSliceFloat32(d *Decoder, p unsafe.Pointer) error {
 	if t == tagPackGorilla {
 		d.i++
 		v, err := d.readPackedGorillaFloat32Slice()
+		if err != nil {
+			return err
+		}
+		*(*[]float32)(p) = v
+		return nil
+	}
+	if t == tagPackALP {
+		d.i++
+		v, err := d.readPackedALPFloat32Slice()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Two related compression changes (the float32-ALP probe surfaced the rANS bug).

## 1. fix(rans): interleaved encode buffer overflow panic

`Marshal(v, OptCompression)` could **panic** `index out of range [-1]` while rANS-encoding certain payloads (repro: monotonic decimal `[]float32`). The interleaved encoder splits the body into N substreams sharing **one** frequency table; a substream skewed against that table (globally-rare bytes) emits up to **2 renorm bytes/symbol** (freq-1 over `scale=2^12`: state in `[2^23,2^31)` past `xMax=2^19`), but the per-substream region was sized `len+16` (≤1 byte/symbol) → backward writer underflow.

Fix: `maxRenormBytesPerSym=2`; size every encode buffer `len*2 + state + slack` (interleaved regions **and** non-interleaved `encodeStream`). **No wire change.** `TestEncode_AdversarialSubstreamNoOverflow` (RED-verified) + fuzz seed.

## 2. feat(qpack): ALP decimal codec for `[]float32`

Extends float64 ALP to float32 slices: a quantized/decimal float32 column (sensor/price/ML-feature stored as the float32-nearest-to-decimal) encodes as FOR-bit-packed integer mantissas `round(v*10^d)` + a 4-byte-value exception list for anything not reconstructing bit-for-bit (NaN/±Inf/-0/arithmetic noise). Mantissa computed via float64 (exact past float32's 24-bit significand); wire reuses `tagPackALP` + new `qpackKindFloat32`. Wired into the `encodeSliceFloat32` never-larger picker (raw vs Gorilla vs ALP), decode, and the skip path.

**Measured: clean decimal `[]float32` 8014→2769 (32→11.1 bits/val, −65%).** A columnar float32 *column* keeps its uint32-bits+rANS path (already beats ALP on that shape, measured) — ALP is the `[]float32`-slice lever.