### PR TITLE
fix(codegen): *named-non-struct fields bypass custom codec + dec.query reset

### DIFF
--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -787,7 +787,15 @@ func (g *gen) emitEncodePointer(w io.Writer, expr string, p *types.Pointer, inde
 			}
 			fmt.Fprintf(w, "%s\tif err := qdf.EncodeNested(e, %s); err != nil {\n%s\t\treturn err\n%s\t}\n", indent, expr, indent, indent)
 		} else {
-			if err := g.emitEncodeValue(w, "(*"+expr+")", named.Underlying(), indent+"\t"); err != nil {
+			// Route the named element through emitEncodeNamed (NOT its underlying)
+			// so a named non-struct with a hand-written MarshalQDF is encoded via
+			// its codec, exactly as the value-field path and the decode side
+			// (emitDecodeNamed) already do. Passing named.Underlying() here bypassed
+			// the MarshalQDF check and wrote a bare scalar/slice/map, so a *Label
+			// field encoded around its codec while decode read it back through the
+			// codec — a round-trip corruption. emitEncodeNamed falls through to the
+			// same underlying encode when the type has no codec (behavior unchanged).
+			if err := g.emitEncodeNamed(w, "(*"+expr+")", named, indent+"\t"); err != nil {
 				return err
 			}
 		}

--- a/cmd/qdfgen/gen/gen_columnar_test.go
+++ b/cmd/qdfgen/gen/gen_columnar_test.go
@@ -49,6 +49,21 @@ func TestColumnarSkipsCustomCodecElem(t *testing.T) {
 		}
 	})
 
+	t.Run("ptr_codec_field_routes_through_codec", func(t *testing.T) {
+		// A *Tag field (named non-struct with a hand-written codec) must encode AND
+		// decode through the custom codec. PtrCodecHolder has only this one field
+		// and no nested structs, so the sole EncodeNested/DecodeNested in the output
+		// is its codec routing. Pre-fix the encode side bypassed MarshalQDF (wrote a
+		// bare string) while decode used UnmarshalQDF — so EncodeNested was absent.
+		src := gen(t, "PtrCodecHolder")
+		if !strings.Contains(src, "EncodeNested") {
+			t.Fatalf("*Tag field encode bypassed its MarshalQDF (no EncodeNested); diverges from the DecodeNested decode side:\n%s", src)
+		}
+		if !strings.Contains(src, "DecodeNested") {
+			t.Fatalf("*Tag field decode missing DecodeNested:\n%s", src)
+		}
+	})
+
 	// A []struct element with a defined-byte-element slice field (`type B byte;
 	// []B`) must NOT classify that field as a columnar Bytes column: the Bytes
 	// emit assumes a literal []byte and would generate `unsafe.SliceData([]B)`

--- a/cmd/qdfgen/gen/testdata/customcodec/types.go
+++ b/cmd/qdfgen/gen/testdata/customcodec/types.go
@@ -74,3 +74,11 @@ func (t *Tag) UnmarshalQDF(src []byte) (int, error) {
 type NamedCodecHolder struct {
 	Label Tag `qdf:"label"`
 }
+
+// PtrCodecHolder holds a POINTER to the named-non-struct codec type. The encode
+// side must route *Tag through its MarshalQDF (EncodeNested), exactly as the
+// value-field path and the decode side (DecodeNested) do; otherwise encode writes
+// a bare string while decode reads it back through UnmarshalQDF — a corruption.
+type PtrCodecHolder struct {
+	Label *Tag `qdf:"label"`
+}

--- a/qdf.go
+++ b/qdf.go
@@ -547,6 +547,7 @@ func unmarshal(data []byte, out any, fields []string, noCopy bool, arena *Arena)
 	dec.noCopy = noCopy
 	dec.arena = arena
 	dec.selectFields = fields
+	dec.query = nil        // parity with UnmarshalT / SetInput: never inherit a prior query decode's plan from the shared pool
 	clear(dec.mapFreeList) // drop maps recycled by a prior decode into a different target
 	if dec.state != nil {
 		dec.state.reset()


### PR DESCRIPTION
Gap-coverage audit pass over the file groups the previous run missed (codegen / bitpack / arenas / entry / fsst / mapsgen). Adversarially verified; each survivor RED-verified manually.

## Fixes

**`cmd/qdfgen/gen/gen.go` (HIGH — codegen round-trip corruption).** `emitEncodePointer` encoded a `*T` field, where `T` is a named non-struct type (e.g. `type Label string` with a hand-written `MarshalQDF`), by descending into `named.Underlying()`. That skips `emitEncodeNamed` and its `hasMethod(MarshalQDF)` check, so a **bare** scalar/slice/map was written. But:
- the decode side (`emitDecodePointer → emitDecodeNamed`) honors `UnmarshalQDF`, and
- the **value**-field path (`emitEncodeNamed`) honors `MarshalQDF`.

So for a `*Label` field whose codec wire form differs from the underlying encoding, **encode wrote around the codec while decode read back through it** — a round-trip corruption, and a divergence from the reflect Marshaler-before-Kind precedence. The same struct encoded a value field through the codec and the pointer field around it.

Fix: route through `emitEncodeNamed`, which emits `qdf.EncodeNested` for a codec-bearing type and falls through to the **identical** underlying encode otherwise — so codec-less `*named` fields generate byte-identical code. New `PtrCodecHolder` fixture + a generation test that asserts the `*Tag` field routes through `EncodeNested` (RED-verified: fails without the fix).

**`qdf.go` (LOW — defensive).** `unmarshal()` was the one shared-pool acquire path that did not reset `dec.query` (`UnmarshalT` and `SetInput` do). Not reachable through any normal flow (`unmarshalQuery` nils it before `Put` on every non-panic path), but a deviation from the documented pool-reset discipline. Reset for parity; no behavior change.

## Refuted (not fixed)
- mapsgen map-encoder "OptCanonical vs OptMapShape precedence reversed" — false positive.
- `delta_keyed.go` orderChanged "missing n*stride cap" — false positive (per-key ≥1-byte bound is input-proportional, same as the FOR/DeltaFor case).
- query `evalOr/evalAnd` redundant `notMask` clone — real but a LOW micro-opt with aliasing subtlety; deferred (matches the earlier decision).

## Verification
`cmd/qdfgen/gen` tests, main suite, `internal/codegen_test` module (fixtures still valid — codec-less generated code is byte-identical), lint 0.