### PR TITLE
docs: publish AI-embeddings article to GitHub Pages

### DIFF
--- a/.github/workflows/pages-ai-article.yml
+++ b/.github/workflows/pages-ai-article.yml
@@ -1,0 +1,53 @@
+# Renders the qdf AI-embeddings article to GitHub Pages, triggered ONLY when the
+# article content changes — not on every push. docs/AI-EMBEDDINGS-ARTICLE.md is
+# the source of truth; docs/ai-article.html is a static shell that fetches and
+# renders it (Markdown via marked, diagrams via mermaid), so a content edit needs
+# no re-render step — this workflow just republishes the shell, the Markdown, and
+# the article's image assets.
+#
+# The site already serves the deep-dive article, the bench-trend dashboard and
+# coverage from the gh-pages branch (see docs/PAGES-SETUP.md); keep_files: true
+# preserves them. This job publishes in ~30 s and shares the gh-pages-deploy
+# concurrency group with the other publishers, so their pushes never overlap.
+name: pages-ai-article
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/AI-EMBEDDINGS-ARTICLE.md
+      - docs/ai-article.html
+      - docs/assets/**
+      - .github/workflows/pages-ai-article.yml
+
+# Least-privilege default; the publish job elevates contents to write.
+permissions:
+  contents: read
+
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: render + publish AI article
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the rendered article to the gh-pages branch
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: stage AI article into ./public
+        run: |
+          set -euo pipefail
+          mkdir -p public/assets
+          cp docs/ai-article.html public/ai-article.html
+          cp docs/AI-EMBEDDINGS-ARTICLE.md public/AI-EMBEDDINGS-ARTICLE.md
+          cp docs/assets/ai-*.svg public/assets/
+
+      - uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./public
+          keep_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,9 @@ diagrams/render-png.sh
 medium-series
 scripts/arm64-test.sh
 *.html
-# published deep-dive article shell (tracked on purpose)
+# published article shells (tracked on purpose)
 !docs/article.html
+!docs/ai-article.html
 golangnews-submission.md
 dev-to-qdf.md
 PR_DESCRIPTION.md
@@ -53,8 +54,9 @@ cmd/qdf-bench/qdf-bench
 # qdf-vecbench RD output artifact
 cmd/qdf-vecbench/rd.csv
 
-# AI embeddings article + its assets/diagrams (local-only, do not commit)
-docs/AI-EMBEDDINGS-ARTICLE.md
-docs/assets/
+# AI embeddings article: the Markdown source + SVG assets are published to
+# GitHub Pages (see pages-ai-article.yml), so they are tracked. The rendered
+# PNG duplicates and the diagrams/ copies stay local-only.
+docs/assets/*.png
 diagrams/svg/ai-*.svg
 diagrams/png/ai-*.png

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ cmd/qdf-bench/qdf-bench
 
 # qdf-vecbench RD output artifact
 cmd/qdf-vecbench/rd.csv
+
+# AI embeddings article + its assets/diagrams (local-only, do not commit)
+docs/AI-EMBEDDINGS-ARTICLE.md
+docs/assets/
+diagrams/svg/ai-*.svg
+diagrams/png/ai-*.png

--- a/docs/AI-EMBEDDINGS-ARTICLE.md
+++ b/docs/AI-EMBEDDINGS-ARTICLE.md
@@ -1,0 +1,419 @@
+---
+title: "Shrinking AI embeddings on the wire — a lossy vector codec that beats Google's TurboQuant at equal recall"
+published: false
+tags: ai, go, vectordatabase, performance
+cover_image: ./assets/ai-rd-curve.svg
+canonical_url:
+---
+
+> A developer's walk-through of `qdf`'s opt-in lossy vector codec: what it does,
+> why it lands within a hair of the information-theoretic floor, and how it
+> measures up against Google's TurboQuant on a reproducible benchmark. Every
+> number here comes from the repo — `docs/LOSSY-VECTOR.md` and
+> `cmd/qdf-vecbench/rd.csv` — not from a slide.
+
+## The problem nobody budgets for
+
+A single 768-dimensional `float32` embedding is **3,072 bytes**. That sounds
+harmless until you have a few million of them. A 10M-document RAG index is
+~30 GB of *just vectors* — before metadata, before the ANN graph, before
+replication. Embeddings are quietly the dominant storage and bandwidth line item
+of every vector database and every retrieval pipeline.
+
+Here's the thing: **embeddings are not telemetry that must round-trip
+bit-for-bit.** Nobody cares whether coordinate 412 comes back as `0.0193847` or
+`0.0193851`. What you care about is that nearest-neighbour search returns *the
+same neighbours* — i.e. that cosine similarity is preserved to a few decimal
+places. That is the exact regime where lossy quantization is free money, and
+it's why `qdf` ships an **opt-in** lossy codec for `[]float32` / `[]float64`
+fields (`OptLossyVec`). Off by default, so no exact workload is ever silently
+approximated; one flag flip when you want it.
+
+The part I find genuinely nice as an application developer: you don't bolt on a
+second system.
+
+![One self-describing blob, not two stores](./assets/ai-one-blob.svg)
+
+You serialize your `[]struct{ ID, Text, Emb []float32 }` with the same
+`Marshal`/`Unmarshal` you already use. The scalar and string fields stay
+bit-exact; the vector field is batched into one lossy column; the blob is
+self-describing, so `Unmarshal` rebuilds the records with **no flag and no side
+schema**. Metadata store and vector store collapse into one blob with one write
+path. (See `Example_aiEmbeddingStore` in the package docs.)
+
+## What the codec actually does
+
+For each float-vector column the encoder runs a four-idea pipeline. Three of the
+four are things a CPU serializer can do that a fixed-width GPU codebook cannot —
+and that's exactly where the size edge comes from.
+
+![OptLossyVec encode pipeline](./assets/ai-pipeline.svg)
+
+1. **Randomized Hadamard rotation** — `R = (1/√n)·H·D`, a seed-driven sign-flip
+   diagonal `D` composed with the Walsh–Hadamard transform `H`. It spreads
+   per-coordinate outliers evenly so the data becomes approximately Gaussian —
+   the ideal shape for low-bit quantization — at `O(n·log n)` cost and with **no
+   stored matrix**: just a `uint64` seed on the wire. This is the same idea
+   Google's TurboQuant uses for KV-cache quantization.
+2. **A lattice, not a grid.** The scalar quantizer snaps each coordinate to the
+   nearest multiple of a step `δ` (the `Z` lattice — a cube). The **E8**
+   quantizer groups coordinates into 8-D blocks and snaps each to the nearest
+   point of E8, the densest packing in 8 dimensions. E8's Voronoi cell is
+   *rounder* than the cube, so it spends fewer bits for the same distortion.
+3. **Entropy-code the indices.** After the rotation the quantization indices are
+   near-Gaussian — a peaked distribution. A fixed-width code wastes bits on that;
+   an order-0 **rANS** pass (the same entropy stage the rest of `qdf` uses)
+   recovers them.
+4. **Never-worse.** The encoder builds *both* quantizers and the plain lossless
+   float encoding, and keeps whichever is smallest. `OptLossyVec` is a hint, never
+   a commitment to inflate — an incompressible or exception-heavy column silently
+   falls back to lossless.
+
+`NaN`/`±Inf` are pulled into an exception list before quantization and written
+back bit-exactly on decode, so non-finite values survive any budget untouched.
+
+## Why this is close to the performance ceiling
+
+This is the claim worth defending, so let me be precise about *which* ceiling.
+
+**Distortion-rate.** For a fixed quantizer, the bits you must spend at a target
+distortion are bounded below by the source entropy after the optimal transform.
+The pipeline attacks every term of that bound:
+
+- The Hadamard rotation **decorrelates and Gaussianizes** the coordinates. Rate-
+  distortion theory says the Gaussian is the worst case for a *fixed* coder but
+  the *best-understood* case for an optimal one — and crucially the rotation
+  makes the per-coordinate distribution uniform, so a single step `δ` is near-
+  optimal for every coordinate instead of being dragged around by outliers.
+- The **E8 lattice** captures the space-filling (granular) gain. Its normalized
+  second moment is `G ≈ 0.0717` versus the scalar cube's `1/12 ≈ 0.0833` — a
+  **~0.65 dB coding gain**, which is most of the gain available in 8 dimensions
+  short of an impractically large vector quantizer.
+- **rANS** captures the entropy (coding) gain — the bits a fixed-width index
+  leaves on the table once the distribution is peaked.
+
+Granular gain + entropy gain are the two levers a *practical* quantizer has.
+`qdf` pulls both. The only thing left on the table is a higher-dimensional
+lattice (Leech in 24-D buys a further fraction of a dB) — which was prototyped
+and **measured-killed**: the extra coset bookkeeping cost more than the packing
+saved at these rates. That's the signature of being near the practical floor — the next idea
+*loses*.
+
+**Implementation.** Separate from the bits-on-the-wire ceiling, the encoder is
+allocation-bound, not algorithm-bound, in steady state. Reusing scratch across
+calls (the pooled `Marshal` path) takes a 256×768 batch from **13,855 → 1,308
+allocs/op** and **21.2 MB → 2.0 MB/op** — ~10× each — with byte-identical
+output. Profiling past that point shows the encoder is output-bound: there's no
+hot loop left to shave.
+
+## The benchmark: vs Google's TurboQuant (and naive, and PQ)
+
+All methods compared on the **same** synthetic Gaussian corpus
+(2,000 vectors × 256 dims), each with pre-built, buffer-reusing scratch so the
+timing is apples-to-apples. Reproduce:
+
+```bash
+go run ./cmd/qdf-vecbench -synthetic -n 2000 -dim 256
+# raw rows live in cmd/qdf-vecbench/rd.csv
+```
+
+The money chart is recall-vs-size. A method is better when its curve sits to the
+**left** — fewer bytes at the same recall.
+
+![Recall@10 vs bytes per vector](./assets/ai-rd-curve.svg)
+
+`qdf-lossy` is Pareto-better than both scalar baselines across the whole useful
+recall band. Read off the iso-recall line at **recall ≈ 0.90**:
+
+| Method | bytes / vector | recall@10 | notes |
+|---|---:|---:|---|
+| **qdf-lossy** (knob 0.05) | **170.4** | **0.931** | smaller *and* higher recall |
+| naive scalar (5-bit) | 176.0 | 0.901 | |
+| TurboQuant rotated-scalar (5-bit) | 184.0 | 0.903 | rotation, but no entropy/lattice |
+
+At ~the same byte budget, `qdf` delivers higher recall; at ~the same recall, it
+spends fewer bytes. `docs/LOSSY-VECTOR.md` quotes the headline as
+**≈17–22 % smaller at equal reconstruction quality** (−18.8 % vs naive, −22.3 %
+vs TurboQuant at the `rel ≈ 0.05` operating point), and the win widens to
+−21 % at looser budgets.
+
+Notice TurboQuant lands *between* naive and qdf: the rotation alone helps (it's
+why TurboQuant beats naive at high recall), but without the lattice and the
+entropy stage it can't reach the qdf curve. That gap is the entropy + granular
+gain, made visible.
+
+**What about Product Quantization?** PQ is on the same chart's data
+(`rd.csv`) and it's a fair question. The honest answer: on this corpus at
+comparable *quality* it doesn't compete. PQ hits tiny sizes (2–16 B/vec) but
+recall@10 collapses to **0.02–0.11** at those rates — it needs a trained
+codebook and many more subspaces to approach 0.9 recall, which is a different
+operating regime (and a separate training step). For a drop-in, training-free,
+self-describing serializer codec, the scalar/lattice family is the right
+comparison, and qdf wins it.
+
+### The honest trade
+
+Smaller wire is not free. `qdf` does strictly more work per vector — a rotation
+and an entropy-decode on the read path, plus a verify-loop on encode — than a
+bare scalar quantizer:
+
+| Method | enc MB/s | dec MB/s | enc allocs |
+|---|---:|---:|---:|
+| qdf-lossy | 174 | 526 | **1** |
+| naive scalar | 993 | 4054 | 0 |
+| TurboQuant rotated-scalar | 543 | 949 | 0 |
+
+*(warm, buffer-reusing; from `docs/LOSSY-VECTOR.md`)*
+
+So if your bottleneck is raw quantization throughput, a naive scalar codec is
+faster. `qdf`'s codec is built for the **write-once, read-many** embedding store
+where storage and bandwidth dominate the bill and a few hundred MB/s of encode
+is irrelevant next to a 20 % smaller index replicated across a fleet. Pick the
+tool for the bottleneck you actually have.
+
+## Why this instead of the usual stacks
+
+The recall-vs-size chart settles *how small* qdf goes. But "use qdf" is an
+architecture decision, not just a codec choice, so here's the honest comparison
+against the four things you'd reach for otherwise.
+
+![Why qdf instead of the usual stacks](./assets/ai-vs-alternatives.svg)
+
+- **A dedicated vector DB (FAISS / pgvector) with Product Quantization.** This is
+  the heavyweight answer, and it's the right one once you need a *served, indexed,
+  updatable* ANN system at scale. But it's two systems — a vector store next to
+  your metadata store — that you keep in sync, and PQ needs a **trained codebook**
+  (a separate fit step, re-fit when the embedding model changes). qdf is the
+  opposite trade: no training, no second store, no index to rebuild — a single
+  file you `Marshal` once and `Unmarshal` anywhere. Use the vector DB when you've
+  outgrown a flat scan; use qdf for the store *underneath* it, or for the very
+  common case where a brute-force cosine scan over a few hundred thousand vectors
+  is already fast enough.
+- **protobuf / msgpack with raw `float32`.** This is what most pipelines actually
+  ship today, and it's exact — but it stores the full 1,024 bytes per 256-dim
+  vector and copies every field on decode. You get correctness and a familiar
+  format; you pay 6–7× the bytes of qdf-lossy and a per-field allocation on every
+  read. If your vectors genuinely must be bit-exact, this is correct (and so is
+  qdf with the flag *off*). If they're search vectors, you're paying for exactness
+  nobody consumes.
+- **Roll-your-own scalar quantization (int8 + glue code).** The DIY path: quantize
+  to int8, stuff it into msgpack, write a decoder. It works and it's small-ish
+  (~176 B at 5-bit), but now *you* own a wire format, a dequantizer, and the
+  edge cases (NaN/Inf, varying norms, the "is this column even worth quantizing"
+  decision). qdf gives you the rotation + lattice + entropy stack, the
+  **never-worse** guarantee, and NaN/Inf survival for free — and it's
+  self-describing, so the reader needs no out-of-band schema.
+
+The one-line version: **qdf is the training-free, single-blob, self-describing
+option.** It won't beat a tuned PQ index on raw bytes, and it won't beat raw
+`float32` on encode speed — but it's the only one of the four where the metadata
+and the vector live in one `Marshal`/`Unmarshal` you already know, with a
+correctness floor (never-worse, exact-by-default) baked in.
+
+## Where it's useful
+
+| Situation | Use it? | Budget knob |
+|---|---|---|
+| Embedding store / RAG index (ANN search) | **Yes** — headline use case | `MinCosine(0.999)` |
+| Bandwidth-bound embedding transfer | **Yes** | `MinCosine` or `MaxRelError(0.01)` |
+| Model weight / activation tensors | Yes, with care | `MaxRelError` / `TargetSNR`, validate downstream |
+| Exact scientific / financial floats | **No** — leave the flag off | — |
+| Short vectors (< 32) or scalar float fields | n/a — won't fire | stays lossless automatically |
+
+The budget API speaks in the metric you actually reason about:
+
+```go
+enc := qdf.NewEncoderWith(qdf.OptBalanced | qdf.OptLossyVec)
+enc.SetVectorBudget(qdf.MinCosine(0.999)) // keep cosine similarity >= 0.999
+if err := enc.EncodeValue(rows); err != nil {
+    log.Fatal(err)
+}
+data := enc.Bytes()
+
+var out []EmbedRow
+_ = qdf.Unmarshal(data, &out) // no flag needed; the 0xFD tag self-describes
+// out[i].Emb approximates rows[i].Emb with cosine >= 0.999
+```
+
+`MinCosine` bounds the dot-product metric ANN relies on; `MaxRelError(eps)`
+bounds per-vector L2 error directly; `TargetSNR(db)` suits signal-style data.
+Looser budget ⇒ smaller and faster — pick the loosest your downstream task
+tolerates and verify recall on a held-out query set.
+
+## Production best practices
+
+The codec is only half the win. The other half is decoding it without throwing
+the size advantage away on allocations — embedding decode is **allocation-bound,
+not CPU-bound**, so where the bytes land matters as much as how few there are.
+This section is the part the API docs assume you'll figure out.
+
+### Write path: reuse one encoder, batch the column
+
+Two habits make the encode side cheap:
+
+1. **Reuse a `*qdf.Encoder` across calls.** `qdf.Marshal` allocates a fresh
+   encoder state per call; a long-lived encoder reuses its rotation, coordinate,
+   widen, and rANS scratch. On a 256×768 batch that's the **13,855 → 1,308
+   allocs/op** (21.2 MB → 2.0 MB/op) difference — ~10× — with byte-identical
+   output.
+
+   ```go
+   enc := qdf.NewEncoderWith(qdf.OptBalanced | qdf.OptLossyVec)
+   enc.SetVectorBudget(qdf.MinCosine(0.999))
+   for _, batch := range batches {
+       _ = enc.EncodeValue(batch) // scratch reused across iterations
+       write(enc.Bytes())
+   }
+   ```
+
+2. **Marshal the whole `[]struct`, not vector-by-vector.** When the element has a
+   `[]float32`/`[]float64` field, qdf gathers *every row's* vector into **one**
+   count-`N` column block (wire tag `0xFE`) instead of one block per row. That
+   amortizes the block header *and* the rANS frequency framing across the batch —
+   the per-row form costs ~290 B/vec vs ~176 B/vec batched on a 256-dim corpus.
+   So the headline numbers are the ones you actually get in production, *because*
+   you marshal the batch. (Needs ≥ 16 rows with the same vector length.)
+
+If you re-encode the same string-column shape repeatedly (same URL space, same log
+format alongside the vectors), train an `FSSTDict` once and reuse it — it skips
+the per-batch symbol-table training, ~5× faster encode.
+
+### Read path: three ways to decode, pick by buffer ownership
+
+This is the lever most people miss. The default `Unmarshal` copies each string
+field into its own heap allocation — always correct, but a record with seven
+string fields pays seven allocations and the GC then scans seven objects. There
+are two cheaper paths, and which one is safe depends entirely on **who owns the
+wire buffer and how long it lives**.
+
+![Three decode paths](./assets/ai-decode-paths.svg)
+
+- **`WithArena` — copy once, packed.** Bump-appends every decoded string into one
+  contiguous block per epoch instead of N separate allocations. The strings are
+  byte-identical; only *where they live* changes. Across a batch the block
+  amortizes to ~0 allocations, the strings sit cache-adjacent, and the GC walks
+  one object instead of N. Measured **−26…−35 %** decode time on string-heavy
+  corpora (4,856 → 605 allocs/op on an AD-style export). It is **safe with a
+  recycled wire buffer** — because it copies the strings *out*, you can hand the
+  buffer straight back to a pool. This is the right default for a server handler
+  or a streaming consumer.
+
+  ```go
+  a := qdf.NewArena()
+  for msg := range stream {
+      var rows []Doc
+      _ = qdf.Unmarshal(msg, &rows, qdf.WithArena(a))
+      use(rows)
+      a.Reset() // only after every value from the last decode is dead
+  }
+  ```
+
+  `Reset` is a *manual* use-after-free contract — call it only once everything
+  decoded since the last reset is dead. If you can't reason about that, drop the
+  arena and `NewArena()` again; never-`Reset` is always safe (the block is plain
+  GC memory).
+
+- **`WithNoCopy` — zero copy.** Decoded strings/`[]byte` **alias the input buffer**
+  directly: zero copies, zero allocations, ~1.7× faster. The catch is the
+  lifetime — the values are valid only while the input stays alive and unmodified.
+  Use it on **owned, long-lived, read-only** input. Never on a pooled/recycled
+  buffer (a server request body): the aliased values become silent garbage when
+  the buffer is reused — a use-after-free the race detector won't catch.
+
+The decision is mechanical: **recycled buffer → `WithArena`; owned long-lived
+buffer → `WithNoCopy`; unsure → default copy.**
+
+### The flagship pattern: an mmap'd, zero-copy embedding store
+
+`WithNoCopy`'s "owned, long-lived, read-only" requirement is *exactly* what an
+`mmap`'d file is — which makes it the natural backing for a write-once / read-many
+embedding index. You marshal the whole corpus into one self-describing `.qdf`
+file once; readers `mmap` it and `Unmarshal` with `WithNoCopy`, serving vectors
+straight out of the page cache with **no per-read allocation and no copy**.
+
+![Write-once / read-many zero-copy store](./assets/ai-store-arch.svg)
+
+```go
+// Writer — once, offline.
+enc := qdf.NewEncoderWith(qdf.OptBalanced | qdf.OptLossyVec)
+enc.SetVectorBudget(qdf.MinCosine(0.999))
+_ = enc.EncodeValue(corpus)        // []Doc{ID, Title, Emb []float32}
+_ = os.WriteFile("index.qdf", enc.Bytes(), 0o644)
+
+// Reader — many times, hot.
+f, _ := os.Open("index.qdf")
+buf, _ := syscall.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)
+defer syscall.Munmap(buf)
+
+var docs []Doc
+_ = qdf.Unmarshal(buf, &docs, qdf.WithNoCopy()) // strings alias the mmap; vectors materialize
+// docs[i].Emb is the approximated vector; scan / ANN over it directly.
+```
+
+The vector field itself is reconstructed (the lossy decode allocates the output
+slice — there's nothing to alias), but the `ID`/`Title` metadata and any other
+string columns cost zero. The whole index is one file, one mmap, one `Unmarshal`
+— no second store, no schema sidecar. Keep the mmap mapped for as long as you
+read `docs`; `Munmap` only after they're done.
+
+### Choosing and validating the budget
+
+The budget knob is the one parameter that actually matters, so don't guess it:
+
+| You reason about… | Knob | Note |
+|---|---|---|
+| ANN recall (cosine / dot-product) | `MinCosine(0.999)` | bounds the metric the index uses — start here for RAG |
+| reconstruction error directly | `MaxRelError(0.01)` | per-vector L2; tighter `eps` ⇒ more bytes |
+| signal-style data (audio, sensor) | `TargetSNR(db)` | dB framing |
+
+A looser budget is smaller *and* faster. The discipline: **pick the loosest
+budget your downstream task tolerates, then verify recall@k on a held-out query
+set** — encode the corpus, decode it, and confirm the top-k neighbours of your
+eval queries are unchanged (the `Example_aiEmbeddingStore` test does exactly this
+top-1 check). Tighten the budget only if recall actually drops. Because the codec
+is **never-worse**, the failure mode of an over-tight budget is "no smaller than
+lossless," not "corrupt" — you lose the size win, not correctness.
+
+### A short checklist
+
+- [ ] `OptLossyVec` **only** on search/embedding vectors — never exact floats.
+- [ ] Marshal the `[]struct` batch (≥ 16 rows) so the vector column batches.
+- [ ] Reuse a `*qdf.Encoder` if you encode in a loop.
+- [ ] Decode: `WithArena` for pooled buffers, `WithNoCopy` for mmap, copy if unsure.
+- [ ] Verify recall@k on held-out queries; loosen the budget to the floor your task allows.
+
+## A note on trust
+
+I deliberately sourced every figure from committed artifacts:
+
+- pipeline & wire format → [`docs/LOSSY-VECTOR.md`](./LOSSY-VECTOR.md)
+- decode paths (arena / zero-copy) → [`docs/ARENA.md`](./ARENA.md)
+- rate-distortion / recall rows → [`cmd/qdf-vecbench/rd.csv`](../cmd/qdf-vecbench/rd.csv)
+- runnable end-to-end → `Example_aiEmbeddingStore` in [`example_lossyvec_test.go`](../example_lossyvec_test.go)
+- reproduce → `go run ./cmd/qdf-vecbench -synthetic -n 2000 -dim 256`
+
+The benchmark is synthetic Gaussian data, which is the *friendly* case for every
+method here; the relative ordering (qdf < TurboQuant < naive at equal recall) is
+the structural result and it holds because it comes from the algorithm, not the
+corpus. On real embeddings the absolute bytes shift, but the entropy + lattice
+gain that puts qdf's curve to the left does not.
+
+## Takeaways
+
+- Embeddings dominate vector-DB storage and they don't need bit-exactness —
+  lossy quantization is the right tool, and it can live inside your serializer
+  instead of a second system.
+- `qdf`'s codec pulls **both** practical quantization levers (E8 granular gain +
+  rANS entropy gain) on top of the TurboQuant-style rotation — which is why it's
+  Pareto-better than rotated-scalar at equal recall, and why the *next* idea
+  (Leech) measured worse.
+- It's an honest CPU-for-size trade: lower throughput, smaller wire, near-zero
+  steady-state allocations. Right for write-once / read-many stores.
+- The size win is only realized if you decode right: `WithArena` for pooled
+  buffers, `WithNoCopy` over an `mmap`'d file for a zero-copy read-many store.
+  Decode is allocation-bound — where the bytes land matters as much as how few.
+- Versus the alternatives it's the training-free, single-blob, self-describing
+  option: it won't beat a tuned PQ index on raw bytes or raw `float32` on encode
+  speed, but it's the only one with metadata + vector in one `Marshal`/`Unmarshal`
+  and a never-worse / exact-by-default correctness floor.
+- One flag, one blob, no schema, never-worse. `qdf.OptLossyVec`.

--- a/docs/ai-article.html
+++ b/docs/ai-article.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>qdf: shrinking AI embeddings on the wire — a lossy vector codec</title>
+<meta name="description" content="A developer's walk-through of qdf's opt-in lossy vector codec for AI embeddings: how it beats Google's TurboQuant at equal recall, when to use the arena vs zero-copy mmap decode path, and why it lands near the rate-distortion floor.">
+<meta property="og:title" content="qdf: shrinking AI embeddings on the wire — a lossy vector codec">
+<meta property="og:description" content="Opt-in lossy []float32/[]float64 codec: rotation + E8 lattice + rANS, ~17–22% smaller than scalar quantization at equal recall, one self-describing blob, never-worse.">
+<meta property="og:type" content="article">
+<meta property="og:image" content="assets/ai-rd-curve.svg">
+<style>
+  :root { --fg:#1b1f24; --muted:#57606a; --bg:#ffffff; --code-bg:#f6f8fa;
+          --border:#d0d7de; --link:#0969da; --accent:#0550ae; }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg:#e6edf3; --muted:#9198a1; --bg:#0d1117; --code-bg:#161b22;
+            --border:#30363d; --link:#4493f8; --accent:#79c0ff; }
+  }
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body { margin:0; background:var(--bg); color:var(--fg);
+         font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }
+  main { max-width: 820px; margin: 0 auto; padding: 2.2rem 1.1rem 5rem; }
+  h1,h2,h3 { line-height:1.25; font-weight:680; margin:2.1em 0 .6em; }
+  h1 { font-size:2.05rem; margin-top:.2em; letter-spacing:-.01em; }
+  h2 { font-size:1.5rem; padding-bottom:.3em; border-bottom:1px solid var(--border); }
+  h3 { font-size:1.18rem; }
+  p,li { color:var(--fg); }
+  em { color:var(--muted); }
+  a { color:var(--link); text-decoration:none; }
+  a:hover { text-decoration:underline; }
+  blockquote { margin:1.2em 0; padding:.2em 1em; border-left:4px solid var(--border);
+               color:var(--muted); }
+  code { background:var(--code-bg); padding:.16em .38em; border-radius:6px;
+         font:0.88em/1.5 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace; }
+  pre { background:var(--code-bg); padding:1rem 1.1rem; border-radius:10px;
+        overflow:auto; border:1px solid var(--border); }
+  pre code { background:none; padding:0; font-size:0.83rem; line-height:1.5; }
+  pre.mermaid { background:transparent; border:none; text-align:center; padding:.5rem 0; }
+  img { max-width:100%; height:auto; display:block; margin:1.4em auto; }
+  table { border-collapse:collapse; width:100%; margin:1.2em 0; display:block; overflow:auto; }
+  th,td { border:1px solid var(--border); padding:.45em .7em; text-align:left; font-size:.92rem; }
+  th { background:var(--code-bg); }
+  tbody tr:nth-child(2n) { background:color-mix(in srgb, var(--code-bg) 45%, transparent); }
+  hr { border:none; border-top:1px solid var(--border); margin:2.4em 0; }
+  .meta { color:var(--muted); font-size:.9rem; margin-top:-.4em; }
+  #status { color:var(--muted); padding:3rem 0; text-align:center; }
+</style>
+</head>
+<body>
+<main>
+  <div id="content">
+    <p id="status">Rendering…</p>
+    <noscript>
+      <p>This page renders Markdown in the browser. With JavaScript disabled, read the
+      source directly:
+      <a href="AI-EMBEDDINGS-ARTICLE.md">AI-EMBEDDINGS-ARTICLE.md</a> ·
+      <a href="https://github.com/alex60217101990/qdf">qdf on GitHub</a>.</p>
+    </noscript>
+  </div>
+</main>
+
+<script type="module">
+  // Pinned CDN versions (jsDelivr). Bump deliberately.
+  import { marked } from 'https://cdn.jsdelivr.net/npm/marked@12.0.2/lib/marked.esm.js';
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.esm.min.mjs';
+
+  const dark = matchMedia('(prefers-color-scheme: dark)').matches;
+  mermaid.initialize({ startOnLoad: false, theme: dark ? 'dark' : 'default',
+                       securityLevel: 'strict' });
+
+  // Strip a leading YAML frontmatter block and return { title, body }.
+  // The AI article carries its title in frontmatter (not an H1), so we lift it
+  // into an <h1> and drop the rest of the frontmatter from the rendered body.
+  function splitFrontmatter(md) {
+    const m = md.match(/^---\n([\s\S]*?)\n---\n?/);
+    if (!m) return { title: '', body: md };
+    const fm = m[1];
+    const t = fm.match(/^title:\s*["']?(.*?)["']?\s*$/m);
+    return { title: t ? t[1] : '', body: md.slice(m[0].length) };
+  }
+
+  const el = document.getElementById('content');
+  try {
+    const res = await fetch('AI-EMBEDDINGS-ARTICLE.md', { cache: 'no-cache' });
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const { title, body } = splitFrontmatter(await res.text());
+    const heading = title ? '# ' + title + '\n\n' : '';
+    el.innerHTML = marked.parse(heading + body);
+
+    // Promote ```mermaid fenced blocks (rendered by marked as
+    // <pre><code class="language-mermaid">) into <pre class="mermaid"> holding
+    // the RAW (un-escaped, via textContent) diagram source, then render them.
+    el.querySelectorAll('code.language-mermaid').forEach((c) => {
+      const pre = document.createElement('pre');
+      pre.className = 'mermaid';
+      pre.textContent = c.textContent;
+      (c.closest('pre') || c).replaceWith(pre);
+    });
+    await mermaid.run({ querySelector: 'pre.mermaid', suppressErrors: true });
+    document.title = (el.querySelector('h1')?.textContent || document.title).trim();
+  } catch (e) {
+    el.innerHTML = '<p>Could not render the article (' + e.message +
+      '). Read the source: <a href="AI-EMBEDDINGS-ARTICLE.md">AI-EMBEDDINGS-ARTICLE.md</a> · ' +
+      '<a href="https://github.com/alex60217101990/qdf">qdf on GitHub</a>.</p>';
+  }
+</script>
+</body>
+</html>

--- a/docs/assets/ai-decode-paths.svg
+++ b/docs/assets/ai-decode-paths.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 470" font-family="-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">
+  <rect width="1180" height="470" fill="#ffffff"/>
+  <defs>
+    <marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M0,0 L9,4.5 L0,9 z" fill="#6b7280"/>
+    </marker>
+  </defs>
+  <text x="40" y="40" font-size="22" font-weight="700" fill="#1a1a2e">Three decode paths — pick by who owns the wire buffer</text>
+  <text x="40" y="62" font-size="13" fill="#9ca3af">source: decoder.go · WithArena / WithNoCopy · internal/bumparena — see docs/ARENA.md</text>
+
+  <!-- column 1: default copy -->
+  <g>
+    <rect x="24" y="92" width="360" height="330" rx="12" fill="#f9fafb" stroke="#e5e7eb"/>
+    <text x="204" y="122" text-anchor="middle" font-size="16" font-weight="700" fill="#111827">default — copy out</text>
+    <text x="204" y="144" text-anchor="middle" font-size="12.5" fill="#6b7280">string(b) per field · always safe</text>
+
+    <!-- N separate allocs -->
+    <g font-size="11">
+      <rect x="56" y="172" width="58" height="34" rx="6" fill="#eef2ff" stroke="#6366f1"/>
+      <rect x="124" y="172" width="58" height="34" rx="6" fill="#eef2ff" stroke="#6366f1"/>
+      <rect x="192" y="172" width="58" height="34" rx="6" fill="#eef2ff" stroke="#6366f1"/>
+      <rect x="260" y="172" width="58" height="34" rx="6" fill="#eef2ff" stroke="#6366f1"/>
+      <text x="187" y="226" text-anchor="middle" fill="#4338ca">N strings → N heap allocs, N GC objects</text>
+    </g>
+
+    <g font-size="12.5" fill="#374151">
+      <text x="56" y="270">✓ wire buffer reusable immediately</text>
+      <text x="56" y="294">✓ safe with pooled / recycled buffers</text>
+      <text x="56" y="318">✓ no lifetime bookkeeping</text>
+      <text x="56" y="342" fill="#b91c1c">✗ one alloc + GC scan per string</text>
+    </g>
+    <rect x="56" y="366" width="296" height="38" rx="8" fill="#ffffff" stroke="#e5e7eb"/>
+    <text x="204" y="390" text-anchor="middle" font-size="12.5" fill="#111827" font-weight="600">use when: anything, by default</text>
+  </g>
+
+  <!-- column 2: arena -->
+  <g>
+    <rect x="410" y="92" width="360" height="330" rx="12" fill="#f9fafb" stroke="#e5e7eb"/>
+    <text x="590" y="122" text-anchor="middle" font-size="16" font-weight="700" fill="#111827">WithArena — copy once, packed</text>
+    <text x="590" y="144" text-anchor="middle" font-size="12.5" fill="#6b7280">bump-append into one block per epoch</text>
+
+    <!-- one block -->
+    <g font-size="11">
+      <rect x="442" y="172" width="296" height="34" rx="6" fill="#ecfdf5" stroke="#10b981"/>
+      <line x1="500" y1="172" x2="500" y2="206" stroke="#10b981" stroke-dasharray="3"/>
+      <line x1="558" y1="172" x2="558" y2="206" stroke="#10b981" stroke-dasharray="3"/>
+      <line x1="616" y1="172" x2="616" y2="206" stroke="#10b981" stroke-dasharray="3"/>
+      <line x1="674" y1="172" x2="674" y2="206" stroke="#10b981" stroke-dasharray="3"/>
+      <text x="590" y="226" text-anchor="middle" fill="#047857">all strings in 1 block → ~0 allocs (amortized)</text>
+    </g>
+
+    <g font-size="12.5" fill="#374151">
+      <text x="442" y="270">✓ wire buffer reusable immediately</text>
+      <text x="442" y="294">✓ safe with pooled / recycled buffers</text>
+      <text x="442" y="318">✓ −26..35 % decode, allocs 4856 → 605</text>
+      <text x="442" y="342" fill="#b45309">! Reset is a manual UAF contract</text>
+    </g>
+    <rect x="442" y="366" width="296" height="38" rx="8" fill="#ffffff" stroke="#e5e7eb"/>
+    <text x="590" y="390" text-anchor="middle" font-size="12.5" fill="#111827" font-weight="600">use when: batch / stream / server handler</text>
+  </g>
+
+  <!-- column 3: nocopy -->
+  <g>
+    <rect x="796" y="92" width="360" height="330" rx="12" fill="#f9fafb" stroke="#e5e7eb"/>
+    <text x="976" y="122" text-anchor="middle" font-size="16" font-weight="700" fill="#111827">WithNoCopy — zero copy</text>
+    <text x="976" y="144" text-anchor="middle" font-size="12.5" fill="#6b7280">strings alias the input (e.g. mmap)</text>
+
+    <!-- alias into wire -->
+    <g font-size="11">
+      <rect x="828" y="172" width="296" height="34" rx="6" fill="#fef9c3" stroke="#eab308"/>
+      <text x="976" y="193" text-anchor="middle" fill="#854d0e">mmap'd wire buffer (the file itself)</text>
+      <text x="976" y="226" text-anchor="middle" fill="#a16207">0 copies · values point INTO the buffer</text>
+    </g>
+
+    <g font-size="12.5" fill="#374151">
+      <text x="828" y="270" fill="#15803d">✓ zero allocations, ~1.7× faster</text>
+      <text x="828" y="294">✓ ideal for mmap'd / long-lived input</text>
+      <text x="828" y="318" fill="#b91c1c">✗ buffer must outlive every value</text>
+      <text x="828" y="342" fill="#b91c1c">✗ pooled buffer ⇒ silent use-after-free</text>
+    </g>
+    <rect x="828" y="366" width="296" height="38" rx="8" fill="#ffffff" stroke="#e5e7eb"/>
+    <text x="976" y="390" text-anchor="middle" font-size="12.5" fill="#111827" font-weight="600">use when: mmap'd read-only embedding store</text>
+  </g>
+
+  <!-- footnote -->
+  <text x="40" y="450" font-size="12.5" fill="#374151">Rule of thumb: recycled buffer (pooled request body) → WithArena · owned long-lived buffer (mmap'd file) → WithNoCopy · unsure → default copy. [ ]byte fields are never arena-backed (caller-mutable).</text>
+</svg>

--- a/docs/assets/ai-one-blob.svg
+++ b/docs/assets/ai-one-blob.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 440" font-family="-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">
+  <rect width="980" height="440" fill="#ffffff"/>
+  <defs>
+    <marker id="a2" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M0,0 L9,4.5 L0,9 z" fill="#6b7280"/>
+    </marker>
+  </defs>
+  <text x="40" y="40" font-size="22" font-weight="700" fill="#1a1a2e">One self-describing blob, not two stores</text>
+  <text x="40" y="62" font-size="13" fill="#9ca3af">source: docs/LOSSY-VECTOR.md · Example_aiEmbeddingStore — exact scalar/string fields + one lossy vector column</text>
+
+  <!-- typical two-system split -->
+  <text x="40" y="104" font-size="15" font-weight="700" fill="#9f1239">Typical stack — two systems, two formats, kept in sync</text>
+  <rect x="40" y="120" width="200" height="86" rx="10" fill="#fff1f2" stroke="#f43f5e" stroke-width="1.5"/>
+  <text x="140" y="150" text-anchor="middle" font-weight="700" fill="#9f1239">metadata DB</text>
+  <text x="140" y="172" text-anchor="middle" font-size="12.5" fill="#6b7280">id, text, tags, ts</text>
+  <text x="140" y="190" text-anchor="middle" font-size="12.5" fill="#6b7280">(row store / JSON)</text>
+
+  <rect x="300" y="120" width="200" height="86" rx="10" fill="#fff1f2" stroke="#f43f5e" stroke-width="1.5"/>
+  <text x="400" y="150" text-anchor="middle" font-weight="700" fill="#9f1239">vector store</text>
+  <text x="400" y="172" text-anchor="middle" font-size="12.5" fill="#6b7280">float32[768] per row</text>
+  <text x="400" y="190" text-anchor="middle" font-size="12.5" fill="#6b7280">(separate index)</text>
+
+  <path d="M240,150 L300,150" stroke="#f43f5e" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#a2)" fill="none"/>
+  <path d="M300,176 L240,176" stroke="#f43f5e" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#a2)" fill="none"/>
+  <text x="270" y="226" text-anchor="middle" font-size="11.5" fill="#be123c">join by id, two writes, drift risk</text>
+
+  <!-- qdf single blob -->
+  <text x="40" y="290" font-size="15" font-weight="700" fill="#166534">With qdf — one Marshal, one blob, one Unmarshal</text>
+
+  <rect x="40" y="306" width="220" height="96" rx="10" fill="#eef2ff" stroke="#6366f1" stroke-width="1.5"/>
+  <text x="150" y="334" text-anchor="middle" font-weight="700" fill="#312e81">[]EmbedRow</text>
+  <text x="150" y="356" text-anchor="middle" font-size="12.5" fill="#4338ca">{ ID, Text, Emb []float32 }</text>
+  <text x="150" y="378" text-anchor="middle" font-size="12.5" fill="#6b7280">your Go structs</text>
+
+  <path d="M260,354 L322,354" stroke="#6b7280" stroke-width="2" marker-end="url(#a2)" fill="none"/>
+  <text x="291" y="344" text-anchor="middle" font-size="12" fill="#374151">Marshal</text>
+  <text x="291" y="372" text-anchor="middle" font-size="11" fill="#9ca3af">+OptLossyVec</text>
+
+  <!-- the blob -->
+  <rect x="324" y="306" width="616" height="96" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="632" y="330" text-anchor="middle" font-weight="700" fill="#166534">one self-describing qdf blob</text>
+  <rect x="344" y="344" width="176" height="42" rx="6" fill="#ffffff" stroke="#86efac"/>
+  <text x="432" y="362" text-anchor="middle" font-size="12.5" font-weight="600" fill="#15803d">id + text columns</text>
+  <text x="432" y="378" text-anchor="middle" font-size="11" fill="#6b7280">bit-exact (lossless)</text>
+  <rect x="536" y="344" width="200" height="42" rx="6" fill="#ffffff" stroke="#86efac"/>
+  <text x="636" y="362" text-anchor="middle" font-size="12.5" font-weight="600" fill="#15803d">vector column (0xFD/0xFE)</text>
+  <text x="636" y="378" text-anchor="middle" font-size="11" fill="#6b7280">lossy, cosine ≥ budget</text>
+  <rect x="752" y="344" width="168" height="42" rx="6" fill="#ffffff" stroke="#86efac"/>
+  <text x="836" y="362" text-anchor="middle" font-size="12.5" font-weight="600" fill="#15803d">never-worse gate</text>
+  <text x="836" y="378" text-anchor="middle" font-size="11" fill="#6b7280">falls back if not smaller</text>
+</svg>

--- a/docs/assets/ai-pipeline.svg
+++ b/docs/assets/ai-pipeline.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 360" font-family="-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">
+  <rect width="1180" height="360" fill="#ffffff"/>
+  <defs>
+    <marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M0,0 L9,4.5 L0,9 z" fill="#6b7280"/>
+    </marker>
+  </defs>
+  <text x="40" y="40" font-size="22" font-weight="700" fill="#1a1a2e">OptLossyVec encode pipeline (wire tag 0xFD)</text>
+  <text x="40" y="62" font-size="13" fill="#9ca3af">source: lossyvec.go · internal/lattice · internal/hadamard · internal/rans — see docs/LOSSY-VECTOR.md</text>
+
+  <!-- stage boxes -->
+  <g font-size="14">
+    <!-- 1 input -->
+    <rect x="24" y="120" width="160" height="84" rx="10" fill="#eef2ff" stroke="#6366f1" stroke-width="1.5"/>
+    <text x="104" y="150" text-anchor="middle" font-weight="700" fill="#312e81">input vector</text>
+    <text x="104" y="172" text-anchor="middle" fill="#4338ca">[]float32 / []float64</text>
+    <text x="104" y="190" text-anchor="middle" fill="#6b7280">≥ 32 elems</text>
+
+    <!-- 2 hadamard -->
+    <rect x="224" y="120" width="160" height="84" rx="10" fill="#fff7ed" stroke="#fb923c" stroke-width="1.5"/>
+    <text x="304" y="148" text-anchor="middle" font-weight="700" fill="#9a3412">Hadamard rotation</text>
+    <text x="304" y="170" text-anchor="middle" fill="#c2410c">R = (1/√n)·H·D</text>
+    <text x="304" y="188" text-anchor="middle" font-size="12" fill="#6b7280">outliers → ~Gaussian</text>
+
+    <!-- 3 budget -->
+    <rect x="424" y="120" width="160" height="84" rx="10" fill="#ecfeff" stroke="#06b6d4" stroke-width="1.5"/>
+    <text x="504" y="148" text-anchor="middle" font-weight="700" fill="#155e75">budget → step δ</text>
+    <text x="504" y="170" text-anchor="middle" font-size="12" fill="#0e7490">MSE ≈ δ²·G_lattice</text>
+    <text x="504" y="188" text-anchor="middle" font-size="12" fill="#6b7280">verify-loop to meet budget</text>
+
+    <!-- 4 quantize fork -->
+    <rect x="624" y="96" width="160" height="52" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="704" y="118" text-anchor="middle" font-weight="700" fill="#166534">scalar (Z)</text>
+    <text x="704" y="136" text-anchor="middle" font-size="12" fill="#6b7280">round to nearest δ</text>
+    <rect x="624" y="176" width="160" height="56" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="704" y="198" text-anchor="middle" font-weight="700" fill="#166534">E8 lattice</text>
+    <text x="704" y="216" text-anchor="middle" font-size="12" fill="#6b7280">D8 vs D8+½ · +1 coset bit</text>
+
+    <!-- 5 rANS -->
+    <rect x="824" y="120" width="150" height="84" rx="10" fill="#fdf4ff" stroke="#d946ef" stroke-width="1.5"/>
+    <text x="899" y="150" text-anchor="middle" font-weight="700" fill="#86198f">rANS entropy</text>
+    <text x="899" y="172" text-anchor="middle" font-size="12" fill="#a21caf">zigzag-varint coords</text>
+    <text x="899" y="190" text-anchor="middle" font-size="12" fill="#6b7280">order-0, interleaved</text>
+
+    <!-- 6 never-worse pick -->
+    <rect x="1014" y="120" width="142" height="84" rx="10" fill="#fff1f2" stroke="#f43f5e" stroke-width="1.5"/>
+    <text x="1085" y="148" text-anchor="middle" font-weight="700" fill="#9f1239">keep smaller</text>
+    <text x="1085" y="170" text-anchor="middle" font-size="12" fill="#be123c">never-worse vs</text>
+    <text x="1085" y="186" text-anchor="middle" font-size="12" fill="#be123c">lossless float</text>
+  </g>
+
+  <!-- arrows -->
+  <g stroke="#6b7280" stroke-width="2" fill="none">
+    <line x1="184" y1="162" x2="222" y2="162" marker-end="url(#arrow)"/>
+    <line x1="384" y1="162" x2="422" y2="162" marker-end="url(#arrow)"/>
+    <line x1="584" y1="150" x2="622" y2="122" marker-end="url(#arrow)"/>
+    <line x1="584" y1="174" x2="622" y2="204" marker-end="url(#arrow)"/>
+    <line x1="784" y1="122" x2="822" y2="150" marker-end="url(#arrow)"/>
+    <line x1="784" y1="204" x2="822" y2="174" marker-end="url(#arrow)"/>
+    <line x1="974" y1="162" x2="1012" y2="162" marker-end="url(#arrow)"/>
+  </g>
+
+  <!-- outputs -->
+  <text x="1085" y="238" text-anchor="middle" font-size="12" fill="#374151">↓</text>
+  <text x="1085" y="262" text-anchor="middle" font-size="13" fill="#111827" font-weight="600">0xFD block</text>
+  <text x="1085" y="280" text-anchor="middle" font-size="11.5" fill="#6b7280">or lossless fallback</text>
+
+  <!-- footnote: exceptions + batched -->
+  <rect x="24" y="300" width="1132" height="40" rx="8" fill="#f9fafb" stroke="#e5e7eb"/>
+  <text x="40" y="325" font-size="12.5" fill="#374151">NaN/±Inf pulled into an exception list first and restored bit-exactly on decode · []struct embedding rows batch into ONE count-N block (tag 0xFE) — amortizes header + rANS framing</text>
+</svg>

--- a/docs/assets/ai-rd-curve.svg
+++ b/docs/assets/ai-rd-curve.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 540" font-family="-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">
+  <rect width="860" height="540" fill="#ffffff"/>
+  <text x="430" y="34" text-anchor="middle" font-size="22" font-weight="700" fill="#1a1a2e">Recall@10 vs bytes / vector — same 2,000×256 Gaussian corpus</text>
+  <text x="430" y="56" text-anchor="middle" font-size="14" fill="#6b7280">qdf-lossy sits to the left: fewer bytes at the same recall (Pareto-better)</text>
+
+  <!-- plot frame -->
+  <rect x="80" y="80" width="700" height="400" fill="#fafafa" stroke="#d1d5db" stroke-width="1"/>
+
+  <!-- y gridlines + labels (recall 0.62..1.00) -->
+  <g font-size="12" fill="#6b7280">
+    <line x1="80" y1="40.0"  x2="780" y2="40.0"  stroke="#eceef1"/>
+    <line x1="80" y1="145.3" x2="780" y2="145.3" stroke="#eceef1"/>
+    <line x1="80" y1="250.5" x2="780" y2="250.5" stroke="#eceef1"/>
+    <line x1="80" y1="355.8" x2="780" y2="355.8" stroke="#eceef1"/>
+    <text x="72" y="44"  text-anchor="end">1.00</text>
+    <text x="72" y="149" text-anchor="end">0.90</text>
+    <text x="72" y="255" text-anchor="end">0.80</text>
+    <text x="72" y="360" text-anchor="end">0.70</text>
+    <text x="72" y="444" text-anchor="end">0.62</text>
+  </g>
+  <text x="26" y="280" text-anchor="middle" font-size="14" fill="#374151" transform="rotate(-90 26 280)">recall@10 (higher = better)</text>
+
+  <!-- x labels (bytes 80..340) -->
+  <g font-size="12" fill="#6b7280" text-anchor="middle">
+    <text x="80"  y="500">80</text>
+    <text x="237" y="500">140</text>
+    <text x="394" y="500">200</text>
+    <text x="551" y="500">260</text>
+    <text x="708" y="500">320</text>
+  </g>
+  <text x="430" y="524" text-anchor="middle" font-size="14" fill="#374151">bytes / vector (lower = smaller wire)</text>
+  <text x="784" y="78" text-anchor="end" font-size="10.5" fill="#9ca3af">source: cmd/qdf-vecbench/rd.csv — go run ./cmd/qdf-vecbench -synthetic -n 2000 -dim 256</text>
+
+  <!-- qdf-lossy -->
+  <polyline fill="none" stroke="#e8590c" stroke-width="3"
+    points="101.6,371.2 149.5,267.2 232.7,158.3 316.5,112.2 420.8,67.4 550.2,57.7 689.2,47.6"/>
+  <g fill="#e8590c">
+    <circle cx="101.6" cy="371.2" r="4.5"/><circle cx="149.5" cy="267.2" r="4.5"/>
+    <circle cx="232.7" cy="158.3" r="4.5"/><circle cx="316.5" cy="112.2" r="4.5"/>
+    <circle cx="420.8" cy="67.4" r="4.5"/><circle cx="550.2" cy="57.7" r="4.5"/>
+    <circle cx="689.2" cy="47.6" r="4.5"/>
+  </g>
+
+  <!-- naive scalar -->
+  <polyline fill="none" stroke="#1971c2" stroke-width="2.5" stroke-dasharray="2 0"
+    points="163.7,430.5 247.4,239.4 331.1,144.4 414.8,98.9 498.5,72.6 582.2,53.7 749.5,42.5"/>
+  <g fill="#1971c2">
+    <circle cx="163.7" cy="430.5" r="4"/><circle cx="247.4" cy="239.4" r="4"/>
+    <circle cx="331.1" cy="144.4" r="4"/><circle cx="414.8" cy="98.9" r="4"/>
+    <circle cx="498.5" cy="72.6" r="4"/><circle cx="582.2" cy="53.7" r="4"/>
+    <circle cx="749.5" cy="42.5" r="4"/>
+  </g>
+
+  <!-- TurboQuant rotated-scalar -->
+  <polyline fill="none" stroke="#2f9e44" stroke-width="2.5" stroke-dasharray="7 5"
+    points="184.6,432.4 268.3,236.8 352,142.3 435.7,95.4 519.4,66.1 603.1,53.7 770.5,41.7"/>
+  <g fill="#2f9e44">
+    <circle cx="184.6" cy="432.4" r="4"/><circle cx="268.3" cy="236.8" r="4"/>
+    <circle cx="352" cy="142.3" r="4"/><circle cx="435.7" cy="95.4" r="4"/>
+    <circle cx="519.4" cy="66.1" r="4"/><circle cx="603.1" cy="53.7" r="4"/>
+    <circle cx="770.5" cy="41.7" r="4"/>
+  </g>
+
+  <!-- iso-recall guide at 0.90 -->
+  <line x1="80" y1="145.3" x2="430" y2="145.3" stroke="#9ca3af" stroke-width="1" stroke-dasharray="3 3"/>
+  <text x="430" y="129" font-size="12" fill="#374151">@ recall 0.90:  qdf ≈170 B  ·  naive 176 B  ·  TurboQuant 184 B</text>
+
+  <!-- legend -->
+  <g font-size="14">
+    <rect x="540" y="380" width="232" height="92" fill="#ffffff" stroke="#e5e7eb"/>
+    <line x1="556" y1="402" x2="586" y2="402" stroke="#e8590c" stroke-width="3"/>
+    <text x="594" y="407" fill="#1a1a2e" font-weight="600">qdf-lossy (this work)</text>
+    <line x1="556" y1="428" x2="586" y2="428" stroke="#1971c2" stroke-width="2.5"/>
+    <text x="594" y="433" fill="#374151">naive scalar quant</text>
+    <line x1="556" y1="454" x2="586" y2="454" stroke="#2f9e44" stroke-width="2.5" stroke-dasharray="7 5"/>
+    <text x="594" y="459" fill="#374151">TurboQuant rotated-scalar</text>
+  </g>
+</svg>

--- a/docs/assets/ai-store-arch.svg
+++ b/docs/assets/ai-store-arch.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 440" font-family="-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">
+  <rect width="1180" height="440" fill="#ffffff"/>
+  <defs>
+    <marker id="arrow2" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M0,0 L9,4.5 L0,9 z" fill="#6b7280"/>
+    </marker>
+  </defs>
+  <text x="40" y="40" font-size="22" font-weight="700" fill="#1a1a2e">Write-once / read-many embedding store — the zero-copy path</text>
+  <text x="40" y="62" font-size="13" fill="#9ca3af">one self-describing blob · mmap + WithNoCopy ⇒ vectors served straight from page cache, no per-read alloc</text>
+
+  <!-- WRITE side -->
+  <text x="40" y="104" font-size="14" font-weight="700" fill="#6b7280">WRITE — once, offline</text>
+  <rect x="40" y="118" width="200" height="92" rx="10" fill="#eef2ff" stroke="#6366f1" stroke-width="1.5"/>
+  <text x="140" y="148" text-anchor="middle" font-size="14" font-weight="700" fill="#312e81">[]struct{ID,Text,Emb}</text>
+  <text x="140" y="170" text-anchor="middle" font-size="12" fill="#4338ca">id + metadata + vector</text>
+  <text x="140" y="190" text-anchor="middle" font-size="12" fill="#6b7280">reuse one *Encoder</text>
+
+  <rect x="290" y="118" width="210" height="92" rx="10" fill="#fff7ed" stroke="#fb923c" stroke-width="1.5"/>
+  <text x="395" y="144" text-anchor="middle" font-size="14" font-weight="700" fill="#9a3412">Marshal</text>
+  <text x="395" y="166" text-anchor="middle" font-size="12" fill="#c2410c">OptBalanced | OptLossyVec</text>
+  <text x="395" y="186" text-anchor="middle" font-size="12" fill="#6b7280">scalar/string exact</text>
+  <text x="395" y="202" text-anchor="middle" font-size="12" fill="#6b7280">vectors → 1 lossy column</text>
+
+  <line x1="240" y1="164" x2="288" y2="164" stroke="#6b7280" stroke-width="2" marker-end="url(#arrow2)"/>
+
+  <!-- file -->
+  <rect x="560" y="110" width="220" height="110" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="670" y="140" text-anchor="middle" font-size="15" font-weight="700" fill="#166534">index.qdf</text>
+  <text x="670" y="162" text-anchor="middle" font-size="12" fill="#15803d">one immutable file on disk</text>
+  <text x="670" y="182" text-anchor="middle" font-size="12" fill="#6b7280">self-describing wire</text>
+  <text x="670" y="200" text-anchor="middle" font-size="12" fill="#6b7280">no side schema, no second store</text>
+  <line x1="500" y1="164" x2="558" y2="164" stroke="#6b7280" stroke-width="2" marker-end="url(#arrow2)"/>
+
+  <!-- READ side -->
+  <text x="40" y="268" font-size="14" font-weight="700" fill="#6b7280">READ — many times, hot</text>
+
+  <rect x="560" y="282" width="220" height="92" rx="10" fill="#fef9c3" stroke="#eab308" stroke-width="2"/>
+  <text x="670" y="312" text-anchor="middle" font-size="14" font-weight="700" fill="#854d0e">mmap(index.qdf)</text>
+  <text x="670" y="334" text-anchor="middle" font-size="12" fill="#a16207">file pages, OS-cached</text>
+  <text x="670" y="354" text-anchor="middle" font-size="12" fill="#6b7280">owned + long-lived + read-only</text>
+  <line x1="670" y1="220" x2="670" y2="280" stroke="#6b7280" stroke-width="2" marker-end="url(#arrow2)"/>
+
+  <rect x="290" y="282" width="210" height="92" rx="10" fill="#ecfeff" stroke="#06b6d4" stroke-width="1.5"/>
+  <text x="395" y="312" text-anchor="middle" font-size="14" font-weight="700" fill="#155e75">Unmarshal</text>
+  <text x="395" y="334" text-anchor="middle" font-size="12" fill="#0e7490">WithNoCopy()</text>
+  <text x="395" y="354" text-anchor="middle" font-size="12" fill="#6b7280">strings alias mmap · 0 copies</text>
+  <line x1="558" y1="328" x2="502" y2="328" stroke="#6b7280" stroke-width="2" marker-end="url(#arrow2)"/>
+
+  <rect x="40" y="282" width="200" height="92" rx="10" fill="#fdf4ff" stroke="#d946ef" stroke-width="1.5"/>
+  <text x="140" y="312" text-anchor="middle" font-size="14" font-weight="700" fill="#86198f">ANN search</text>
+  <text x="140" y="334" text-anchor="middle" font-size="12" fill="#a21caf">cosine / dot-product</text>
+  <text x="140" y="354" text-anchor="middle" font-size="12" fill="#6b7280">recall preserved by budget</text>
+  <line x1="288" y1="328" x2="242" y2="328" stroke="#6b7280" stroke-width="2" marker-end="url(#arrow2)"/>
+
+  <!-- footnote -->
+  <rect x="40" y="396" width="1100" height="34" rx="8" fill="#f9fafb" stroke="#e5e7eb"/>
+  <text x="56" y="418" font-size="12.5" fill="#374151">Caveat: WithNoCopy aliases the mmap — values are valid only while it stays mapped and unmodified. If the buffer is pooled/recycled instead, use WithArena (copies once) — never WithNoCopy.</text>
+</svg>

--- a/docs/assets/ai-vs-alternatives.svg
+++ b/docs/assets/ai-vs-alternatives.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 480" font-family="-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">
+  <rect width="1180" height="480" fill="#ffffff"/>
+  <text x="40" y="40" font-size="22" font-weight="700" fill="#1a1a2e">Why qdf instead of the usual stacks</text>
+  <text x="40" y="62" font-size="13" fill="#9ca3af">drop-in, training-free, self-describing — the metadata and the vector live in one blob</text>
+
+  <!-- header row -->
+  <g font-size="12.5" fill="#6b7280" font-weight="700">
+    <text x="320" y="104" text-anchor="middle">storage shape</text>
+    <text x="520" y="104" text-anchor="middle">vector size</text>
+    <text x="690" y="104" text-anchor="middle">training</text>
+    <text x="870" y="104" text-anchor="middle">exactness</text>
+    <text x="1050" y="104" text-anchor="middle">read cost</text>
+  </g>
+  <line x1="40" y1="114" x2="1140" y2="114" stroke="#e5e7eb"/>
+
+  <!-- row: qdf -->
+  <rect x="40" y="124" width="1100" height="62" rx="10" fill="#ecfdf5" stroke="#10b981" stroke-width="1.5"/>
+  <text x="60" y="150" font-size="15" font-weight="700" fill="#065f46">qdf + OptLossyVec</text>
+  <text x="60" y="172" font-size="11.5" fill="#6b7280">rotation + E8 lattice + rANS</text>
+  <g font-size="12.5" fill="#111827">
+    <text x="320" y="160" text-anchor="middle">one self-describing blob</text>
+    <text x="520" y="160" text-anchor="middle" font-weight="700" fill="#047857">~143 B / 256-dim</text>
+    <text x="690" y="160" text-anchor="middle" fill="#047857">none</text>
+    <text x="870" y="160" text-anchor="middle">lossy vec · exact meta</text>
+    <text x="1050" y="160" text-anchor="middle" fill="#047857">zero-copy (mmap)</text>
+  </g>
+
+  <!-- row: separate vector DB -->
+  <rect x="40" y="196" width="1100" height="62" rx="10" fill="#fafafa" stroke="#e5e7eb"/>
+  <text x="60" y="222" font-size="15" font-weight="700" fill="#374151">FAISS / pgvector + PQ</text>
+  <text x="60" y="244" font-size="11.5" fill="#6b7280">product quantization codebook</text>
+  <g font-size="12.5" fill="#374151">
+    <text x="320" y="232" text-anchor="middle" fill="#b91c1c">vector store + metadata DB</text>
+    <text x="520" y="232" text-anchor="middle">tiny (2–16 B)</text>
+    <text x="690" y="232" text-anchor="middle" fill="#b91c1c">trained codebook</text>
+    <text x="870" y="232" text-anchor="middle">lossy, recall drops at low B</text>
+    <text x="1050" y="232" text-anchor="middle">two systems to keep in sync</text>
+  </g>
+
+  <!-- row: protobuf/msgpack raw -->
+  <rect x="40" y="268" width="1100" height="62" rx="10" fill="#fafafa" stroke="#e5e7eb"/>
+  <text x="60" y="294" font-size="15" font-weight="700" fill="#374151">protobuf / msgpack</text>
+  <text x="60" y="316" font-size="11.5" fill="#6b7280">raw float32, per-record</text>
+  <g font-size="12.5" fill="#374151">
+    <text x="320" y="304" text-anchor="middle">one blob</text>
+    <text x="520" y="304" text-anchor="middle" fill="#b91c1c">1024 B (full)</text>
+    <text x="690" y="304" text-anchor="middle" fill="#047857">none</text>
+    <text x="870" y="304" text-anchor="middle">exact (no shrink)</text>
+    <text x="1050" y="304" text-anchor="middle">copy per field</text>
+  </g>
+
+  <!-- row: manual quant + msgpack -->
+  <rect x="40" y="340" width="1100" height="62" rx="10" fill="#fafafa" stroke="#e5e7eb"/>
+  <text x="60" y="366" font-size="15" font-weight="700" fill="#374151">manual scalar quant</text>
+  <text x="60" y="388" font-size="11.5" fill="#6b7280">int8 + your own glue code</text>
+  <g font-size="12.5" fill="#374151">
+    <text x="320" y="376" text-anchor="middle">DIY format you maintain</text>
+    <text x="520" y="376" text-anchor="middle">~176 B (5-bit)</text>
+    <text x="690" y="376" text-anchor="middle" fill="#047857">none</text>
+    <text x="870" y="376" text-anchor="middle">lossy, no never-worse</text>
+    <text x="1050" y="376" text-anchor="middle" fill="#b91c1c">hand-rolled decode</text>
+  </g>
+
+  <!-- footnote -->
+  <rect x="40" y="416" width="1100" height="48" rx="8" fill="#f9fafb" stroke="#e5e7eb"/>
+  <text x="56" y="436" font-size="12" fill="#374151">qdf trades raw quantization throughput for the smallest wire at a given recall — no second system, no codebook training.</text>
+  <text x="56" y="453" font-size="12" fill="#374151">PQ reaches smaller sizes, but recall@10 collapses to 0.02–0.11 at those rates.</text>
+</svg>


### PR DESCRIPTION
Adds a single-article GitHub Pages publisher for the qdf AI-embeddings / lossy-vector article, mirroring the existing `pages-article.yml` flow.

## What

| File | Role |
|---|---|
| `docs/AI-EMBEDDINGS-ARTICLE.md` | article source (now tracked + published) |
| `docs/ai-article.html` | static render shell (marked + mermaid) — strips YAML frontmatter, lifts the title into an `<h1>`, resolves `./assets/*.svg` images |
| `docs/assets/ai-*.svg` | diagrams referenced by the article |
| `.github/workflows/pages-ai-article.yml` | publishes shell + md + svg assets to `gh-pages` |

## Workflow notes (by analogy with `pages-article.yml`)

- Triggers **only** on `push` to `main` when the article, shell, assets, or workflow change — not every push.
- `keep_files: true` preserves the existing deep-dive article, bench-trend dashboard and coverage already on `gh-pages`.
- Shares the `gh-pages-deploy` concurrency group so publisher pushes never overlap.
- Pinned action SHAs identical to the existing publisher.

Rendered PNG duplicates and the `diagrams/` copies stay local-only via `.gitignore`.

Branched off `audit/full-codebase` per request; rebase onto `main` after that PR merges.