### PR TITLE
perf(columnar): dict-code skewed low-card string columns

### DIFF
--- a/dict_idx_qpack_test.go
+++ b/dict_idx_qpack_test.go
@@ -1,0 +1,91 @@
+package qdf
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// A skewed (Zipf-like) low-cardinality string column must dictionary-compress
+// just as well as a uniform one: the dict index spends ceil(log2 d) bits/row
+// regardless of distribution, so wire size is set by cardinality, not skew.
+//
+// Before the never-worse gate was corrected, a skewed column whose dominant
+// value clusters into few runs was REJECTED from the dictionary form (the gate
+// modeled the per-value fallback as run-length-collapsing, which the gathered-
+// column loop never does) and fell back to per-value strings — bloating it
+// ~2-3x. The fallback costs >= n bytes (one >=1-byte ref per row), so for any
+// d < 256 the bitpacked index is strictly smaller and dict must be chosen.
+type dictQRow struct {
+	Status string
+	Seq    int64
+}
+
+func dictQInputs(n int, skewed bool) []dictQRow {
+	r := rand.New(rand.NewSource(11))
+	// Longer values make the per-value-vs-dict gap unmistakable.
+	vals := []string{
+		"status_active_connection_established_ok",
+		"status_pending_retry_backoff_queued",
+		"status_closed_graceful_shutdown_done",
+		"status_failed_timeout_deadline_exceeded",
+		"status_draining_inflight_requests_wait",
+	}
+	rows := make([]dictQRow, n)
+	for i := range rows {
+		if skewed {
+			if r.Float64() < 0.90 {
+				rows[i].Status = vals[0]
+			} else {
+				rows[i].Status = vals[1+r.Intn(len(vals)-1)]
+			}
+		} else {
+			rows[i].Status = vals[i%len(vals)] // even spread
+		}
+		rows[i].Seq = int64(i)
+	}
+	return rows
+}
+
+func TestDictIndexSkewNotBloated(t *testing.T) {
+	const n = 2000
+	uni, err := MarshalT(dictQInputs(n, false), OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	skew, err := MarshalT(dictQInputs(n, true), OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Same distinct table, same n: both must take the dict form, so the skewed
+	// column may not be materially larger than the uniform one. (Pre-fix it was
+	// ~2.7x larger.) Allow a small slack for index-codec/framing differences.
+	if float64(len(skew)) > 1.15*float64(len(uni)) {
+		t.Fatalf("skewed dict column bloated: skew=%d uniform=%d (%.2fx); gate likely rejecting dict for clustered low-card data",
+			len(skew), len(uni), float64(len(skew))/float64(len(uni)))
+	}
+}
+
+func TestDictIndexSkewRoundTrip(t *testing.T) {
+	const n = 2000
+	for _, skewed := range []bool{false, true} {
+		in := dictQInputs(n, skewed)
+		for _, opt := range []Options{OptBalanced, OptCompression} {
+			b, err := MarshalT(in, opt)
+			if err != nil {
+				t.Fatalf("marshal skewed=%v opt=%v: %v", skewed, opt, err)
+			}
+			var out []dictQRow
+			if err := Unmarshal(b, &out); err != nil {
+				t.Fatalf("unmarshal skewed=%v opt=%v: %v", skewed, opt, err)
+			}
+			if len(out) != len(in) {
+				t.Fatalf("len skewed=%v opt=%v: got %d want %d", skewed, opt, len(out), len(in))
+			}
+			for i := range in {
+				if out[i] != in[i] {
+					t.Fatalf("row %d skewed=%v opt=%v: got %+v want %+v", i, skewed, opt, out[i], in[i])
+				}
+			}
+		}
+	}
+}

--- a/qpack_strdict.go
+++ b/qpack_strdict.go
@@ -16,10 +16,13 @@ import (
 // ceil(log2 distinct) bits. Wire format documented at tagColStrDict.
 //
 // The codec is gated so it never grows the wire: it is chosen only when the
-// bitpacked index body is smaller than the per-value run cost (one byte per
-// run boundary is the floor for the interned/repeat path). Run-heavy
-// (clustered) columns keep the per-value path, which repeat-codes runs more
-// cheaply than a flat index.
+// bitpacked index body is smaller than the per-value floor of n bytes (the
+// gathered-column fallback emits at least a 1-byte string/intern-ref tag per
+// row and does NOT run-length-collapse consecutive identical rows). Because the
+// distinct count is capped at 256, the index spends at most 8 bits/row, so a
+// bitpacked index beats per-value refs for every column the high-cardinality
+// probe does not already reject — including skewed (clustered) low-card columns,
+// which an earlier run-count floor wrongly sent to the per-value path.
 
 const (
 	// qpackStrDictMaxDistinct caps the distinct count. 256 keeps the index
@@ -36,7 +39,7 @@ const (
 
 // tryWriteStringColumnDict attempts to emit strs as a tagColStrDict block.
 // It returns true when the dictionary form was written (and is strictly
-// smaller than the per-value run floor), false when the caller should fall
+// smaller than the per-value n-byte floor), false when the caller should fall
 // back to per-value WriteString. Encode-side scratch is reused across
 // columns to avoid per-column allocation.
 func (e *Encoder) tryWriteStringColumnDict(strs []string) bool {
@@ -53,8 +56,6 @@ func (e *Encoder) tryWriteStringColumnDict(strs []string) bool {
 	}
 	table := e.state.colDictTable[:0]
 	idx := e.state.colScratchU64[:0]
-	runs := 0
-	prev := ^uint32(0)
 	// gp tracks the longest byte prefix shared by EVERY distinct value, computed
 	// for free as the table is built (no sort, no extra pass). It is a sort-free
 	// signal for the front-coded table form: gp >= 2 guarantees the front-coded
@@ -80,10 +81,6 @@ func (e *Encoder) tryWriteStringColumnDict(strs []string) bool {
 			}
 		}
 		idx = append(idx, uint64(id))
-		if id != prev {
-			runs++
-		}
-		prev = id
 		// High-cardinality bail: after the sample, if the column is mostly
 		// distinct it will not dict-compress — stop before scanning the rest.
 		if i+1 == qpackStrDictSampleN && len(m)*100 > qpackStrDictSampleN*qpackStrDictSampleMaxPct {
@@ -108,11 +105,19 @@ func (e *Encoder) tryWriteStringColumnDict(strs []string) bool {
 	bits := bitsForDistinct(d)
 	bodyBytes := (n*bits + 7) >> 3
 	// Never-worse gate. The distinct table bytes are paid by both forms (the
-	// per-value path emits each distinct string once too), so they cancel;
-	// compare only the dict's fixed overhead + index body against the
-	// per-value run floor (>= 1 byte per run boundary).
+	// per-value fallback emits each distinct string once too), so they cancel;
+	// compare only the dict's fixed overhead + index body against the per-value
+	// floor. That floor is n, not the run count: the gathered-column fallback is
+	// a per-value loop (writeStringColumn) that does NOT run-length-collapse
+	// consecutive identical rows — each of the n rows emits at least a 1-byte
+	// string/intern-ref tag, so the fallback costs >= n bytes after the table
+	// cancels. (An earlier `runs` floor assumed RLE collapse that never happens;
+	// it wrongly rejected dict for skewed low-card columns whose dominant value
+	// clusters into few runs, bloating them ~2-3x.) Since distinct <= 256, the
+	// index spends <= 8 bits/row, so a bitpacked index strictly beats 1-byte refs
+	// for every d < 256 and ties (rejects) at d == 256 — exactly the n floor.
 	overhead := 1 + uvarintLen(uint64(d)) + uvarintLen(uint64(n))
-	if bodyBytes+overhead >= runs {
+	if bodyBytes+overhead >= n {
 		return false
 	}
 


### PR DESCRIPTION
## Problem

The string-dictionary codec's never-worse gate rejected the dictionary form for **skewed low-cardinality columns** (status / level / severity / region — the dominant value clustering into few runs) and fell back to the per-value path, bloating them **~2–3x**.

Measured on a 2000-row `status` column (8 distinct, 90% one value):

| distribution | wire | codec |
|---|---|---|
| uniform | 954 B | dictFC |
| skewed (before) | 2567 B | per-value (no dict) |
| skewed (after) | 954 B | dictFC |

## Root cause

The gate compared the bitpacked index body against a **run-count floor**, on the assumption that the per-value fallback run-length-collapses consecutive identical rows. The gathered-column fallback (`writeStringColumn`'s per-value loop) does no such collapse — it emits **at least a 1-byte string/intern-ref tag per row** — so its true floor is **n bytes**, not the run count. When the dominant value clusters, `runs` drops below the index body and dict is wrongly rejected.

## Fix

Compare the index body against the **n-byte floor**. The distinct count is capped at 256, so the index spends ≤ 8 bits/row: a bitpacked index is strictly smaller than 1-byte refs for every `d < 256` and ties (rejects) at 256 — the gate stays **never-larger** (per-value remainder after the shared distinct table = `n + d` ≥ the index).

## Validation

- Full suite + `-race`, lint 0 issues
- Fuzz: `FuzzColDiffStringOracle` 340k execs, `FuzzRoundTrip_StructTriad` 930k execs
- `internal/codegen_test` module green
- New regression test: skewed column may not exceed 1.15× the uniform one; round-trip across Balanced/Compression
- **Real adalanche data** (`cmd/qdf-bench`): GenHost wire **−1.2%**, `[]Service` and the columnar metric payloads **byte-identical**, no regression (map-field payloads vary ±~10 B run-to-run from Go map iteration order, unrelated)