### PR TITLE
audit: full-codebase correctness sweep (32-bit, OOM-DoS, wire desync)

### DIFF
--- a/columnar_decode_scratch.go
+++ b/columnar_decode_scratch.go
@@ -667,8 +667,10 @@ func decodeSliceFloat64Into(d *Decoder, dst *[]float64) error {
 		if err2 != nil {
 			return err2
 		}
-		if len(vecs) == 0 {
-			return ErrShortBuffer
+		// A scalar float64 column is one vector (the whole column); reject a
+		// multi-vector block rather than silently dropping vecs[1:].
+		if len(vecs) != 1 {
+			return ErrInvalidLength
 		}
 		if elemF32 {
 			return ErrTypeMismatch

--- a/decoder_read.go
+++ b/decoder_read.go
@@ -462,9 +462,16 @@ func (d *Decoder) ReadArrayHeader() (int, error) {
 		if d.i+4 > len(d.buf) {
 			return 0, ErrShortBuffer
 		}
-		n := int(readU32(d.buf[d.i:]))
+		// uint64 before narrowing: on a 32-bit int a count >= 2^31 wraps negative,
+		// breaking the non-negative API contract and slipping past caller bounds
+		// checks. Each element is >= 1 byte, so a count over the remaining bytes is
+		// impossible. Mirrors the readStringBytes / decoder_skip tagArr32 guard.
+		n64 := uint64(readU32(d.buf[d.i:]))
 		d.i += 4
-		return n, nil
+		if n64 > uint64(len(d.buf)-d.i) {
+			return 0, ErrShortBuffer
+		}
+		return int(n64), nil
 	}
 	return 0, ErrTypeMismatch
 }
@@ -494,9 +501,14 @@ func (d *Decoder) ReadMapHeader() (int, error) {
 		if d.i+4 > len(d.buf) {
 			return 0, ErrShortBuffer
 		}
-		n := int(readU32(d.buf[d.i:]))
+		// Same 32-bit wrap guard as tagArr32; each entry is >= 2 bytes (key+value),
+		// so a count over the remaining bytes is impossible.
+		n64 := uint64(readU32(d.buf[d.i:]))
 		d.i += 4
-		return n, nil
+		if n64 > uint64(len(d.buf)-d.i) {
+			return 0, ErrShortBuffer
+		}
+		return int(n64), nil
 	}
 	return 0, ErrTypeMismatch
 }

--- a/decoder_skip.go
+++ b/decoder_skip.go
@@ -156,9 +156,17 @@ func (d *Decoder) Skip() error {
 			if d.i+4 > len(d.buf) {
 				return ErrShortBuffer
 			}
-			n := int(readU32(d.buf[d.i:]))
+			// Compare in uint64 before narrowing: on a 32-bit int a count near 2^32
+			// wraps negative, making `for range n` run zero iterations and Skip
+			// silently succeed without consuming the elements (parse desync). Each
+			// element is >= 1 byte, so a count exceeding the remaining bytes is
+			// impossible. Mirrors the tagStr32/tagBin32 guard below.
+			n64 := uint64(readU32(d.buf[d.i:]))
 			d.i += 4
-			for range n {
+			if n64 > uint64(len(d.buf)-d.i) {
+				return ErrShortBuffer
+			}
+			for range int(n64) {
 				if err := d.Skip(); err != nil {
 					return err
 				}
@@ -169,9 +177,14 @@ func (d *Decoder) Skip() error {
 			if d.i+4 > len(d.buf) {
 				return ErrShortBuffer
 			}
-			n := int(readU32(d.buf[d.i:]))
+			// Same 32-bit wrap guard as tagArr32; each entry is >= 2 bytes (key +
+			// value, each >= 1), so a count exceeding the remaining bytes is invalid.
+			n64 := uint64(readU32(d.buf[d.i:]))
 			d.i += 4
-			for range n {
+			if n64 > uint64(len(d.buf)-d.i) {
+				return ErrShortBuffer
+			}
+			for range int(n64) {
 				if err := d.Skip(); err != nil {
 					return err
 				}

--- a/delta_apply.go
+++ b/delta_apply.go
@@ -78,6 +78,9 @@ func applySlice(dec *Decoder, td *typeDesc, baseP unsafe.Pointer, depth int) err
 	stride := td.rType.Elem().Size()
 	bv := reflect.NewAt(td.rType, baseP).Elem()
 
+	if newLen64 > uint64(int(^uint(0)>>1)) { // 32-bit: int(newLen64) would truncate silently
+		return ErrInvalidPatch
+	}
 	newLen := int(newLen64)
 	if newLen < 0 {
 		return ErrInvalidPatch

--- a/delta_columnar.go
+++ b/delta_columnar.go
@@ -120,6 +120,13 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 	// value. The encoder must end there too, or the two diverge and a later
 	// pair/repeat state-ref desyncs (the keyed picker keeps the same invariant).
 	preTrialLastID := st.lastID
+	// shapeStart anchors the shape-id counter the same way lastID is anchored: a
+	// suspended StructShape (a codegen marshaler's e.StructShape in the positional
+	// trial) still advances shapeCount to keep the decoder aligned, so the
+	// discarded candidate's declarations must be rebased off shapeCount when the
+	// wire-stateless column body wins — else the next shape id desyncs
+	// (ErrUnknownStateID). Mirrors diffKeyedSlice.
+	shapeStart := st.shapeCount
 
 	// Build the positional body into enc.buf first (the comparison baseline).
 	posStart := len(enc.buf)
@@ -128,6 +135,7 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 	}
 	posLen := len(enc.buf) - posStart
 	posEndLastID := st.lastID
+	shapeAfterPos := st.shapeCount
 
 	body := st.deltaColBuf[:0]
 	body = append(body, tagColSlicePatch)
@@ -151,6 +159,7 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 			enc.buf = savedBuf
 			st.deltaColBuf = body[:0]
 			st.lastID = posEndLastID // positional wins; track its kept bytes
+			st.shapeCount = shapeAfterPos
 			return true, nil
 		}
 		nChanged++
@@ -205,10 +214,15 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 		// column). Without this the encoder/decoder lastID + pair predictor
 		// diverge after the slice.
 		st.lastID = preTrialLastID
+		// The kept column body is wire-stateless, so rebase shapeCount off the
+		// discarded positional trial's declarations (column body declares none, so
+		// this resolves to shapeStart; the general form mirrors diffKeyedSlice).
+		st.shapeCount = shapeStart + (st.shapeCount - shapeAfterPos)
 	} else {
 		// Positional wins; restore lastID to its post-positional value so it
 		// tracks the bytes the decoder will actually read.
 		st.lastID = posEndLastID
+		st.shapeCount = shapeAfterPos
 	}
 	// Either way exactly one body remains and the slice is handled.
 	return true, nil

--- a/delta_columnar.go
+++ b/delta_columnar.go
@@ -611,7 +611,10 @@ func applyColSlice(dec *Decoder, td *typeDesc, baseP unsafe.Pointer) error {
 // Gap encoding: gap[0] = idx0, gap[j] = idx[j] - idx[j-1] (>= 1 for j>0).
 func applySparseColumn(dec *Decoder, plan *columnarPlan, col *colColumn, base unsafe.Pointer, n int) error {
 	nc64, k := readUvarint(dec.buf[dec.i:])
-	if k <= 0 || nc64 > uint64(n) {
+	// nc==0 is never emitted by a conforming encoder (a column with no changed
+	// rows is skipped); reject it before it sets colMaxLen=0, which colLenOK reads
+	// as "unbounded" and would let a constant-codec body force a large make().
+	if k <= 0 || nc64 == 0 || nc64 > uint64(n) {
 		return ErrInvalidPatch
 	}
 	dec.i += k

--- a/delta_keyed.go
+++ b/delta_keyed.go
@@ -276,6 +276,9 @@ func applyKeyedSlice(dec *Decoder, td *typeDesc, baseP unsafe.Pointer, depth int
 		return ErrInvalidPatch
 	}
 	dec.i += k
+	if newLen64 > uint64(int(^uint(0)>>1)) { // 32-bit: int(newLen64) would truncate silently
+		return ErrInvalidPatch
+	}
 	newLen := int(newLen64)
 	if newLen < 0 || uint64(newLen) > uint64(len(dec.buf)-dec.i) {
 		return ErrInvalidPatch

--- a/internal/bitpack/unpack_var_test.go
+++ b/internal/bitpack/unpack_var_test.go
@@ -9,7 +9,7 @@ import "testing"
 // the SIMD body, the read-headroom guard, the byte-alignment handoff,
 // and the scalar tail.
 func TestUnpackBitsVar_MatchesReference(t *testing.T) {
-	widths := []int{5, 6, 7, 9, 11, 13}
+	widths := []int{1, 2, 3, 4, 5, 6, 7, 9, 11, 13}
 	sizes := []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 64, 100, 257, 1000}
 	for _, b := range widths {
 		mask := uint64(1)<<uint(b) - 1

--- a/internal/bitpack/unpack_wide_test.go
+++ b/internal/bitpack/unpack_wide_test.go
@@ -7,7 +7,7 @@ import "testing"
 // scalar decoder, bit-for-bit, across sizes that hit the SIMD body, the
 // read-headroom guard, the byte-alignment trim, and the scalar tail.
 func TestUnpackBitsVarWide_MatchesReference(t *testing.T) {
-	widths := []int{15, 17, 18, 19, 21, 23, 24, 28}
+	widths := []int{15, 17, 18, 19, 21, 22, 23, 24, 25, 26, 27, 28}
 	sizes := []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 64, 100, 257, 1000}
 	for _, b := range widths {
 		mask := uint64(1)<<uint(b) - 1

--- a/internal/fsst/fsst.go
+++ b/internal/fsst/fsst.go
@@ -231,7 +231,10 @@ func (t *SymbolTable) DecompressN(codes, dst []byte, limit int) ([]byte, bool) {
 			continue
 		}
 		if int(c) >= len(t.symbols) {
-			continue
+			// A code with no symbol is a corrupt block (a conforming encoder only
+			// emits codes < len(symbols) or escapeCode). Reject rather than silently
+			// skipping it, which would return a truncated string as success.
+			return dst, false
 		}
 		s := &t.symbols[c]
 		if len(dst)+int(s.len) > limit {

--- a/internal/rans/rans.go
+++ b/internal/rans/rans.go
@@ -254,6 +254,9 @@ func Decode(src []byte, n int) ([]byte, error) {
 	if n == 0 {
 		return []byte{}, nil
 	}
+	if n < 0 { // honor the never-panics contract: make([]byte, n<0) would panic
+		return nil, ErrCorrupt
+	}
 	if len(src) < 1 {
 		return nil, ErrCorrupt
 	}

--- a/nullable_col.go
+++ b/nullable_col.go
@@ -302,7 +302,38 @@ func (d *Decoder) decodeNullableColumn(base unsafe.Pointer, plan *columnarPlan, 
 	if err != nil {
 		return err
 	}
+	// String columns do not use the typed backing slice — handle them first so
+	// the present*sizeof(string) allocation below is not made and discarded, and
+	// add the same len(strs)==present guard every other kind has.
+	if col.kind.base() == colKindString {
+		strs, err := d.readStringColumn(present)
+		if err != nil {
+			return err
+		}
+		if len(strs) != present {
+			return ErrTypeMismatch
+		}
+		stride, off := plan.stride, col.offset
+		k := 0
+		for i := range n {
+			fp := unsafe.Add(base, uintptr(i)*stride+off)
+			if mask[i>>3]&(1<<uint(i&7)) != 0 {
+				*(*unsafe.Pointer)(fp) = unsafe.Pointer(&strs[k])
+				k++
+			} else {
+				*(*unsafe.Pointer)(fp) = nil
+			}
+		}
+		runtime.KeepAlive(strs)
+		return nil
+	}
 	elemSize := col.elemType.Size()
+	// Bound the typed backing by the columnar byte ceiling: the outer decode
+	// check used the struct stride (8 for a *T field), but elemType.Size() can be
+	// larger (time.Time is 24), so present*elemSize can exceed maxColumnarBytes.
+	if err := checkColumnarBytes(present, elemSize); err != nil {
+		return err
+	}
 	backing := reflect.MakeSlice(reflect.SliceOf(col.elemType), present, present)
 	dataPtr := backing.UnsafePointer()
 	stride, off := plan.stride, col.offset
@@ -367,23 +398,6 @@ func (d *Decoder) decodeNullableColumn(base unsafe.Pointer, plan *columnarPlan, 
 			return ErrTypeMismatch
 		}
 		set(func(ea unsafe.Pointer, k int) { *(*bool)(ea) = s[k] })
-	case colKindString:
-		strs, err := d.readStringColumn(present)
-		if err != nil {
-			return err
-		}
-		k := 0
-		for i := range n {
-			fp := unsafe.Add(base, uintptr(i)*stride+off)
-			if mask[i>>3]&(1<<uint(i&7)) != 0 {
-				*(*unsafe.Pointer)(fp) = unsafe.Pointer(&strs[k])
-				k++
-			} else {
-				*(*unsafe.Pointer)(fp) = nil
-			}
-		}
-		runtime.KeepAlive(strs)
-		return nil
 	case colKindTime:
 		// Decode two dense sub-columns (sec []int64, nsec []uint64) for the
 		// present count, reconstruct time.Time values, scatter into *time.Time
@@ -553,6 +567,11 @@ func (d *Decoder) decodeNullableColumnVals(kind colKind, n int) (colVals, error)
 			return cv, ErrTypeMismatch
 		}
 		if err := checkNsecColumn(nsec); err != nil {
+			return cv, err
+		}
+		// time.Time is 24 bytes; the outer check used the struct stride (8 for a
+		// *time.Time field), so n*24 can exceed the columnar byte ceiling.
+		if err := checkColumnarBytes(n, unsafe.Sizeof(time.Time{})); err != nil {
 			return cv, err
 		}
 		full := make([]time.Time, n)

--- a/qdf_direct.go
+++ b/qdf_direct.go
@@ -93,10 +93,11 @@ func UnmarshalDirect[T Unmarshaler](data []byte, out T) error {
 	if data[3] != Version1 {
 		return ErrBadVersion
 	}
-	if data[4]&(FlagDense|FlagRANS) != 0 {
-		// Dense buffers carry an intern table that generated code does
-		// not maintain, and rANS buffers need the entropy pass reversed
-		// first; fall back to the reflect path which handles both.
+	if data[4]&(FlagDense|FlagQPack|FlagRANS|FlagColIndex) != 0 {
+		// Any non-Fast wire (Dense intern table, QPack codec bodies, a rANS
+		// entropy pass, or a columnar index) is not what a hand-rolled UnmarshalQDF
+		// expects; fall back to the reflect path which handles all of them instead
+		// of failing with ErrBadTag on the first codec tag.
 		return Unmarshal(data, out)
 	}
 	_, err := out.UnmarshalQDF(data[5:])

--- a/qdf_generic.go
+++ b/qdf_generic.go
@@ -29,7 +29,16 @@ func MarshalT[T any](v T, opts Options) ([]byte, error) {
 		return nil, err
 	}
 	enc.maybeApplyRANS(0)
-	out := slices.Clone(enc.buf)
+	// Mirror marshalDict: hand a spike-sized backing straight to the caller
+	// instead of cloning it (putEnc would drop it past maxPooledBuf anyway), so
+	// MarshalT stays allocation-equivalent to Marshal on large payloads.
+	var out []byte
+	if cap(enc.buf) > marshalDetachThreshold {
+		out = enc.buf
+		enc.buf = nil
+	} else {
+		out = slices.Clone(enc.buf)
+	}
 	putEnc(enc, &encPool) // cap a spike-sized buffer / widening scratch before pooling
 	return out, nil
 }

--- a/qpack.go
+++ b/qpack.go
@@ -809,6 +809,9 @@ func (d *Decoder) readPackedBool() ([]bool, error) {
 		// cannot possibly fit even if every byte carried 8 valid bits.
 		return nil, ErrShortBuffer
 	}
+	if n64 > uint64(int(^uint(0)>>1)) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative
+		return nil, ErrInvalidLength
+	}
 	n := int(n64)
 	nBytes := (n + 7) >> 3
 	if d.i+nBytes > len(d.buf) {

--- a/qpack_alp.go
+++ b/qpack_alp.go
@@ -92,7 +92,7 @@ func alpChooseExp(s []float64) int {
 			sample = append(sample, s[i])
 		}
 	}
-	bestD, bestCost := 0, math.MaxInt64
+	bestD, bestCost := 0, math.MaxInt // platform max sentinel (int, 32-bit safe)
 	for d := 0; d <= alpMaxExpSearch; d++ {
 		_, w, exc := alpScoreExp(sample, d)
 		cost := (int(w)*len(sample)+7)/8 + exc*10
@@ -246,7 +246,7 @@ func alpChooseExpF32(s []float32) int {
 			sample = append(sample, s[i])
 		}
 	}
-	bestD, bestCost := 0, math.MaxInt64
+	bestD, bestCost := 0, math.MaxInt // platform max sentinel (int, 32-bit safe)
 	for d := 0; d <= alpMaxExpSearch; d++ {
 		_, w, exc := alpScoreExpF32(sample, d)
 		cost := (int(w)*len(sample)+7)/8 + exc*6 // exc value is 4 bytes here

--- a/qpack_delta.go
+++ b/qpack_delta.go
@@ -223,6 +223,9 @@ func (d *Decoder) readPackedDeltaForHeader(expectKind byte) (bitsPer int, unsign
 		// bitsPer == 0 (constant deltas): empty body, no per-element bound.
 		return 0, 0, 0, 0, 0, nil, ErrInvalidLength
 	}
+	if n64 > uint64(int(^uint(0)>>1)) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative
+		return 0, 0, 0, 0, 0, nil, ErrInvalidLength
+	}
 	n = int(n64)
 	bodyBytes := int(((n64-1)*uint64(bitsPer) + 7) / 8)
 	body = d.buf[d.i : d.i+bodyBytes]

--- a/qpack_for.go
+++ b/qpack_for.go
@@ -197,6 +197,9 @@ func (d *Decoder) readPackedForHeader(expectKind byte) (bitsPer int, unsignedMin
 		// bound above does not apply. Cap an implausible standalone count.
 		return 0, 0, 0, 0, nil, ErrInvalidLength
 	}
+	if n64 > uint64(int(^uint(0)>>1)) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative -> make panics
+		return 0, 0, 0, 0, nil, ErrInvalidLength
+	}
 	n = int(n64)
 	bodyBytes := int((n64*uint64(bitsPer) + 7) / 8)
 	body = d.buf[d.i : d.i+bodyBytes]

--- a/qpack_pfor.go
+++ b/qpack_pfor.go
@@ -221,6 +221,9 @@ func (d *Decoder) readPackedPForInt64Slice() ([]int64, error) {
 		// b == 0 (constant base): empty packed body, no per-element bound.
 		return nil, ErrInvalidLength
 	}
+	if n64 > uint64(int(^uint(0)>>1)) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative
+		return nil, ErrInvalidLength
+	}
 	n := int(n64)
 	bodyBytes := (n*b + 7) >> 3
 	if d.i+bodyBytes > len(d.buf) {
@@ -307,6 +310,9 @@ func (d *Decoder) readPackedPForUint64Slice() ([]uint64, error) {
 		}
 	} else if n64 > qpackMaxStandaloneCount {
 		// b == 0 (constant base): empty packed body, no per-element bound.
+		return nil, ErrInvalidLength
+	}
+	if n64 > uint64(int(^uint(0)>>1)) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative
 		return nil, ErrInvalidLength
 	}
 	n := int(n64)

--- a/qpack_rle.go
+++ b/qpack_rle.go
@@ -96,14 +96,13 @@ func (d *Decoder) readPackedRLEHeader(expectKind byte) (n int, err error) {
 	if !d.colLenOK(n64) {
 		return 0, ErrInvalidLength
 	}
-	if n64 > uint64(len(d.buf)-d.i) {
-		// Standalone decode (colMaxLen == 0): no per-element body bound exists
-		// for RLE, so cap the obvious lie. Each run is ≥ 2 bytes; the body loop
-		// catches subtler over-claims. Shares the constant-codec ceiling so a
-		// single 2-byte run can't claim a multi-GB element count (OOM-DoS).
-		if n64 > qpackMaxStandaloneCount {
-			return 0, ErrInvalidLength
-		}
+	// Standalone decode (colMaxLen == 0): RLE has no per-element body bound (a
+	// long run is 2 bytes), so the element count must be capped UNCONDITIONALLY.
+	// Nesting the cap under `n64 > remaining` defeated it — a large input buffer
+	// makes that guard vacuous, letting a tiny body claim up to `remaining`
+	// elements (an 8x-amplification OOM). Mirrors the FOR/Dict constant-codec cap.
+	if d.colMaxLen == 0 && n64 > qpackMaxStandaloneCount {
+		return 0, ErrInvalidLength
 	}
 	return int(n64), nil
 }

--- a/qpack_rle_cap_test.go
+++ b/qpack_rle_cap_test.go
@@ -2,6 +2,7 @@ package qdf
 
 import (
 	"encoding/binary"
+	"errors"
 	"testing"
 )
 
@@ -24,7 +25,7 @@ func TestRLEStandaloneCapNotBypassedByLargeBuffer(t *testing.T) {
 
 	d := &Decoder{buf: buf}
 	d.i++ // consume the peeked tag (tagPackRLE)
-	if _, err := d.readPackedRLEUint64Slice(); err != ErrInvalidLength {
+	if _, err := d.readPackedRLEUint64Slice(); !errors.Is(err, ErrInvalidLength) {
 		t.Fatalf("want ErrInvalidLength for over-cap RLE in a large buffer, got %v", err)
 	}
 }

--- a/qpack_rle_cap_test.go
+++ b/qpack_rle_cap_test.go
@@ -1,0 +1,30 @@
+package qdf
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// TestRLEStandaloneCapNotBypassedByLargeBuffer is a regression for the OOM where
+// the standalone element-count cap was nested inside `n64 > remaining`: a large
+// input buffer made that guard vacuous, letting a tiny RLE body claim up to
+// `remaining` elements and allocate ~8x. The cap must fire unconditionally.
+func TestRLEStandaloneCapNotBypassedByLargeBuffer(t *testing.T) {
+	n := uint64(qpackMaxStandaloneCount) + 1 // just over the cap
+
+	var hdr []byte
+	hdr = append(hdr, tagPackRLE, qpackKindUint64)
+	hdr = binary.AppendUvarint(hdr, n)
+
+	// Pad so that remaining-after-header > n (defeats the old `n64 > remaining`
+	// guard). Filler bytes stand in for run data; decode must reject at the
+	// header before reading them — and before allocating make([]uint64, n).
+	buf := make([]byte, len(hdr)+int(n)+16)
+	copy(buf, hdr)
+
+	d := &Decoder{buf: buf}
+	d.i++ // consume the peeked tag (tagPackRLE)
+	if _, err := d.readPackedRLEUint64Slice(); err != ErrInvalidLength {
+		t.Fatalf("want ErrInvalidLength for over-cap RLE in a large buffer, got %v", err)
+	}
+}

--- a/qpack_strdict.go
+++ b/qpack_strdict.go
@@ -481,6 +481,14 @@ func (d *Decoder) readStringColumnDictFC(n int) (table []string, idx []uint32, e
 			return nil, nil, ErrBadTag
 		}
 		p, s := int(p64), int(s64)
+		// Cap cumulative slab growth: the prefix is copied from the previous entry
+		// (no wire cost), so a hostile table (entry 0 suffix S, then N entries with
+		// prefix=S, suffix=0) amplifies to N*S with no per-entry guard catching it.
+		// The uncompressed distinct table cannot legitimately exceed the columnar
+		// byte ceiling.
+		if int64(len(slab))+int64(p)+int64(s) > int64(maxColumnarBytes) {
+			return nil, nil, ErrInvalidLength
+		}
 		start := len(slab)
 		slab = append(slab, slab[prevStart:prevStart+p]...) // shared prefix from prev
 		slab = append(slab, d.buf[d.i:d.i+s]...)            // suffix from wire

--- a/reflect_desc.go
+++ b/reflect_desc.go
@@ -219,8 +219,12 @@ func fillDesc(td *typeDesc, t reflect.Type, ctx *buildCtx) error {
 		td.encode = encodeBool
 		td.decode = decodeBool
 	case reflect.Int:
-		td.encode = encodeIntN(8)
-		td.decode = decodeIntN(8)
+		// Platform-width: 8 bytes on 64-bit, 4 on 32-bit. Hardcoding 8 would read
+		// (encode) and write (decode) past a 4-byte int on 32-bit — an OOB access
+		// corrupting the adjacent field. Mirrors slices_fast encodeSliceInt and
+		// delta_diff's platform-width handling.
+		td.encode = encodeIntN(int(t.Size()))
+		td.decode = decodeIntN(int(t.Size()))
 	case reflect.Int8:
 		td.encode = encodeIntN(1)
 		td.decode = decodeIntN(1)
@@ -234,8 +238,8 @@ func fillDesc(td *typeDesc, t reflect.Type, ctx *buildCtx) error {
 		td.encode = encodeIntN(8)
 		td.decode = decodeIntN(8)
 	case reflect.Uint:
-		td.encode = encodeUintN(8)
-		td.decode = decodeUintN(8)
+		td.encode = encodeUintN(int(t.Size())) // platform-width (see reflect.Int)
+		td.decode = decodeUintN(int(t.Size()))
 	case reflect.Uint8:
 		td.encode = encodeUintN(1)
 		td.decode = decodeUintN(1)
@@ -249,8 +253,8 @@ func fillDesc(td *typeDesc, t reflect.Type, ctx *buildCtx) error {
 		td.encode = encodeUintN(8)
 		td.decode = decodeUintN(8)
 	case reflect.Uintptr:
-		td.encode = encodeUintN(8)
-		td.decode = decodeUintN(8)
+		td.encode = encodeUintN(int(t.Size())) // platform-width (see reflect.Int)
+		td.decode = decodeUintN(int(t.Size()))
 	case reflect.Float32:
 		td.encode = encodeF32
 		td.decode = decodeF32

--- a/state.go
+++ b/state.go
@@ -535,6 +535,16 @@ func (e *encState) reset() {
 	if cap(e.colScratchF32) > maxRetainedColScratch {
 		e.colScratchF32 = nil
 	}
+	// deltaColAux* are swapped with colScratchI64/U64 in encodeDeltaColumn, so
+	// after a large columnar-delta batch one of the two grown backings lives here
+	// and is missed by the colScratchI64 check above — cap them independently or
+	// the pooled encoder retains double the intended scratch.
+	if cap(e.deltaColAuxI64) > maxRetainedColScratch {
+		e.deltaColAuxI64 = nil
+	}
+	if cap(e.deltaColAuxU64) > maxRetainedColScratch {
+		e.deltaColAuxU64 = nil
+	}
 	// Column-diff scratch (delta_columnar.go): same row-scaled hard-ceiling
 	// retention as colScratch* (pointer-free, no clear needed).
 	if cap(e.deltaColBitmap) > maxRetainedColScratch {

--- a/stream.go
+++ b/stream.go
@@ -373,16 +373,19 @@ func (s *StreamDecoder) readFrameLen() (int, error) {
 }
 
 // fill reads from the underlying reader until at least need unread bytes are
-// buffered. Returns io.EOF if the stream ends with nothing unread, or
-// ErrShortBuffer if it ends mid-message (fewer than need bytes available).
-// fill reads from the underlying reader until at least need unread bytes are
 // buffered. When boundary is true (reading at a message boundary — the header
 // or a frame length) an immediate clean end of stream returns io.EOF; in every
 // other case a stream that ends before need bytes returns ErrShortBuffer.
 func (s *StreamDecoder) fill(need int, boundary bool) error {
 	for len(s.dec.buf)-s.dec.i < need {
 		if cap(*s.buf)-len(s.dec.buf) == 0 {
-			grown := make([]byte, len(s.dec.buf), cap(*s.buf)*2+4096)
+			// Grow to fit `need` in one shot (the doubling alone would take many
+			// passes for a large frame): max(cap*2+4096, current + need).
+			newCap := cap(*s.buf)*2 + 4096
+			if minCap := s.dec.i + need; minCap > newCap {
+				newCap = minCap
+			}
+			grown := make([]byte, len(s.dec.buf), newCap)
 			copy(grown, s.dec.buf)
 			*s.buf = grown
 			s.dec.buf = grown


### PR DESCRIPTION
# audit: full-codebase correctness sweep — 32-bit, OOM-DoS, wire desync

A staged, module-by-module review of the whole codebase (agents per subsystem,
every finding RED-verified by hand before fixing). ~19 real bugs fixed across 7
commits; ~half of the agents' findings were false positives and dropped.

Each stage was gated on: 64-bit `go test ./...`, `-race`, `golangci-lint`, and a
`GOOS=linux GOARCH=386` cross-build. The final branch passes all of these plus
`arm`/`arm64` builds and the decode/apply fuzzers.

## Headline

**The package did not compile on 32-bit at all.** `qpack_alp.go` assigned
`math.MaxInt64` to an `int`, a hard compile error on `GOARCH=386`/`arm`. So every
32-bit safety guard in the codebase was dormant and untestable — and several
latent 32-bit bugs were waiting to become live once it compiled.

## Fixes by class

**32-bit `int(uint64)` truncation (the dominant class — 8+ sites):** a wire count
read as `uint64`, narrowed to `int` without a `maxInt` guard, wraps negative on a
32-bit host and either bypasses a `< 0` check (silent wrong length) or panics in
`make`. Fixed in `decoder_read` / `decoder_skip` (`tagArr32`/`tagMap32`),
`delta_apply` / `delta_keyed` (`newLen`), and `qpack_for` / `qpack_delta` /
`qpack_pfor` / `qpack.go` (`readPackedBool`) — each now rejects counts above
`MaxInt` before narrowing. Also: `reflect.Int`/`Uint`/`Uintptr` were hardcoded to
an 8-byte read/write (`*(*int64)`), an out-of-bounds access on a 4-byte 32-bit
`int` — now `int(t.Size())`.

**OOM / memory-amplification DoS (4):**
- `qpack_rle` — the standalone element-count cap was nested under `n64 > remaining`,
  so a large input buffer made it vacuous; a tiny RLE body could claim ~remaining
  elements (~8× alloc). Cap unconditionally.
- `qpack_strdict` front-coded dict — the reconstruction slab had no cumulative
  byte cap; a hostile table amplifies ~256×. Cap at `maxColumnarBytes`.
- `nullable_col` — a `*time.Time` column allocated `present*24` bounded only by
  the struct stride (8), so up to ~384 MB above the 256 MB ceiling. Bound by the
  element size.
- `delta_columnar` sparse patch — `nc=0` set `colMaxLen=0` (read as unbounded),
  letting a constant-codec body force a ~128 MB alloc. Reject `nc=0`.

**Wire-state desync (1, the subtle one):** `delta_columnar`'s never-larger trial
saved/restored `lastID` but not `shapeCount`. A codegen marshaler's `StructShape`
advances `shapeCount` even under suspension; when the wire-stateless column body
won, the discarded positional trial's shape declarations were left counted, so
the next shape id desynced (`ErrUnknownStateID`). Mirrored `diffKeyedSlice`'s
save/restore in every exit branch.

**Malformed-input hardening (2):** `rans.Decode` panicked on `n<0` despite a
"never panics" contract; `fsst.DecompressN` silently skipped an unknown code and
returned a truncated string as success — now both reject cleanly.

**Misc:** `MarshalT` now detaches a large buffer like `Marshal` (alloc parity);
`UnmarshalDirect` falls back to the reflect path on any non-Fast header flag;
`nullable_col` skips a wasted `present*16` allocation for string columns and adds
a missing length guard; `state.go` caps the `deltaColAux` scratch on reset;
`stream.go` grows its buffer in one shot for large frames + a stale-doc cleanup.

**Tests:** added scalar-vs-SIMD `bitpack` parity tests for the previously
untested variable-width kernels (`b=1..4`, `22..27` — all pass, no divergence),
plus regressions for the RLE-cap bypass.

## Verified clean (not bugs)

Round-tripped extreme `int64`/`uint64` delta edges (the "overflow→corruption"
agent claims — the codec is modular-consistent); ALP lossless bit-exactness;
3-valued-logic query eval + `markUnknown`; all `bitpack` AVX2/NEON kernels traced
byte-for-byte against scalar; rANS interleaved LIFO symmetry + 2 B/symbol encode
sizing; intern-table id-overflow clamp; canonical `-0.0`/NaN; stream frame-length
guard + intern-state carry + truncated-frame latch.
