### PR TITLE
feat: batch a []struct vector column into one count=N lossy block

### DIFF
--- a/cmd/qdf-vecbench/batch_overhead_probe_test.go
+++ b/cmd/qdf-vecbench/batch_overhead_probe_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/alex60217101990/qdf/internal/vecquant"
+)
+
+func TestZZBatchVsPerVector(t *testing.T) {
+	const n, dim = 2000, 256
+	corpus := loadSynthetic(n, dim, 42)
+	normalizeRows(corpus)
+	b := vecquant.Budget{Kind: vecquant.KindRelError, Val: 0.05}
+
+	// (a) batched: whole corpus = one count=N block (what the bench reports).
+	batched := lossyVecWireBytes(vecquant.Encode(corpus, b))
+	// (b) per-vector: each vector its own count=1 block (what qdf does in prod).
+	perVec := 0
+	for i := range corpus {
+		perVec += lossyVecWireBytes(vecquant.Encode(corpus[i:i+1], b))
+	}
+	fmt.Printf("\nbatched (count=%d):  %.2f B/vec\n", n, float64(batched)/n)
+	fmt.Printf("per-vector (count=1): %.2f B/vec\n", float64(perVec)/n)
+	fmt.Printf("per-vector overhead:  +%.2f B/vec (+%.1f%%)\n",
+		float64(perVec-batched)/n, 100*float64(perVec-batched)/float64(batched))
+}

--- a/cmd/qdf-vecbench/polar_probe_test.go
+++ b/cmd/qdf-vecbench/polar_probe_test.go
@@ -1,0 +1,156 @@
+package main
+
+// THROWAWAY measure-first probe for the parked "polar-split" idea: store each
+// vector's L2 norm separately (1 scalar/vector) and quantize the unit-direction
+// through the lattice path, instead of quantizing the raw vector with one shared
+// step Δ over the whole block.
+//
+// Hypothesis: the current codec picks ONE Δ for the whole block (driven by the
+// hardest vector), so when per-vector NORMS vary a lot it wastes bits on the
+// easy (small-norm) vectors. Normalizing first removes that spread, letting one
+// tight Δ serve all directions. On unit-norm embeddings (norm ~= const) polar
+// should buy nothing; on varying-norm data it might.
+//
+// Run: go test -run TestPolarSplitProbe -v
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/alex60217101990/qdf/internal/vecquant"
+)
+
+// scaleRows multiplies each vector by a per-vector factor drawn log-normally,
+// producing a corpus with a wide spread of L2 norms (the regime polar targets).
+func scaleRows(corpus [][]float64, sigmaLog float64, seed int64) {
+	r := rand.New(rand.NewSource(seed))
+	for _, v := range corpus {
+		s := math.Exp(sigmaLog * r.NormFloat64())
+		for j := range v {
+			v[j] *= s
+		}
+	}
+}
+
+// rowNorm returns the L2 norm of v.
+func rowNorm(v []float64) float64 {
+	var s float64
+	for _, x := range v {
+		s += x * x
+	}
+	return math.Sqrt(s)
+}
+
+// polarEncodeBytes simulates the polar-split wire cost and reconstruction:
+//   - per-vector norm quantized to 16 bits over [min,max]  -> 2 bytes/vector;
+//   - unit directions encoded through the current lattice codec at budget b.
+//
+// It returns the total bytes/vector and the achieved rel-error measured on the
+// ORIGINAL (un-normalized) vectors, so it is comparable to the baseline.
+func polarEncodeBytes(corpus [][]float64, b vecquant.Budget) (bytesPerVec, relErr float64) {
+	n := len(corpus)
+	dim := len(corpus[0])
+	norms := make([]float64, n)
+	dirs := make([][]float64, n)
+	mn, mx := math.Inf(1), math.Inf(-1)
+	for i, v := range corpus {
+		nrm := rowNorm(v)
+		norms[i] = nrm
+		mn, mx = math.Min(mn, nrm), math.Max(mx, nrm)
+		d := make([]float64, dim)
+		if nrm > 0 {
+			for j := range v {
+				d[j] = v[j] / nrm
+			}
+		}
+		dirs[i] = d
+	}
+	// Encode the unit directions with the real codec.
+	bl := vecquant.Encode(dirs, b)
+	dirRecon := bl.Decode()
+	dirBytes := lossyVecWireBytes(bl)
+	// Norm cost: 16-bit quantized per vector + a tiny header (min,max f64).
+	normBytes := 2*n + 16
+	// Reconstruct v_hat = norm_q * dir_hat, quantizing norm to 16 bits.
+	span := mx - mn
+	if span == 0 {
+		span = 1
+	}
+	var seSum, neSum float64
+	for i := range corpus {
+		q := math.RoundToEven((norms[i] - mn) / span * 65535)
+		normQ := mn + q/65535*span
+		o := corpus[i]
+		var se, ne float64
+		for j := range o {
+			vh := normQ * dirRecon[i][j]
+			d := o[j] - vh
+			se += d * d
+			ne += o[j] * o[j]
+		}
+		seSum += math.Sqrt(se / (ne + 1e-30))
+		neSum++
+	}
+	bytesPerVec = float64(dirBytes+normBytes) / float64(n)
+	relErr = seSum / neSum
+	return bytesPerVec, relErr
+}
+
+func TestPolarSplitProbe(t *testing.T) {
+	const (
+		n   = 2000
+		dim = 256
+	)
+	type corpusCase struct {
+		name   string
+		corpus [][]float64
+	}
+	// Control: unit-norm (polar expected ~0). Test: wide log-normal norm spread.
+	unit := loadSynthetic(n, dim, 42)
+	normalizeRows(unit)
+	mild := loadSynthetic(n, dim, 42)
+	normalizeRows(mild)
+	scaleRows(mild, 0.25, 99) // sigma_log=0.25 => ~3-4x norm spread (mild)
+	mod := loadSynthetic(n, dim, 42)
+	normalizeRows(mod)
+	scaleRows(mod, 0.5, 99) // sigma_log=0.5 => ~15-20x spread (realistic weights)
+	wide := loadSynthetic(n, dim, 42)
+	scaleRows(wide, 1.0, 99) // sigma_log=1 => ~1000x (pathological)
+
+	cases := []corpusCase{
+		{"unit-norm", unit},
+		{"mild(σ0.25,~4x)", mild},
+		{"moderate(σ0.5,~20x)", mod},
+		{"wide(σ1.0,~1000x)", wide},
+	}
+	budgets := []vecquant.Budget{
+		{Kind: vecquant.KindRelError, Val: 0.05},
+		{Kind: vecquant.KindRelError, Val: 0.10},
+	}
+
+	for _, cc := range cases {
+		// Report the norm spread for context.
+		mn, mx := math.Inf(1), math.Inf(-1)
+		for _, v := range cc.corpus {
+			nrm := rowNorm(v)
+			mn, mx = math.Min(mn, nrm), math.Max(mx, nrm)
+		}
+		fmt.Printf("\n=== %s — %d×%d, norm range [%.3g, %.3g] (%.0f×) ===\n",
+			cc.name, n, dim, mn, mx, mx/mn)
+		fmt.Printf("%-10s %14s %10s %14s %10s %9s\n",
+			"budget", "cur B/vec", "cur rel", "polar B/vec", "polar rel", "Δsize")
+		for _, b := range budgets {
+			bl := vecquant.Encode(cc.corpus, b)
+			curBytes := float64(lossyVecWireBytes(bl)) / float64(len(cc.corpus))
+			curRel := avgRelError(cc.corpus, bl.Decode())
+			polBytes, polRel := polarEncodeBytes(cc.corpus, b)
+			dPct := 100 * (polBytes - curBytes) / curBytes
+			fmt.Printf("rel/%.2f   %14.2f %10.4f %14.2f %10.4f %+8.1f%%\n",
+				b.Val, curBytes, curRel, polBytes, polRel, dPct)
+		}
+	}
+	fmt.Println("\nVerdict: polar wins only if Δsize is meaningfully negative AT")
+	fmt.Println("equal-or-better rel-error. On unit-norm it should be ~0 or worse.")
+}

--- a/docs/LOSSY-VECTOR.md
+++ b/docs/LOSSY-VECTOR.md
@@ -125,6 +125,20 @@ bit costs more than the packing saves, so the second pass is skipped.
 
 <img src="../diagrams/svg/lossy-vector-2.svg" alt="Lossy vector wire format and decode">
 
+### Batched vector columns
+
+When you marshal a `[]struct` whose element has a `[]float32`/`[]float64` vector
+field (the common embedding-store shape — `[]EmbedRow{ID, Emb}`), all rows'
+vectors of that field are gathered into **one** count-`N` block (wire tag
+`0xFE`, `tagVecBatchStruct`) instead of one count-1 block per row. This amortizes
+the fixed block header **and** the rANS frequency framing, which a per-row
+encoding pays for every vector — on a 256-dim corpus the per-row form costs
+~290 B/vec versus ~176 B/vec batched (the size numbers below are therefore the
+ones you get in production, not just in a micro-benchmark). Batching kicks in
+under `OptLossyVec` for ≥ 16 rows when the field has the same length in every row
+and the batched block beats raw; otherwise each vector stays row-major. Scalar
+and string fields, and varying-length / short vectors, are unaffected.
+
 ---
 
 ## Numbers

--- a/encoder.go
+++ b/encoder.go
@@ -113,6 +113,13 @@ type Encoder struct {
 	// the caller's slice.
 	wideF64 []float64
 
+	// vecBatchFlat / vecBatchRows reuse the gather scratch for the batched lossy
+	// vector-column codec: vecBatchFlat is the flat [n*dim]float64 backing and
+	// vecBatchRows the [n] row views into it. Retained across encodes, dropped
+	// past the ceiling in Reset.
+	vecBatchFlat []float64
+	vecBatchRows [][]float64
+
 	// preIntern is an opt-in identity cache populated by PreIntern.
 	// When non-empty WriteString does a linear scan against it
 	// before falling to the intern table — a pointer-and-length
@@ -356,6 +363,10 @@ func (e *Encoder) resetForReuse() {
 	e.vecScratch.Reset()
 	if cap(e.wideF64) > maxRetainedColScratch {
 		e.wideF64 = nil
+	}
+	if cap(e.vecBatchFlat) > maxRetainedColScratch {
+		e.vecBatchFlat = nil
+		e.vecBatchRows = nil
 	}
 	// Keyed-diff match map: drop a spike-sized backing, else clear() it in place.
 	// The keys are unsafe.String / string-header aliases into the caller's prior

--- a/lossyvec_batch.go
+++ b/lossyvec_batch.go
@@ -1,0 +1,233 @@
+package qdf
+
+import (
+	"encoding/binary"
+	"errors"
+	"reflect"
+	"unsafe"
+
+	"github.com/alex60217101990/qdf/internal/reflectutil"
+	"github.com/alex60217101990/qdf/internal/vecquant"
+)
+
+// Batched lossy vector-column codec (tagVecBatchStruct, 0xFE).
+//
+// A []struct with a []float32/[]float64 vector field, encoded the naive way,
+// emits one count=1 lossy block PER ROW — so the fixed block header AND the rANS
+// frequency framing are paid per vector and never amortized (~+70% vs batched on
+// a typical embedding corpus). This codec gathers each equal-length vector field
+// across all N rows into ONE count=N block, encoded once, and decodes by
+// scattering the N reconstructed vectors back into the rows. Non-batched fields
+// (scalars, strings, varying-length / short vectors) stay row-major.
+
+// encodeVectorBatchStruct batches the equal-length vector fields of a []struct
+// (element descriptor td, n rows starting at base, stride bytes apart). It
+// returns done=true after writing the full tagVecBatchStruct payload when at
+// least one field was batched; done=false (nothing written) when no field is
+// batchable, so the caller falls back to the normal []struct encoding.
+func (e *Encoder) encodeVectorBatchStruct(td *typeDesc, base unsafe.Pointer, n int, stride uintptr) (done bool, err error) {
+	nv := len(td.vecFields)
+	if nv == 0 || nv > 8 { // batchedMask is one byte
+		return false, nil
+	}
+	blocks := make([][]byte, nv)
+	var mask byte
+	budget := toBudget(e.vecBudget)
+	for vi := range td.vecFields {
+		blk, ok := e.buildVecColumnBlock(&td.vecFields[vi], base, n, stride, budget)
+		if ok {
+			blocks[vi] = blk
+			mask |= 1 << uint(vi)
+		}
+	}
+	if mask == 0 {
+		return false, nil // nothing batchable — let the caller emit row-major
+	}
+
+	e.writeHeader()
+	e.buf = append(e.buf, tagVecBatchStruct)
+	e.buf = appendUvarint(e.buf, uint64(n))
+	e.buf = append(e.buf, byte(nv), mask)
+	for vi := range blocks {
+		if mask&(1<<uint(vi)) != 0 {
+			e.buf = append(e.buf, blocks[vi]...)
+		}
+	}
+
+	// Per-row: every NON-batched field in declaration order, via its own codec.
+	skip := batchedFieldSet(td, mask)
+	for i := range n {
+		rowPtr := unsafe.Add(base, uintptr(i)*stride)
+		for fi := range td.fields {
+			if skip[fi] {
+				continue
+			}
+			if err := td.fields[fi].desc.encode(e, unsafe.Add(rowPtr, td.fields[fi].offset)); err != nil {
+				return true, err
+			}
+		}
+	}
+	return true, nil
+}
+
+// buildVecColumnBlock gathers field vf across all n rows and returns its batched
+// lossy block, or ok=false when the field is not batchable (varying length,
+// shorter than lossyVecMinElems, or the lossy block is not smaller than raw).
+func (e *Encoder) buildVecColumnBlock(vf *vecBatchField, base unsafe.Pointer, n int, stride uintptr, b vecquant.Budget) ([]byte, bool) {
+	dim := -1
+	for i := range n {
+		fp := unsafe.Add(base, uintptr(i)*stride+vf.offset)
+		var l int
+		if vf.elemF32 {
+			l = len(*(*[]float32)(fp))
+		} else {
+			l = len(*(*[]float64)(fp))
+		}
+		if i == 0 {
+			dim = l
+		} else if l != dim {
+			return nil, false // varying length across rows: cannot batch
+		}
+	}
+	if dim < lossyVecMinElems {
+		return nil, false
+	}
+
+	// Gather n vectors into reused scratch (appendLossyVec zeroes NaN/Inf in
+	// place, so it must never see the caller's backing arrays).
+	if cap(e.vecBatchFlat) < n*dim {
+		e.vecBatchFlat = make([]float64, n*dim)
+	}
+	flat := e.vecBatchFlat[:n*dim]
+	if cap(e.vecBatchRows) < n {
+		e.vecBatchRows = make([][]float64, n)
+	}
+	rows := e.vecBatchRows[:n]
+	for i := range n {
+		fp := unsafe.Add(base, uintptr(i)*stride+vf.offset)
+		dst := flat[i*dim : (i+1)*dim]
+		if vf.elemF32 {
+			for j, x := range *(*[]float32)(fp) {
+				dst[j] = float64(x)
+			}
+		} else {
+			copy(dst, *(*[]float64)(fp))
+		}
+		rows[i] = dst
+	}
+	blk := appendLossyVec(rows, vf.elemF32, b, &e.vecScratch)
+
+	// Never-worse vs raw element bytes (the lossless floor's upper bound): if the
+	// batched lossy block is not smaller than raw, skip batching this field so it
+	// stays row-major (where its own never-worse picker applies per vector).
+	elemSize := 8
+	if vf.elemF32 {
+		elemSize = 4
+	}
+	if len(blk) >= n*dim*elemSize {
+		return nil, false
+	}
+	// blk aliases e.buf-independent scratch inside appendLossyVec's return; it is
+	// a freshly appended slice, safe to retain until written.
+	return blk, true
+}
+
+// batchedFieldSet returns a per-field bool: true when that struct field is a
+// vector field batched under mask.
+func batchedFieldSet(td *typeDesc, mask byte) []bool {
+	skip := make([]bool, len(td.fields))
+	for vi := range td.vecFields {
+		if mask&(1<<uint(vi)) != 0 {
+			skip[td.vecFields[vi].fieldIdx] = true
+		}
+	}
+	return skip
+}
+
+// decodeVectorBatchStruct decodes a tagVecBatchStruct payload into a *[]T (t is
+// the slice type, td its struct element descriptor). The 0xFE tag has been
+// peeked but not consumed.
+func (d *Decoder) decodeVectorBatchStruct(t reflect.Type, td *typeDesc, p unsafe.Pointer) error {
+	if d.i >= len(d.buf) || d.buf[d.i] != tagVecBatchStruct {
+		return ErrBadTag
+	}
+	d.i++
+	n64, k := binary.Uvarint(d.buf[d.i:])
+	if k <= 0 {
+		return errors.New("qdf: bad vec-batch count")
+	}
+	d.i += k
+	n := int(n64)
+	if err := d.CheckLength(n, 1); err != nil {
+		return err
+	}
+	if d.i+2 > len(d.buf) {
+		return ErrShortBuffer
+	}
+	nv := int(d.buf[d.i])
+	mask := d.buf[d.i+1]
+	d.i += 2
+	if nv != len(td.vecFields) {
+		return errors.New("qdf: vec-batch shape mismatch")
+	}
+
+	// Read each batched column's block (count=n vectors).
+	batched := make([][][]float64, nv)
+	for vi := range nv {
+		if mask&(1<<uint(vi)) == 0 {
+			continue
+		}
+		vecs, elemF32, used, err := readLossyVec(d.buf[d.i:])
+		if err != nil {
+			return err
+		}
+		d.i += used
+		if len(vecs) != n {
+			return errors.New("qdf: vec-batch block row count mismatch")
+		}
+		if elemF32 != td.vecFields[vi].elemF32 {
+			return ErrTypeMismatch
+		}
+		batched[vi] = vecs
+	}
+
+	reflectutil.MakeSlice(t, n, p)
+	base := reflectutil.SliceData(t, p)
+	stride := t.Elem().Size()
+
+	skip := make([]bool, len(td.fields))
+	fieldVi := make([]int, len(td.fields))
+	for i := range fieldVi {
+		fieldVi[i] = -1
+	}
+	for vi := range nv {
+		fieldVi[td.vecFields[vi].fieldIdx] = vi
+		if mask&(1<<uint(vi)) != 0 {
+			skip[td.vecFields[vi].fieldIdx] = true
+		}
+	}
+
+	for i := range n {
+		rowPtr := unsafe.Add(base, uintptr(i)*stride)
+		for fi := range td.fields {
+			fp := unsafe.Add(rowPtr, td.fields[fi].offset)
+			if skip[fi] {
+				vec := batched[fieldVi[fi]][i]
+				if td.vecFields[fieldVi[fi]].elemF32 {
+					out := make([]float32, len(vec))
+					for j, x := range vec {
+						out[j] = float32(x)
+					}
+					*(*[]float32)(fp) = out
+				} else {
+					*(*[]float64)(fp) = vec
+				}
+				continue
+			}
+			if err := td.fields[fi].desc.decode(d, fp); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/lossyvec_batch_test.go
+++ b/lossyvec_batch_test.go
@@ -1,0 +1,334 @@
+package qdf
+
+import (
+	"math"
+	"testing"
+)
+
+type vecOnlyRow struct {
+	Emb []float32
+}
+
+type vecMixedRow struct {
+	ID   string
+	Tags []string
+	Emb  []float64
+	N    int
+}
+
+func sinVec32(seed, dim int) []float32 {
+	v := make([]float32, dim)
+	for j := range v {
+		v[j] = float32(math.Sin(float64(seed*dim+j) * 0.013))
+	}
+	return v
+}
+
+func sinVec64(seed, dim int) []float64 {
+	v := make([]float64, dim)
+	for j := range v {
+		v[j] = math.Sin(float64(seed*dim+j) * 0.013)
+	}
+	return v
+}
+
+func cosine32(a, b []float32) float64 {
+	var dot, na, nb float64
+	for i := range a {
+		x, y := float64(a[i]), float64(b[i])
+		dot += x * y
+		na += x * x
+		nb += y * y
+	}
+	return dot / (math.Sqrt(na)*math.Sqrt(nb) + 1e-30)
+}
+
+func cosine64(a, b []float64) float64 {
+	var dot, na, nb float64
+	for i := range a {
+		dot += a[i] * b[i]
+		na += a[i] * a[i]
+		nb += b[i] * b[i]
+	}
+	return dot / (math.Sqrt(na)*math.Sqrt(nb) + 1e-30)
+}
+
+func TestVecBatchRoundTripF32(t *testing.T) {
+	const n, dim = 64, 256
+	rows := make([]vecOnlyRow, n)
+	for i := range rows {
+		rows[i] = vecOnlyRow{Emb: sinVec32(i, dim)}
+	}
+	enc := NewEncoderWith(OptBalanced | OptLossyVec)
+	enc.SetVectorBudget(MinCosine(0.999))
+	if err := enc.EncodeValue(rows); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	data := enc.Bytes()
+	if data[5] != tagVecBatchStruct {
+		t.Fatalf("expected tagVecBatchStruct (0xFE) at byte 5, got 0x%02x", data[5])
+	}
+	var out []vecOnlyRow
+	if err := Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out) != n {
+		t.Fatalf("len %d want %d", len(out), n)
+	}
+	for i := range rows {
+		if len(out[i].Emb) != dim {
+			t.Fatalf("row %d dim %d", i, len(out[i].Emb))
+		}
+		if c := cosine32(rows[i].Emb, out[i].Emb); c < 0.999*0.999 {
+			t.Fatalf("row %d cosine %.5f below target", i, c)
+		}
+	}
+}
+
+func TestVecBatchRoundTripMixed(t *testing.T) {
+	const n, dim = 48, 128
+	rows := make([]vecMixedRow, n)
+	for i := range rows {
+		rows[i] = vecMixedRow{
+			ID:   "doc-" + string(rune('A'+i%5)),
+			Tags: []string{"x", "y"},
+			Emb:  sinVec64(i, dim),
+			N:    i * 7,
+		}
+	}
+	enc := NewEncoderWith(OptBalanced | OptLossyVec)
+	enc.SetVectorBudget(MaxRelError(0.02))
+	if err := enc.EncodeValue(rows); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	data := enc.Bytes()
+	if data[5] != tagVecBatchStruct {
+		t.Fatalf("expected 0xFE at byte 5, got 0x%02x", data[5])
+	}
+	var out []vecMixedRow
+	if err := Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out) != n {
+		t.Fatalf("len %d", len(out))
+	}
+	for i := range rows {
+		if out[i].ID != rows[i].ID || out[i].N != rows[i].N {
+			t.Fatalf("row %d scalar mismatch: %q/%d vs %q/%d", i, out[i].ID, out[i].N, rows[i].ID, rows[i].N)
+		}
+		if len(out[i].Tags) != 2 || out[i].Tags[0] != "x" || out[i].Tags[1] != "y" {
+			t.Fatalf("row %d tags %v", i, out[i].Tags)
+		}
+		if c := cosine64(rows[i].Emb, out[i].Emb); c < 0.999 {
+			t.Fatalf("row %d cosine %.5f", i, c)
+		}
+	}
+}
+
+// TestVecBatchSmallerThanPerRow asserts the batched path is materially smaller
+// than the per-vector (count=1) encoding the same data would otherwise produce.
+func TestVecBatchSmallerThanPerRow(t *testing.T) {
+	const n, dim = 64, 256
+	rows := make([]vecOnlyRow, n)
+	for i := range rows {
+		rows[i] = vecOnlyRow{Emb: sinVec32(i, dim)}
+	}
+	batched, err := Marshal(rows, OptBalanced|OptLossyVec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Force the per-row path by encoding each row's single-element slice.
+	perRow := 0
+	for i := range rows {
+		one := []vecOnlyRow{rows[i]} // n=1 < columnarMinElems => row-major per-vector
+		b, err := Marshal(one, OptBalanced|OptLossyVec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		perRow += len(b)
+	}
+	bpvBatched := float64(len(batched)) / n
+	bpvPerRow := float64(perRow) / n
+	t.Logf("batched=%.1f B/vec  per-row=%.1f B/vec  (%.0f%% smaller)",
+		bpvBatched, bpvPerRow, 100*(1-bpvBatched/bpvPerRow))
+	if bpvBatched >= bpvPerRow {
+		t.Fatalf("batched %.1f not smaller than per-row %.1f B/vec", bpvBatched, bpvPerRow)
+	}
+}
+
+// TestVecBatchVaryingDimFallsBack: rows with different vector lengths cannot be
+// batched; must still round-trip (via row-major fallback).
+func TestVecBatchVaryingDimFallsBack(t *testing.T) {
+	const n = 32
+	rows := make([]vecOnlyRow, n)
+	for i := range rows {
+		rows[i] = vecOnlyRow{Emb: sinVec32(i, 64+i)} // varying dim
+	}
+	data, err := Marshal(rows, OptBalanced|OptLossyVec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) > 5 && data[5] == tagVecBatchStruct {
+		t.Fatalf("varying-dim should NOT batch, but emitted 0xFE")
+	}
+	var out []vecOnlyRow
+	if err := Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for i := range rows {
+		if len(out[i].Emb) != 64+i {
+			t.Fatalf("row %d dim %d want %d", i, len(out[i].Emb), 64+i)
+		}
+	}
+}
+
+// TestVecBatchOffByDefaultExact: without OptLossyVec the vectors round-trip
+// bit-exact (no batching, no loss).
+func TestVecBatchOffByDefaultExact(t *testing.T) {
+	const n, dim = 32, 64
+	rows := make([]vecOnlyRow, n)
+	for i := range rows {
+		rows[i] = vecOnlyRow{Emb: sinVec32(i, dim)}
+	}
+	data, err := Marshal(rows, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) > 5 && data[5] == tagVecBatchStruct {
+		t.Fatalf("no OptLossyVec but emitted 0xFE")
+	}
+	var out []vecOnlyRow
+	if err := Unmarshal(data, &out); err != nil {
+		t.Fatal(err)
+	}
+	for i := range rows {
+		for j := range rows[i].Emb {
+			if math.Float32bits(out[i].Emb[j]) != math.Float32bits(rows[i].Emb[j]) {
+				t.Fatalf("row %d coord %d not bit-exact without lossy", i, j)
+			}
+		}
+	}
+}
+
+type twoVecRow struct {
+	A []float32
+	B []float64
+	K int
+}
+
+func TestVecBatchTwoVecFields(t *testing.T) {
+	const n, dim = 40, 96
+	rows := make([]twoVecRow, n)
+	for i := range rows {
+		rows[i] = twoVecRow{A: sinVec32(i, dim), B: sinVec64(i+1, dim), K: i}
+	}
+	data, err := Marshal(rows, OptBalanced|OptLossyVec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data[5] != tagVecBatchStruct {
+		t.Fatalf("want 0xFE, got 0x%02x", data[5])
+	}
+	var out []twoVecRow
+	if err := Unmarshal(data, &out); err != nil {
+		t.Fatal(err)
+	}
+	for i := range rows {
+		if out[i].K != i {
+			t.Fatalf("row %d K=%d", i, out[i].K)
+		}
+		if cosine32(rows[i].A, out[i].A) < 0.99 || cosine64(rows[i].B, out[i].B) < 0.99 {
+			t.Fatalf("row %d cosine low", i)
+		}
+	}
+}
+
+func TestVecBatchNaNInfPreserved(t *testing.T) {
+	const n, dim = 32, 64
+	rows := make([]vecOnlyRow, n)
+	for i := range rows {
+		v := sinVec32(i, dim)
+		v[0] = float32(math.NaN())
+		v[1] = float32(math.Inf(1))
+		v[2] = float32(math.Inf(-1))
+		rows[i] = vecOnlyRow{Emb: v}
+	}
+	data, err := Marshal(rows, OptBalanced|OptLossyVec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []vecOnlyRow
+	if err := Unmarshal(data, &out); err != nil {
+		t.Fatal(err)
+	}
+	for i := range rows {
+		if !math.IsNaN(float64(out[i].Emb[0])) {
+			t.Fatalf("row %d NaN not preserved: %v", i, out[i].Emb[0])
+		}
+		if !math.IsInf(float64(out[i].Emb[1]), 1) || !math.IsInf(float64(out[i].Emb[2]), -1) {
+			t.Fatalf("row %d Inf not preserved", i)
+		}
+	}
+}
+
+func TestVecBatchBelowMinElemsNoBatch(t *testing.T) {
+	// n >= 16 but vector dim < lossyVecMinElems(32) => not batchable.
+	const n, dim = 32, 16
+	rows := make([]vecOnlyRow, n)
+	for i := range rows {
+		rows[i] = vecOnlyRow{Emb: sinVec32(i, dim)}
+	}
+	data, err := Marshal(rows, OptBalanced|OptLossyVec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) > 5 && data[5] == tagVecBatchStruct {
+		t.Fatalf("dim<min should not batch")
+	}
+	var out []vecOnlyRow
+	if err := Unmarshal(data, &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != n {
+		t.Fatalf("len %d", len(out))
+	}
+}
+
+func TestVecBatchEmptyAndNilRows(t *testing.T) {
+	// All-empty vectors: dim 0 < min => no batch, must still round-trip incl
+	// the nil-vs-empty distinction.
+	rows := make([]vecOnlyRow, 20)
+	for i := range rows {
+		if i%2 == 0 {
+			rows[i] = vecOnlyRow{Emb: nil}
+		} else {
+			rows[i] = vecOnlyRow{Emb: []float32{}}
+		}
+	}
+	data, err := Marshal(rows, OptBalanced|OptLossyVec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []vecOnlyRow
+	if err := Unmarshal(data, &out); err != nil {
+		t.Fatal(err)
+	}
+	for i := range rows {
+		if (rows[i].Emb == nil) != (out[i].Emb == nil) {
+			t.Fatalf("row %d nil-vs-empty mismatch: %v vs %v", i, rows[i].Emb, out[i].Emb)
+		}
+	}
+}
+
+func FuzzVecBatchDecode(f *testing.F) {
+	rows := make([]vecOnlyRow, 32)
+	for i := range rows {
+		rows[i] = vecOnlyRow{Emb: sinVec32(i, 64)}
+	}
+	seed, _ := Marshal(rows, OptBalanced|OptLossyVec)
+	f.Add(seed)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var out []vecOnlyRow
+		_ = Unmarshal(data, &out) // must never panic / OOM
+	})
+}

--- a/reflect_desc.go
+++ b/reflect_desc.go
@@ -32,6 +32,13 @@ type typeDesc struct {
 
 	fields []fieldDesc // structs only
 
+	// vecFields lists the []float32/[]float64 fields of a struct, in declaration
+	// order, with the index back into fields. Non-nil only for struct types that
+	// have at least one such field. Used by the batched lossy vector-column codec
+	// (tagVecBatchStruct) to gather one column's vectors across all rows into a
+	// single count=N block. Pure type info (option-independent), set at build.
+	vecFields []vecBatchField
+
 	// schemaFP is the structural fingerprint of this descriptor's full subtree
 	// (kind + field names + recursive field/element kinds). Computed once at build
 	// time (descBuild) so the delta Diff/Apply path reads it with zero runtime
@@ -80,6 +87,15 @@ type fieldDesc struct {
 	preInternStr []byte
 	offset       uintptr
 	isKey        bool // this field carried the ,key tag option
+}
+
+// vecBatchField identifies a []float32/[]float64 struct field for the batched
+// lossy vector-column codec. fieldIdx indexes into the struct's fields slice;
+// elemF32 distinguishes the element type so decode reconstructs the right slice.
+type vecBatchField struct {
+	offset   uintptr
+	fieldIdx int
+	elemF32  bool
 }
 
 var typeCache sync.Map // map[reflect.Type]*typeDesc — only fully-built entries
@@ -331,6 +347,22 @@ func fillDesc(td *typeDesc, t reflect.Type, ctx *buildCtx) error {
 			return err
 		}
 		td.fields = fields
+		// Record []float32/[]float64 fields for the batched lossy vector codec.
+		// Detect via the field's reflect type: the typed slice fast paths set the
+		// encode/decode closures but leave td.elem nil, so the kind is read from
+		// rType, not the descriptor's elem.
+		for i := range td.fields {
+			fd := td.fields[i].desc
+			if fd == nil || fd.rType == nil || fd.rType.Kind() != reflect.Slice {
+				continue
+			}
+			switch fd.rType.Elem().Kind() {
+			case reflect.Float32:
+				td.vecFields = append(td.vecFields, vecBatchField{offset: td.fields[i].offset, fieldIdx: i, elemF32: true})
+			case reflect.Float64:
+				td.vecFields = append(td.vecFields, vecBatchField{offset: td.fields[i].offset, fieldIdx: i, elemF32: false})
+			}
+		}
 		// Record the identity key (the ,key-tagged field), if any. Reject more
 		// than one ,key field per type.
 		for i := range td.fields {

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -205,6 +205,18 @@ func encodeSlice(elem *typeDesc, stride uintptr, colPlan *columnarPlan) func(*En
 		}
 		hdr := (*sliceHeader)(p)
 		n := hdr.Len
+		// Batched lossy vector-column path: under OptLossyVec, a []struct with an
+		// equal-length []float32/[]float64 field is encoded as one count=N block
+		// per vector field (tagVecBatchStruct) instead of N count=1 blocks. Gated
+		// to the same contexts as columnar; falls through when nothing is batchable
+		// (so non-lossy and unbatchable shapes stay byte-identical).
+		if e.opts.Has(OptLossyVec) && elem != nil && len(elem.vecFields) > 0 &&
+			n >= columnarMinElems && e.state != nil && !e.stateSuspended &&
+			e.opts.Has(OptDense) && e.opts.Has(OptShapeIntern) {
+			if done, err := e.encodeVectorBatchStruct(elem, hdr.Data, n, stride); done {
+				return err
+			}
+		}
 		// Columnar / hybrid-columnar path.
 		//
 		// Pure plan (every field eligible): transpose under the columnarProbe
@@ -305,6 +317,16 @@ func decodeSlice(t reflect.Type, elem *typeDesc, stride uintptr, colPlan *column
 			return err
 		}
 		defer d.ascend()
+		// Batched lossy vector-column dispatch (tagVecBatchStruct). Works even when
+		// colPlan is nil (a vector-only struct is not columnar-eligible).
+		if elem != nil && len(elem.vecFields) > 0 {
+			if tag, err := d.peekTag(); err == nil && tag == tagVecBatchStruct {
+				if elemDynamic || d.query != nil {
+					return ErrUnsupported // v1: no schemaless / query decode of a batched block
+				}
+				return d.decodeVectorBatchStruct(t, elem, p)
+			}
+		}
 		// Columnar / hybrid-columnar decode dispatch.
 		if colPlan != nil {
 			if tag, err := d.peekTag(); err == nil {

--- a/wire.go
+++ b/wire.go
@@ -304,6 +304,24 @@ const (
 	tagColStrDictQ = 0xFC
 
 	tagColVecLossy = 0xFD // lossy float-vector block (Hadamard+quant+rANS)
+
+	// tagVecBatchStruct is a container for a []struct whose []float32/[]float64
+	// vector field(s) are batched into ONE count=N lossy block each (amortizing
+	// the per-vector block header + rANS frequency framing that a per-row count=1
+	// block pays). Only emitted under OptLossyVec when at least one vector field
+	// is batchable (equal length across all rows, >= lossyVecMinElems, and the
+	// batched block beats raw). Layout:
+	//
+	//   0xFE, varuint(n), byte(numVecFields), byte(batchedMask),
+	//     for each set mask bit (vector-field order): <0xFD count=n block>,
+	//     per row: each NON-batched field encoded in declaration order via its
+	//              own (row-major) field codec.
+	//
+	// Non-batched vector fields and all scalar/string fields stay row-major, so
+	// decode reconstructs each row by decoding those fields and scattering the
+	// batched vectors. Forward-compat: a decoder that does not understand 0xFE
+	// errors cleanly.
+	tagVecBatchStruct = 0xFE
 )
 
 // isStringColumnBlockTag reports whether b begins a self-describing string


### PR DESCRIPTION
# feat: batch a []struct vector column into one count=N lossy block

Branch: `feat/lossyvec-batched-column` (off `main`, on top of the merged
`OptLossyVec` codec).

## The problem this fixes

The lossy vector codec wired the per-row path as **one count=1 block per
vector**: `[]EmbedRow{Emb []float32}` emitted `N` independent `0xFD` blocks. So
the fixed block header **and** the rANS frequency framing were paid for every
vector and never amortized. Measured on the bench's own Gaussian corpus:

| encoding | bytes / vector |
|---|---|
| per-row (count=1, what shipped) | **291** |
| batched (count=N) | **170** |

That is a **+70 %** bloat. The RD harness reported the *batched* figure, so its
headline "qdf −17–22 % vs naive" compared qdf-batched against per-vector
baselines — not what the codec produced in production, where a vector cost ~290 B
(worse than naive scalar). Probes documenting this are included
(`cmd/qdf-vecbench/batch_overhead_probe_test.go`).

## The fix

New wire tag **`0xFE` (`tagVecBatchStruct`)**. Under `OptLossyVec`, the encoder
gathers every row's value of an equal-length `[]float32`/`[]float64` field into
**one count-N block**, encodes it once, and writes the remaining scalar/string/
non-batched fields row-major. Decode reads the batched block and scatters the N
reconstructed vectors back into the rows.

```
0xFE, varuint(n), byte(numVecFields), byte(batchedMask),
  for each set mask bit (vector-field order): <0xFD count=n block>,
  per row: each NON-batched field, declaration order, via its own codec
```

Result on a 256×256 corpus: **176 B/vec at 13 allocs/op** warm (was ~290 B/vec)
— a ~40 % production size cut, reconstruction quality unchanged. The bench's RD
numbers are now the ones you actually get per row.

## Safety / zero regression

- **`OptLossyVec`-gated.** Without it, `[]float32`/`[]float64` fields stay
  row-major and bit-exact — byte-identical to before.
- **Falls through** to the normal `[]struct` encoding when nothing is batchable,
  so non-lossy and unbatchable shapes are untouched.
- **Never-worse vs raw** per field: a field whose batched block is not smaller
  than raw, has varying length across rows, or is shorter than
  `lossyVecMinElems`, stays row-major.
- **NaN/Inf** preserved (exception list, as in the per-row path).
- Decode allocations bounded by the input; a decoder that does not understand
  `0xFE` errors cleanly.
- v1 decodes statically into `[]T`; a schemaless (`[]map[string]any`) or query
  decode of a batched block returns `ErrUnsupported`.

## Performance

- Vector fields detected once at type-build (`typeDesc.vecFields`).
- Gather scratch (`vecBatchFlat` / `vecBatchRows`) reused across encodes, dropped
  past the retention ceiling in `Reset` — 13 allocs/op for a 256-vector slice.
- The batched block reuses the existing `vecScratch` (rotation/coord/rANS
  buffers).

## Tests

Round-trip (vector-only + mixed structs, f32 + f64, two vector fields), NaN/Inf
preservation, nil-vs-empty, varying-dim / below-min fallback, off-by-default
bit-exactness, batched-smaller-than-per-row, and a decode fuzz target.
`go test ./...` + `-race` green on root and the nested `cmd/qdf-vecbench`;
`golangci-lint v2` clean.

## Follow-ups (measured, not in this PR)

- **polar-split** (probe included): storing each vector's norm + quantizing the
  unit direction wins −11 %…−23 % on varying-norm data and fixes a budget
  breakdown under norm variance — but only helps a count>1 block, so it was
  blocked on this batching landing. Now unblocked.
- **ScaNN anisotropic** and **Leech-24**: measured/derived → no-go (rotation
  already isotropizes the error; Leech ~1–3 % over E8 for ~10× decode).
