### PR TITLE
feat(qpack): per-block adaptive integer codec (tagPackBlock 0xF0)

### DIFF
--- a/columnar.go
+++ b/columnar.go
@@ -1449,9 +1449,16 @@ func (d *Decoder) runQueryColumns(
 	// Single forward pass: decode projected or referenced columns once, skip rest.
 	retained = make([]*colVals, len(sh.kinds))
 	colCV := make([]*colVals, len(sh.kinds))
+	// Projected-only block columns are deferred: a predicate over OTHER columns
+	// narrows the row set first, then these are decoded block-selectively so only
+	// the blocks covering matched rows are materialized. Requires the column-length
+	// index (colLens) to seek past the deferred column cheaply in this pass.
+	type deferredBlock struct{ c, start int }
+	var deferred []deferredBlock
 	for c := range sh.kinds {
 		proj := isProj(c)
-		if !proj && !referenced[c] {
+		ref := referenced[c]
+		if !proj && !ref {
 			if colLens != nil {
 				if d.i+int(colLens[c]) > len(d.buf) {
 					return nil, nil, ErrShortBuffer
@@ -1462,14 +1469,25 @@ func (d *Decoder) runQueryColumns(
 			}
 			continue
 		}
-		cv, e := d.decodeColumnVals(sh.kinds[c], n, isByte(c))
+		k := sh.kinds[c]
+		if proj && !ref && colLens != nil && !k.isNullable() &&
+			(k == colKindInt || k == colKindUint) &&
+			d.i < len(d.buf) && d.buf[d.i] == tagPackBlock {
+			if d.i+int(colLens[c]) > len(d.buf) {
+				return nil, nil, ErrShortBuffer
+			}
+			deferred = append(deferred, deferredBlock{c, d.i})
+			d.i += int(colLens[c])
+			continue
+		}
+		cv, e := d.decodeColumnVals(k, n, isByte(c))
 		if e != nil {
 			return nil, nil, e
 		}
 		if proj {
 			retained[c] = &cv
 		}
-		if referenced[c] {
+		if ref {
 			colCV[c] = &cv
 		}
 	}
@@ -1489,6 +1507,17 @@ func (d *Decoder) runQueryColumns(
 		combined, _ = evalCond(flat, 0, n)
 	}
 	matched = matchedIndices(combined, n, nil)
+
+	// Decode the deferred block columns for matched rows only. d.i is irrelevant
+	// here (each call seeks via the column's recorded start and restores), so the
+	// forward-pass cursor left at the end of all columns is untouched.
+	for _, db := range deferred {
+		cv, e := d.decodeBlockColumnSelective(db.start, sh.kinds[db.c], n, matched)
+		if e != nil {
+			return nil, nil, e
+		}
+		retained[db.c] = &cv
+	}
 	return retained, matched, nil
 }
 

--- a/columnar_decode_scratch.go
+++ b/columnar_decode_scratch.go
@@ -337,6 +337,9 @@ func decodeSliceInt64Into(d *Decoder, dst *[]int64) error {
 	case tagPackPFor:
 		d.i++
 		return d.readPackedPForInt64SliceInto(dst)
+	case tagPackBlock:
+		d.i++
+		return d.readBlockInt64Into(dst)
 	}
 	// Fallback: element-by-element array decode.
 	n, err := d.ReadArrayHeader()
@@ -631,6 +634,9 @@ func decodeSliceUint64Into(d *Decoder, dst *[]uint64) error {
 	case tagPackPFor:
 		d.i++
 		return d.readPackedPForUint64SliceInto(dst)
+	case tagPackBlock:
+		d.i++
+		return d.readBlockUint64Into(dst)
 	}
 	// Fallback: element-by-element array decode.
 	n, err := d.ReadArrayHeader()

--- a/encoder.go
+++ b/encoder.go
@@ -142,6 +142,13 @@ type Encoder struct {
 	wideI64 []int64
 	wideU64 []uint64
 
+	// blkPlanI64 / blkPlanU64 cache the per-block codec picks made while costing
+	// the per-block adaptive codec, so the emit pass reuses them instead of
+	// re-picking every block (pickI64Codec is the dominant encode cost). Reused
+	// across columns; bounded on return to the pool.
+	blkPlanI64 []blockPlanI64
+	blkPlanU64 []blockPlanU64
+
 	// minIntern is the minimum string length eligible for interning;
 	// shorter values go in line.
 	minIntern int

--- a/qdf.go
+++ b/qdf.go
@@ -414,6 +414,12 @@ func putEnc(enc *Encoder, pool *sync.Pool) {
 	if cap(enc.wideU64) > maxRetainedWideScratch {
 		enc.wideU64 = nil
 	}
+	if cap(enc.blkPlanI64) > maxRetainedWideScratch {
+		enc.blkPlanI64 = nil
+	}
+	if cap(enc.blkPlanU64) > maxRetainedWideScratch {
+		enc.blkPlanU64 = nil
+	}
 	pool.Put(enc)
 }
 

--- a/qpack_block.go
+++ b/qpack_block.go
@@ -1,0 +1,540 @@
+package qdf
+
+import (
+	"encoding/binary"
+
+	"github.com/alex60217101990/qdf/internal/bitpack"
+)
+
+// Per-block adaptive integer codec (wire tag tagPackBlock, 0xF0).
+//
+// A long integer column is split into fixed-size blocks; each block is encoded
+// independently with the existing whole-column picker (pickI64Codec /
+// pickU64Codec → FOR / Delta+FOR / RLE / dict / PFOR / raw). A column whose
+// statistics shift along its length (sorted-then-random, bursty timestamps,
+// mixed-cardinality IDs, counters with resets) packs each region optimally
+// instead of paying one codec for the whole. An offset table prefixes the
+// blocks so a predicate query can seek to and decode only the blocks covering
+// its matched rows.
+//
+// Strictly never-larger: the block form is emitted only when its exact byte
+// cost is smaller than the whole-column codec. The block-cost estimate is exact
+// (each block's pickXXXCodec.bestCost is exact for the codec it picks, and the
+// header + offset table are sized exactly), and the whole-column cost is exact
+// for non-constant columns — constant columns are filtered out by the flat
+// pre-gate before any per-block work — so the comparison cannot be wrong in a
+// way that inflates the wire.
+
+const (
+	// blockCodecMinLen is the smallest column the block codec considers: two
+	// blocks of the smaller size, below which there is nothing to adapt.
+	blockCodecMinLen = 2 * blockSizeSmall
+	blockSizeSmall   = 256
+	blockSizeLarge   = 1024
+	blkLogSmall      = 8  // log2(256)
+	blkLogLarge      = 10 // log2(1024)
+
+	blockKindInt  = 0x00
+	blockKindUint = 0x01
+
+	// The cheap pre-gate samples blockGateSamples blocks, measures each one's FOR
+	// width over just a blockGateWindow-element window (one tiny min/max pass —
+	// orders of magnitude cheaper than a full pickXXXCodec), and fires when the
+	// spread between the widest and narrowest sampled block is >= blockGateBitsSpread.
+	// It keys on block-to-block HETEROGENEITY, not block-vs-whole tightness, so a
+	// globally monotonic column (small per-block FOR width but delta-optimal as a
+	// whole) is correctly skipped instead of triggering a wasted full probe. The
+	// gate only filters probe CPU — the full probe + never-larger still decide, so
+	// a gate miss costs size, never correctness.
+	blockGateSamples    = 8
+	blockGateWindow     = 64
+	blockGateBitsSpread = 4
+
+	// blockGateWideBits is the cheapest gate: a column whose whole-column FOR and
+	// delta widths are BOTH below this is already compact (delta/RLE/dict or a
+	// narrow FOR — the common flat column), so blocks have no headroom and the
+	// sampling pass is skipped entirely. Only genuinely wide columns (the kind a
+	// regime shift can shrink) ever reach the sampling gate.
+	blockGateWideBits = 12
+)
+
+// blockSizeFor maps a wire blkLog byte to its block size, rejecting any value
+// other than the two the encoder emits.
+func blockSizeFor(blkLog byte) (int, bool) {
+	switch blkLog {
+	case blkLogSmall:
+		return blockSizeSmall, true
+	case blkLogLarge:
+		return blockSizeLarge, true
+	}
+	return 0, false
+}
+
+// blockRegimeLikelyI64 cheaply tests whether s is heterogeneous enough to be
+// worth a full per-block probe. It samples up to blockGateSamples blocks and
+// compares the average per-block FOR width (one min/max pass each — far cheaper
+// than a full pickI64Codec) to the whole-column width: blocks that pack markedly
+// tighter mean local structure a single codec can't exploit. Catches trend
+// (sorted-then-random), periodic (bursty, mixed-card), and constant-run
+// (rle-then-noise) regimes; misses only the rare case where width is uniform but
+// codec choice shifts — a size miss, never a correctness one.
+func blockRegimeLikelyI64(s []int64, wholeForBits int) bool {
+	if wholeForBits <= 2 {
+		return false // already near-incompressible by FOR; blocks can't help
+	}
+	n := len(s)
+	nb := (n + blockSizeSmall - 1) / blockSizeSmall
+	step := max(nb/blockGateSamples, 1)
+	minB, maxB := 64, -1
+	for b := 0; b < nb; b += step {
+		i := b * blockSizeSmall
+		j := min(i+blockGateWindow, n)
+		mn, mx := minMaxI64(s[i:j])
+		w := bitpack.BitsForDelta(uint64(mx) - uint64(mn))
+		minB, maxB = min(minB, w), max(maxB, w)
+	}
+	return maxB-minB >= blockGateBitsSpread
+}
+
+func blockRegimeLikelyU64(s []uint64, wholeForBits int) bool {
+	if wholeForBits <= 2 {
+		return false
+	}
+	n := len(s)
+	nb := (n + blockSizeSmall - 1) / blockSizeSmall
+	step := max(nb/blockGateSamples, 1)
+	minB, maxB := 64, -1
+	for b := 0; b < nb; b += step {
+		i := b * blockSizeSmall
+		j := min(i+blockGateWindow, n)
+		mn, mx := minMaxU64(s[i:j])
+		w := bitpack.BitsForDelta(mx - mn)
+		minB, maxB = min(minB, w), max(maxB, w)
+	}
+	return maxB-minB >= blockGateBitsSpread
+}
+
+// ---- encode (int64) ----
+
+// tryWriteBlockInt64 emits the per-block adaptive form of s when it is strictly
+// smaller than the whole-column codec, returning true. It returns false (having
+// written nothing) when the column is too short, statistically flat, or the
+// block form would not win — the caller then falls back to writeQPackInt64.
+// blockCodecEnabled gates the per-block codec. Always true in production; tests
+// flip it to obtain a whole-column baseline wire for never-larger assertions.
+var blockCodecEnabled = true
+
+// blockSelectiveBlocksDecoded counts blocks materialized by the selective decode
+// path. Test-only instrumentation (to assert untouched blocks are skipped); the
+// counter is otherwise inert.
+var blockSelectiveBlocksDecoded int
+
+// tryWriteBlockInt64 emits the smaller of the per-block form and the whole-column
+// form when the cheap gates say the block form is plausible, returning true (the
+// column is fully written). It returns false when the gates reject the column —
+// the caller then emits the whole-column form itself.
+//
+// The whole-column codec is passed in (picked once by the caller). The size
+// decision is made by EMITTING BOTH forms and keeping the smaller, not by
+// comparing predicted costs: pickI64Codec's PFOR cost is a conservative UPPER
+// bound, so a predicted-cost compare could keep a block form that is actually
+// larger than the real whole-column emit (a never-larger violation). Emitting and
+// measuring is exact. The gates ensure this double-emit only happens on the rare
+// regime column, never on flat columns.
+func (e *Encoder) tryWriteBlockInt64(s []int64, codec qpackCodec, mn int64, forBits int, first, minDelta int64, deltaBits, pforBits int) bool {
+	if !blockCodecEnabled || e.rans {
+		// Skip under the outer rANS pass: the per-block offset table (high-entropy
+		// uint32s) and repeated sub-headers rANS-compress worse than the homogeneous
+		// whole-column form, so even a raw-smaller block can inflate the final wire.
+		// Keeping the whole-column form leaves OptCompression byte-identical to before.
+		return false
+	}
+	if len(s) < blockCodecMinLen {
+		return false
+	}
+	// Cheapest gate first: a compact column (narrow FOR and narrow delta) has no
+	// headroom — skip before sampling.
+	if forBits < blockGateWideBits && deltaBits < blockGateWideBits {
+		return false
+	}
+	if !blockRegimeLikelyI64(s, forBits) {
+		return false
+	}
+	// Emit whole first (the safe fallback), then the block form, and keep whichever
+	// is actually smaller — block usually wins when the gates fire, so it is emitted
+	// last and re-emission only happens on a gate false-positive. planBlocksI64
+	// caches the per-block picks so writeBlockInt64 does not re-pick.
+	start := len(e.buf)
+	hdr, flag := e.headerOut, e.headerFlagAt
+	e.emitQPackInt64(s, codec, mn, forBits, first, minDelta, deltaBits, pforBits)
+	wholeSz := len(e.buf) - start
+	e.buf = e.buf[:start]
+	e.headerOut, e.headerFlagAt = hdr, flag
+	e.planBlocksI64(s, blockSizeSmall)
+	e.writeBlockInt64(s, blockSizeSmall)
+	if len(e.buf)-start >= wholeSz {
+		// Block not smaller — roll back and re-emit the whole-column form. Restore
+		// the header latch so a rolled-away top-level stream header is re-emitted
+		// (mirrors the Gorilla never-worse rollback).
+		e.buf = e.buf[:start]
+		e.headerOut, e.headerFlagAt = hdr, flag
+		e.emitQPackInt64(s, codec, mn, forBits, first, minDelta, deltaBits, pforBits)
+	}
+	return true
+}
+
+// blockPlanI64 caches one block's picked codec so the emit pass does not re-pick.
+type blockPlanI64 struct {
+	mn, first, minDelta          int64
+	codec                        qpackCodec
+	forBits, deltaBits, pforBits int
+}
+
+// planBlocksI64 picks the codec for every block of s (size blk) and caches the
+// choices in e.blkPlanI64 so writeBlockInt64 emits without re-picking (pickI64Codec
+// is the dominant encode cost).
+func (e *Encoder) planBlocksI64(s []int64, blk int) {
+	n := len(s)
+	nBlocks := (n + blk - 1) / blk
+	if cap(e.blkPlanI64) < nBlocks {
+		e.blkPlanI64 = make([]blockPlanI64, nBlocks)
+	}
+	plans := e.blkPlanI64[:nBlocks]
+	bi := 0
+	for i := 0; i < n; i += blk {
+		j := min(i+blk, n)
+		codec, mn, forBits, first, minDelta, deltaBits, pforBits, _ := pickI64Codec(s[i:j])
+		plans[bi] = blockPlanI64{mn: mn, first: first, minDelta: minDelta, codec: codec, forBits: forBits, deltaBits: deltaBits, pforBits: pforBits}
+		bi++
+	}
+	e.blkPlanI64 = plans
+}
+
+func (e *Encoder) writeBlockInt64(s []int64, blk int) {
+	// Emit the stream header before appending directly to e.buf, exactly as the
+	// other QPack writers do — a bare top-level slice has no header yet, and the
+	// per-block emitQPackInt64 calls would otherwise insert it after the tag.
+	// Idempotent (no-op for the struct-field case where it already exists).
+	e.writeHeader()
+	n := len(s)
+	nBlocks := (n + blk - 1) / blk
+	plans := e.blkPlanI64[:nBlocks] // filled by planBlocksI64 (same s, same blk)
+	e.buf = append(e.buf, tagPackBlock, blockKindInt, blkLogSmall)
+	e.buf = appendUvarint(e.buf, uint64(n))
+	offAt := len(e.buf)
+	e.buf = append(e.buf, make([]byte, 4*nBlocks)...)
+	bodyStart := len(e.buf)
+	bi := 0
+	for i := 0; i < n; i += blk {
+		j := min(i+blk, n)
+		binary.LittleEndian.PutUint32(e.buf[offAt+4*bi:], uint32(len(e.buf)-bodyStart))
+		p := &plans[bi]
+		e.emitQPackInt64(s[i:j], p.codec, p.mn, p.forBits, p.first, p.minDelta, p.deltaBits, p.pforBits)
+		bi++
+	}
+}
+
+// ---- encode (uint64) ----
+
+func (e *Encoder) tryWriteBlockUint64(s []uint64, codec qpackCodec, mn uint64, forBits int, first uint64, minDelta int64, deltaBits, pforBits int) bool {
+	if !blockCodecEnabled || e.rans {
+		return false // see tryWriteBlockInt64: offset table is rANS-hostile
+	}
+	if len(s) < blockCodecMinLen {
+		return false
+	}
+	if forBits < blockGateWideBits && deltaBits < blockGateWideBits {
+		return false
+	}
+	if !blockRegimeLikelyU64(s, forBits) {
+		return false
+	}
+	// Emit-measure-keep-smaller (see tryWriteBlockInt64 for why predicted costs
+	// are not trustworthy for the never-larger decision).
+	start := len(e.buf)
+	hdr, flag := e.headerOut, e.headerFlagAt
+	e.emitQPackUint64(s, codec, mn, forBits, first, minDelta, deltaBits, pforBits)
+	wholeSz := len(e.buf) - start
+	e.buf = e.buf[:start]
+	e.headerOut, e.headerFlagAt = hdr, flag
+	e.planBlocksU64(s, blockSizeSmall)
+	e.writeBlockUint64(s, blockSizeSmall)
+	if len(e.buf)-start >= wholeSz {
+		e.buf = e.buf[:start]
+		e.headerOut, e.headerFlagAt = hdr, flag
+		e.emitQPackUint64(s, codec, mn, forBits, first, minDelta, deltaBits, pforBits)
+	}
+	return true
+}
+
+// blockPlanU64 caches one block's picked codec so the emit pass does not re-pick.
+type blockPlanU64 struct {
+	mn, first                    uint64
+	minDelta                     int64
+	codec                        qpackCodec
+	forBits, deltaBits, pforBits int
+}
+
+func (e *Encoder) planBlocksU64(s []uint64, blk int) {
+	n := len(s)
+	nBlocks := (n + blk - 1) / blk
+	if cap(e.blkPlanU64) < nBlocks {
+		e.blkPlanU64 = make([]blockPlanU64, nBlocks)
+	}
+	plans := e.blkPlanU64[:nBlocks]
+	bi := 0
+	for i := 0; i < n; i += blk {
+		j := min(i+blk, n)
+		codec, mn, forBits, first, minDelta, deltaBits, pforBits, _ := pickU64Codec(s[i:j])
+		plans[bi] = blockPlanU64{mn: mn, first: first, minDelta: minDelta, codec: codec, forBits: forBits, deltaBits: deltaBits, pforBits: pforBits}
+		bi++
+	}
+	e.blkPlanU64 = plans
+}
+
+func (e *Encoder) writeBlockUint64(s []uint64, blk int) {
+	e.writeHeader()
+	n := len(s)
+	nBlocks := (n + blk - 1) / blk
+	plans := e.blkPlanU64[:nBlocks]
+	e.buf = append(e.buf, tagPackBlock, blockKindUint, blkLogSmall)
+	e.buf = appendUvarint(e.buf, uint64(n))
+	offAt := len(e.buf)
+	e.buf = append(e.buf, make([]byte, 4*nBlocks)...)
+	bodyStart := len(e.buf)
+	bi := 0
+	for i := 0; i < n; i += blk {
+		j := min(i+blk, n)
+		binary.LittleEndian.PutUint32(e.buf[offAt+4*bi:], uint32(len(e.buf)-bodyStart))
+		p := &plans[bi]
+		e.emitQPackUint64(s[i:j], p.codec, p.mn, p.forBits, p.first, p.minDelta, p.deltaBits, p.pforBits)
+		bi++
+	}
+}
+
+// ---- decode header (shared) ----
+
+// readBlockHeader consumes the block-container header (the tag is already
+// consumed by the caller), validates it, and returns the block size, total
+// element count, the byte offset where the offset table begins, and the byte
+// offset where the block bodies begin. It does NOT consume the offset table.
+func (d *Decoder) readBlockHeader(expectKind byte) (blk, n, offBase, bodyStart, nBlocks int, err error) {
+	if d.i+2 > len(d.buf) {
+		return 0, 0, 0, 0, 0, ErrShortBuffer
+	}
+	if d.buf[d.i] != expectKind {
+		return 0, 0, 0, 0, 0, ErrTypeMismatch
+	}
+	d.i++
+	blk, ok := blockSizeFor(d.buf[d.i])
+	if !ok {
+		return 0, 0, 0, 0, 0, ErrBadTag
+	}
+	d.i++
+	n64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return 0, 0, 0, 0, 0, ErrInvalidLength
+	}
+	d.i += nr
+	if !d.colLenOK(n64) || n64 == 0 || n64 > uint64(int(^uint(0)>>1)) {
+		return 0, 0, 0, 0, 0, ErrInvalidLength
+	}
+	n = int(n64)
+	// Bound the make([]T, n) below by the same 256 MiB ceiling the columnar path
+	// uses. A standalone block wire (top-level []int64) has no colMaxLen, so n is
+	// otherwise capped only by the offset table (4 B/block) — constant sub-blocks
+	// pack 256 elems into ~5 B, so a hostile tiny buffer could request a huge
+	// slice. This caps the pre-block allocation regardless. (In the columnar path
+	// colMaxLen already bounds n to the row count; this is redundant but cheap.)
+	if checkColumnarBytes(n, 8) != nil {
+		return 0, 0, 0, 0, 0, ErrInvalidLength
+	}
+	nBlocks = (n + blk - 1) / blk
+	offBase = d.i
+	if d.i+4*nBlocks > len(d.buf) {
+		return 0, 0, 0, 0, 0, ErrShortBuffer
+	}
+	d.i += 4 * nBlocks
+	bodyStart = d.i
+	// Validate the offset table once: offsets[0]==0, strictly increasing, each
+	// within the buffer. Selective and decode-all both rely on this.
+	prev := -1
+	for b := 0; b < nBlocks; b++ {
+		off := int(binary.LittleEndian.Uint32(d.buf[offBase+4*b:]))
+		if b == 0 && off != 0 {
+			return 0, 0, 0, 0, 0, ErrInvalidLength
+		}
+		if off <= prev {
+			return 0, 0, 0, 0, 0, ErrInvalidLength
+		}
+		if bodyStart+off > len(d.buf) {
+			return 0, 0, 0, 0, 0, ErrShortBuffer
+		}
+		prev = off
+	}
+	return blk, n, offBase, bodyStart, nBlocks, nil
+}
+
+// blockLen returns the element count of block b (the last block holds the
+// remainder).
+func blockLen(b, nBlocks, n, blk int) int {
+	if b == nBlocks-1 {
+		return n - b*blk
+	}
+	return blk
+}
+
+// ---- decode-all (int64) ----
+
+func (d *Decoder) readBlockInt64() ([]int64, error) {
+	var s []int64
+	if err := d.readBlockInt64Into(&s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// readBlockInt64Into is the scratch-reusing form: it grows *dst to the column
+// length and decodes every block into it. The tag is already consumed.
+func (d *Decoder) readBlockInt64Into(dst *[]int64) error {
+	blk, n, offBase, bodyStart, nBlocks, err := d.readBlockHeader(blockKindInt)
+	if err != nil {
+		return err
+	}
+	growI64(dst, n)
+	out := *dst
+	for b := range nBlocks {
+		off := int(binary.LittleEndian.Uint32(d.buf[offBase+4*b:]))
+		d.i = bodyStart + off
+		t, err := d.peekTag()
+		if err != nil {
+			return err
+		}
+		v, err := d.readQPackInt64(t)
+		if err != nil {
+			return err
+		}
+		if len(v) != blockLen(b, nBlocks, n, blk) {
+			return ErrInvalidLength
+		}
+		copy(out[b*blk:], v)
+	}
+	return nil
+}
+
+// ---- selective decode (predicate-matched rows only) ----
+
+// decodeBlockColumnSelective decodes only the blocks of a block-tagged column
+// that cover the matched row indices, scattering their values into a colVals of
+// length n (matched positions filled, the rest left zero). matched must be
+// ascending (matchedIndices guarantees this), so each needed block is decoded
+// at most once and in wire order. The column starts at byte offset start;
+// d.i is restored to its entry value on return. kind must be colKindInt or
+// colKindUint and the column must be non-nullable (the caller gates this).
+func (d *Decoder) decodeBlockColumnSelective(start int, kind colKind, n int, matched []int) (colVals, error) {
+	save := d.i
+	defer func() { d.i = save }()
+	d.i = start + 1 // skip the tagPackBlock byte (recorded start points at it)
+
+	expect := byte(blockKindInt)
+	if kind == colKindUint {
+		expect = blockKindUint
+	}
+	blk, hn, offBase, bodyStart, nBlocks, err := d.readBlockHeader(expect)
+	if err != nil {
+		return colVals{}, err
+	}
+	if hn != n {
+		return colVals{}, ErrTypeMismatch
+	}
+	log := blkLogSmall
+	if blk == blockSizeLarge {
+		log = blkLogLarge
+	}
+
+	cv := colVals{kind: kind}
+	if kind == colKindInt {
+		cv.i64 = make([]int64, n)
+	} else {
+		cv.u64 = make([]uint64, n)
+	}
+
+	mi := 0
+	for mi < len(matched) {
+		b := matched[mi] >> log
+		if b >= nBlocks { // defensive; matched indices are < n so this cannot trip
+			return colVals{}, ErrInvalidLength
+		}
+		off := int(binary.LittleEndian.Uint32(d.buf[offBase+4*b:]))
+		d.i = bodyStart + off
+		blockSelectiveBlocksDecoded++
+		t, err := d.peekTag()
+		if err != nil {
+			return colVals{}, err
+		}
+		want := blockLen(b, nBlocks, n, blk)
+		bstart := b * blk
+		if kind == colKindInt {
+			v, err := d.readQPackInt64(t)
+			if err != nil {
+				return colVals{}, err
+			}
+			if len(v) != want {
+				return colVals{}, ErrInvalidLength
+			}
+			for mi < len(matched) && matched[mi]>>log == b {
+				cv.i64[matched[mi]] = v[matched[mi]-bstart]
+				mi++
+			}
+		} else {
+			v, err := d.readQPackUint64(t)
+			if err != nil {
+				return colVals{}, err
+			}
+			if len(v) != want {
+				return colVals{}, ErrInvalidLength
+			}
+			for mi < len(matched) && matched[mi]>>log == b {
+				cv.u64[matched[mi]] = v[matched[mi]-bstart]
+				mi++
+			}
+		}
+	}
+	return cv, nil
+}
+
+// ---- decode-all (uint64) ----
+
+func (d *Decoder) readBlockUint64() ([]uint64, error) {
+	var s []uint64
+	if err := d.readBlockUint64Into(&s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (d *Decoder) readBlockUint64Into(dst *[]uint64) error {
+	blk, n, offBase, bodyStart, nBlocks, err := d.readBlockHeader(blockKindUint)
+	if err != nil {
+		return err
+	}
+	growU64(dst, n)
+	out := *dst
+	for b := range nBlocks {
+		off := int(binary.LittleEndian.Uint32(d.buf[offBase+4*b:]))
+		d.i = bodyStart + off
+		t, err := d.peekTag()
+		if err != nil {
+			return err
+		}
+		v, err := d.readQPackUint64(t)
+		if err != nil {
+			return err
+		}
+		if len(v) != blockLen(b, nBlocks, n, blk) {
+			return ErrInvalidLength
+		}
+		copy(out[b*blk:], v)
+	}
+	return nil
+}

--- a/qpack_block_test.go
+++ b/qpack_block_test.go
@@ -1,0 +1,530 @@
+package qdf
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+)
+
+// blockArchetypes returns int64 columns: regime-shifting ones (where the
+// per-block codec should win) and flat ones (where it must not fire / never
+// grow). Deterministic seed for reproducibility.
+func blockArchetypes() []struct {
+	name   string
+	regime bool
+	gen    func() []int64
+} {
+	const N = 8192
+	rng := rand.New(rand.NewSource(42))
+	return []struct {
+		name   string
+		regime bool
+		gen    func() []int64
+	}{
+		{"sorted-then-random", true, func() []int64 {
+			s := make([]int64, N)
+			for i := range N / 2 {
+				s[i] = int64(1_700_000_000 + i)
+			}
+			for i := N / 2; i < N; i++ {
+				s[i] = rng.Int63n(1 << 40)
+			}
+			return s
+		}},
+		{"bursty-timestamps", true, func() []int64 {
+			s := make([]int64, N)
+			v := int64(1_700_000_000)
+			for i := range s {
+				if i%512 == 0 {
+					v += rng.Int63n(1 << 30)
+				}
+				v += rng.Int63n(3)
+				s[i] = v
+			}
+			return s
+		}},
+		{"mixed-card-id", true, func() []int64 {
+			s := make([]int64, N)
+			for i := range s {
+				if (i/1024)%2 == 0 {
+					s[i] = int64(rng.Intn(4))
+				} else {
+					s[i] = rng.Int63n(1 << 48)
+				}
+			}
+			return s
+		}},
+		{"rle-then-noise", true, func() []int64 {
+			s := make([]int64, N)
+			for i := range N * 3 / 4 {
+				s[i] = 200
+			}
+			for i := N * 3 / 4; i < N; i++ {
+				s[i] = rng.Int63n(1 << 20)
+			}
+			return s
+		}},
+		{"flat-low-card-enum", false, func() []int64 {
+			s := make([]int64, N)
+			for i := range s {
+				s[i] = int64(rng.Intn(6))
+			}
+			return s
+		}},
+		{"flat-uniform-random", false, func() []int64 {
+			s := make([]int64, N)
+			for i := range s {
+				s[i] = rng.Int63n(1 << 32)
+			}
+			return s
+		}},
+		{"flat-tight-monotonic", false, func() []int64 {
+			s := make([]int64, N)
+			for i := range s {
+				s[i] = int64(1_700_000_000 + i*3)
+			}
+			return s
+		}},
+		{"flat-small-values", false, func() []int64 {
+			s := make([]int64, N)
+			for i := range s {
+				s[i] = int64(1000 + rng.Intn(200))
+			}
+			return s
+		}},
+		{"short-below-floor", false, func() []int64 { // < blockCodecMinLen
+			s := make([]int64, 300)
+			for i := range s {
+				s[i] = int64(i)
+			}
+			return s
+		}},
+	}
+}
+
+// marshalBaseline encodes v with the block codec disabled (whole-column path).
+func marshalBaselineI64(t *testing.T, v []int64, opts Options) []byte {
+	t.Helper()
+	blockCodecEnabled = false
+	defer func() { blockCodecEnabled = true }()
+	b, err := Marshal(v, opts)
+	if err != nil {
+		t.Fatalf("baseline marshal: %v", err)
+	}
+	return b
+}
+
+func TestBlockRoundtripI64(t *testing.T) {
+	opts := []Options{OptSpeed, OptQPack, OptBalanced, OptCompression}
+	for _, a := range blockArchetypes() {
+		for _, o := range opts {
+			s := a.gen()
+			b, err := Marshal(s, o)
+			if err != nil {
+				t.Fatalf("%s/%v marshal: %v", a.name, o, err)
+			}
+			var out []int64
+			if err := Unmarshal(b, &out); err != nil {
+				t.Fatalf("%s/%v unmarshal: %v", a.name, o, err)
+			}
+			if len(out) != len(s) {
+				t.Fatalf("%s/%v len %d != %d", a.name, o, len(out), len(s))
+			}
+			for i := range s {
+				if out[i] != s[i] {
+					t.Fatalf("%s/%v [%d] = %d != %d", a.name, o, i, out[i], s[i])
+				}
+			}
+		}
+	}
+}
+
+func TestBlockRoundtripU64(t *testing.T) {
+	for _, a := range blockArchetypes() {
+		si := a.gen()
+		s := make([]uint64, len(si))
+		for i, v := range si {
+			if v < 0 {
+				v = -v
+			}
+			s[i] = uint64(v)
+		}
+		for _, o := range []Options{OptQPack, OptBalanced, OptCompression} {
+			b, err := Marshal(s, o)
+			if err != nil {
+				t.Fatalf("%s/%v marshal: %v", a.name, o, err)
+			}
+			var out []uint64
+			if err := Unmarshal(b, &out); err != nil {
+				t.Fatalf("%s/%v unmarshal: %v", a.name, o, err)
+			}
+			if len(out) != len(s) {
+				t.Fatalf("%s/%v len mismatch", a.name, o)
+			}
+			for i := range s {
+				if out[i] != s[i] {
+					t.Fatalf("%s/%v [%d] mismatch", a.name, o, i)
+				}
+			}
+		}
+	}
+}
+
+// TestBlockNeverLarger: the block wire is never larger than the whole-column
+// baseline; flat columns are byte-identical (block did not fire); at least one
+// regime column is strictly smaller (the codec earns its keep).
+func TestBlockNeverLarger(t *testing.T) {
+	regimeWon := false
+	for _, a := range blockArchetypes() {
+		s := a.gen()
+		block, err := Marshal(s, OptQPack)
+		if err != nil {
+			t.Fatalf("%s marshal: %v", a.name, err)
+		}
+		base := marshalBaselineI64(t, s, OptQPack)
+		if len(block) > len(base) {
+			t.Fatalf("%s: block %d > baseline %d (never-larger violated)", a.name, len(block), len(base))
+		}
+		if !a.regime {
+			if !bytes.Equal(block, base) {
+				t.Fatalf("%s: flat column not byte-identical to baseline (block %d, base %d)",
+					a.name, len(block), len(base))
+			}
+		}
+		if a.regime && len(block) < len(base) {
+			regimeWon = true
+			t.Logf("%s: %d -> %d (%.1f%% smaller)", a.name, len(base), len(block),
+				100*float64(len(base)-len(block))/float64(len(base)))
+		}
+	}
+	if !regimeWon {
+		t.Fatal("no regime column won — block codec never fired")
+	}
+}
+
+// TestBlockSelectiveDecode: a predicate over one column narrows the row set,
+// and a projected-only block column is then decoded for matched rows only —
+// untouched blocks are skipped (asserted via the instrumentation counter), and
+// the result equals a full decode + manual filter.
+func TestBlockSelectiveDecode(t *testing.T) {
+	type BRow struct {
+		Sel int64 // predicate column (low-card, not block)
+		Val int64 // block-tagged regime column, projected but not referenced
+	}
+	const N = 4096
+	rng := rand.New(rand.NewSource(7))
+	rows := make([]BRow, N)
+	for i := range rows {
+		// Val: sorted-then-random regime so it stores as a block column.
+		if i < N/2 {
+			rows[i].Val = int64(1_700_000_000 + i)
+		} else {
+			rows[i].Val = rng.Int63n(1 << 40)
+		}
+		// Sel == 1 only for the first 512 rows → matched rows cluster in the
+		// first 1-2 blocks, so most blocks need never be decoded.
+		if i < 512 {
+			rows[i].Sel = 1
+		}
+	}
+
+	b, err := Marshal(rows, OptBalanced|OptColumnIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blockSelectiveBlocksDecoded = 0
+	var out []BRow
+	if err := Unmarshal(b, &out,
+		Where("Sel", func(v int64) bool { return v == 1 }),
+		Select("Sel", "Val")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Expected = full filter.
+	var want []BRow
+	for _, r := range rows {
+		if r.Sel == 1 {
+			want = append(want, r)
+		}
+	}
+	if len(out) != len(want) {
+		t.Fatalf("len %d != %d", len(out), len(want))
+	}
+	for i := range want {
+		if out[i] != want[i] {
+			t.Fatalf("[%d] = %+v != %+v", i, out[i], want[i])
+		}
+	}
+	if blockSelectiveBlocksDecoded == 0 {
+		t.Fatal("selective path did not run (Val column was not block-tagged?)")
+	}
+	if blockSelectiveBlocksDecoded > 2 {
+		t.Fatalf("selective decoded %d blocks; matched rows span only the first ~2 blocks",
+			blockSelectiveBlocksDecoded)
+	}
+	t.Logf("selective decoded %d block(s) for %d matched rows", blockSelectiveBlocksDecoded, len(out))
+}
+
+// TestBlockSelectiveAdversarial exercises the selective decode integration
+// across predicate shapes that the happy-path test does not: all-match,
+// scattered-match (every block), zero-match, two deferred block columns, a block
+// column used as BOTH predicate and projection (must not defer), and the
+// no-ColumnIndex fallback. Each must equal a full decode + manual filter.
+func TestBlockSelectiveAdversarial(t *testing.T) {
+	type R struct {
+		Sel int64 // predicate column
+		A   int64 // block-tagged regime column
+		B   int64 // second block-tagged regime column
+	}
+	const N = 4096
+	rng := rand.New(rand.NewSource(11))
+	rows := make([]R, N)
+	for i := range rows {
+		rows[i].Sel = int64(i % 10) // 0..9
+		if i < N/2 {
+			rows[i].A = int64(1_700_000_000 + i)
+			rows[i].B = int64(2_000_000_000 + i*2)
+		} else {
+			rows[i].A = rng.Int63n(1 << 40)
+			rows[i].B = rng.Int63n(1 << 44)
+		}
+	}
+
+	filter := func(pred func(R) bool) []R {
+		var w []R
+		for _, r := range rows {
+			if pred(r) {
+				w = append(w, r)
+			}
+		}
+		return w
+	}
+	eq := func(t *testing.T, name string, got, want []R) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("%s: len %d != %d", name, len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("%s: [%d] %+v != %+v", name, i, got[i], want[i])
+			}
+		}
+	}
+
+	cases := []struct {
+		name  string
+		opts  Options
+		pred  func(R) bool
+		qpred func(int64) bool
+	}{
+		{"all-match", OptBalanced | OptColumnIndex, func(r R) bool { return r.Sel >= 0 }, func(v int64) bool { return v >= 0 }},
+		{"scattered-every-block", OptBalanced | OptColumnIndex, func(r R) bool { return r.Sel == 3 }, func(v int64) bool { return v == 3 }},
+		{"zero-match", OptBalanced | OptColumnIndex, func(r R) bool { return r.Sel == 99 }, func(v int64) bool { return v == 99 }},
+		{"two-deferred", OptBalanced | OptColumnIndex, func(r R) bool { return r.Sel < 2 }, func(v int64) bool { return v < 2 }},
+		{"no-colindex-fallback", OptBalanced, func(r R) bool { return r.Sel < 2 }, func(v int64) bool { return v < 2 }},
+	}
+	for _, c := range cases {
+		b, err := Marshal(rows, c.opts)
+		if err != nil {
+			t.Fatalf("%s marshal: %v", c.name, err)
+		}
+		var out []R
+		// Project ALL fields so the full-struct comparison is valid; A and B are
+		// projected-not-referenced (only Sel is the predicate) → block-selective.
+		if err := Unmarshal(b, &out,
+			Where("Sel", c.qpred),
+			Select("Sel", "A", "B")); err != nil {
+			t.Fatalf("%s unmarshal: %v", c.name, err)
+		}
+		eq(t, c.name, out, filter(c.pred))
+	}
+
+	// Block column used as BOTH predicate and projection: must full-decode (not
+	// defer), and filtering on it must be correct.
+	{
+		b, _ := Marshal(rows, OptBalanced|OptColumnIndex)
+		var out []R
+		if err := Unmarshal(b, &out,
+			Where("A", func(v int64) bool { return v < 1_700_000_100 }),
+			Select("Sel", "A", "B")); err != nil {
+			t.Fatalf("pred-on-block: %v", err)
+		}
+		eq(t, "pred-on-block", out, filter(func(r R) bool { return r.A < 1_700_000_100 }))
+	}
+}
+
+// TestBlockProperty fuzzes many random int64/uint64 columns (varied sizes incl.
+// block-boundary edges, varied distributions) and asserts every one round-trips
+// bit-exactly AND is never larger than the whole-column baseline.
+func TestBlockProperty(t *testing.T) {
+	rng := rand.New(rand.NewSource(99))
+	sizes := []int{511, 512, 513, 768, 1024, 1025, 2000, 4097}
+	for iter := range 200 {
+		n := sizes[rng.Intn(len(sizes))]
+		s := make([]int64, n)
+		mode := rng.Intn(6)
+		seg := 1 + rng.Intn(8) // number of regime segments
+		segLen := n/seg + 1
+		for i := range s {
+			switch (i/segLen + mode) % 6 {
+			case 0:
+				s[i] = int64(1_700_000_000 + i) // monotonic
+			case 1:
+				s[i] = rng.Int63n(1 << uint(8+rng.Intn(48))) // random varied width
+			case 2:
+				s[i] = int64(rng.Intn(8)) // low-card
+			case 3:
+				s[i] = 42 // constant run
+			case 4:
+				s[i] = int64(rng.Intn(3)) - 1 // tiny signed incl negatives
+			default:
+				s[i] = -rng.Int63n(1 << 30) // negative wide
+			}
+		}
+		for _, o := range []Options{OptQPack, OptBalanced, OptCompression} {
+			block, err := Marshal(s, o)
+			if err != nil {
+				t.Fatalf("iter %d n=%d %v marshal: %v", iter, n, o, err)
+			}
+			var out []int64
+			if err := Unmarshal(block, &out); err != nil {
+				t.Fatalf("iter %d n=%d %v unmarshal: %v", iter, n, o, err)
+			}
+			if len(out) != n {
+				t.Fatalf("iter %d n=%d %v len %d", iter, n, o, len(out))
+			}
+			for i := range s {
+				if out[i] != s[i] {
+					t.Fatalf("iter %d n=%d %v [%d] %d != %d", iter, n, o, i, out[i], s[i])
+				}
+			}
+			base := marshalBaselineI64(t, s, o)
+			if len(block) > len(base) {
+				t.Fatalf("iter %d n=%d %v never-larger VIOLATED: block %d > base %d",
+					iter, n, o, len(block), len(base))
+			}
+		}
+	}
+}
+
+// TestBlockColumnarFullDecode exercises the scratch-reusing Into decode path
+// (decodeColumnInto / the codegen ReadIntColumn path) with a block-tagged
+// column — a non-query columnar round-trip.
+func TestBlockColumnarFullDecode(t *testing.T) {
+	type R struct {
+		A int64
+		V int64
+		U uint64
+	}
+	const N = 4096
+	rng := rand.New(rand.NewSource(3))
+	rows := make([]R, N)
+	for i := range rows {
+		rows[i].A = int64(i)
+		if i < N/2 { // regime → V and U store as block columns
+			rows[i].V = int64(1_700_000_000 + i)
+			rows[i].U = uint64(1_700_000_000 + i)
+		} else {
+			rows[i].V = rng.Int63n(1 << 40)
+			rows[i].U = rng.Uint64() & (1<<40 - 1)
+		}
+	}
+	for _, o := range []Options{OptBalanced, OptCompression, OptBalanced | OptColumnIndex} {
+		b, err := Marshal(rows, o)
+		if err != nil {
+			t.Fatalf("%v marshal: %v", o, err)
+		}
+		var out []R
+		if err := Unmarshal(b, &out); err != nil {
+			t.Fatalf("%v unmarshal: %v", o, err)
+		}
+		if len(out) != N {
+			t.Fatalf("%v len %d", o, len(out))
+		}
+		for i := range rows {
+			if out[i] != rows[i] {
+				t.Fatalf("%v [%d] = %+v != %+v", o, i, out[i], rows[i])
+			}
+		}
+	}
+}
+
+// TestBlockMalformed: corrupted block wire must error, never panic / OOM.
+func TestBlockMalformed(t *testing.T) {
+	s := blockArchetypes()[0].gen() // sorted-then-random → block form
+	good, err := Marshal(s, OptQPack)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx := bytes.IndexByte(good, tagPackBlock)
+	if idx < 0 {
+		t.Fatal("no block tag in wire")
+	}
+
+	mutate := func(name string, f func(b []byte)) {
+		b := append([]byte(nil), good...)
+		f(b)
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("%s: panic %v", name, r)
+			}
+		}()
+		var out []int64
+		_ = Unmarshal(b, &out) // error is fine; a panic/OOM is not
+	}
+
+	mutate("bad blkLog", func(b []byte) { b[idx+2] = 7 }) // not 8 or 10
+	mutate("kind byte garbage", func(b []byte) { b[idx+1] = 0x55 })
+	// Truncation (an actually shorter slice):
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("truncate: panic %v", r)
+			}
+		}()
+		var out []int64
+		_ = Unmarshal(good[:idx+3], &out)
+	}()
+
+	// Deterministic byte-flip fuzz over the block region.
+	for off := idx; off < len(good); off++ {
+		for _, bitp := range []byte{0x01, 0x80, 0xff} {
+			b := append([]byte(nil), good...)
+			b[off] ^= bitp
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("flip off=%d bit=%#x: panic %v", off, bitp, r)
+					}
+				}()
+				var out []int64
+				_ = Unmarshal(b, &out)
+			}()
+		}
+	}
+}
+
+// FuzzBlockDecode: arbitrary bytes decoded as []int64 must never panic.
+func FuzzBlockDecode(f *testing.F) {
+	s := blockArchetypes()[1].gen()
+	if b, err := Marshal(s, OptQPack); err == nil {
+		f.Add(b)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var out []int64
+		_ = Unmarshal(data, &out)
+	})
+}
+
+// TestBlockWireTag: a regime column's wire actually carries tagPackBlock.
+func TestBlockWireTag(t *testing.T) {
+	s := blockArchetypes()[1].gen() // bursty-timestamps
+	b, err := Marshal(s, OptQPack)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.IndexByte(b, tagPackBlock) < 0 {
+		t.Fatal("wire does not contain tagPackBlock")
+	}
+}

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -197,9 +197,14 @@ func decodeSliceString(d *Decoder, p unsafe.Pointer) error {
 
 // ----- QPack codec helpers shared by 64-bit and widened 32-bit paths -----
 
-// writeQPackUint64 runs the codec picker over s and writes the chosen QPack form.
+// writeQPackUint64 runs the codec picker over s and writes the chosen QPack form,
+// first trying the per-block adaptive codec (reusing the single pick so a
+// non-firing column is picked exactly once).
 func (e *Encoder) writeQPackUint64(s []uint64) {
 	codec, mn, forBits, first, minDelta, deltaBits, pforBits, _ := pickU64Codec(s)
+	if e.tryWriteBlockUint64(s, codec, mn, forBits, first, minDelta, deltaBits, pforBits) {
+		return
+	}
 	e.emitQPackUint64(s, codec, mn, forBits, first, minDelta, deltaBits, pforBits)
 }
 
@@ -252,9 +257,14 @@ func (e *Encoder) emitQPackUint64(s []uint64, codec qpackCodec, mn uint64, forBi
 	}
 }
 
-// writeQPackInt64 runs the codec picker over s and writes the chosen QPack form.
+// writeQPackInt64 runs the codec picker over s and writes the chosen QPack form,
+// first trying the per-block adaptive codec (reusing the single pick so a
+// non-firing column is picked exactly once).
 func (e *Encoder) writeQPackInt64(s []int64) {
 	codec, mn, forBits, first, minDelta, deltaBits, pforBits, _ := pickI64Codec(s)
+	if e.tryWriteBlockInt64(s, codec, mn, forBits, first, minDelta, deltaBits, pforBits) {
+		return
+	}
 	e.emitQPackInt64(s, codec, mn, forBits, first, minDelta, deltaBits, pforBits)
 }
 
@@ -311,7 +321,7 @@ func decodeSliceInt(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	switch t {
-	case tagPackRaw, tagPackFor, tagPackDeltaFor, tagPackRLE, tagPackDict, tagPackPFor:
+	case tagPackRaw, tagPackFor, tagPackDeltaFor, tagPackRLE, tagPackDict, tagPackPFor, tagPackBlock:
 		if unsafe.Sizeof(int(0)) == 8 {
 			var dest []int64
 			if err := decodeSliceInt64(d, unsafe.Pointer(&dest)); err != nil {
@@ -422,6 +432,8 @@ func (d *Decoder) readQPackUint64(t byte) ([]uint64, error) {
 		return d.readPackedDictUint64Slice()
 	case tagPackPFor:
 		return d.readPackedPForUint64Slice()
+	case tagPackBlock:
+		return d.readBlockUint64()
 	}
 	return nil, ErrBadTag
 }
@@ -444,6 +456,8 @@ func (d *Decoder) readQPackInt64(t byte) ([]int64, error) {
 		return d.readPackedDictInt64Slice()
 	case tagPackPFor:
 		return d.readPackedPForInt64Slice()
+	case tagPackBlock:
+		return d.readBlockInt64()
 	}
 	return nil, ErrBadTag
 }
@@ -509,7 +523,7 @@ func decodeSliceInt32(d *Decoder, p unsafe.Pointer) error {
 func encodeSliceInt64(e *Encoder, p unsafe.Pointer) error {
 	s := *(*[]int64)(p)
 	if e.qpack {
-		e.writeQPackInt64(s)
+		e.writeQPackInt64(s) // tries the per-block codec, else the whole-column pick
 		return nil
 	}
 	e.WriteArrayHeader(len(s))
@@ -567,6 +581,14 @@ func decodeSliceInt64(d *Decoder, p unsafe.Pointer) error {
 	case tagPackPFor:
 		d.i++
 		v, err := d.readPackedPForInt64Slice()
+		if err != nil {
+			return err
+		}
+		*(*[]int64)(p) = v
+		return nil
+	case tagPackBlock:
+		d.i++
+		v, err := d.readBlockInt64()
 		if err != nil {
 			return err
 		}
@@ -681,7 +703,7 @@ func decodeSliceUint32(d *Decoder, p unsafe.Pointer) error {
 func encodeSliceUint64(e *Encoder, p unsafe.Pointer) error {
 	s := *(*[]uint64)(p)
 	if e.qpack {
-		e.writeQPackUint64(s)
+		e.writeQPackUint64(s) // tries the per-block codec, else the whole-column pick
 		return nil
 	}
 	e.WriteArrayHeader(len(s))
@@ -739,6 +761,14 @@ func decodeSliceUint64(d *Decoder, p unsafe.Pointer) error {
 	case tagPackPFor:
 		d.i++
 		v, err := d.readPackedPForUint64Slice()
+		if err != nil {
+			return err
+		}
+		*(*[]uint64)(p) = v
+		return nil
+	case tagPackBlock:
+		d.i++
+		v, err := d.readBlockUint64()
 		if err != nil {
 			return err
 		}

--- a/wire.go
+++ b/wire.go
@@ -178,7 +178,23 @@ const (
 	//                    the dense non-nil values encoded with the base kind's
 	//                    codec.
 
-	// 0xF0..0xF2 unassigned (reserved for a future MessagePack-style ext type).
+	tagPackBlock = 0xF0 // Per-block adaptive integer slice. A long int/uint
+	//                    column is split into fixed-size blocks; each block is an
+	//                    independent QPack sub-slice (FOR/Delta/RLE/dict/PFOR/raw)
+	//                    so a column whose statistics shift along its length packs
+	//                    each region optimally instead of one codec for the whole.
+	//                    Wire:
+	//                       tag, kind(1), blkLog(1; 8=>256, 10=>1024),
+	//                       varuint(n),
+	//                       nBlocks x uint32 LE  (byte offset of each block body,
+	//                                             relative to the first body),
+	//                       nBlocks x <QPack int sub-slice (tag+header+body)>.
+	//                    nBlocks = ceil(n / (1<<blkLog)); the last block holds the
+	//                    remainder. The offset table enables O(1) block seek, so a
+	//                    predicate query can decode only the blocks covering its
+	//                    matched rows. Selected only when strictly smaller than the
+	//                    whole-column codec (never-larger), so the wire never grows.
+	// 0xF1..0xF2 unassigned (reserved for a future MessagePack-style ext type).
 	tagTimestamp = 0xF3
 
 	// ALP (Adaptive Lossless floating-Point, CWI 2023), decimal path,


### PR DESCRIPTION
## What

A new QPack integer-slice codec (wire tag `0xF0`, `tagPackBlock`) that splits a long `int64`/`uint64` column into fixed 256-element blocks and encodes each block independently with the existing whole-column picker (FOR / Delta+FOR / RLE / dict / PFOR / raw). A column whose statistics shift along its length packs each region optimally instead of paying one codec for the whole. An offset table prefixes the blocks so a predicate query can decode **only** the blocks covering its matched rows.

## Why

A single codec is suboptimal for columns with regime shifts (sorted-then-random, bursty timestamps, mixed-cardinality IDs, counters with resets, RLE-runs-then-noise). Measured (conservative cost model, real `pickI64Codec`):

| column | wire vs whole |
|---|--:|
| bursty timestamps | **−91.7%** |
| sorted-then-random | −49.7% |
| rle-then-noise | −36.3% |
| mixed-card id | −26.1% |
| flat / homogeneous | byte-identical (never-larger) |

## Design

- **Auto** under `OptBalanced+` / `OptQPack` — no new `Options` bit; self-describing wire tag. Decode needs no flag.
- **never-larger by emit-measure-keep-smaller**: emit both forms, keep the actually-smaller. A predicted-cost compare is unsound (PFOR's `bestCost` is a conservative upper bound → could keep a block form that is really larger). Mirrors the existing Gorilla/ALP never-worse rollback.
- **Cheap gates** so flat columns pay ~nothing: skip under the outer rANS pass (`OptCompression` stays byte-identical — the offset table is rANS-hostile), skip compact columns (FOR & delta both < 12 bits), then a block-width-heterogeneity sample gate before the full probe.
- **Per-block picks cached** (`blkPlanI64/U64`) so the emit pass does not re-pick.
- **Selective decode**: projected-only block columns under a `Where` predicate are deferred and decoded block-selectively (only blocks covering matched rows), wired into `runQueryColumns`; requires `OptColumnIndex` to seek, else full-decode fallback. All decode paths (reflect, codegen `Into`, `[]int`) dispatch `0xF0`.

## Performance (benchstat, bracket main/branch/main, thermal-noise discipline)

- **Flat / realistic data (IoT, AD): encode ~0%, decode ~0%** — the codec gates out before any per-block work.
- **Regime columns (codec fires): encode +~11%** for −26..91% wire — CPU-for-size on the write-once path.
- AD wire byte-identical on the deterministic tier (non-canonical AD wire is run-to-run nondeterministic from `map[string]string` field order — verified via a main-vs-main noise floor, branch diffs are within it).

## Safety

Every decode allocation bounded (`checkColumnarBytes`, 256 MiB ceiling), offset table validated (`offsets[0]==0`, strictly increasing, in-buffer), `blkLog` restricted to {8,10}, fuzz-clean (no panic/OOM; fixed an alloc-amplification that also sped the fuzzer 35 → 396k execs).

## Tests

- Roundtrip across Speed/QPack/Balanced/Compression (int64 + uint64).
- never-larger byte-identical on flat columns.
- **Randomized property test** (distributions × sizes incl. block-boundary edges) asserting roundtrip + never-larger — this caught the PFOR never-larger violation.
- Selective correctness incl. adversarial predicate shapes (all-match / scattered-every-block / zero-match / two-deferred / no-index fallback / predicate-on-block).
- Full-decode `Into` path, malformed-input, fuzz.

All green: suite · lint 0 · race · fuzz · codegen module.

Bugs found and fixed during review/benchmarking: double-pick encode regression, alloc-amplification (fuzz/DoS), pre-gate false-positive on monotonic columns, and the PFOR never-larger violation.