### PR TITLE
perf(columnar): defer probe alphabet scan behind its cardinality gate

### DIFF
--- a/colcodegen.go
+++ b/colcodegen.go
@@ -480,9 +480,6 @@ func stringColumnsBeneficial(internAware bool, cols ...[]string) bool {
 		var tableBytes, perValue, sampleChars int
 		prev := ""
 		first := true
-		var alphaSeen [256]bool
-		alphaCount := 0
-		alphaOK := internAware
 		for i := range sample {
 			s := strs[i]
 			fresh := true
@@ -507,10 +504,25 @@ func stringColumnsBeneficial(internAware bool, cols ...[]string) bool {
 			} else {
 				rowBytes += 2 + len(s)
 			}
+			sampleChars += len(s)
 			prev = s
 			first = false
-			if alphaOK {
-				sampleChars += len(s)
+		}
+		dictBytes := tableBytes + (sample*bitsForDistinct(nseen)+7)/8
+		best := min(perValue, dictBytes)
+		// Defer the O(chars) per-byte alphabet scan behind the cheap alpha
+		// preconditions (cardinality + average length), so low-card / short string
+		// columns skip it entirely — byte-identical to the columnar decision (the
+		// scan's alphaOK/alphaCount feed only the alphaEst below). Mirrors
+		// columnarProbe.
+		if internAware &&
+			nseen*100 >= sample*alphaMinDistinctPct &&
+			sampleChars >= sample*alphaProbeMinAvgLen {
+			var alphaSeen [256]bool
+			alphaCount := 0
+			alphaOK := true
+			for i := range sample {
+				s := strs[i]
 				for k := 0; k < len(s); k++ {
 					if !alphaSeen[s[k]] {
 						if alphaCount >= qpackStrAlphaMaxAlphabet {
@@ -521,16 +533,15 @@ func stringColumnsBeneficial(internAware bool, cols ...[]string) bool {
 						alphaCount++
 					}
 				}
+				if !alphaOK {
+					break
+				}
 			}
-		}
-		dictBytes := tableBytes + (sample*bitsForDistinct(nseen)+7)/8
-		best := min(perValue, dictBytes)
-		if alphaOK && alphaCount >= 2 &&
-			nseen*100 >= sample*alphaMinDistinctPct &&
-			sampleChars >= sample*alphaProbeMinAvgLen {
-			alphaEst := alphaCount + sample + (sampleChars*bitsForDistinct(alphaCount)+7)/8
-			if alphaEst < best {
-				best = alphaEst
+			if alphaOK && alphaCount >= 2 {
+				alphaEst := alphaCount + sample + (sampleChars*bitsForDistinct(alphaCount)+7)/8
+				if alphaEst < best {
+					best = alphaEst
+				}
 			}
 		}
 		colBytes += best

--- a/columnar.go
+++ b/columnar.go
@@ -501,12 +501,6 @@ func columnarProbe(plan *columnarPlan, base unsafe.Pointer, n int, fsstEnabled b
 			var tableBytes, perValue, sampleChars int
 			prev := ""
 			first := true
-			// Alphabet tracking (intern-aware path only) for the alpha-packed
-			// estimate. alphaOK drops the moment the alphabet exceeds 64 distinct
-			// bytes, so a text column pays only a short prefix scan.
-			var alphaSeen [256]bool
-			alphaCount := 0
-			alphaOK := internAware
 			for i := range sample {
 				s := loadStringField(base, plan.stride, col, i)
 				fresh := true
@@ -536,21 +530,9 @@ func columnarProbe(plan *columnarPlan, base unsafe.Pointer, n int, fsstEnabled b
 				} else {
 					rowBytes += 2 + len(s)
 				}
+				sampleChars += len(s)
 				prev = s
 				first = false
-				if alphaOK {
-					sampleChars += len(s)
-					for k := 0; k < len(s); k++ {
-						if !alphaSeen[s[k]] {
-							if alphaCount >= qpackStrAlphaMaxAlphabet {
-								alphaOK = false
-								break
-							}
-							alphaSeen[s[k]] = true
-							alphaCount++
-						}
-					}
-				}
 			}
 			dictBytes := tableBytes + (sample*bitsForDistinct(nseen)+7)/8
 			best := min(perValue, dictBytes)
@@ -563,12 +545,42 @@ func columnarProbe(plan *columnarPlan, base unsafe.Pointer, n int, fsstEnabled b
 			// when this estimate brought the struct into columnar — the estimate
 			// governs only the columnar-vs-row-major decision, not the per-column
 			// codec.
-			if alphaOK && alphaCount >= 2 &&
+			//
+			// The per-byte alphabet scan is DEFERRED behind these cheap gates
+			// (cardinality + average length, both already known): low-card or short
+			// string columns — the common case — skip the O(chars) scan entirely,
+			// and only a high-card long column (where alpha could win) pays it. The
+			// scan's alphaOK/alphaCount feed only this estimate, so deferring it is
+			// byte-identical to the columnar decision. sampleChars is the full sum
+			// here, but it only affects alphaEst when alphaOK holds (restricted
+			// alphabet), where the old partial sum equalled the full sum anyway.
+			if internAware &&
 				nseen*100 >= sample*alphaMinDistinctPct &&
 				sampleChars >= sample*alphaProbeMinAvgLen {
-				alphaEst := alphaCount + sample + (sampleChars*bitsForDistinct(alphaCount)+7)/8
-				if alphaEst < best {
-					best = alphaEst
+				var alphaSeen [256]bool
+				alphaCount := 0
+				alphaOK := true
+				for i := range sample {
+					s := loadStringField(base, plan.stride, col, i)
+					for k := 0; k < len(s); k++ {
+						if !alphaSeen[s[k]] {
+							if alphaCount >= qpackStrAlphaMaxAlphabet {
+								alphaOK = false
+								break
+							}
+							alphaSeen[s[k]] = true
+							alphaCount++
+						}
+					}
+					if !alphaOK {
+						break
+					}
+				}
+				if alphaOK && alphaCount >= 2 {
+					alphaEst := alphaCount + sample + (sampleChars*bitsForDistinct(alphaCount)+7)/8
+					if alphaEst < best {
+						best = alphaEst
+					}
 				}
 			}
 			// FSST competes only when enabled (OptFSST). High-cardinality,


### PR DESCRIPTION
## Regression

Comparing the 23-06 vs 21-06 adalanche bench matrices showed typed **Balanced encode +14%**. Most of that was environmental (msgpack, a baseline qdf does not touch, also moved +8%), but a clean same-machine interleaved bracket isolated a real **+6.5%** qdf encode regression on the Balanced/columnar path (Speed and Dense&^QPack were flat).

`pprof` pinned it: `columnarProbe` went from invisible to **~7% cumulative**. The intern-aware probe (added with the alpha codec) runs an **O(chars) per-byte alphabet scan** over every sampled string of every string column — but the alpha size estimate it feeds is only used for a **high-cardinality, long-value** column. On the AD typed corpus (many low-card enum-like string columns) the scan was pure overhead.

## Fix

Move the alphabet scan **after** the cheap preconditions (distinct count + average length, both already computed) in both `columnarProbe` and its codegen twin `stringColumnsBeneficial`. A low-card or short string column now skips the scan entirely; only a high-card long column (where alpha could win) pays it.

**Byte-identical decision.** The scan's `alphaOK`/`alphaCount` feed only the deferred `alphaEst`; `sampleChars` is now the full sum but only affects `alphaEst` when the alphabet stays restricted, where the old partial sum equalled the full sum. Verified: identical wire on a hex-ID alpha-path payload (Balanced/Compression byte-for-byte), full golden + round-trip + intern-aware suite green.

## Measured

Same machine, **interleaved bracket** (cancels thermal drift), n=6:

```
typed Balanced encode   main 3.968m → fix 3.798m   -4.29% (p=0.002)
```

Recovers the regression (fix ≈ pre-intern-aware build). Wire byte-identical, allocs unchanged, lint 0.