### PR TITLE
feat: polar-split for varying-norm batched vector columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,10 +764,26 @@ _ = enc.EncodeValue(rows)
 data := enc.Bytes()
 ```
 
+**Built for embedding stores.** The natural shape of a RAG index or vector
+database is a `[]struct` — `{ID, Title, Emb []float32}` — i.e. id + metadata +
+vector per record. qdf serializes the whole thing as **one** self-describing
+blob, and under `OptLossyVec` it **batches the vector field across all rows into
+a single column block**, so the per-vector header and entropy-coding overhead are
+amortized once over the batch instead of paid per row (a per-row encoding is
+~70 % larger). A 256-dim `float32` vector lands at roughly a third of its 1 KiB
+raw size while cosine recall is preserved — no separate vector store, no second
+metadata store, no custom format.
+
+For columns whose vectors have **widely varying magnitudes** (model-weight rows,
+un-normalized vectors) the codec automatically switches to a *polar split* —
+storing each vector's norm separately and quantizing the unit direction — so one
+tight step serves every vector and the column keeps its fidelity budget. Unit-
+norm embeddings, where it cannot help, pay nothing for it.
+
 NaN and Inf values are preserved exactly via an exception list in the wire
 format — they are never corrupted or silently dropped. The encode never exceeds
 the lossless size (never-worse), and reuses pooled scratch for near-zero warm
-allocations.
+allocations. See the runnable `Example_aiEmbeddingStore`.
 
 Full details — pipeline, budget knobs, `0xFD` wire format, the
 [diagram](diagrams/lossy-vector.md), benchmark numbers, and runnable examples —

--- a/docs/LOSSY-VECTOR.md
+++ b/docs/LOSSY-VECTOR.md
@@ -139,6 +139,16 @@ under `OptLossyVec` for ≥ 16 rows when the field has the same length in every 
 and the batched block beats raw; otherwise each vector stays row-major. Scalar
 and string fields, and varying-length / short vectors, are unaffected.
 
+**Polar split (varying-norm columns).** A single quantization step over a whole
+batch is driven by the largest-norm vector, so when the per-vector norms vary
+widely (model weights, un-normalized vectors) the small ones are over-quantized.
+For such a column the codec stores each vector's L2 norm separately (16-bit in
+the log domain, ~2 B/vector) and quantizes the **unit directions**, so one tight
+step serves every direction — −10…−20 % at equal quality on varying-norm data,
+and it keeps the codec within budget where a shared step would not. It is
+never-worse and probe-gated on the norm spread, so unit-norm embeddings (where it
+cannot win) pay nothing.
+
 ---
 
 ## Numbers

--- a/docs/LOSSY-VECTOR.md
+++ b/docs/LOSSY-VECTOR.md
@@ -46,6 +46,15 @@ comes from:
 2. **Use a lattice.** The E8 lattice's Voronoi cell is rounder than the scalar
    cube, so it needs fewer bits for the same distortion.
 
+**One blob, not two stores.** A typical embedding record is id + metadata +
+vector. With qdf you serialize the whole `[]struct` as a single self-describing
+blob: the scalar/string fields stay exact, the vector field is batched into one
+lossy column block, and `Unmarshal` rebuilds the records with no flag and no side
+schema. You do not run a separate vector store next to a metadata store, and you
+do not invent a wire format — it is the same `Marshal`/`Unmarshal` you already
+use, with one option flipped. See the runnable `Example_aiEmbeddingStore` in the
+package docs.
+
 ---
 
 ## When to use it (and which budget)

--- a/encoder.go
+++ b/encoder.go
@@ -119,6 +119,9 @@ type Encoder struct {
 	// past the ceiling in Reset.
 	vecBatchFlat []float64
 	vecBatchRows [][]float64
+	// vecBatchNorms reuses the per-vector L2 norm scratch for the polar-split
+	// variant of the batched vector codec.
+	vecBatchNorms []float64
 
 	// preIntern is an opt-in identity cache populated by PreIntern.
 	// When non-empty WriteString does a linear scan against it
@@ -367,6 +370,9 @@ func (e *Encoder) resetForReuse() {
 	if cap(e.vecBatchFlat) > maxRetainedColScratch {
 		e.vecBatchFlat = nil
 		e.vecBatchRows = nil
+	}
+	if cap(e.vecBatchNorms) > maxRetainedColScratch {
+		e.vecBatchNorms = nil
 	}
 	// Keyed-diff match map: drop a spike-sized backing, else clear() it in place.
 	// The keys are unsafe.String / string-header aliases into the caller's prior

--- a/encoder.go
+++ b/encoder.go
@@ -369,6 +369,12 @@ func (e *Encoder) resetForReuse() {
 	}
 	if cap(e.vecBatchFlat) > maxRetainedColScratch {
 		e.vecBatchFlat = nil
+	}
+	// vecBatchRows holds slice headers into vecBatchFlat; drop it independently
+	// (many rows × small dim keeps flat under the ceiling) and clear first so the
+	// retained headers do not GC-pin the prior flat backing.
+	if cap(e.vecBatchRows) > maxRetainedColScratch || e.vecBatchFlat == nil {
+		clear(e.vecBatchRows[:cap(e.vecBatchRows)])
 		e.vecBatchRows = nil
 	}
 	if cap(e.vecBatchNorms) > maxRetainedColScratch {

--- a/example_lossyvec_test.go
+++ b/example_lossyvec_test.go
@@ -109,3 +109,81 @@ func ExampleMaxRelError() {
 	// +Inf preserved: true
 	// rel error <= 1%: true
 }
+
+// Example_aiEmbeddingStore is the headline use case: a RAG index / vector
+// database stored as ONE self-describing qdf blob — id + metadata + the
+// embedding vector per record — instead of a separate vector store plus a
+// metadata store.
+//
+// Why this is a good fit:
+//   - The records are a []struct with a []float32 vector field. Under OptLossyVec
+//     qdf batches that field across ALL rows into a single column block, so the
+//     per-vector header and entropy-coding overhead are amortized once over the
+//     whole batch (not paid per row) — a 256-dim float32 vector lands at roughly
+//     a third of its 1 KiB raw size.
+//   - The fidelity budget is the metric the index relies on (cosine here), so
+//     nearest-neighbour results are preserved while the bytes shrink.
+//   - It is never-worse (a column that would not shrink stays lossless) and the
+//     default path is bit-exact, so turning the flag off restores exact vectors.
+func Example_aiEmbeddingStore() {
+	type Doc struct {
+		ID    string
+		Title string
+		Emb   []float32 // the embedding — batched + lossily compressed
+	}
+
+	// A small deterministic "corpus" of 128 documents, 256-dim embeddings.
+	const n, dim = 128, 256
+	docs := make([]Doc, n)
+	for i := range docs {
+		v := make([]float32, dim)
+		for j := range v {
+			v[j] = float32(math.Sin(float64(i)*0.3 + float64(j)*0.02))
+		}
+		docs[i] = Doc{ID: fmt.Sprintf("doc-%04d", i), Title: "title", Emb: v}
+	}
+
+	// Store the whole index in one blob; cosine recall kept >= 0.999.
+	data, err := qdf.Marshal(docs, qdf.OptBalanced|qdf.OptLossyVec)
+	if err != nil {
+		panic(err)
+	}
+
+	var out []Doc
+	if err := qdf.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+
+	cos := func(a, b []float32) float64 {
+		var dot, na, nb float64
+		for j := range a {
+			x, y := float64(a[j]), float64(b[j])
+			dot, na, nb = dot+x*y, na+x*x, nb+y*y
+		}
+		return dot / (math.Sqrt(na)*math.Sqrt(nb) + 1e-30)
+	}
+	// Top-1 retrieval: for a handful of original query vectors, the nearest
+	// DECODED vector must still be the same document (recall survives the loss).
+	hits := 0
+	for _, q := range []int{0, 17, 63, 100} {
+		best, bestC := -1, -1.0
+		for i := range out {
+			if c := cos(docs[q].Emb, out[i].Emb); c > bestC {
+				bestC, best = c, i
+			}
+		}
+		if best == q {
+			hits++
+		}
+	}
+
+	rawF32 := n * dim * 4
+	fmt.Println("metadata intact:", out[0].ID == "doc-0000" && out[0].Title == "title")
+	fmt.Println("smaller than raw f32:", len(data) < rawF32/2) // well under half
+	fmt.Println("top-1 recall preserved:", hits == 4)
+
+	// Output:
+	// metadata intact: true
+	// smaller than raw f32: true
+	// top-1 recall preserved: true
+}

--- a/lossyvec_batch.go
+++ b/lossyvec_batch.go
@@ -107,6 +107,12 @@ func (e *Encoder) buildVecColumnBlock(vf *vecBatchField, base unsafe.Pointer, n 
 	if dim < lossyVecMinElems {
 		return nil, false, false
 	}
+	// Bound the gather before n*dim is computed as int (cannot overflow on 32-bit;
+	// also keeps the batch within the columnar byte budget). Over the cap, the
+	// field stays row-major.
+	if int64(n)*int64(dim) > int64(maxColumnarBytes/8) {
+		return nil, false, false
+	}
 
 	// Gather n vectors into reused scratch (appendLossyVec zeroes NaN/Inf in
 	// place, so it must never see the caller's backing arrays).
@@ -201,6 +207,9 @@ func (e *Encoder) buildVecColumnBlock(vf *vecBatchField, base unsafe.Pointer, n 
 // log domain gives uniform RELATIVE precision, so a wide norm range (1000x)
 // still round-trips to ~1e-4. norms must all be finite and positive.
 func appendNormStream(dst []byte, norms []float64) []byte {
+	if len(norms) == 0 {
+		return dst // never reached in practice (n >= columnarMinElems); guards ±Inf header
+	}
 	logMin, logMax := math.Inf(1), math.Inf(-1)
 	for _, nrm := range norms {
 		l := math.Log(nrm)
@@ -222,7 +231,7 @@ func appendNormStream(dst []byte, norms []float64) []byte {
 // readNormStream reads n quantized norms written by appendNormStream and returns
 // them plus the number of bytes consumed.
 func readNormStream(src []byte, n int) (norms []float64, used int, err error) {
-	if len(src) < 16+2*n {
+	if uint64(len(src)) < 16+2*uint64(n) { // uint64 intermediate: 2*n cannot wrap
 		return nil, 0, ErrShortBuffer
 	}
 	logMin := math.Float64frombits(binary.LittleEndian.Uint64(src[0:]))
@@ -266,8 +275,17 @@ func (d *Decoder) decodeVectorBatchStruct(t reflect.Type, td *typeDesc, p unsafe
 		return errors.New("qdf: bad vec-batch count")
 	}
 	d.i += k
+	if n64 > uint64(maxColumnarElems) { // uint64->int maxInt clause (32-bit) + ceiling
+		return ErrInvalidLength
+	}
 	n := int(n64)
-	if err := d.CheckLength(n, 1); err != nil {
+	// Bound the result allocation by the input: MakeSlice(t, n) below allocates
+	// n*stride, so CheckLength(n, 1) is not enough — a hostile count amplifies by
+	// the struct stride. Mirror the columnar decoders' count + byte caps.
+	if err := checkColumnarN(n); err != nil {
+		return err
+	}
+	if err := checkColumnarBytes(n, t.Elem().Size()); err != nil {
 		return err
 	}
 	if d.i+3 > len(d.buf) {
@@ -279,6 +297,9 @@ func (d *Decoder) decodeVectorBatchStruct(t reflect.Type, td *typeDesc, p unsafe
 	d.i += 3
 	if nv != len(td.vecFields) {
 		return errors.New("qdf: vec-batch shape mismatch")
+	}
+	if polarMask&^mask != 0 { // polar bit on a non-batched field would desync d.i
+		return errors.New("qdf: vec-batch polarMask not a subset of mask")
 	}
 
 	// Read each batched column's block (count=n vectors). A polar field carries a

--- a/lossyvec_batch.go
+++ b/lossyvec_batch.go
@@ -3,6 +3,7 @@ package qdf
 import (
 	"encoding/binary"
 	"errors"
+	"math"
 	"reflect"
 	"unsafe"
 
@@ -31,13 +32,16 @@ func (e *Encoder) encodeVectorBatchStruct(td *typeDesc, base unsafe.Pointer, n i
 		return false, nil
 	}
 	blocks := make([][]byte, nv)
-	var mask byte
+	var mask, polarMask byte
 	budget := toBudget(e.vecBudget)
 	for vi := range td.vecFields {
-		blk, ok := e.buildVecColumnBlock(&td.vecFields[vi], base, n, stride, budget)
+		blk, polar, ok := e.buildVecColumnBlock(&td.vecFields[vi], base, n, stride, budget)
 		if ok {
 			blocks[vi] = blk
 			mask |= 1 << uint(vi)
+			if polar {
+				polarMask |= 1 << uint(vi)
+			}
 		}
 	}
 	if mask == 0 {
@@ -47,7 +51,7 @@ func (e *Encoder) encodeVectorBatchStruct(td *typeDesc, base unsafe.Pointer, n i
 	e.writeHeader()
 	e.buf = append(e.buf, tagVecBatchStruct)
 	e.buf = appendUvarint(e.buf, uint64(n))
-	e.buf = append(e.buf, byte(nv), mask)
+	e.buf = append(e.buf, byte(nv), mask, polarMask)
 	for vi := range blocks {
 		if mask&(1<<uint(vi)) != 0 {
 			e.buf = append(e.buf, blocks[vi]...)
@@ -70,10 +74,21 @@ func (e *Encoder) encodeVectorBatchStruct(td *typeDesc, base unsafe.Pointer, n i
 	return true, nil
 }
 
+// polarMinCV is the smallest per-vector norm coefficient of variation
+// (std/mean) at which the polar-split variant is worth attempting. Below it the
+// norms are near-constant (unit-norm embeddings), so storing them separately
+// only adds overhead — the never-worse compare would reject polar anyway, so we
+// skip the second encode. Above it (varying-norm data: weights, raw vectors) a
+// shared step over the raw vectors is driven by the largest norm and wastes bits
+// on the small ones; normalizing first lets one tight step serve every direction.
+const polarMinCV = 0.08
+
 // buildVecColumnBlock gathers field vf across all n rows and returns its batched
-// lossy block, or ok=false when the field is not batchable (varying length,
-// shorter than lossyVecMinElems, or the lossy block is not smaller than raw).
-func (e *Encoder) buildVecColumnBlock(vf *vecBatchField, base unsafe.Pointer, n int, stride uintptr, b vecquant.Budget) ([]byte, bool) {
+// payload plus polar (true when the payload is the polar-split form: a per-vector
+// norm stream followed by the lossy block of unit directions). ok=false when the
+// field is not batchable (varying length, shorter than lossyVecMinElems, or no
+// form beats raw).
+func (e *Encoder) buildVecColumnBlock(vf *vecBatchField, base unsafe.Pointer, n int, stride uintptr, b vecquant.Budget) (payload []byte, polar bool, ok bool) {
 	dim := -1
 	for i := range n {
 		fp := unsafe.Add(base, uintptr(i)*stride+vf.offset)
@@ -86,11 +101,11 @@ func (e *Encoder) buildVecColumnBlock(vf *vecBatchField, base unsafe.Pointer, n 
 		if i == 0 {
 			dim = l
 		} else if l != dim {
-			return nil, false // varying length across rows: cannot batch
+			return nil, false, false // varying length across rows: cannot batch
 		}
 	}
 	if dim < lossyVecMinElems {
-		return nil, false
+		return nil, false, false
 	}
 
 	// Gather n vectors into reused scratch (appendLossyVec zeroes NaN/Inf in
@@ -103,6 +118,15 @@ func (e *Encoder) buildVecColumnBlock(vf *vecBatchField, base unsafe.Pointer, n 
 		e.vecBatchRows = make([][]float64, n)
 	}
 	rows := e.vecBatchRows[:n]
+	// Gather, and in the same pass compute each vector's L2 norm and whether any
+	// coordinate is non-finite — BEFORE the plain encode, which zeroes NaN/Inf in
+	// flat (so the norms must be read here, while flat still holds the originals).
+	if cap(e.vecBatchNorms) < n {
+		e.vecBatchNorms = make([]float64, n)
+	}
+	norms := e.vecBatchNorms[:n]
+	finite := true
+	var mean float64
 	for i := range n {
 		fp := unsafe.Add(base, uintptr(i)*stride+vf.offset)
 		dst := flat[i*dim : (i+1)*dim]
@@ -114,22 +138,107 @@ func (e *Encoder) buildVecColumnBlock(vf *vecBatchField, base unsafe.Pointer, n 
 			copy(dst, *(*[]float64)(fp))
 		}
 		rows[i] = dst
+		var s float64
+		for _, x := range dst {
+			s += x * x
+		}
+		nrm := math.Sqrt(s)
+		norms[i] = nrm
+		if nrm <= 0 || math.IsNaN(nrm) || math.IsInf(nrm, 0) {
+			finite = false
+		}
+		mean += nrm
 	}
-	blk := appendLossyVec(rows, vf.elemF32, b, &e.vecScratch)
+	plain := appendLossyVec(rows, vf.elemF32, b, &e.vecScratch)
 
-	// Never-worse vs raw element bytes (the lossless floor's upper bound): if the
-	// batched lossy block is not smaller than raw, skip batching this field so it
-	// stays row-major (where its own never-worse picker applies per vector).
 	elemSize := 8
 	if vf.elemF32 {
 		elemSize = 4
 	}
-	if len(blk) >= n*dim*elemSize {
-		return nil, false
+	rawBytes := n * dim * elemSize
+	best, bestPolar := plain, false
+
+	// Polar candidate: only when every vector is finite and positive-norm (so the
+	// plain encode did not zero any coordinate in flat) and the norm spread (CV)
+	// is large enough to plausibly beat the per-vector norm overhead.
+	if finite {
+		mean /= float64(n)
+		var varsum float64
+		for _, nrm := range norms {
+			d := nrm - mean
+			varsum += d * d
+		}
+		cv := math.Sqrt(varsum/float64(n)) / (mean + 1e-30)
+		if cv > polarMinCV {
+			// Normalize flat in place (no NaN/Inf in this branch, so plain's encode
+			// left it intact) → unit directions; encode those.
+			for i := range n {
+				inv := 1.0 / norms[i]
+				seg := flat[i*dim : (i+1)*dim]
+				for j := range seg {
+					seg[j] *= inv
+				}
+			}
+			dirsBlk := appendLossyVec(rows, vf.elemF32, b, &e.vecScratch)
+			polarPayload := appendNormStream(nil, norms)
+			polarPayload = append(polarPayload, dirsBlk...)
+			if len(polarPayload) < len(best) {
+				best, bestPolar = polarPayload, true
+			}
+		}
 	}
-	// blk aliases e.buf-independent scratch inside appendLossyVec's return; it is
-	// a freshly appended slice, safe to retain until written.
-	return blk, true
+
+	// Never-worse vs raw: if even the smaller form is not below raw, keep the
+	// field row-major (its own per-vector never-worse picker applies there).
+	if len(best) >= rawBytes {
+		return nil, false, false
+	}
+	return best, bestPolar, true
+}
+
+// appendNormStream writes the polar-split norm stream: f64 log-min, f64 log-max,
+// then one uint16 per vector quantizing log(norm) over [log-min, log-max]. The
+// log domain gives uniform RELATIVE precision, so a wide norm range (1000x)
+// still round-trips to ~1e-4. norms must all be finite and positive.
+func appendNormStream(dst []byte, norms []float64) []byte {
+	logMin, logMax := math.Inf(1), math.Inf(-1)
+	for _, nrm := range norms {
+		l := math.Log(nrm)
+		logMin, logMax = math.Min(logMin, l), math.Max(logMax, l)
+	}
+	dst = binary.LittleEndian.AppendUint64(dst, math.Float64bits(logMin))
+	dst = binary.LittleEndian.AppendUint64(dst, math.Float64bits(logMax))
+	span := logMax - logMin
+	if span <= 0 {
+		span = 1 // all norms equal: every quantum maps to log-min
+	}
+	for _, nrm := range norms {
+		q := math.RoundToEven((math.Log(nrm) - logMin) / span * 65535)
+		dst = binary.LittleEndian.AppendUint16(dst, uint16(q))
+	}
+	return dst
+}
+
+// readNormStream reads n quantized norms written by appendNormStream and returns
+// them plus the number of bytes consumed.
+func readNormStream(src []byte, n int) (norms []float64, used int, err error) {
+	if len(src) < 16+2*n {
+		return nil, 0, ErrShortBuffer
+	}
+	logMin := math.Float64frombits(binary.LittleEndian.Uint64(src[0:]))
+	logMax := math.Float64frombits(binary.LittleEndian.Uint64(src[8:]))
+	span := logMax - logMin
+	if span <= 0 {
+		span = 1
+	}
+	norms = make([]float64, n)
+	off := 16
+	for i := range n {
+		q := binary.LittleEndian.Uint16(src[off:])
+		off += 2
+		norms[i] = math.Exp(logMin + float64(q)/65535*span)
+	}
+	return norms, off, nil
 }
 
 // batchedFieldSet returns a per-field bool: true when that struct field is a
@@ -161,21 +270,32 @@ func (d *Decoder) decodeVectorBatchStruct(t reflect.Type, td *typeDesc, p unsafe
 	if err := d.CheckLength(n, 1); err != nil {
 		return err
 	}
-	if d.i+2 > len(d.buf) {
+	if d.i+3 > len(d.buf) {
 		return ErrShortBuffer
 	}
 	nv := int(d.buf[d.i])
 	mask := d.buf[d.i+1]
-	d.i += 2
+	polarMask := d.buf[d.i+2]
+	d.i += 3
 	if nv != len(td.vecFields) {
 		return errors.New("qdf: vec-batch shape mismatch")
 	}
 
-	// Read each batched column's block (count=n vectors).
+	// Read each batched column's block (count=n vectors). A polar field carries a
+	// norm stream before the directions block; rescale to recover the vectors.
 	batched := make([][][]float64, nv)
 	for vi := range nv {
 		if mask&(1<<uint(vi)) == 0 {
 			continue
+		}
+		var norms []float64
+		if polarMask&(1<<uint(vi)) != 0 {
+			ns, used, err := readNormStream(d.buf[d.i:], n)
+			if err != nil {
+				return err
+			}
+			d.i += used
+			norms = ns
 		}
 		vecs, elemF32, used, err := readLossyVec(d.buf[d.i:])
 		if err != nil {
@@ -187,6 +307,14 @@ func (d *Decoder) decodeVectorBatchStruct(t reflect.Type, td *typeDesc, p unsafe
 		}
 		if elemF32 != td.vecFields[vi].elemF32 {
 			return ErrTypeMismatch
+		}
+		if norms != nil {
+			for i := range vecs {
+				scale := norms[i]
+				for j := range vecs[i] {
+					vecs[i][j] *= scale
+				}
+			}
 		}
 		batched[vi] = vecs
 	}

--- a/lossyvec_batch_test.go
+++ b/lossyvec_batch_test.go
@@ -332,3 +332,85 @@ func FuzzVecBatchDecode(f *testing.F) {
 		_ = Unmarshal(data, &out) // must never panic / OOM
 	})
 }
+
+// vecBatchPolarMask parses a tagVecBatchStruct stream and returns its polarMask
+// byte (0 if not a batched stream). Layout after the 5-byte header:
+//
+//	0xFE, uvarint(n), nv, mask, polarMask, ...
+func vecBatchPolarMask(t *testing.T, data []byte) byte {
+	t.Helper()
+	if len(data) < 6 || data[5] != tagVecBatchStruct {
+		return 0
+	}
+	i := 6
+	for i < len(data) && data[i] >= 0x80 { // skip uvarint(n) continuation bytes
+		i++
+	}
+	i++ // last uvarint byte
+	if i+3 > len(data) {
+		return 0
+	}
+	return data[i+2] // nv, mask, polarMask
+}
+
+func TestVecBatchPolarVaryingNorm(t *testing.T) {
+	const n, dim = 64, 256
+	rows := make([]vecOnlyRow, n)
+	for i := range rows {
+		v := sinVec32(i, dim)
+		scale := float32(math.Exp(math.Sin(float64(i)) * 2)) // ~e^-2..e^2 spread
+		for j := range v {
+			v[j] *= scale
+		}
+		rows[i] = vecOnlyRow{Emb: v}
+	}
+	enc := NewEncoderWith(OptBalanced | OptLossyVec)
+	enc.SetVectorBudget(MaxRelError(0.05))
+	if err := enc.EncodeValue(rows); err != nil {
+		t.Fatal(err)
+	}
+	data := enc.Bytes()
+	if pm := vecBatchPolarMask(t, data); pm == 0 {
+		t.Fatalf("polar should engage on varying-norm data, polarMask=0")
+	}
+	var out []vecOnlyRow
+	if err := Unmarshal(data, &out); err != nil {
+		t.Fatal(err)
+	}
+	for i := range rows {
+		var se, ne float64
+		for j := range rows[i].Emb {
+			d := float64(rows[i].Emb[j] - out[i].Emb[j])
+			se += d * d
+			ne += float64(rows[i].Emb[j]) * float64(rows[i].Emb[j])
+		}
+		if rel := math.Sqrt(se / (ne + 1e-30)); rel > 0.08 {
+			t.Fatalf("row %d relErr %.4f exceeds budget+slack", i, rel)
+		}
+	}
+}
+
+func TestVecBatchPolarSkippedUnitNorm(t *testing.T) {
+	// Unit-norm vectors: norm CV ~0, polar must be skipped (polarMask=0).
+	const n, dim = 64, 256
+	rows := make([]vecOnlyRow, n)
+	for i := range rows {
+		v := sinVec32(i, dim)
+		var s float64
+		for _, x := range v {
+			s += float64(x) * float64(x)
+		}
+		inv := float32(1 / math.Sqrt(s))
+		for j := range v {
+			v[j] *= inv
+		}
+		rows[i] = vecOnlyRow{Emb: v}
+	}
+	data, err := Marshal(rows, OptBalanced|OptLossyVec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pm := vecBatchPolarMask(t, data); pm != 0 {
+		t.Fatalf("polar should be skipped on unit-norm data, polarMask=0x%02x", pm)
+	}
+}

--- a/lossyvec_batch_test.go
+++ b/lossyvec_batch_test.go
@@ -414,3 +414,63 @@ func TestVecBatchPolarSkippedUnitNorm(t *testing.T) {
 		t.Fatalf("polar should be skipped on unit-norm data, polarMask=0x%02x", pm)
 	}
 }
+
+// NamedVec is a named []float32 type; it must NOT be batched (a named slice type
+// could carry a custom codec), but must still round-trip via the row-major path.
+type NamedVec []float32
+type namedVecRow struct {
+	V NamedVec
+}
+
+func TestVecBatchExcludesNamedType(t *testing.T) {
+	const n, dim = 32, 64
+	rows := make([]namedVecRow, n)
+	for i := range rows {
+		rows[i] = namedVecRow{V: NamedVec(sinVec32(i, dim))}
+	}
+	data, err := Marshal(rows, OptBalanced|OptLossyVec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) > 5 && data[5] == tagVecBatchStruct {
+		t.Fatalf("named slice type must not batch (0xFE emitted)")
+	}
+	var out []namedVecRow
+	if err := Unmarshal(data, &out); err != nil {
+		t.Fatal(err)
+	}
+	for i := range rows {
+		if len(out[i].V) != dim {
+			t.Fatalf("row %d len %d", i, len(out[i].V))
+		}
+	}
+}
+
+// TestVecBatchHostileCountNoOOM crafts a 0xFE block claiming a huge row count and
+// asserts decode rejects it cleanly (no panic, no giant allocation).
+func TestVecBatchHostileCountNoOOM(t *testing.T) {
+	// Valid stream to get the 5-byte header, then a crafted 0xFE body.
+	rows := make([]vecOnlyRow, 32)
+	for i := range rows {
+		rows[i] = vecOnlyRow{Emb: sinVec32(i, 64)}
+	}
+	good, _ := Marshal(rows, OptBalanced|OptLossyVec)
+	hdr := good[:5] // QDF header
+	// 0xFE, uvarint(huge), nv, mask, polarMask
+	body := make([]byte, 0, 1+10+3)
+	body = append(body, tagVecBatchStruct)
+	huge := make([]byte, 0, 10)
+	x := uint64(1) << 40
+	for x >= 0x80 {
+		huge = append(huge, byte(x)|0x80)
+		x >>= 7
+	}
+	huge = append(huge, byte(x))
+	body = append(body, huge...)
+	body = append(body, 1, 1, 0) // nv=1, mask=1, polarMask=0
+	hostile := append(append([]byte{}, hdr...), body...)
+	var out []vecOnlyRow
+	if err := Unmarshal(hostile, &out); err == nil {
+		t.Fatal("expected error on hostile huge count, got nil")
+	}
+}

--- a/reflect_desc.go
+++ b/reflect_desc.go
@@ -353,13 +353,18 @@ func fillDesc(td *typeDesc, t reflect.Type, ctx *buildCtx) error {
 		// rType, not the descriptor's elem.
 		for i := range td.fields {
 			fd := td.fields[i].desc
-			if fd == nil || fd.rType == nil || fd.rType.Kind() != reflect.Slice {
+			if fd == nil || fd.rType == nil {
 				continue
 			}
-			switch fd.rType.Elem().Kind() {
-			case reflect.Float32:
+			// Only the exact unnamed []float32 / []float64 types qualify. A named
+			// slice type (type Vec []float32) can carry a custom Marshaler/
+			// Unmarshaler, and batching would bypass it; unnamed slices cannot have
+			// methods, so restricting to the canonical types is both safe and the
+			// shape the typed slice fast paths already special-case.
+			switch fd.rType {
+			case sliceFloat32Type:
 				td.vecFields = append(td.vecFields, vecBatchField{offset: td.fields[i].offset, fieldIdx: i, elemF32: true})
-			case reflect.Float64:
+			case sliceFloat64Type:
 				td.vecFields = append(td.vecFields, vecBatchField{offset: td.fields[i].offset, fieldIdx: i, elemF32: false})
 			}
 		}

--- a/wire.go
+++ b/wire.go
@@ -312,10 +312,16 @@ const (
 	// is batchable (equal length across all rows, >= lossyVecMinElems, and the
 	// batched block beats raw). Layout:
 	//
-	//   0xFE, varuint(n), byte(numVecFields), byte(batchedMask),
-	//     for each set mask bit (vector-field order): <0xFD count=n block>,
+	//   0xFE, varuint(n), byte(numVecFields), byte(batchedMask), byte(polarMask),
+	//     for each set batchedMask bit (vector-field order):
+	//       if polarMask bit set: <norm stream: f64 logMin, f64 logMax, n×uint16>,
+	//       <0xFD count=n block>,
 	//     per row: each NON-batched field encoded in declaration order via its
 	//              own (row-major) field codec.
+	//
+	// polarMask (a subset of batchedMask) marks fields stored in polar-split form:
+	// each vector's L2 norm separately (log-domain 16-bit) plus the quantized unit
+	// direction in the block, which the decoder rescales.
 	//
 	// Non-batched vector fields and all scalar/string fields stay row-major, so
 	// decode reconstructs each row by decoding those fields and scattering the


### PR DESCRIPTION
# feat: polar-split for varying-norm batched vector columns

Branch: `feat/lossyvec-polar-split` (off `main`, on top of the merged batched
vector-column codec #127).

## Why

The batched vector codec uses one quantization step over a whole column, so the
step is driven by the **largest-norm** vector. When per-vector norms vary widely
(model weights, un-normalized vectors) the small-norm vectors are over-quantized
and the column can miss its fidelity budget entirely — a measured `rel 0.40` at a
`0.05` budget on a 32× norm spread.

## What

A **polar-split** form for the batched codec: per vector field, when the norm
spread is large enough, store each vector's L2 norm separately (16-bit in the
**log domain**, so a 1000× range still round-trips to ~1e-4, ~2 B/vector) and
quantize the **unit directions** through the lossy block. One tight step then
serves every direction.

- A per-field `polarMask` bit (in the `0xFE` container) records the choice;
  decode reads the norm stream and rescales.
- **Never-worse + CV-gated**: the polar payload is kept only when it beats the
  plain batched block, and the second encode is attempted only when the norm
  spread makes it plausible — so unit-norm embeddings (where polar cannot win)
  skip it and pay nothing.

On a 256-dim corpus a wide norm spread now costs **~178 B/vec** (vs ~176 for
unit-norm, and ~217+ unbatched-per-vector while *missing* the budget).

## Hardening (audit follow-up, second commit)

A multi-agent re-audit of the whole batched+polar codec surfaced and fixed:

- **decode DoS (HIGH):** the row count `n` was bounded only by input bytes, but
  `MakeSlice(t, n)` allocates `n*stride` — a hostile count amplifies by the
  struct stride. Added the `maxColumnarElems` ceiling + `checkColumnarN` /
  `checkColumnarBytes`, matching the columnar decoders.
- **detection (correctness):** restricted batching to the exact unnamed
  `[]float32`/`[]float64` types — a named slice type (`type Vec []float32`) can
  carry a custom `Marshaler` that batching would otherwise bypass.
- Defensive: reject a `polarMask` not ⊆ the batched mask (cursor desync),
  `uint64` length intermediates (32-bit overflow), empty-norm-slice guard,
  independent `vecBatchRows` reset (GC-pin), corrected wire-format comment.

## Tests

Polar engages on varying-norm / skipped on unit-norm (asserted by parsing
`polarMask` off the wire), varying-norm round-trips within budget, named-type
exclusion, hostile huge-count decode rejects cleanly, plus all existing batched
round-trips (NaN/Inf, nil/empty, two fields). `go test ./...` + `-race` + fuzz +
`golangci-lint v2` clean.
