### PR TITLE
fix: correctness + robustness (line-by-line audit)

### DIFF
--- a/codegen_float32_canonical_test.go
+++ b/codegen_float32_canonical_test.go
@@ -1,0 +1,43 @@
+package qdf
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+// The codegen float32 column writer (WriteFloat32Column) must honor OptCanonical
+// exactly like the reflect colKindFloat32 path: -0.0 normalizes to +0.0 and every
+// NaN to one quiet NaN, so semantically-equal columns are byte-identical. Before
+// the fix it always wrote raw Float32bits, so a -0.0 column diverged from a +0.0
+// column (and from the reflect wire) under OptCanonical.
+func TestCodegenFloat32ColumnCanonical(t *testing.T) {
+	neg0 := float32(math.Copysign(0, -1))
+	pos0 := float32(0)
+
+	encCol := func(opt Options, v float32) []byte {
+		e := &Encoder{}
+		e.applyOpts(opt)
+		if err := e.WriteFloat32Column([]float32{v}); err != nil {
+			t.Fatal(err)
+		}
+		return append([]byte(nil), e.buf...)
+	}
+
+	// Under OptCanonical the -0.0 and +0.0 columns must encode identically.
+	if !bytes.Equal(encCol(OptBalanced|OptCanonical, neg0), encCol(OptBalanced|OptCanonical, pos0)) {
+		t.Fatal("codegen float32 column not canonical under OptCanonical: -0.0 encodes differently from +0.0")
+	}
+	// Sanity: without OptCanonical the raw sign bit is preserved, so they differ.
+	if bytes.Equal(encCol(OptBalanced, neg0), encCol(OptBalanced, pos0)) {
+		t.Fatal("expected -0.0 and +0.0 to encode differently without OptCanonical")
+	}
+
+	// NaN canonicalization: two different NaN bit patterns collapse to one under
+	// OptCanonical.
+	nanA := math.Float32frombits(0x7FC00001)
+	nanB := math.Float32frombits(0x7FE00000)
+	if !bytes.Equal(encCol(OptBalanced|OptCanonical, nanA), encCol(OptBalanced|OptCanonical, nanB)) {
+		t.Fatal("codegen float32 column did not canonicalize distinct NaN patterns under OptCanonical")
+	}
+}

--- a/colcodegen.go
+++ b/colcodegen.go
@@ -134,8 +134,18 @@ func (e *Encoder) WriteFloat32Column(s []float32) error {
 		st.colScratchU64 = make([]uint64, len(s))
 	}
 	u := st.colScratchU64[:len(s)]
-	for i, v := range s {
-		u[i] = uint64(math.Float32bits(v))
+	if e.opts.Has(OptCanonical) {
+		// Mirror the reflect colKindFloat32 path (columnar.go): under OptCanonical
+		// normalize -0.0 -> +0.0 and every NaN -> one quiet NaN so semantically
+		// equal columns are byte-identical. Without this the codegen wire diverged
+		// from reflect for -0.0/NaN columns under OptCanonical.
+		for i, v := range s {
+			u[i] = canonicalizeFloat32Bits(uint64(math.Float32bits(v)))
+		}
+	} else {
+		for i, v := range s {
+			u[i] = uint64(math.Float32bits(v))
+		}
 	}
 	st.colScratchU64 = u
 	return encodeSliceUint64(e, unsafe.Pointer(&u))

--- a/decoder_skip.go
+++ b/decoder_skip.go
@@ -455,13 +455,16 @@ func (d *Decoder) Skip() error {
 		}
 		d.i += nr
 		if n64 >= 2 {
-			// Body holds (n-1) elements at bitsPer each. Compute the
-			// byte size in uint64 to keep the bounds check overflow-safe.
-			bodyBits := (n64 - 1) * uint64(bitsPer)
-			bodyBytes := (bodyBits + 7) >> 3
-			if bodyBytes > uint64(len(d.buf)-d.i) {
+			// Body holds (n-1) elements at bitsPer each. Bound (n-1) by the
+			// remaining bytes via DIVISION before the multiply — n64 is an
+			// unbounded varuint, so `(n64-1)*bitsPer` would overflow uint64 for a
+			// large n64 (wrapping to a small bodyBytes that passes the size check
+			// and desyncs the skip cursor). Mirrors readPackedDeltaForHeader.
+			rem := uint64(len(d.buf) - d.i)
+			if bitsPer > 0 && n64-1 > rem*8/uint64(bitsPer) {
 				return ErrShortBuffer
 			}
+			bodyBytes := ((n64-1)*uint64(bitsPer) + 7) >> 3
 			d.i += int(bodyBytes)
 		}
 		return nil

--- a/qdf_generic.go
+++ b/qdf_generic.go
@@ -74,6 +74,11 @@ func UnmarshalT[T any](data []byte, out *T) error {
 	// alias the input buffer; inheriting selectFields/query would mis-project.
 	dec.noCopy = false
 	dec.colIndex = false
+	// A generated columnar DecodeQDF that errors between ReadColStructHeader and
+	// ClearColMaxLen returns the pooled decoder with a stale colMaxLen; reset it
+	// so this decode's slice codecs are not spuriously clamped (mirrors the reset
+	// in unmarshal / unmarshalQuery — UnmarshalT shares the same decoder pool).
+	dec.colMaxLen = 0
 	dec.selectFields = nil
 	dec.query = nil
 	clear(dec.mapFreeList) // drop maps recycled by a prior decode into a different target

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -271,7 +271,10 @@ func encodeSlice(elem *typeDesc, stride uintptr, colPlan *columnarPlan) func(*En
 			// without forcing another doubling on a slight
 			// underestimate.
 			remaining := n - sliceProbeSize
-			projected := probeBytes * remaining / sliceProbeSize
+			// 64-bit intermediate: probeBytes*remaining can exceed int32 on a
+			// 32-bit build for a large slice, wrapping projected negative and
+			// panicking slices.Grow.
+			projected := int(int64(probeBytes) * int64(remaining) / int64(sliceProbeSize))
 			projected += projected >> 2
 			e.buf = slices.Grow(e.buf, projected)
 		}
@@ -1337,7 +1340,9 @@ func encodeSliceAny(e *Encoder, p unsafe.Pointer) error {
 	// Project the remaining size from the probe (+25% slack) and grow once,
 	// killing the doubling chain on large dynamic arrays.
 	if probeBytes := len(e.buf) - probeStart; probeBytes > 0 {
-		projected := probeBytes * (n - probe) / probe
+		// 64-bit intermediate: the product can exceed int32 on a 32-bit build for
+		// a large slice, wrapping projected negative and panicking slices.Grow.
+		projected := int(int64(probeBytes) * int64(n-probe) / int64(probe))
 		projected += projected >> 2
 		e.buf = slices.Grow(e.buf, projected)
 	}

--- a/skip_deltafor_overflow_test.go
+++ b/skip_deltafor_overflow_test.go
@@ -1,0 +1,24 @@
+package qdf
+
+import "testing"
+
+// A tagPackDeltaFor value whose element count makes (n64-1)*bitsPer overflow
+// uint64 must be rejected by Skip, not silently mis-advanced. With bitsPer=56
+// and n64=329406144173384852, (n64-1)*56 wraps to 40 (bodyBits) -> bodyBytes=5,
+// so the pre-fix multiply produced a 5-byte body size that passed the bounds
+// check against a 5-byte tail and desynced the skip cursor (returning nil). The
+// division-based bound rejects it (ErrShortBuffer) before the multiply.
+func TestSkipDeltaForCountOverflow(t *testing.T) {
+	var buf []byte
+	buf = append(buf, tagPackDeltaFor, qpackKindInt64, 56) // tag, kind, bitsPer=56
+	buf = appendUvarint(buf, 0)                            // firstVal
+	buf = appendUvarint(buf, 0)                            // minDelta
+	buf = appendUvarint(buf, 329406144173384852)           // n64: (n64-1)*56 overflows to 40
+	buf = append(buf, 0, 0, 0, 0, 0)                       // 5-byte tail the wrapped bodyBytes would consume
+
+	d := &Decoder{buf: buf, headerRead: true}
+	err := d.Skip()
+	if err == nil {
+		t.Fatal("Skip accepted an overflowing tagPackDeltaFor count (cursor desynced); want a bounds error")
+	}
+}


### PR DESCRIPTION
Second, deeper audit pass (per-file, line-by-line, 26 file groups). Findings were adversarially verified, then each survivor RED-verified manually (the agent verifier pass was cut short by a session limit, so I verified all by reading code and, where testable, a fail-without-the-fix test).

## Fixes

| sev | file | issue |
|-----|------|-------|
| high | `qdf_generic.go` | `UnmarshalT` did not reset `dec.colMaxLen` on acquire. It shares the decoder pool with `unmarshal`/`unmarshalQuery`/`SetInput`, which all reset it (a generated columnar `DecodeQDF` that errors between `ReadColStructHeader` and `ClearColMaxLen` returns a stale bound). Without the reset, `UnmarshalT` could inherit the bound and have `colLenOK` spuriously reject valid slice lengths. The one acquire path that was missed. |
| medium | `colcodegen.go` | `WriteFloat32Column` (codegen) always wrote raw `Float32bits`, ignoring `OptCanonical` — diverging from the reflect `colKindFloat32` path (which normalizes `-0.0→+0.0`, `NaN→`one quiet NaN). Codegen + reflect now produce identical canonical wire. RED-verified test. |
| medium | `decoder_skip.go` | the `tagPackDeltaFor` skip computed `(n64-1)*bitsPer` before bounding `n64`, so a large varuint count overflowed uint64, wrapped to a small body size, passed the bounds check, and desynced the skip cursor. Bound via DIVISION first (like `readPackedDeltaForHeader`; the other skip codecs already do). RED-verified test. |
| low | `reflect_encode.go` | the probe-and-grow projection `probeBytes*remaining` could exceed int32 on a 32-bit build → negative `slices.Grow` arg → panic. int64 intermediate (two sites). |

## Refuted (not fixed)
- "Standalone FOR/DeltaFor decode has no element cap (64× amplification)" — FALSE POSITIVE: the `n64 > rem*8/bitsPer` bound is input-proportional (1 bit packed → 8-byte uint64 is the legitimate bitpack ratio, not a bomb); the `qpackMaxStandaloneCount` cap is correctly scoped to the `bitsPer==0` empty-body case. Capping would break valid large slices.
- Several LOW items (mapShapes `[:0]` GC-retention, nullable `time.Time` raw-byte compare, two micro-opts) deferred — low value / need a measurement.
- 3 findings duplicated already-merged PR #122 work (ALP colLenOK, delta origLen 32-bit, stream frameLen).

## Verification
Full suite + `-race`, lint 0, codegen_test module, StructTriad round-trip fuzz. Two RED-verified regression tests (skip overflow, codegen canonical).