### PR TITLE
feat(query): zone-chunked columns + min/max zonemap zone-skip (OptZoneMap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,11 @@ filtered, projected subset of a batch without first decoding the whole thing.
 The full rationale, API reference, nullable/error semantics, internals, and a
 step-by-step tutorial live in **[`docs/PREDICATE-PUSHDOWN.md`](docs/PREDICATE-PUSHDOWN.md)**.
 
+Go one level deeper with **zone maps** (`OptZoneMap`): an ordered int/uint/float64
+column is chunked into 256-row zones with a `[min,max]` summary, so a range filter
+(`WhereRange` / `WhereCmp`) **skips whole zones without decoding them** — 87–97 %
+of an ordered column. Guide: **[`docs/ZONEMAP.md`](docs/ZONEMAP.md)**.
+
 ### Structural delta (`Diff` / `Apply`)
 
 qdf can compute a **structural delta** between two values and ship only what

--- a/columnar.go
+++ b/columnar.go
@@ -1472,6 +1472,11 @@ func (d *Decoder) runQueryColumns(
 	// index (colLens) to seek past the deferred column cheaply in this pass.
 	type deferredBlock struct{ c, start int }
 	var deferred []deferredBlock
+	// Projected zone-chunked columns are deferred too: their values must follow the
+	// FINAL matched set (a row matched via an OR/NOT sibling can live in a zone this
+	// column's predicate bounds skipped), so they are filled selectively after the
+	// match is computed.
+	var deferredZones []deferredBlock
 	for c := range sh.kinds {
 		proj := isProj(c)
 		ref := referenced[c]
@@ -1499,12 +1504,12 @@ func (d *Decoder) runQueryColumns(
 				return nil, nil, ErrShortBuffer
 			}
 			start := d.i
-			cv, e := d.decodeZoneChunkQuery(start, []*cnode{leaf}, n, proj)
-			if e != nil {
+			// Filter only: produce the leaf's precompT mask via zone-skip.
+			if e := d.decodeZoneChunkQuery(start, []*cnode{leaf}, n); e != nil {
 				return nil, nil, e
 			}
 			if proj {
-				retained[c] = cv
+				deferredZones = append(deferredZones, deferredBlock{c, start})
 			}
 			d.i = start + int(colLens[c]) // leaf uses precompT; colCV[c] stays nil
 			continue
@@ -1556,6 +1561,14 @@ func (d *Decoder) runQueryColumns(
 			return nil, nil, e
 		}
 		retained[db.c] = &cv
+	}
+	// Fill projected zone-chunked columns from the matched set (see deferredZones).
+	for _, dz := range deferredZones {
+		cv, e := d.decodeZoneChunkSelective(dz.start, n, matched)
+		if e != nil {
+			return nil, nil, e
+		}
+		retained[dz.c] = cv
 	}
 	return retained, matched, nil
 }

--- a/columnar.go
+++ b/columnar.go
@@ -1524,6 +1524,19 @@ func (d *Decoder) runQueryColumns(
 			d.i += int(colLens[c])
 			continue
 		}
+		// Projected-only zone-chunked column: defer it too — a predicate over OTHER
+		// columns narrows the rows first, then only the zones covering matched rows
+		// are decoded (decodeZoneChunkSelective), instead of full-decoding every zone.
+		if proj && !ref && colLens != nil && !k.isNullable() &&
+			(k == colKindInt || k == colKindUint || k == colKindFloat) &&
+			d.i < len(d.buf) && d.buf[d.i] == tagZoneChunk {
+			if d.i+int(colLens[c]) > len(d.buf) {
+				return nil, nil, ErrShortBuffer
+			}
+			deferredZones = append(deferredZones, deferredBlock{c, d.i})
+			d.i += int(colLens[c])
+			continue
+		}
 		cv, e := d.decodeColumnVals(k, n, isByte(c))
 		if e != nil {
 			return nil, nil, e

--- a/columnar.go
+++ b/columnar.go
@@ -733,10 +733,20 @@ func (e *Encoder) encodeOneColumn(plan *columnarPlan, base unsafe.Pointer, col *
 	case colKindInt:
 		s := gatherColI64(st.colScratchI64, base, plan.stride, col, n)
 		st.colScratchI64 = s
+		// OptZoneMap: zone-chunk the column with a min/max zonemap for predicate
+		// zone-skip (columnar-only, explicit size-for-query-speed opt-in).
+		if e.zonemap && n >= zoneChunkMinLen {
+			e.writeZoneChunkInt64(s)
+			return nil
+		}
 		return encodeSliceInt64(e, unsafe.Pointer(&s))
 	case colKindUint:
 		s := gatherColU64(st.colScratchU64, base, plan.stride, col, n)
 		st.colScratchU64 = s
+		if e.zonemap && n >= zoneChunkMinLen {
+			e.writeZoneChunkUint64(s)
+			return nil
+		}
 		return encodeSliceUint64(e, unsafe.Pointer(&s))
 	case colKindFloat:
 		s := st.colScratchF64[:0]
@@ -1470,6 +1480,28 @@ func (d *Decoder) runQueryColumns(
 			continue
 		}
 		k := sh.kinds[c]
+		// Zone-skip: a referenced zone-chunked int/uint column whose every
+		// referencing leaf carries comparison bounds is decoded zone-selectively —
+		// zones whose [min,max] cannot match any leaf are skipped, and each leaf's T
+		// mask is produced directly (precompT). Needs colLens to reposition past the
+		// column afterwards.
+		if leaf := singleBoundedLeafForCol(flat, c); leaf != nil && colLens != nil &&
+			!k.isNullable() && (k == colKindInt || k == colKindUint) &&
+			d.i < len(d.buf) && d.buf[d.i] == tagZoneChunk {
+			if d.i+int(colLens[c]) > len(d.buf) {
+				return nil, nil, ErrShortBuffer
+			}
+			start := d.i
+			cv, e := d.decodeZoneChunkQuery(start, []*cnode{leaf}, n, proj)
+			if e != nil {
+				return nil, nil, e
+			}
+			if proj {
+				retained[c] = cv
+			}
+			d.i = start + int(colLens[c]) // leaf uses precompT; colCV[c] stays nil
+			continue
+		}
 		if proj && !ref && colLens != nil && !k.isNullable() &&
 			(k == colKindInt || k == colKindUint) &&
 			d.i < len(d.buf) && d.buf[d.i] == tagPackBlock {

--- a/columnar.go
+++ b/columnar.go
@@ -754,6 +754,13 @@ func (e *Encoder) encodeOneColumn(plan *columnarPlan, base unsafe.Pointer, col *
 			s = append(s, loadFloat64Field(base, plan.stride, col, i))
 		}
 		st.colScratchF64 = s
+		// OptZoneMap: zone-chunk with a finite min/max zonemap for predicate
+		// zone-skip (lossless per zone). Lossless regardless: a SCALAR float64
+		// column must never become lossy, even under OptLossyVec.
+		if e.zonemap && n >= zoneChunkMinLen {
+			e.writeZoneChunkFloat64(s)
+			return nil
+		}
 		// Lossless: a SCALAR float64 column must never become lossy, even under
 		// OptLossyVec (which targets genuine []float64/[]float32 VECTOR fields).
 		return encodeSliceFloat64Lossless(e, s)
@@ -1486,7 +1493,7 @@ func (d *Decoder) runQueryColumns(
 		// mask is produced directly (precompT). Needs colLens to reposition past the
 		// column afterwards.
 		if leaf := singleBoundedLeafForCol(flat, c); leaf != nil && colLens != nil &&
-			!k.isNullable() && (k == colKindInt || k == colKindUint) &&
+			!k.isNullable() && (k == colKindInt || k == colKindUint || k == colKindFloat) &&
 			d.i < len(d.buf) && d.buf[d.i] == tagZoneChunk {
 			if d.i+int(colLens[c]) > len(d.buf) {
 				return nil, nil, ErrShortBuffer

--- a/columnar_decode_scratch.go
+++ b/columnar_decode_scratch.go
@@ -340,6 +340,9 @@ func decodeSliceInt64Into(d *Decoder, dst *[]int64) error {
 	case tagPackBlock:
 		d.i++
 		return d.readBlockInt64Into(dst)
+	case tagZoneChunk:
+		d.i++
+		return d.readZoneChunkInt64Into(dst)
 	}
 	// Fallback: element-by-element array decode.
 	n, err := d.ReadArrayHeader()
@@ -637,6 +640,9 @@ func decodeSliceUint64Into(d *Decoder, dst *[]uint64) error {
 	case tagPackBlock:
 		d.i++
 		return d.readBlockUint64Into(dst)
+	case tagZoneChunk:
+		d.i++
+		return d.readZoneChunkUint64Into(dst)
 	}
 	// Fallback: element-by-element array decode.
 	n, err := d.ReadArrayHeader()

--- a/columnar_decode_scratch.go
+++ b/columnar_decode_scratch.go
@@ -691,6 +691,10 @@ func decodeSliceFloat64Into(d *Decoder, dst *[]float64) error {
 		*dst = vecs[0]
 		return nil
 	}
+	if t == tagZoneChunk {
+		d.i++
+		return d.readZoneChunkFloat64Into(dst)
+	}
 	if t == tagPackRaw {
 		d.i++
 		n, body, err2 := d.readPackedRawHeader(qpackKindFloat64)

--- a/docs/PREDICATE-PUSHDOWN.md
+++ b/docs/PREDICATE-PUSHDOWN.md
@@ -90,6 +90,12 @@ per value**, which is what keeps a million-row scan cheap.
 With **no** query options, `Unmarshal` behaves exactly as before — passing
 zero `QueryOption`s is the plain decode path, byte-for-byte.
 
+For **range and comparison** filters there are two bound-carrying constructors,
+`WhereCmp(field, op, val)` and `WhereRange(field, lo, hi)`. They behave like
+`Where` per row, but because they expose their comparison bounds they unlock
+**zone-skip** on `OptZoneMap` columns — skipping whole row-ranges without
+decoding them. See **[ZONEMAP.md](ZONEMAP.md)**.
+
 ---
 
 ## Tutorial
@@ -332,21 +338,29 @@ The decode is **whole-column**:
    column, copy only those rows into the output `[]struct` or
    `[]map[string]any`. Wire order is preserved.
 
-The seek is **column-granular, not element-granular**: a column body is a
-single codec payload (Frame-of-Reference / bit-pack / dictionary) with no
+The seek is **column-granular, not element-granular** by default: a column body
+is a single codec payload (Frame-of-Reference / bit-pack / dictionary) with no
 per-row byte offsets, so skipping a column is a direct offset add, but skipping
 *rows within a column* still requires decoding that column whole. The win comes
 from (a) never touching the columns a row is filtered out on, and (b)
 materializing only the surviving rows of the projected columns.
 
+**`OptZoneMap` adds intra-column skipping** for ordered int/uint/float64
+columns: the column is chunked into 256-row zones with a `[min,max]` summary, so
+a range predicate skips whole zones — and projection decodes only the zones
+covering matched rows. Full guide in **[ZONEMAP.md](ZONEMAP.md)**.
+
 ---
 
 ## Limitations and roadmap
 
-- **Element-addressable seek (deferred).** Today every predicate column is
-  decoded in full before any row is tested. A finer scheme — decode only the
-  rows that survived earlier predicates — would need per-row addressing inside
-  the codec payloads. It is on the roadmap, not yet implemented.
+- **Zone-skip (delivered for ordered int/uint/float64 columns).** Plain pushdown
+  decodes every predicate column *whole* before testing a row. `OptZoneMap`
+  chunks an integer/float column into 256-row zones with a per-zone `[min,max]`
+  summary, and a range/comparison predicate (`WhereRange`, `WhereCmp`) then skips
+  whole zones whose `[min,max]` cannot match — **without decoding them** (87–97 %
+  on an ordered column). Full guide: **[ZONEMAP.md](ZONEMAP.md)**. Finer
+  element-addressable seek for non-ordered columns remains future work.
 - **Single message only.** Like the column index, pushdown applies to a
   single `Unmarshal` of a columnar `[]struct`. It is not a streaming-mode
   feature (the column index is not emitted in streaming mode).

--- a/docs/ZONEMAP.md
+++ b/docs/ZONEMAP.md
@@ -195,14 +195,17 @@ Tag `tagZoneChunk` (**0xF1**), emitted per column only under `OptZoneMap`.
 ![Zone-chunked column wire layout](assets/zonemap-wire.svg)
 
 ```
-0xF1  kind  blkLog  uvarint(n)
+0xF1  kind  zmap  blkLog  uvarint(n)
       ├ kind   : 0x00 int64 · 0x01 uint64 · 0x02 float64
+      ├ zmap   : 0x00 min/max index · 0x01 learned linear model (int/uint only)
       └ blkLog : log2(zone size) — 8 ⇒ 256-row zones
 
 uint32 offsetTable[zoneCount]      // body offset of each zone, relative to bodyStart
-zonemap[zoneCount]                 // per zone:
+zonemap                            // zmap == min/max:  per zone
       int/uint : zigzag-varint(min), zigzag-varint(max)   (variable length)
       float64  : float64bits(min), float64bits(max)       (8 + 8 bytes, LE)
+                                   // zmap == linear:   one model for the whole column
+      int/uint : float64(c), float64(d), uvarint(epsP)    (~18 bytes total)
 zone bodies[zoneCount]             // each an independent sub-slice:
       int/uint : a QPack codec picked per zone (FOR / Δ-FOR / RLE / dict / PFOR)
       float64  : a lossless float slice (a SCALAR float column never goes lossy)
@@ -210,9 +213,30 @@ zone bodies[zoneCount]             // each an independent sub-slice:
 
 `zoneCount = ⌈n / 256⌉`. The per-zone codec picks are shared with the block
 codec's planner (`blkPlanI64/U64`), so chunking does not re-run codec selection.
-There is **no never-larger gate** — chunking an already-tight ordered column is
-expected to cost a little wire; that cost *is* the price of zone-skippability,
-and it is gated behind the opt-in flag.
+The zone-chunk container itself has **no never-larger gate** — chunking an
+already-tight ordered column is expected to cost a little wire; that cost *is*
+the price of zone-skippability, and it is gated behind the opt-in flag.
+
+### Learned linear zonemap (`zmap == 0x01`)
+
+On a **sorted** int/uint column the per-zone `[min,max]` index dominates the
+wire — the body delta-codes to almost nothing while the index stays
+`O(zoneCount)` (it is 8–40 % of such a column). For these columns the whole
+index collapses to a single learned model: the row position of a value is
+`pos ≈ c·value + d` within `±epsP` positions (an ε-PLA with one segment, fit by
+least squares). A query range `[lo,hi]` then maps to the row range
+`[c·lo+d−epsP, c·hi+d+epsP]`, hence to a contiguous **zone** range — and because
+every matching row provably lands inside it, **no zone with a match is ever
+skipped** (`epsP` carries a +1 margin for float rounding; the exact per-row test
+still runs in the decoded zones).
+
+It is chosen by a **never-worse picker**: the linear model is emitted only when
+the column is monotonic, the fit holds within one zone (`epsP ≤ blk`, so skip
+stays tight), and it is strictly smaller than the min/max index — otherwise
+min/max is kept. `float64` columns always use min/max in v1. Measured: −6.7 % of
+the *whole* wire on a realistic 4-column struct with a sorted id/ts (81597 →
+76106 bytes), up to −40 % on an all-sorted column; multi-segment (irregular)
+columns are rejected by the picker and keep min/max.
 
 ---
 
@@ -227,11 +251,13 @@ Decode splits cleanly into **filter** and **projection**:
 
 ![Filter mask + selective projection](assets/zonemap-skip.svg)
 
-1. **Filter pass** (`decodeZoneChunkQuery`) — load the zonemap, and for each zone
-   test `zoneMax >= lo && zoneMin <= hi`. Zones that fail are skipped (their rows
-   stay `FALSE` in the leaf's precomputed `precompT` mask); zones that pass are
-   decoded and their rows tested by the exact per-row predicate. This produces
-   the leaf's truth mask directly.
+1. **Filter pass** (`decodeZoneChunkQuery`) — load the zonemap and decide which
+   zones can match. With the min/max index, each zone is tested
+   `zoneMax >= lo && zoneMin <= hi`; with the linear model, the predicate range
+   maps once to a contiguous zone range. Zones that cannot match are skipped
+   (their rows stay `FALSE` in the leaf's precomputed `precompT` mask); the rest
+   are decoded and tested by the exact per-row predicate. This produces the
+   leaf's truth mask directly.
 2. **Combine** — `precompT` feeds the boolean tree exactly like any other leaf
    mask; AND/OR/NOT and three-valued NULL logic are unchanged.
 3. **Projection pass** (`decodeZoneChunkSelective`) — *after* the final matched

--- a/docs/ZONEMAP.md
+++ b/docs/ZONEMAP.md
@@ -1,0 +1,266 @@
+# Zone maps — skip non-matching rows *without decoding them* (`OptZoneMap`)
+
+> **Predicate pushdown, one level deeper.** Plain pushdown
+> ([PREDICATE-PUSHDOWN.md](PREDICATE-PUSHDOWN.md)) never touches the columns a
+> row is filtered out on, but it still decodes each *predicate* column **whole**
+> before testing a single row. `OptZoneMap` removes that last full-column decode:
+> it chops an integer/float column into fixed **256-row zones**, tags each zone
+> with its `[min, max]`, and a range/comparison predicate then **skips entire
+> zones whose `[min, max]` cannot satisfy it — their bytes are never decoded.**
+> On an ordered column (timestamps, monotonic ids, sorted keys) this skips
+> **87–97 %** of the data.
+
+This is the classic data-warehouse *zone map* / *min-max index* (Netezza,
+Snowflake, Parquet row-group statistics) brought to a plain `Unmarshal`.
+
+- [Why](#why)
+- [The API](#the-api)
+- [Tutorial](#tutorial)
+- [When it helps (and when it doesn't)](#when-it-helps-and-when-it-doesnt)
+- [Semantics](#semantics)
+- [Performance](#performance)
+- [Wire format](#wire-format)
+- [How it works](#how-it-works)
+- [Limitations](#limitations)
+
+---
+
+## Why
+
+Plain pushdown decodes a predicate column's *whole* codec body before testing
+rows, because the body is one Frame-of-Reference / bit-pack / delta payload with
+no per-row addressing — you cannot seek to row 9 000 without decoding rows
+0–8 999. For a wide filter (`ts BETWEEN a AND b`) over a 50 000-row batch that
+is 50 000 integers decoded to keep maybe 200.
+
+A zone map breaks the column into independent 256-row **zones** and stores a
+tiny `[min, max]` summary per zone *before* the bodies. A bound-carrying
+predicate compares its target range against each zone's summary first:
+
+- If the zone's `[min, max]` **cannot intersect** the predicate's range, the
+  zone matches nothing — **skip it, decode nothing.**
+- Otherwise decode just that zone (256 values) and test its rows exactly.
+
+The summary is ~2–16 bytes per zone and is built for free during encode. The
+trade is deliberate: chunking a column costs a little wire (offset table +
+summaries + per-zone codec framing), so it is **opt-in and never automatic** —
+you pay a small fixed size for a large query speedup on the columns you actually
+range-scan.
+
+![Zone-skip: predicate bounds vs per-zone min/max](assets/zonemap-skip.svg)
+
+---
+
+## The API
+
+Zone maps need a predicate that **carries its comparison bounds** so the engine
+can test them against a zone's `[min, max]`. The opaque `Where(field, func)`
+closure cannot expose its bounds, so two bound-carrying constructors are added
+(`query_bounds.go`):
+
+```go
+// WhereCmp keeps rows where (field OP val). OP is one of the composable CmpOps.
+func WhereCmp[T Ordered](field string, op CmpOp, val T) QueryOption
+
+// WhereRange keeps rows where lo <= field <= hi (inclusive, two-sided).
+func WhereRange[T Ordered](field string, lo, hi T) QueryOption
+```
+
+`CmpOp` is built from three primitive bits — *accept less-than*, *accept equal*,
+*accept greater-than* — so the named operators compose and both the per-row test
+and the zone bounds derive directly from the bits:
+
+```go
+LT  // field <  val      ( cmpLT )
+LE  // field <= val      ( cmpLT | cmpEQ )
+EQ  // field == val      ( cmpEQ )
+GE  // field >= val      ( cmpGT | cmpEQ )
+GT  // field >  val      ( cmpGT )
+NE  // field != val      ( cmpLT | cmpGT )
+```
+
+`Ordered` is the queryable element types that support `<,<=,>,>=`: every
+int/uint width, `float32`, `float64`, and `string`. (Only int/uint/`float64`
+columns are zone-chunked on the wire today — see [Limitations](#limitations).)
+
+To **produce** a zone-chunked payload, add `OptZoneMap` (and `OptColumnIndex`,
+which the zone-skip seek needs) at encode time:
+
+```go
+buf, _ := qdf.Marshal(rows, qdf.OptBalanced|qdf.OptZoneMap|qdf.OptColumnIndex)
+```
+
+`OptZoneMap` is **columnar-only and opt-in**: without it the wire is
+byte-identical to a normal columnar payload. The opaque `Where(func)` path still
+works against a zone-chunked column — it just decodes every zone (no skip),
+identical results.
+
+---
+
+## Tutorial
+
+```go
+type Event struct {
+    TS   int64  `qdf:"ts"`   // ordered → great zone-skip
+    Code uint32 `qdf:"code"`
+    Msg  string `qdf:"msg"`
+}
+
+events := loadEvents() // many rows, ts ascending
+buf, _ := qdf.Marshal(events, qdf.OptBalanced|qdf.OptZoneMap|qdf.OptColumnIndex)
+
+// Range query — only the zones overlapping [lo, hi] are decoded.
+var win []Event
+_ = qdf.Unmarshal(buf, &win,
+    qdf.WhereRange("ts", loTS, hiTS),
+    qdf.Select("ts", "code", "msg"))
+
+// Single comparison — GE skips every zone whose max < cutoff.
+var recent []Event
+_ = qdf.Unmarshal(buf, &recent,
+    qdf.WhereCmp("ts", qdf.GE, cutoffTS),
+    qdf.Select("ts", "code"))
+```
+
+The predicate column does **not** have to be projected, and projected columns
+that you do not filter on are themselves decoded zone-selectively — only the
+zones covering surviving rows are materialized.
+
+---
+
+## When it helps (and when it doesn't)
+
+| Column shape | Zone-skip |
+| --- | --- |
+| **Ordered** (timestamps, monotonic / sequential ids, sorted keys) | **87–97 %** zones skipped — each zone's `[min,max]` is a tight, disjoint slice of the domain |
+| **Clustered / bursty** (values grouped in runs) | high — adjacent zones cover different sub-ranges |
+| **Uniformly random** | ~0 % — every zone's `[min,max]` spans the whole domain, so nothing can be excluded. Harmless: opt-in, you simply would not enable it here |
+
+Zone-skip is a *range* optimization. It shines exactly where a column is sorted
+or time-ordered — the common case for the `ts`/`id` columns you actually
+range-scan. On a random column it costs a little wire and skips nothing, which
+is why it is never on by default.
+
+---
+
+## Semantics
+
+- **Results are exact.** Zone-skip only ever drops zones that *provably* contain
+  no matching row; every surviving zone is decoded and its rows tested by the
+  same per-row predicate as plain pushdown. Strict comparators (`GT`/`LT`) record
+  a *conservative inclusive* bound, so a boundary zone is decoded and tested
+  exactly rather than skipped on a guess.
+- **One bounded leaf per column.** Zone-skip fires when a column is referenced by
+  **exactly one** bound-carrying leaf. Two leaves on the same column (e.g.
+  `WhereCmp("ts", GE, lo)` *and* `WhereCmp("ts", LE, hi)`) are decoded
+  independently and their bounds *union* to the whole domain — skipping nothing.
+  Express a two-sided range as a single `WhereRange` to keep the skip.
+- **Composes with AND / OR / NOT.** A zone-chunked leaf can sit anywhere in a
+  boolean tree; the projected value of a row matched via an `OR`/`NOT` sibling is
+  still materialized correctly (projection follows the final matched set, not the
+  leaf's own zone bounds).
+- **NaN-aware (float64).** A per-row float predicate rejects `NaN`. A zone's
+  summary stores the *finite* `[min, max]`; an all-`NaN` zone stores the empty
+  interval `(+Inf, -Inf)`, so it intersects no finite range and is skipped — and
+  `NaN` round-trips bit-exact in any decoded zone.
+- **`Where(func)` still works**, with no skip — back-compat, identical results.
+
+---
+
+## Performance
+
+Intel i7-9750H, 32 768 rows, three zone-chunked columns (`OptBalanced |
+OptZoneMap | OptColumnIndex`).
+
+**Narrow range query** (`WhereRange` over ~0.6 % of rows, projecting all three
+columns), zone-selective projection on vs off:
+
+| | ns/op | B/op | allocs/op |
+| --- | ---: | ---: | ---: |
+| zone-selective decode | ~150 k | 816 k | 48 |
+| full-decode each projected column | ~325 k | 1.33 M | 298 |
+
+≈ **2.2× faster, −39 % bytes, −84 % allocs** — the projected columns decode only
+the zones covering surviving rows instead of every zone.
+
+Skip rates measured on ordered columns: **int/uint 87–97 %**, **float64 range
+56–63 %** of zones never decoded.
+
+---
+
+## Wire format
+
+Tag `tagZoneChunk` (**0xF1**), emitted per column only under `OptZoneMap`.
+
+![Zone-chunked column wire layout](assets/zonemap-wire.svg)
+
+```
+0xF1  kind  blkLog  uvarint(n)
+      ├ kind   : 0x00 int64 · 0x01 uint64 · 0x02 float64
+      └ blkLog : log2(zone size) — 8 ⇒ 256-row zones
+
+uint32 offsetTable[zoneCount]      // body offset of each zone, relative to bodyStart
+zonemap[zoneCount]                 // per zone:
+      int/uint : zigzag-varint(min), zigzag-varint(max)   (variable length)
+      float64  : float64bits(min), float64bits(max)       (8 + 8 bytes, LE)
+zone bodies[zoneCount]             // each an independent sub-slice:
+      int/uint : a QPack codec picked per zone (FOR / Δ-FOR / RLE / dict / PFOR)
+      float64  : a lossless float slice (a SCALAR float column never goes lossy)
+```
+
+`zoneCount = ⌈n / 256⌉`. The per-zone codec picks are shared with the block
+codec's planner (`blkPlanI64/U64`), so chunking does not re-run codec selection.
+There is **no never-larger gate** — chunking an already-tight ordered column is
+expected to cost a little wire; that cost *is* the price of zone-skippability,
+and it is gated behind the opt-in flag.
+
+---
+
+## How it works
+
+Encode (`qpack_zonechunk.go`, reached from `encodeOneColumn` when `OptZoneMap` is
+set and the column has ≥ 2 zones): split the gathered column into 256-row zones,
+write the offset table placeholder, the per-zone `[min,max]` summaries, then each
+zone body, back-patching its offset.
+
+Decode splits cleanly into **filter** and **projection**:
+
+![Filter mask + selective projection](assets/zonemap-skip.svg)
+
+1. **Filter pass** (`decodeZoneChunkQuery`) — load the zonemap, and for each zone
+   test `zoneMax >= lo && zoneMin <= hi`. Zones that fail are skipped (their rows
+   stay `FALSE` in the leaf's precomputed `precompT` mask); zones that pass are
+   decoded and their rows tested by the exact per-row predicate. This produces
+   the leaf's truth mask directly.
+2. **Combine** — `precompT` feeds the boolean tree exactly like any other leaf
+   mask; AND/OR/NOT and three-valued NULL logic are unchanged.
+3. **Projection pass** (`decodeZoneChunkSelective`) — *after* the final matched
+   row set is known, each projected zone-chunked column decodes **only the zones
+   that span a matched row** and scatters their values. Splitting projection from
+   the filter is what keeps an `OR`/`NOT`-matched row correct: its value comes
+   from the final match set, never from the filtering leaf's own zone bounds.
+
+The full-decode path (`Unmarshal` with no query) and the selective path **skip
+the zonemap entirely** — they read all / matched zones regardless, so the
+per-zone summaries are walked only to locate the bodies, never materialized.
+
+---
+
+## Limitations
+
+- **Columnar `int` / `uint` / `float64` only.** `string` zone maps were built and
+  **measured-killed**: a bounded-prefix summary skips ~0 % on the structured
+  strings people actually range-scan (`user-000123`, `/srv/data/…`) because they
+  share a common prefix, and a full-string summary bloats the map on long values.
+  `float32` columns and nullable (`*T`) columns are not zone-chunked.
+- **Needs `OptColumnIndex`** for the query-time zone-skip seek (to reposition past
+  a column). Full decode of a zone-chunked column works without it.
+- **One bounded leaf per column** to skip (see [Semantics](#semantics)); use
+  `WhereRange` for two-sided ranges.
+- **Base types only** for `WhereCmp` / `WhereRange`, same as `Where` — named
+  types (`type ID int64`) are matched on their base type.
+- **Single message.** Like the column index and pushdown, this is a single
+  `Unmarshal` of a columnar `[]struct`, not a streaming-mode feature.
+
+See also: [PREDICATE-PUSHDOWN.md](PREDICATE-PUSHDOWN.md),
+[GUIDE.md](GUIDE.md), [CHOOSING.md](CHOOSING.md).

--- a/docs/assets/zonemap-skip.svg
+++ b/docs/assets/zonemap-skip.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 470" font-family="-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">
+  <rect width="980" height="470" fill="#ffffff"/>
+  <defs>
+    <marker id="zb" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M0,0 L9,4.5 L0,9 z" fill="#6b7280"/>
+    </marker>
+  </defs>
+  <text x="40" y="40" font-size="22" font-weight="700" fill="#1a1a2e">Zone-skip: test [min,max] before decoding a single byte</text>
+  <text x="40" y="62" font-size="13" fill="#9ca3af">source: qpack_zonechunk.go decodeZoneChunkQuery · ordered column, WhereRange(lo,hi)</text>
+
+  <!-- predicate window across the domain -->
+  <text x="40" y="100" font-size="13" font-weight="700" fill="#374151">value domain →</text>
+  <rect x="40" y="112" width="900" height="26" rx="6" fill="#f8fafc" stroke="#e2e8f0"/>
+  <rect x="360" y="112" width="200" height="26" rx="6" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="460" y="130" text-anchor="middle" font-size="12.5" font-weight="700" fill="#1e40af">predicate window [lo, hi]</text>
+
+  <!-- zones as min/max bars, positioned along the domain -->
+  <text x="40" y="176" font-size="13" font-weight="700" fill="#374151">per-zone [min,max] (256 rows each, ascending column)</text>
+
+  <!-- zone 0 : below window -> skip -->
+  <rect x="40"  y="190" width="150" height="30" rx="5" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="115" y="210" text-anchor="middle" font-size="12" fill="#64748b">zone 0  [a₀,b₀]</text>
+  <!-- zone 1 : touches left edge -> decode -->
+  <rect x="300" y="190" width="150" height="30" rx="5" fill="#dcfce7" stroke="#22c55e" stroke-width="1.8"/>
+  <text x="375" y="210" text-anchor="middle" font-size="12" font-weight="700" fill="#166534">zone 1  [a₁,b₁]</text>
+  <!-- zone 2 : inside window -> decode -->
+  <rect x="430" y="190" width="150" height="30" rx="5" fill="#dcfce7" stroke="#22c55e" stroke-width="1.8"/>
+  <text x="505" y="210" text-anchor="middle" font-size="12" font-weight="700" fill="#166534">zone 2  [a₂,b₂]</text>
+  <!-- zone 3 : above window -> skip -->
+  <rect x="620" y="190" width="150" height="30" rx="5" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="695" y="210" text-anchor="middle" font-size="12" fill="#64748b">zone 3  [a₃,b₃]</text>
+  <rect x="790" y="190" width="150" height="30" rx="5" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="865" y="210" text-anchor="middle" font-size="12" fill="#64748b">zone 4  [a₄,b₄]</text>
+
+  <!-- decisions -->
+  <text x="40" y="262" font-size="13" font-weight="700" fill="#374151">decision:  zoneMax ≥ lo  AND  zoneMin ≤ hi  ?</text>
+
+  <rect x="40"  y="276" width="150" height="48" rx="6" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="115" y="298" text-anchor="middle" font-size="12.5" font-weight="700" fill="#64748b">SKIP</text>
+  <text x="115" y="315" text-anchor="middle" font-size="10.5" fill="#94a3b8">0 bytes decoded</text>
+  <rect x="300" y="276" width="280" height="48" rx="6" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.8"/>
+  <text x="440" y="298" text-anchor="middle" font-size="12.5" font-weight="700" fill="#166534">DECODE 256 + test each row exactly</text>
+  <text x="440" y="315" text-anchor="middle" font-size="10.5" fill="#6b7280">sets the leaf precompT mask bits</text>
+  <rect x="620" y="276" width="320" height="48" rx="6" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="780" y="298" text-anchor="middle" font-size="12.5" font-weight="700" fill="#64748b">SKIP — rows stay FALSE</text>
+  <text x="780" y="315" text-anchor="middle" font-size="10.5" fill="#94a3b8">87–97% of zones on an ordered column</text>
+
+  <!-- two-phase decode -->
+  <line x1="40" y1="350" x2="940" y2="350" stroke="#e5e7eb"/>
+  <text x="40" y="380" font-size="14" font-weight="700" fill="#1a1a2e">Two passes keep OR/NOT-matched projections correct</text>
+
+  <rect x="40" y="396" width="270" height="54" rx="8" fill="#eef2ff" stroke="#6366f1" stroke-width="1.5"/>
+  <text x="175" y="419" text-anchor="middle" font-size="12.5" font-weight="700" fill="#312e81">1 · filter pass</text>
+  <text x="175" y="437" text-anchor="middle" font-size="11" fill="#4338ca">skip zones → precompT mask</text>
+
+  <path d="M310,423 L356,423" stroke="#6b7280" stroke-width="2" marker-end="url(#zb)" fill="none"/>
+
+  <rect x="358" y="396" width="240" height="54" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="478" y="419" text-anchor="middle" font-size="12.5" font-weight="700" fill="#166534">2 · combine tree</text>
+  <text x="478" y="437" text-anchor="middle" font-size="11" fill="#15803d">AND / OR / NOT → matched set</text>
+
+  <path d="M598,423 L644,423" stroke="#6b7280" stroke-width="2" marker-end="url(#zb)" fill="none"/>
+
+  <rect x="646" y="396" width="294" height="54" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="793" y="419" text-anchor="middle" font-size="12.5" font-weight="700" fill="#92400e">3 · selective projection</text>
+  <text x="793" y="437" text-anchor="middle" font-size="11" fill="#b45309">decode only zones spanning matched rows</text>
+</svg>

--- a/docs/assets/zonemap-wire.svg
+++ b/docs/assets/zonemap-wire.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 380" font-family="-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">
+  <rect width="980" height="380" fill="#ffffff"/>
+  <text x="40" y="40" font-size="22" font-weight="700" fill="#1a1a2e">Zone-chunked column wire layout (tagZoneChunk 0xF1)</text>
+  <text x="40" y="62" font-size="13" fill="#9ca3af">source: qpack_zonechunk.go · OptZoneMap · 256-row zones, min/max zonemap precedes the bodies</text>
+
+  <!-- header bytes -->
+  <text x="40" y="104" font-size="14" font-weight="700" fill="#374151">header</text>
+  <rect x="40"  y="116" width="64"  height="44" rx="6" fill="#eef2ff" stroke="#6366f1" stroke-width="1.5"/>
+  <text x="72"  y="139" text-anchor="middle" font-size="13" font-weight="700" fill="#312e81">0xF1</text>
+  <text x="72"  y="154" text-anchor="middle" font-size="10.5" fill="#6b7280">tag</text>
+  <rect x="108" y="116" width="64"  height="44" rx="6" fill="#eef2ff" stroke="#6366f1" stroke-width="1.5"/>
+  <text x="140" y="139" text-anchor="middle" font-size="13" font-weight="700" fill="#312e81">kind</text>
+  <text x="140" y="154" text-anchor="middle" font-size="10" fill="#6b7280">int/uint/f64</text>
+  <rect x="176" y="116" width="64"  height="44" rx="6" fill="#eef2ff" stroke="#6366f1" stroke-width="1.5"/>
+  <text x="208" y="139" text-anchor="middle" font-size="13" font-weight="700" fill="#312e81">blkLog</text>
+  <text x="208" y="154" text-anchor="middle" font-size="10.5" fill="#6b7280">8 ⇒ 256</text>
+  <rect x="244" y="116" width="84"  height="44" rx="6" fill="#eef2ff" stroke="#6366f1" stroke-width="1.5"/>
+  <text x="286" y="139" text-anchor="middle" font-size="13" font-weight="700" fill="#312e81">uvarint n</text>
+  <text x="286" y="154" text-anchor="middle" font-size="10.5" fill="#6b7280">row count</text>
+
+  <!-- offset table -->
+  <text x="40" y="204" font-size="14" font-weight="700" fill="#374151">offset table — uint32 × zoneCount</text>
+  <rect x="40" y="216" width="288" height="40" rx="6" fill="#fff7ed" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="184" y="241" text-anchor="middle" font-size="12.5" fill="#92400e">off[0]=0 · off[1] · off[2] · … (relative to bodyStart)</text>
+
+  <!-- zonemap -->
+  <text x="360" y="204" font-size="14" font-weight="700" fill="#374151">zonemap — [min,max] per zone</text>
+  <rect x="360" y="216" width="580" height="40" rx="6" fill="#fef2f2" stroke="#f43f5e" stroke-width="1.5"/>
+  <text x="650" y="234" text-anchor="middle" font-size="12" fill="#9f1239">int/uint: zigzag-varint(min),(max)   ·   float64: float64bits(min),(max) 8+8B LE</text>
+  <text x="650" y="250" text-anchor="middle" font-size="11" fill="#be123c">the index the predicate tests — ~2–16 B/zone, built free at encode</text>
+
+  <!-- zone bodies -->
+  <text x="40" y="300" font-size="14" font-weight="700" fill="#374151">zone bodies — one independent sub-slice per 256-row zone</text>
+  <rect x="40"  y="312" width="150" height="46" rx="6" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="115" y="333" text-anchor="middle" font-size="12.5" font-weight="700" fill="#166534">zone 0</text>
+  <text x="115" y="349" text-anchor="middle" font-size="10.5" fill="#6b7280">QPack / lossless f64</text>
+  <rect x="196" y="312" width="150" height="46" rx="6" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="271" y="333" text-anchor="middle" font-size="12.5" font-weight="700" fill="#166534">zone 1</text>
+  <text x="271" y="349" text-anchor="middle" font-size="10.5" fill="#6b7280">codec picked per zone</text>
+  <rect x="352" y="312" width="150" height="46" rx="6" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="427" y="333" text-anchor="middle" font-size="12.5" font-weight="700" fill="#166534">zone 2</text>
+  <text x="427" y="349" text-anchor="middle" font-size="10.5" fill="#6b7280">FOR/Δ-FOR/RLE/dict</text>
+  <text x="540" y="340" font-size="22" font-weight="700" fill="#9ca3af">…</text>
+  <rect x="580" y="312" width="360" height="46" rx="6" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="5 4"/>
+  <text x="760" y="333" text-anchor="middle" font-size="12.5" font-weight="700" fill="#166534">zone ⌈n/256⌉−1</text>
+  <text x="760" y="349" text-anchor="middle" font-size="10.5" fill="#6b7280">skipped zones here are never decoded</text>
+</svg>

--- a/encoder.go
+++ b/encoder.go
@@ -219,6 +219,11 @@ type Encoder struct {
 	// reader skip columns without decoding them.
 	colIndex bool
 
+	// zonemap stores eligible columnar int columns as zone-chunked containers
+	// (tag 0xF1) with a per-zone [min,max] map for predicate zone-skip. Set from
+	// OptZoneMap (requires qpack). See qpack_zonechunk.go.
+	zonemap bool
+
 	// pairPred / mtf cache OptPairPred / OptMTF (both on in OptBalanced) so the
 	// hot Dense state-ref emit path tests a bool field instead of re-running
 	// opts.Has() several times per repeated value. Set in applyOpts, cleared in
@@ -270,6 +275,7 @@ func (e *Encoder) applyOpts(opts Options) {
 	e.gorillaFloat = e.qpack && opts.Has(OptGorillaFloat)
 	e.rans = opts.Has(OptRANS)
 	e.colIndex = opts.Has(OptColumnIndex)
+	e.zonemap = e.qpack && opts.Has(OptZoneMap)
 	e.fsst = e.qpack && opts.Has(OptFSST)
 	e.pairPred = opts.Has(OptPairPred)
 	e.mtf = opts.Has(OptMTF)

--- a/internal/bitflag/bitflag.go
+++ b/internal/bitflag/bitflag.go
@@ -1,0 +1,26 @@
+// Package bitflag provides tiny generic helpers for bit-flag enums over any
+// unsigned integer type. It centralizes the set/test idioms so flag enums (e.g.
+// a comparison operator built from less/equal/greater bits) read by intent
+// rather than raw `&` / `|` expressions and stay consistent across the codebase.
+package bitflag
+
+// Flag is any unsigned integer usable as a bit set.
+type Flag interface {
+	~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uint
+}
+
+// Has reports whether v has ANY of the bits in f set (v & f != 0). For a
+// single-bit f this is the usual membership test.
+func Has[F Flag](v, f F) bool { return v&f != 0 }
+
+// All reports whether v has ALL of the bits in f set (v & f == f).
+func All[F Flag](v, f F) bool { return v&f == f }
+
+// Set returns v with the bits in f set.
+func Set[F Flag](v, f F) F { return v | f }
+
+// Clear returns v with the bits in f cleared.
+func Clear[F Flag](v, f F) F { return v &^ f }
+
+// Toggle returns v with the bits in f flipped.
+func Toggle[F Flag](v, f F) F { return v ^ f }

--- a/qdf.go
+++ b/qdf.go
@@ -344,7 +344,18 @@ const (
 	// fires unless this bit is set; never larger than the raw/lossless form.
 	OptLossyVec // bit 12
 
-	// Bits 13..31 reserved for future codecs (LZ77, n-gram dictionary, etc.).
+	// OptZoneMap stores eligible columnar integer columns as zone-chunked
+	// containers (tag 0xF1): the column is split into 256-row zones, each zone
+	// independently codec-picked, prefixed by a per-zone [min,max] zonemap. A
+	// bound-carrying predicate (WhereRange / WhereGE / WhereLE / WhereEq) then
+	// skips zones that provably cannot match WITHOUT decoding them — a large
+	// speedup for range/equality queries over positionally-ordered columns
+	// (timestamps, sorted IDs). An explicit size-for-query-speed trade (chunking
+	// + zonemap cost wire), so it is opt-in; without the bit the wire is
+	// unchanged. v1 covers int/uint columns; string/float are a follow-up.
+	OptZoneMap // bit 13
+
+	// Bits 14..31 reserved for future codecs (LZ77, n-gram dictionary, etc.).
 
 	// OptSpeed is the zero-bit preset: Fast mode, no codecs, no
 	// predictors. Maximum throughput, smallest CPU footprint.

--- a/qpack_block.go
+++ b/qpack_block.go
@@ -397,6 +397,13 @@ func (d *Decoder) readBlockInt64() ([]int64, error) {
 // readBlockInt64Into is the scratch-reusing form: it grows *dst to the column
 // length and decodes every block into it. The tag is already consumed.
 func (d *Decoder) readBlockInt64Into(dst *[]int64) error {
+	// A block body could itself carry tagPackBlock or tagZoneChunk (both dispatched
+	// by readQPackInt64); bound the nesting so a hostile payload of nested blocks
+	// cannot overflow the goroutine stack.
+	if err := d.descend(); err != nil {
+		return err
+	}
+	defer d.ascend()
 	blk, n, offBase, bodyStart, nBlocks, err := d.readBlockHeader(blockKindInt)
 	if err != nil {
 		return err
@@ -514,6 +521,10 @@ func (d *Decoder) readBlockUint64() ([]uint64, error) {
 }
 
 func (d *Decoder) readBlockUint64Into(dst *[]uint64) error {
+	if err := d.descend(); err != nil {
+		return err
+	}
+	defer d.ascend()
 	blk, n, offBase, bodyStart, nBlocks, err := d.readBlockHeader(blockKindUint)
 	if err != nil {
 		return err

--- a/qpack_block_test.go
+++ b/qpack_block_test.go
@@ -2,9 +2,26 @@ package qdf
 
 import (
 	"bytes"
+	"errors"
 	"math/rand"
 	"testing"
 )
+
+// TestBlockDepthGuard verifies the block decoders bound recursion depth: a block
+// body could itself carry tagPackBlock/tagZoneChunk, so nested payloads must not
+// overflow the stack. At the depth cap the decoder returns ErrCycleDetected
+// without touching the buffer.
+func TestBlockDepthGuard(t *testing.T) {
+	for _, fn := range []func(d *Decoder) error{
+		func(d *Decoder) error { return d.readBlockInt64Into(new([]int64)) },
+		func(d *Decoder) error { return d.readBlockUint64Into(new([]uint64)) },
+	} {
+		d := &Decoder{maxDepth: DefaultMaxDepth, depth: DefaultMaxDepth}
+		if err := fn(d); !errors.Is(err, ErrCycleDetected) {
+			t.Fatalf("want ErrCycleDetected at depth cap, got %v", err)
+		}
+	}
+}
 
 // blockArchetypes returns int64 columns: regime-shifting ones (where the
 // per-block codec should win) and flat ones (where it must not fire / never

--- a/qpack_zonechunk.go
+++ b/qpack_zonechunk.go
@@ -1,6 +1,9 @@
 package qdf
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"math"
+)
 
 // Zone-chunked integer column with a min/max zonemap (wire tag tagZoneChunk,
 // 0xF1, OptZoneMap).
@@ -19,11 +22,27 @@ import "encoding/binary"
 // is the price of zone-skippability). Without OptZoneMap the wire is unchanged.
 
 const (
-	zoneKindInt  = 0x00
-	zoneKindUint = 0x01
+	zoneKindInt   = 0x00
+	zoneKindUint  = 0x01
+	zoneKindFloat = 0x02 // float64
 	// zoneChunkMinLen: a column shorter than two zones has nothing to chunk.
 	zoneChunkMinLen = 2 * blockSizeSmall // reuse the block codec's 256-row zone
 )
+
+// finiteMinMaxF64 returns the min and max of s over non-NaN values. ±Inf are
+// ordered and included. An all-NaN (or empty) slice yields the empty interval
+// (+Inf, -Inf), which intersects no finite predicate range — so such a zone is
+// correctly skipped (NaN never matches a comparison). Caller passes len(s) > 0.
+func finiteMinMaxF64(s []float64) (mn, mx float64) {
+	mn, mx = math.Inf(1), math.Inf(-1)
+	for _, v := range s {
+		if v != v { // NaN: builtin min/max would propagate it, so skip explicitly
+			continue
+		}
+		mn, mx = min(mn, v), max(mx, v)
+	}
+	return mn, mx
+}
 
 // ---- encode (int64) ----
 
@@ -86,6 +105,34 @@ func (e *Encoder) writeZoneChunkUint64(s []uint64) {
 	}
 }
 
+// ---- encode (float64) ----
+
+func (e *Encoder) writeZoneChunkFloat64(s []float64) {
+	e.writeHeader()
+	n := len(s)
+	zoneCount := (n + blockSizeSmall - 1) / blockSizeSmall
+	e.buf = append(e.buf, tagZoneChunk, zoneKindFloat, blkLogSmall)
+	e.buf = appendUvarint(e.buf, uint64(n))
+	offAt := len(e.buf)
+	e.buf = append(e.buf, make([]byte, 4*zoneCount)...)
+	// zonemap: per-zone finite min,max as 8-byte IEEE-754 bits (LE).
+	for i := 0; i < n; i += blockSizeSmall {
+		j := min(i+blockSizeSmall, n)
+		mn, mx := finiteMinMaxF64(s[i:j])
+		e.buf = binary.LittleEndian.AppendUint64(e.buf, math.Float64bits(mn))
+		e.buf = binary.LittleEndian.AppendUint64(e.buf, math.Float64bits(mx))
+	}
+	bodyStart := len(e.buf)
+	zi := 0
+	for i := 0; i < n; i += blockSizeSmall {
+		j := min(i+blockSizeSmall, n)
+		binary.LittleEndian.PutUint32(e.buf[offAt+4*zi:], uint32(len(e.buf)-bodyStart))
+		ss := s[i:j]
+		_ = encodeSliceFloat64Lossless(e, ss) // never errors for a plain []float64
+		zi++
+	}
+}
+
 // ---- decode header (shared) ----
 
 // zoneChunkHeader is the decoded geometry + zonemap of a zone-chunked column.
@@ -94,6 +141,7 @@ func (e *Encoder) writeZoneChunkUint64(s []uint64) {
 type zoneChunkHeader struct {
 	minI64, maxI64 []int64
 	minU64, maxU64 []uint64
+	minF64, maxF64 []float64
 	offBase        int // byte offset of the uint32 offset table
 	bodyStart      int // byte offset of the first zone body
 	n              int
@@ -111,7 +159,7 @@ func (d *Decoder) readZoneChunkHeader() (zoneChunkHeader, error) {
 		return h, ErrShortBuffer
 	}
 	h.kind = d.buf[d.i]
-	if h.kind != zoneKindInt && h.kind != zoneKindUint {
+	if h.kind != zoneKindInt && h.kind != zoneKindUint && h.kind != zoneKindFloat {
 		return h, ErrTypeMismatch
 	}
 	d.i++
@@ -142,8 +190,9 @@ func (d *Decoder) readZoneChunkHeader() (zoneChunkHeader, error) {
 	}
 	d.i += 4 * h.zoneCount
 
-	// zonemap (zoneCount x min,max varints)
-	if h.kind == zoneKindInt {
+	// zonemap (per-kind min,max)
+	switch h.kind {
+	case zoneKindInt:
 		h.minI64 = make([]int64, h.zoneCount)
 		h.maxI64 = make([]int64, h.zoneCount)
 		for z := 0; z < h.zoneCount; z++ {
@@ -163,7 +212,7 @@ func (d *Decoder) readZoneChunkHeader() (zoneChunkHeader, error) {
 				return h, ErrInvalidLength
 			}
 		}
-	} else {
+	case zoneKindUint:
 		h.minU64 = make([]uint64, h.zoneCount)
 		h.maxU64 = make([]uint64, h.zoneCount)
 		for z := 0; z < h.zoneCount; z++ {
@@ -182,6 +231,19 @@ func (d *Decoder) readZoneChunkHeader() (zoneChunkHeader, error) {
 			if h.minU64[z] > h.maxU64[z] {
 				return h, ErrInvalidLength
 			}
+		}
+	default: // zoneKindFloat: 8-byte min + 8-byte max per zone (IEEE-754 bits LE)
+		if d.i+16*h.zoneCount > len(d.buf) {
+			return h, ErrShortBuffer
+		}
+		h.minF64 = make([]float64, h.zoneCount)
+		h.maxF64 = make([]float64, h.zoneCount)
+		for z := 0; z < h.zoneCount; z++ {
+			h.minF64[z] = math.Float64frombits(binary.LittleEndian.Uint64(d.buf[d.i:]))
+			h.maxF64[z] = math.Float64frombits(binary.LittleEndian.Uint64(d.buf[d.i+8:]))
+			d.i += 16
+			// No min<=max check: an all-NaN zone stores the empty interval
+			// (+Inf, -Inf) on purpose, and NaN bounds are not ordered.
 		}
 	}
 
@@ -217,6 +279,40 @@ func (h *zoneChunkHeader) zoneLen(z int) int {
 	return h.blk
 }
 
+// ---- decode-all (float64) ----
+
+func (d *Decoder) readZoneChunkFloat64() ([]float64, error) {
+	var s []float64
+	if err := d.readZoneChunkFloat64Into(&s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (d *Decoder) readZoneChunkFloat64Into(dst *[]float64) error {
+	h, err := d.readZoneChunkHeader()
+	if err != nil {
+		return err
+	}
+	if h.kind != zoneKindFloat {
+		return ErrTypeMismatch
+	}
+	growF64(dst, h.n)
+	out := *dst
+	var tmp []float64
+	for z := range h.zoneCount {
+		d.i = h.zoneOff(d, z)
+		if err := decodeSliceFloat64Into(d, &tmp); err != nil {
+			return err
+		}
+		if len(tmp) != h.zoneLen(z) {
+			return ErrInvalidLength
+		}
+		copy(out[z*h.blk:], tmp)
+	}
+	return nil
+}
+
 // zoneSkippedZones counts zones the query path proved cannot match and did not
 // decode. Test-only instrumentation; otherwise inert.
 var zoneSkippedZones int
@@ -243,26 +339,35 @@ func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int, proj b
 	}
 	var cv *colVals
 	if proj {
-		if h.kind == zoneKindInt {
+		switch h.kind {
+		case zoneKindInt:
 			cv = &colVals{kind: colKindInt, i64: make([]int64, n)}
-		} else {
+		case zoneKindUint:
 			cv = &colVals{kind: colKindUint, u64: make([]uint64, n)}
+		default:
+			cv = &colVals{kind: colKindFloat, f64: make([]float64, n)}
 		}
 	}
 	for z := range h.zoneCount {
 		needed := false
 		for _, lf := range leaves {
 			// Zone z intersects the leaf's bounds iff zoneMax >= lo && zoneMin <= hi.
-			if h.kind == zoneKindInt {
+			switch h.kind {
+			case zoneKindInt:
 				if h.maxI64[z] >= lf.term.loI64 && h.minI64[z] <= lf.term.hiI64 {
 					needed = true
-					break
 				}
-			} else {
+			case zoneKindUint:
 				if h.maxU64[z] >= lf.term.loU64 && h.minU64[z] <= lf.term.hiU64 {
 					needed = true
-					break
 				}
+			default: // float: empty-interval (all-NaN) zones never intersect → skipped
+				if h.maxF64[z] >= lf.term.loF64 && h.minF64[z] <= lf.term.hiF64 {
+					needed = true
+				}
+			}
+			if needed {
+				break
 			}
 		}
 		if !needed {
@@ -276,7 +381,8 @@ func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int, proj b
 		}
 		base := z * h.blk
 		want := h.zoneLen(z)
-		if h.kind == zoneKindInt {
+		switch h.kind {
+		case zoneKindInt:
 			v, err := d.readQPackInt64(tg)
 			if err != nil {
 				return nil, err
@@ -296,7 +402,7 @@ func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int, proj b
 			if proj {
 				copy(cv.i64[base:], v)
 			}
-		} else {
+		case zoneKindUint:
 			v, err := d.readQPackUint64(tg)
 			if err != nil {
 				return nil, err
@@ -315,6 +421,26 @@ func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int, proj b
 			}
 			if proj {
 				copy(cv.u64[base:], v)
+			}
+		default: // float64
+			var v []float64
+			if err := decodeSliceFloat64Into(d, &v); err != nil {
+				return nil, err
+			}
+			if len(v) != want {
+				return nil, ErrInvalidLength
+			}
+			for _, lf := range leaves {
+				p := lf.term.pF64
+				m := lf.precompT
+				for r, x := range v {
+					if p(x) {
+						setBit(m, base+r)
+					}
+				}
+			}
+			if proj {
+				copy(cv.f64[base:], v)
 			}
 		}
 	}

--- a/qpack_zonechunk.go
+++ b/qpack_zonechunk.go
@@ -29,6 +29,99 @@ const (
 	zoneChunkMinLen = 2 * blockSizeSmall // reuse the block codec's 256-row zone
 )
 
+// Zonemap encoding (the byte after kind). minmax is the per-zone [min,max] index;
+// linear is a single learned model pos≈c·value+d (±epsP) over a SORTED int/uint
+// column, which collapses the whole per-zone index to ~18 bytes. The encoder
+// picks linear only when the column is monotonic, the fit holds within ~one zone
+// (so zone-skip is preserved), and the model is strictly smaller than the minmax
+// index (never-worse). See fitLinearZmap.
+const (
+	zmapMinMax = 0x00
+	zmapLinear = 0x01
+)
+
+// linearFit is a learned zonemap: the row position of a value v is predicted by
+// c*v+d within ±epsP positions. A query range [lo,hi] therefore maps to the row
+// range [c*lo+d-epsP, c*hi+d+epsP], hence to a contiguous zone range — every
+// matching row provably lands inside it, so no zone with a match is ever skipped.
+type linearFit struct {
+	c, d float64
+	epsP int
+}
+
+// fitLinearZmap fits a single line pos≈c*value+d over a monotonic non-decreasing
+// integer column (values widened to float64) and returns it iff (a) the column is
+// sorted, (b) the values are not all equal (c>0), and (c) the worst-case position
+// residual is at most blk — i.e. the model locates any value to within one zone,
+// so zone-skip stays tight. epsP carries a +1 margin to absorb float rounding in
+// the query-side re-evaluation. The caller still compares the encoded size
+// against the minmax index and keeps whichever is smaller.
+func fitLinearZmap[T int64 | uint64](s []T, blk int) (linearFit, bool) {
+	n := len(s)
+	if n < 2 {
+		return linearFit{}, false
+	}
+	// Monotonic non-decreasing? (position == rank requires a sorted column.)
+	for i := 1; i < n; i++ {
+		if s[i] < s[i-1] {
+			return linearFit{}, false
+		}
+	}
+	// Least-squares regression of position (y=i) on value (x=s[i]), in float64.
+	var sx, sy, sxx, sxy float64
+	fn := float64(n)
+	for i := range n {
+		x := float64(s[i])
+		y := float64(i)
+		sx += x
+		sy += y
+		sxx += x * x
+		sxy += x * y
+	}
+	denom := fn*sxx - sx*sx
+	if denom <= 0 { // all values equal (or degenerate) → no usable slope
+		return linearFit{}, false
+	}
+	c := (fn*sxy - sx*sy) / denom
+	d := (sy - c*sx) / fn
+	if !(c > 0) || math.IsInf(c, 0) || math.IsNaN(d) {
+		return linearFit{}, false
+	}
+	// Worst-case position residual.
+	var maxRes float64
+	for i := range n {
+		r := math.Abs(float64(i) - (c*float64(s[i]) + d))
+		if r > maxRes {
+			maxRes = r
+		}
+	}
+	epsP := int(math.Ceil(maxRes)) + 1 // +1: float-rounding margin for query re-eval
+	if epsP > blk {
+		return linearFit{}, false // fit too loose → zone-skip would degrade
+	}
+	return linearFit{c: c, d: d, epsP: epsP}, true
+}
+
+// zoneRangeFor maps a predicate value range [lo,hi] to the inclusive zone range
+// [zlo,zhi] that can contain a matching row, per the linear model. Returns
+// ok=false when the range cannot intersect the column (no zone needed).
+func (lf linearFit) zoneRangeFor(lo, hi float64, n, blk int) (zlo, zhi int, ok bool) {
+	pLo := lf.c*lo + lf.d - float64(lf.epsP)
+	pHi := lf.c*hi + lf.d + float64(lf.epsP)
+	if pHi < 0 || pLo > float64(n-1) {
+		return 0, 0, false
+	}
+	loI := int(math.Floor(pLo))
+	hiI := int(math.Floor(pHi))
+	if loI < 0 {
+		loI = 0
+	}
+	if hiI > n-1 {
+		hiI = n - 1
+	}
+	return loI / blk, hiI / blk, true
+}
+
 // finiteMinMaxF64 returns the min and max of s over non-NaN values. ±Inf are
 // ordered and included. An all-NaN (or empty) slice yields the empty interval
 // (+Inf, -Inf), which intersects no finite predicate range — so such a zone is
@@ -46,6 +139,16 @@ func finiteMinMaxF64(s []float64) (mn, mx float64) {
 
 // ---- encode (int64) ----
 
+// linearZmapBytes is the encoded size of a linear zonemap (2 float64 + epsP).
+func linearZmapBytes(f linearFit) int { return 16 + uvarintLen(uint64(f.epsP)) }
+
+func zmapByte(linear bool) byte {
+	if linear {
+		return zmapLinear
+	}
+	return zmapMinMax
+}
+
 func (e *Encoder) writeZoneChunkInt64(s []int64) {
 	e.writeHeader()
 	n := len(s)
@@ -53,16 +156,35 @@ func (e *Encoder) writeZoneChunkInt64(s []int64) {
 	e.planBlocksI64(s, blockSizeSmall) // cache per-zone codec picks (no re-pick on emit)
 	plans := e.blkPlanI64[:zoneCount]
 
-	e.buf = append(e.buf, tagZoneChunk, zoneKindInt, blkLogSmall)
+	// Pick the learned linear zonemap over per-zone min/max only when it is both
+	// valid (monotonic, tight fit) and strictly smaller (never-worse).
+	fit, linOK := fitLinearZmap(s, blockSizeSmall)
+	if linOK {
+		var mmBytes int
+		for i := 0; i < n; i += blockSizeSmall {
+			j := min(i+blockSizeSmall, n)
+			mn, mx := minMaxI64(s[i:j])
+			mmBytes += uvarintLen(zigzagEncode64(mn)) + uvarintLen(zigzagEncode64(mx))
+		}
+		linOK = linearZmapBytes(fit) < mmBytes
+	}
+
+	e.buf = append(e.buf, tagZoneChunk, zoneKindInt, zmapByte(linOK), blkLogSmall)
 	e.buf = appendUvarint(e.buf, uint64(n))
 	offAt := len(e.buf)
 	e.buf = append(e.buf, make([]byte, 4*zoneCount)...)
-	// zonemap: per-zone min,max as zigzag-varint (variable length), before bodies.
-	for i := 0; i < n; i += blockSizeSmall {
-		j := min(i+blockSizeSmall, n)
-		mn, mx := minMaxI64(s[i:j])
-		e.buf = appendUvarint(e.buf, zigzagEncode64(mn))
-		e.buf = appendUvarint(e.buf, zigzagEncode64(mx))
+	if linOK {
+		e.buf = binary.LittleEndian.AppendUint64(e.buf, math.Float64bits(fit.c))
+		e.buf = binary.LittleEndian.AppendUint64(e.buf, math.Float64bits(fit.d))
+		e.buf = appendUvarint(e.buf, uint64(fit.epsP))
+	} else {
+		// zonemap: per-zone min,max as zigzag-varint (variable length), before bodies.
+		for i := 0; i < n; i += blockSizeSmall {
+			j := min(i+blockSizeSmall, n)
+			mn, mx := minMaxI64(s[i:j])
+			e.buf = appendUvarint(e.buf, zigzagEncode64(mn))
+			e.buf = appendUvarint(e.buf, zigzagEncode64(mx))
+		}
 	}
 	bodyStart := len(e.buf)
 	zi := 0
@@ -84,15 +206,32 @@ func (e *Encoder) writeZoneChunkUint64(s []uint64) {
 	e.planBlocksU64(s, blockSizeSmall)
 	plans := e.blkPlanU64[:zoneCount]
 
-	e.buf = append(e.buf, tagZoneChunk, zoneKindUint, blkLogSmall)
+	fit, linOK := fitLinearZmap(s, blockSizeSmall)
+	if linOK {
+		var mmBytes int
+		for i := 0; i < n; i += blockSizeSmall {
+			j := min(i+blockSizeSmall, n)
+			mn, mx := minMaxU64(s[i:j])
+			mmBytes += uvarintLen(mn) + uvarintLen(mx)
+		}
+		linOK = linearZmapBytes(fit) < mmBytes
+	}
+
+	e.buf = append(e.buf, tagZoneChunk, zoneKindUint, zmapByte(linOK), blkLogSmall)
 	e.buf = appendUvarint(e.buf, uint64(n))
 	offAt := len(e.buf)
 	e.buf = append(e.buf, make([]byte, 4*zoneCount)...)
-	for i := 0; i < n; i += blockSizeSmall {
-		j := min(i+blockSizeSmall, n)
-		mn, mx := minMaxU64(s[i:j])
-		e.buf = appendUvarint(e.buf, mn)
-		e.buf = appendUvarint(e.buf, mx)
+	if linOK {
+		e.buf = binary.LittleEndian.AppendUint64(e.buf, math.Float64bits(fit.c))
+		e.buf = binary.LittleEndian.AppendUint64(e.buf, math.Float64bits(fit.d))
+		e.buf = appendUvarint(e.buf, uint64(fit.epsP))
+	} else {
+		for i := 0; i < n; i += blockSizeSmall {
+			j := min(i+blockSizeSmall, n)
+			mn, mx := minMaxU64(s[i:j])
+			e.buf = appendUvarint(e.buf, mn)
+			e.buf = appendUvarint(e.buf, mx)
+		}
 	}
 	bodyStart := len(e.buf)
 	zi := 0
@@ -111,7 +250,8 @@ func (e *Encoder) writeZoneChunkFloat64(s []float64) {
 	e.writeHeader()
 	n := len(s)
 	zoneCount := (n + blockSizeSmall - 1) / blockSizeSmall
-	e.buf = append(e.buf, tagZoneChunk, zoneKindFloat, blkLogSmall)
+	// float64 uses the per-zone min/max index only (no linear model in v1).
+	e.buf = append(e.buf, tagZoneChunk, zoneKindFloat, zmapMinMax, blkLogSmall)
 	e.buf = appendUvarint(e.buf, uint64(n))
 	offAt := len(e.buf)
 	e.buf = append(e.buf, make([]byte, 4*zoneCount)...)
@@ -142,12 +282,14 @@ type zoneChunkHeader struct {
 	minI64, maxI64 []int64
 	minU64, maxU64 []uint64
 	minF64, maxF64 []float64
-	offBase        int // byte offset of the uint32 offset table
-	bodyStart      int // byte offset of the first zone body
+	lin            linearFit // valid when zmap == zmapLinear (int/uint only)
+	offBase        int       // byte offset of the uint32 offset table
+	bodyStart      int       // byte offset of the first zone body
 	n              int
 	zoneCount      int
 	blk            int
 	kind           byte
+	zmap           byte // zmapMinMax | zmapLinear
 }
 
 // readZoneChunkHeader consumes the tag-less header (caller consumed the tag),
@@ -161,12 +303,21 @@ type zoneChunkHeader struct {
 // values are decoded.
 func (d *Decoder) readZoneChunkHeader(loadZonemap bool) (zoneChunkHeader, error) {
 	var h zoneChunkHeader
-	if d.i+2 > len(d.buf) {
+	if d.i+3 > len(d.buf) {
 		return h, ErrShortBuffer
 	}
 	h.kind = d.buf[d.i]
 	if h.kind != zoneKindInt && h.kind != zoneKindUint && h.kind != zoneKindFloat {
 		return h, ErrTypeMismatch
+	}
+	d.i++
+	h.zmap = d.buf[d.i]
+	// A linear zonemap is only defined for int/uint columns.
+	if h.zmap != zmapMinMax && h.zmap != zmapLinear {
+		return h, ErrBadTag
+	}
+	if h.zmap == zmapLinear && h.kind == zoneKindFloat {
+		return h, ErrBadTag
 	}
 	d.i++
 	blk, ok := blockSizeFor(d.buf[d.i])
@@ -195,6 +346,39 @@ func (d *Decoder) readZoneChunkHeader(loadZonemap bool) (zoneChunkHeader, error)
 		return h, ErrShortBuffer
 	}
 	d.i += 4 * h.zoneCount
+
+	// Linear zonemap: a single model (2 float64 + epsP varint) replaces the whole
+	// per-zone min/max index. Read it (or skip its fixed bytes) and return.
+	if h.zmap == zmapLinear {
+		if d.i+16 > len(d.buf) {
+			return h, ErrShortBuffer
+		}
+		if loadZonemap {
+			h.lin.c = math.Float64frombits(binary.LittleEndian.Uint64(d.buf[d.i:]))
+			h.lin.d = math.Float64frombits(binary.LittleEndian.Uint64(d.buf[d.i+8:]))
+		}
+		d.i += 16
+		eps64, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return h, ErrInvalidLength
+		}
+		d.i += nr
+		if eps64 > uint64(int(^uint(0)>>1)) {
+			return h, ErrInvalidLength
+		}
+		if loadZonemap {
+			h.lin.epsP = int(eps64)
+			// A non-finite model or non-positive slope cannot bound positions.
+			if !(h.lin.c > 0) || math.IsInf(h.lin.c, 0) || math.IsNaN(h.lin.d) || math.IsInf(h.lin.d, 0) {
+				return h, ErrInvalidLength
+			}
+		}
+		h.bodyStart = d.i
+		if err := h.validateOffsets(d); err != nil {
+			return h, err
+		}
+		return h, nil
+	}
 
 	// zonemap (per-kind min,max)
 	switch h.kind {
@@ -266,22 +450,30 @@ func (d *Decoder) readZoneChunkHeader(loadZonemap bool) (zoneChunkHeader, error)
 	}
 
 	h.bodyStart = d.i
-	// Validate the offset table: offsets[0]==0, strictly increasing, in-buffer.
+	if err := h.validateOffsets(d); err != nil {
+		return h, err
+	}
+	return h, nil
+}
+
+// validateOffsets checks the offset table: offsets[0]==0, strictly increasing,
+// each in-buffer. Call after h.bodyStart is set.
+func (h *zoneChunkHeader) validateOffsets(d *Decoder) error {
 	prev := -1
 	for z := 0; z < h.zoneCount; z++ {
 		off := int(binary.LittleEndian.Uint32(d.buf[h.offBase+4*z:]))
 		if z == 0 && off != 0 {
-			return h, ErrInvalidLength
+			return ErrInvalidLength
 		}
 		if off <= prev {
-			return h, ErrInvalidLength
+			return ErrInvalidLength
 		}
 		if h.bodyStart+off > len(d.buf) {
-			return h, ErrShortBuffer
+			return ErrShortBuffer
 		}
 		prev = off
 	}
-	return h, nil
+	return nil
 }
 
 // zoneOff returns the absolute byte offset of zone z's body.
@@ -360,9 +552,38 @@ func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int) error 
 	for _, lf := range leaves {
 		lf.precompT = newBitset(n)
 	}
+	// For the linear zonemap, each leaf's value range maps once to a contiguous
+	// zone range; a zone is then needed iff it falls inside some leaf's range.
+	type zr struct {
+		zlo, zhi int
+		ok       bool
+	}
+	var lzr []zr
+	if h.zmap == zmapLinear {
+		lzr = make([]zr, len(leaves))
+		for li, lf := range leaves {
+			var lo, hi float64
+			if h.kind == zoneKindInt {
+				lo, hi = float64(lf.term.loI64), float64(lf.term.hiI64)
+			} else {
+				lo, hi = float64(lf.term.loU64), float64(lf.term.hiU64)
+			}
+			a, b, ok := h.lin.zoneRangeFor(lo, hi, h.n, h.blk)
+			lzr[li] = zr{a, b, ok}
+		}
+	}
 	for z := range h.zoneCount {
 		needed := false
-		for _, lf := range leaves {
+		for li, lf := range leaves {
+			if h.zmap == zmapLinear {
+				if lzr[li].ok && z >= lzr[li].zlo && z <= lzr[li].zhi {
+					needed = true
+				}
+				if needed {
+					break
+				}
+				continue
+			}
 			// Zone z intersects the leaf's bounds iff zoneMax >= lo && zoneMin <= hi.
 			switch h.kind {
 			case zoneKindInt:

--- a/qpack_zonechunk.go
+++ b/qpack_zonechunk.go
@@ -290,6 +290,10 @@ func (d *Decoder) readZoneChunkFloat64() ([]float64, error) {
 }
 
 func (d *Decoder) readZoneChunkFloat64Into(dst *[]float64) error {
+	if err := d.descend(); err != nil {
+		return err
+	}
+	defer d.ascend()
 	h, err := d.readZoneChunkHeader()
 	if err != nil {
 		return err
@@ -318,35 +322,25 @@ func (d *Decoder) readZoneChunkFloat64Into(dst *[]float64) error {
 var zoneSkippedZones int
 
 // decodeZoneChunkQuery decodes only the zones of a zone-chunked column that
-// intersect at least one of the referencing leaves' bounds, evaluates each
+// intersect at least one of the referencing leaves' bounds and evaluates each
 // leaf's predicate over those zones into the leaf's precompT mask (zones that
-// cannot match are skipped — their rows stay FALSE), and, when proj is set, fills
-// a colVals of length n with the decoded zones' values (skipped zones left zero;
-// they can never be matched, so are never scattered). The column starts at byte
-// offset start (pointing at the tag); the caller repositions d.i afterwards via
-// the column-length index.
-func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int, proj bool) (*colVals, error) {
+// cannot match are skipped — their rows stay FALSE). It is FILTER-only: it never
+// materialises projected values, because a row matched via an OR/NOT sibling can
+// live in a zone this column's bounds skipped, so projection must follow the
+// FINAL matched set (decodeZoneChunkSelective), not the leaf bounds. The column
+// starts at byte offset start (pointing at the tag); the caller repositions d.i
+// afterwards via the column-length index.
+func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int) error {
 	d.i = start + 1 // skip tag
 	h, err := d.readZoneChunkHeader()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if h.n != n {
-		return nil, ErrTypeMismatch
+		return ErrTypeMismatch
 	}
 	for _, lf := range leaves {
 		lf.precompT = newBitset(n)
-	}
-	var cv *colVals
-	if proj {
-		switch h.kind {
-		case zoneKindInt:
-			cv = &colVals{kind: colKindInt, i64: make([]int64, n)}
-		case zoneKindUint:
-			cv = &colVals{kind: colKindUint, u64: make([]uint64, n)}
-		default:
-			cv = &colVals{kind: colKindFloat, f64: make([]float64, n)}
-		}
 	}
 	for z := range h.zoneCount {
 		needed := false
@@ -377,7 +371,7 @@ func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int, proj b
 		d.i = h.zoneOff(d, z)
 		tg, err := d.peekTag()
 		if err != nil {
-			return nil, err
+			return err
 		}
 		base := z * h.blk
 		want := h.zoneLen(z)
@@ -385,10 +379,10 @@ func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int, proj b
 		case zoneKindInt:
 			v, err := d.readQPackInt64(tg)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			if len(v) != want {
-				return nil, ErrInvalidLength
+				return ErrInvalidLength
 			}
 			for _, lf := range leaves {
 				p := lf.term.pI64
@@ -399,16 +393,13 @@ func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int, proj b
 					}
 				}
 			}
-			if proj {
-				copy(cv.i64[base:], v)
-			}
 		case zoneKindUint:
 			v, err := d.readQPackUint64(tg)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			if len(v) != want {
-				return nil, ErrInvalidLength
+				return ErrInvalidLength
 			}
 			for _, lf := range leaves {
 				p := lf.term.pU64
@@ -419,16 +410,13 @@ func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int, proj b
 					}
 				}
 			}
-			if proj {
-				copy(cv.u64[base:], v)
-			}
 		default: // float64
 			var v []float64
 			if err := decodeSliceFloat64Into(d, &v); err != nil {
-				return nil, err
+				return err
 			}
 			if len(v) != want {
-				return nil, ErrInvalidLength
+				return ErrInvalidLength
 			}
 			for _, lf := range leaves {
 				p := lf.term.pF64
@@ -439,9 +427,83 @@ func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int, proj b
 					}
 				}
 			}
-			if proj {
-				copy(cv.f64[base:], v)
+		}
+	}
+	return nil
+}
+
+// decodeZoneChunkSelective decodes only the zones spanning at least one matched
+// row and fills a length-n colVals with their values (rows in undecoded zones
+// stay zero — they are not matched, so are never scattered). It is the projection
+// counterpart to decodeZoneChunkQuery's filter pass: a row matched via an OR/NOT
+// sibling can fall in a zone this column's bounds skipped, so projection must
+// follow the FINAL matched set rather than the leaf bounds. start points at the
+// tag; matched holds the surviving row indices.
+func (d *Decoder) decodeZoneChunkSelective(start, n int, matched []int) (*colVals, error) {
+	d.i = start + 1 // skip tag
+	h, err := d.readZoneChunkHeader()
+	if err != nil {
+		return nil, err
+	}
+	if h.n != n {
+		return nil, ErrTypeMismatch
+	}
+	var cv *colVals
+	switch h.kind {
+	case zoneKindInt:
+		cv = &colVals{kind: colKindInt, i64: make([]int64, n)}
+	case zoneKindUint:
+		cv = &colVals{kind: colKindUint, u64: make([]uint64, n)}
+	default:
+		cv = &colVals{kind: colKindFloat, f64: make([]float64, n)}
+	}
+	need := make([]bool, h.zoneCount)
+	for _, r := range matched {
+		need[r/h.blk] = true
+	}
+	var ftmp []float64
+	for z := range h.zoneCount {
+		if !need[z] {
+			continue
+		}
+		d.i = h.zoneOff(d, z)
+		base := z * h.blk
+		want := h.zoneLen(z)
+		switch h.kind {
+		case zoneKindInt:
+			tg, err := d.peekTag()
+			if err != nil {
+				return nil, err
 			}
+			v, err := d.readQPackInt64(tg)
+			if err != nil {
+				return nil, err
+			}
+			if len(v) != want {
+				return nil, ErrInvalidLength
+			}
+			copy(cv.i64[base:], v)
+		case zoneKindUint:
+			tg, err := d.peekTag()
+			if err != nil {
+				return nil, err
+			}
+			v, err := d.readQPackUint64(tg)
+			if err != nil {
+				return nil, err
+			}
+			if len(v) != want {
+				return nil, ErrInvalidLength
+			}
+			copy(cv.u64[base:], v)
+		default: // float64
+			if err := decodeSliceFloat64Into(d, &ftmp); err != nil {
+				return nil, err
+			}
+			if len(ftmp) != want {
+				return nil, ErrInvalidLength
+			}
+			copy(cv.f64[base:], ftmp)
 		}
 	}
 	return cv, nil
@@ -458,6 +520,12 @@ func (d *Decoder) readZoneChunkInt64() ([]int64, error) {
 }
 
 func (d *Decoder) readZoneChunkInt64Into(dst *[]int64) error {
+	// A zone body could itself carry tagZoneChunk; bound the nesting so a hostile
+	// payload of nested zone chunks cannot overflow the goroutine stack.
+	if err := d.descend(); err != nil {
+		return err
+	}
+	defer d.ascend()
 	h, err := d.readZoneChunkHeader()
 	if err != nil {
 		return err
@@ -496,6 +564,10 @@ func (d *Decoder) readZoneChunkUint64() ([]uint64, error) {
 }
 
 func (d *Decoder) readZoneChunkUint64Into(dst *[]uint64) error {
+	if err := d.descend(); err != nil {
+		return err
+	}
+	defer d.ascend()
 	h, err := d.readZoneChunkHeader()
 	if err != nil {
 		return err

--- a/qpack_zonechunk.go
+++ b/qpack_zonechunk.go
@@ -1,0 +1,398 @@
+package qdf
+
+import "encoding/binary"
+
+// Zone-chunked integer column with a min/max zonemap (wire tag tagZoneChunk,
+// 0xF1, OptZoneMap).
+//
+// The column is split into fixed 256-row zones (same chunk size as the block
+// codec, so the per-zone codec picks are shared via e.blkPlanI64). Each zone is
+// an independent QPack int sub-slice; a uint32 offset table and a per-zone
+// [min,max] zonemap precede the bodies. A bound-carrying predicate
+// (WhereRange/GE/LE/Eq) skips zones whose [min,max] cannot intersect its bounds
+// WITHOUT decoding them — the whole point of the feature. See decodeZoneSkip* in
+// columnar.go for the query-side use.
+//
+// Unlike the block codec this is an explicit size-for-query-speed trade: it is
+// emitted only under OptZoneMap, never auto, and carries no never-larger gate
+// (chunking an ordered column costs more than a single whole-column codec — that
+// is the price of zone-skippability). Without OptZoneMap the wire is unchanged.
+
+const (
+	zoneKindInt  = 0x00
+	zoneKindUint = 0x01
+	// zoneChunkMinLen: a column shorter than two zones has nothing to chunk.
+	zoneChunkMinLen = 2 * blockSizeSmall // reuse the block codec's 256-row zone
+)
+
+// ---- encode (int64) ----
+
+func (e *Encoder) writeZoneChunkInt64(s []int64) {
+	e.writeHeader()
+	n := len(s)
+	zoneCount := (n + blockSizeSmall - 1) / blockSizeSmall
+	e.planBlocksI64(s, blockSizeSmall) // cache per-zone codec picks (no re-pick on emit)
+	plans := e.blkPlanI64[:zoneCount]
+
+	e.buf = append(e.buf, tagZoneChunk, zoneKindInt, blkLogSmall)
+	e.buf = appendUvarint(e.buf, uint64(n))
+	offAt := len(e.buf)
+	e.buf = append(e.buf, make([]byte, 4*zoneCount)...)
+	// zonemap: per-zone min,max as zigzag-varint (variable length), before bodies.
+	for i := 0; i < n; i += blockSizeSmall {
+		j := min(i+blockSizeSmall, n)
+		mn, mx := minMaxI64(s[i:j])
+		e.buf = appendUvarint(e.buf, zigzagEncode64(mn))
+		e.buf = appendUvarint(e.buf, zigzagEncode64(mx))
+	}
+	bodyStart := len(e.buf)
+	zi := 0
+	for i := 0; i < n; i += blockSizeSmall {
+		j := min(i+blockSizeSmall, n)
+		binary.LittleEndian.PutUint32(e.buf[offAt+4*zi:], uint32(len(e.buf)-bodyStart))
+		p := &plans[zi]
+		e.emitQPackInt64(s[i:j], p.codec, p.mn, p.forBits, p.first, p.minDelta, p.deltaBits, p.pforBits)
+		zi++
+	}
+}
+
+// ---- encode (uint64) ----
+
+func (e *Encoder) writeZoneChunkUint64(s []uint64) {
+	e.writeHeader()
+	n := len(s)
+	zoneCount := (n + blockSizeSmall - 1) / blockSizeSmall
+	e.planBlocksU64(s, blockSizeSmall)
+	plans := e.blkPlanU64[:zoneCount]
+
+	e.buf = append(e.buf, tagZoneChunk, zoneKindUint, blkLogSmall)
+	e.buf = appendUvarint(e.buf, uint64(n))
+	offAt := len(e.buf)
+	e.buf = append(e.buf, make([]byte, 4*zoneCount)...)
+	for i := 0; i < n; i += blockSizeSmall {
+		j := min(i+blockSizeSmall, n)
+		mn, mx := minMaxU64(s[i:j])
+		e.buf = appendUvarint(e.buf, mn)
+		e.buf = appendUvarint(e.buf, mx)
+	}
+	bodyStart := len(e.buf)
+	zi := 0
+	for i := 0; i < n; i += blockSizeSmall {
+		j := min(i+blockSizeSmall, n)
+		binary.LittleEndian.PutUint32(e.buf[offAt+4*zi:], uint32(len(e.buf)-bodyStart))
+		p := &plans[zi]
+		e.emitQPackUint64(s[i:j], p.codec, p.mn, p.forBits, p.first, p.minDelta, p.deltaBits, p.pforBits)
+		zi++
+	}
+}
+
+// ---- decode header (shared) ----
+
+// zoneChunkHeader is the decoded geometry + zonemap of a zone-chunked column.
+// minI64/maxI64 (or minU64/maxU64) hold the per-zone bounds for predicate
+// zone-skip; the other-kind slices stay nil.
+type zoneChunkHeader struct {
+	minI64, maxI64 []int64
+	minU64, maxU64 []uint64
+	offBase        int // byte offset of the uint32 offset table
+	bodyStart      int // byte offset of the first zone body
+	n              int
+	zoneCount      int
+	blk            int
+	kind           byte
+}
+
+// readZoneChunkHeader consumes the tag-less header (caller consumed the tag),
+// validates it, decodes the offset table position and the zonemap, and returns
+// the geometry. It leaves d.i at bodyStart.
+func (d *Decoder) readZoneChunkHeader() (zoneChunkHeader, error) {
+	var h zoneChunkHeader
+	if d.i+2 > len(d.buf) {
+		return h, ErrShortBuffer
+	}
+	h.kind = d.buf[d.i]
+	if h.kind != zoneKindInt && h.kind != zoneKindUint {
+		return h, ErrTypeMismatch
+	}
+	d.i++
+	blk, ok := blockSizeFor(d.buf[d.i])
+	if !ok {
+		return h, ErrBadTag
+	}
+	h.blk = blk
+	d.i++
+	n64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return h, ErrInvalidLength
+	}
+	d.i += nr
+	if !d.colLenOK(n64) || n64 == 0 || n64 > uint64(int(^uint(0)>>1)) {
+		return h, ErrInvalidLength
+	}
+	h.n = int(n64)
+	if checkColumnarBytes(h.n, 8) != nil {
+		return h, ErrInvalidLength
+	}
+	h.zoneCount = (h.n + blk - 1) / blk
+
+	// offset table
+	h.offBase = d.i
+	if d.i+4*h.zoneCount > len(d.buf) {
+		return h, ErrShortBuffer
+	}
+	d.i += 4 * h.zoneCount
+
+	// zonemap (zoneCount x min,max varints)
+	if h.kind == zoneKindInt {
+		h.minI64 = make([]int64, h.zoneCount)
+		h.maxI64 = make([]int64, h.zoneCount)
+		for z := 0; z < h.zoneCount; z++ {
+			mnZ, nr := readUvarint(d.buf[d.i:])
+			if nr <= 0 {
+				return h, ErrInvalidLength
+			}
+			d.i += nr
+			mxZ, nr2 := readUvarint(d.buf[d.i:])
+			if nr2 <= 0 {
+				return h, ErrInvalidLength
+			}
+			d.i += nr2
+			h.minI64[z] = zigzagDecode64(mnZ)
+			h.maxI64[z] = zigzagDecode64(mxZ)
+			if h.minI64[z] > h.maxI64[z] {
+				return h, ErrInvalidLength
+			}
+		}
+	} else {
+		h.minU64 = make([]uint64, h.zoneCount)
+		h.maxU64 = make([]uint64, h.zoneCount)
+		for z := 0; z < h.zoneCount; z++ {
+			mnZ, nr := readUvarint(d.buf[d.i:])
+			if nr <= 0 {
+				return h, ErrInvalidLength
+			}
+			d.i += nr
+			mxZ, nr2 := readUvarint(d.buf[d.i:])
+			if nr2 <= 0 {
+				return h, ErrInvalidLength
+			}
+			d.i += nr2
+			h.minU64[z] = mnZ
+			h.maxU64[z] = mxZ
+			if h.minU64[z] > h.maxU64[z] {
+				return h, ErrInvalidLength
+			}
+		}
+	}
+
+	h.bodyStart = d.i
+	// Validate the offset table: offsets[0]==0, strictly increasing, in-buffer.
+	prev := -1
+	for z := 0; z < h.zoneCount; z++ {
+		off := int(binary.LittleEndian.Uint32(d.buf[h.offBase+4*z:]))
+		if z == 0 && off != 0 {
+			return h, ErrInvalidLength
+		}
+		if off <= prev {
+			return h, ErrInvalidLength
+		}
+		if h.bodyStart+off > len(d.buf) {
+			return h, ErrShortBuffer
+		}
+		prev = off
+	}
+	return h, nil
+}
+
+// zoneOff returns the absolute byte offset of zone z's body.
+func (h *zoneChunkHeader) zoneOff(d *Decoder, z int) int {
+	return h.bodyStart + int(binary.LittleEndian.Uint32(d.buf[h.offBase+4*z:]))
+}
+
+// zoneLen returns the element count of zone z.
+func (h *zoneChunkHeader) zoneLen(z int) int {
+	if z == h.zoneCount-1 {
+		return h.n - z*h.blk
+	}
+	return h.blk
+}
+
+// zoneSkippedZones counts zones the query path proved cannot match and did not
+// decode. Test-only instrumentation; otherwise inert.
+var zoneSkippedZones int
+
+// decodeZoneChunkQuery decodes only the zones of a zone-chunked column that
+// intersect at least one of the referencing leaves' bounds, evaluates each
+// leaf's predicate over those zones into the leaf's precompT mask (zones that
+// cannot match are skipped — their rows stay FALSE), and, when proj is set, fills
+// a colVals of length n with the decoded zones' values (skipped zones left zero;
+// they can never be matched, so are never scattered). The column starts at byte
+// offset start (pointing at the tag); the caller repositions d.i afterwards via
+// the column-length index.
+func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int, proj bool) (*colVals, error) {
+	d.i = start + 1 // skip tag
+	h, err := d.readZoneChunkHeader()
+	if err != nil {
+		return nil, err
+	}
+	if h.n != n {
+		return nil, ErrTypeMismatch
+	}
+	for _, lf := range leaves {
+		lf.precompT = newBitset(n)
+	}
+	var cv *colVals
+	if proj {
+		if h.kind == zoneKindInt {
+			cv = &colVals{kind: colKindInt, i64: make([]int64, n)}
+		} else {
+			cv = &colVals{kind: colKindUint, u64: make([]uint64, n)}
+		}
+	}
+	for z := range h.zoneCount {
+		needed := false
+		for _, lf := range leaves {
+			// Zone z intersects the leaf's bounds iff zoneMax >= lo && zoneMin <= hi.
+			if h.kind == zoneKindInt {
+				if h.maxI64[z] >= lf.term.loI64 && h.minI64[z] <= lf.term.hiI64 {
+					needed = true
+					break
+				}
+			} else {
+				if h.maxU64[z] >= lf.term.loU64 && h.minU64[z] <= lf.term.hiU64 {
+					needed = true
+					break
+				}
+			}
+		}
+		if !needed {
+			zoneSkippedZones++
+			continue
+		}
+		d.i = h.zoneOff(d, z)
+		tg, err := d.peekTag()
+		if err != nil {
+			return nil, err
+		}
+		base := z * h.blk
+		want := h.zoneLen(z)
+		if h.kind == zoneKindInt {
+			v, err := d.readQPackInt64(tg)
+			if err != nil {
+				return nil, err
+			}
+			if len(v) != want {
+				return nil, ErrInvalidLength
+			}
+			for _, lf := range leaves {
+				p := lf.term.pI64
+				m := lf.precompT
+				for r, x := range v {
+					if p(x) {
+						setBit(m, base+r)
+					}
+				}
+			}
+			if proj {
+				copy(cv.i64[base:], v)
+			}
+		} else {
+			v, err := d.readQPackUint64(tg)
+			if err != nil {
+				return nil, err
+			}
+			if len(v) != want {
+				return nil, ErrInvalidLength
+			}
+			for _, lf := range leaves {
+				p := lf.term.pU64
+				m := lf.precompT
+				for r, x := range v {
+					if p(x) {
+						setBit(m, base+r)
+					}
+				}
+			}
+			if proj {
+				copy(cv.u64[base:], v)
+			}
+		}
+	}
+	return cv, nil
+}
+
+// ---- decode-all (int64) ----
+
+func (d *Decoder) readZoneChunkInt64() ([]int64, error) {
+	var s []int64
+	if err := d.readZoneChunkInt64Into(&s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (d *Decoder) readZoneChunkInt64Into(dst *[]int64) error {
+	h, err := d.readZoneChunkHeader()
+	if err != nil {
+		return err
+	}
+	if h.kind != zoneKindInt {
+		return ErrTypeMismatch
+	}
+	growI64(dst, h.n)
+	out := *dst
+	for z := range h.zoneCount {
+		d.i = h.zoneOff(d, z)
+		t, err := d.peekTag()
+		if err != nil {
+			return err
+		}
+		v, err := d.readQPackInt64(t)
+		if err != nil {
+			return err
+		}
+		if len(v) != h.zoneLen(z) {
+			return ErrInvalidLength
+		}
+		copy(out[z*h.blk:], v)
+	}
+	return nil
+}
+
+// ---- decode-all (uint64) ----
+
+func (d *Decoder) readZoneChunkUint64() ([]uint64, error) {
+	var s []uint64
+	if err := d.readZoneChunkUint64Into(&s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (d *Decoder) readZoneChunkUint64Into(dst *[]uint64) error {
+	h, err := d.readZoneChunkHeader()
+	if err != nil {
+		return err
+	}
+	if h.kind != zoneKindUint {
+		return ErrTypeMismatch
+	}
+	growU64(dst, h.n)
+	out := *dst
+	for z := range h.zoneCount {
+		d.i = h.zoneOff(d, z)
+		t, err := d.peekTag()
+		if err != nil {
+			return err
+		}
+		v, err := d.readQPackUint64(t)
+		if err != nil {
+			return err
+		}
+		if len(v) != h.zoneLen(z) {
+			return ErrInvalidLength
+		}
+		copy(out[z*h.blk:], v)
+	}
+	return nil
+}

--- a/qpack_zonechunk.go
+++ b/qpack_zonechunk.go
@@ -151,9 +151,15 @@ type zoneChunkHeader struct {
 }
 
 // readZoneChunkHeader consumes the tag-less header (caller consumed the tag),
-// validates it, decodes the offset table position and the zonemap, and returns
-// the geometry. It leaves d.i at bodyStart.
-func (d *Decoder) readZoneChunkHeader() (zoneChunkHeader, error) {
+// validates it, decodes the offset table position and (when loadZonemap) the
+// per-zone min/max zonemap, and returns the geometry. It leaves d.i at bodyStart.
+//
+// Only the predicate zone-skip path needs the zonemap; the full-decode and
+// selective paths read all/matched zones regardless, so they pass loadZonemap
+// false — the zonemap bytes are still walked to locate bodyStart (the int/uint
+// entries are variable-length varints), but no slices are allocated and no
+// values are decoded.
+func (d *Decoder) readZoneChunkHeader(loadZonemap bool) (zoneChunkHeader, error) {
 	var h zoneChunkHeader
 	if d.i+2 > len(d.buf) {
 		return h, ErrShortBuffer
@@ -193,8 +199,10 @@ func (d *Decoder) readZoneChunkHeader() (zoneChunkHeader, error) {
 	// zonemap (per-kind min,max)
 	switch h.kind {
 	case zoneKindInt:
-		h.minI64 = make([]int64, h.zoneCount)
-		h.maxI64 = make([]int64, h.zoneCount)
+		if loadZonemap {
+			h.minI64 = make([]int64, h.zoneCount)
+			h.maxI64 = make([]int64, h.zoneCount)
+		}
 		for z := 0; z < h.zoneCount; z++ {
 			mnZ, nr := readUvarint(d.buf[d.i:])
 			if nr <= 0 {
@@ -206,15 +214,19 @@ func (d *Decoder) readZoneChunkHeader() (zoneChunkHeader, error) {
 				return h, ErrInvalidLength
 			}
 			d.i += nr2
-			h.minI64[z] = zigzagDecode64(mnZ)
-			h.maxI64[z] = zigzagDecode64(mxZ)
-			if h.minI64[z] > h.maxI64[z] {
-				return h, ErrInvalidLength
+			if loadZonemap {
+				h.minI64[z] = zigzagDecode64(mnZ)
+				h.maxI64[z] = zigzagDecode64(mxZ)
+				if h.minI64[z] > h.maxI64[z] {
+					return h, ErrInvalidLength
+				}
 			}
 		}
 	case zoneKindUint:
-		h.minU64 = make([]uint64, h.zoneCount)
-		h.maxU64 = make([]uint64, h.zoneCount)
+		if loadZonemap {
+			h.minU64 = make([]uint64, h.zoneCount)
+			h.maxU64 = make([]uint64, h.zoneCount)
+		}
 		for z := 0; z < h.zoneCount; z++ {
 			mnZ, nr := readUvarint(d.buf[d.i:])
 			if nr <= 0 {
@@ -226,24 +238,30 @@ func (d *Decoder) readZoneChunkHeader() (zoneChunkHeader, error) {
 				return h, ErrInvalidLength
 			}
 			d.i += nr2
-			h.minU64[z] = mnZ
-			h.maxU64[z] = mxZ
-			if h.minU64[z] > h.maxU64[z] {
-				return h, ErrInvalidLength
+			if loadZonemap {
+				h.minU64[z] = mnZ
+				h.maxU64[z] = mxZ
+				if h.minU64[z] > h.maxU64[z] {
+					return h, ErrInvalidLength
+				}
 			}
 		}
 	default: // zoneKindFloat: 8-byte min + 8-byte max per zone (IEEE-754 bits LE)
 		if d.i+16*h.zoneCount > len(d.buf) {
 			return h, ErrShortBuffer
 		}
-		h.minF64 = make([]float64, h.zoneCount)
-		h.maxF64 = make([]float64, h.zoneCount)
-		for z := 0; z < h.zoneCount; z++ {
-			h.minF64[z] = math.Float64frombits(binary.LittleEndian.Uint64(d.buf[d.i:]))
-			h.maxF64[z] = math.Float64frombits(binary.LittleEndian.Uint64(d.buf[d.i+8:]))
-			d.i += 16
-			// No min<=max check: an all-NaN zone stores the empty interval
-			// (+Inf, -Inf) on purpose, and NaN bounds are not ordered.
+		if loadZonemap {
+			h.minF64 = make([]float64, h.zoneCount)
+			h.maxF64 = make([]float64, h.zoneCount)
+			for z := 0; z < h.zoneCount; z++ {
+				h.minF64[z] = math.Float64frombits(binary.LittleEndian.Uint64(d.buf[d.i:]))
+				h.maxF64[z] = math.Float64frombits(binary.LittleEndian.Uint64(d.buf[d.i+8:]))
+				d.i += 16
+				// No min<=max check: an all-NaN zone stores the empty interval
+				// (+Inf, -Inf) on purpose, and NaN bounds are not ordered.
+			}
+		} else {
+			d.i += 16 * h.zoneCount
 		}
 	}
 
@@ -294,7 +312,7 @@ func (d *Decoder) readZoneChunkFloat64Into(dst *[]float64) error {
 		return err
 	}
 	defer d.ascend()
-	h, err := d.readZoneChunkHeader()
+	h, err := d.readZoneChunkHeader(false)
 	if err != nil {
 		return err
 	}
@@ -332,7 +350,7 @@ var zoneSkippedZones int
 // afterwards via the column-length index.
 func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int) error {
 	d.i = start + 1 // skip tag
-	h, err := d.readZoneChunkHeader()
+	h, err := d.readZoneChunkHeader(true)
 	if err != nil {
 		return err
 	}
@@ -441,7 +459,7 @@ func (d *Decoder) decodeZoneChunkQuery(start int, leaves []*cnode, n int) error 
 // tag; matched holds the surviving row indices.
 func (d *Decoder) decodeZoneChunkSelective(start, n int, matched []int) (*colVals, error) {
 	d.i = start + 1 // skip tag
-	h, err := d.readZoneChunkHeader()
+	h, err := d.readZoneChunkHeader(false)
 	if err != nil {
 		return nil, err
 	}
@@ -526,7 +544,7 @@ func (d *Decoder) readZoneChunkInt64Into(dst *[]int64) error {
 		return err
 	}
 	defer d.ascend()
-	h, err := d.readZoneChunkHeader()
+	h, err := d.readZoneChunkHeader(false)
 	if err != nil {
 		return err
 	}
@@ -568,7 +586,7 @@ func (d *Decoder) readZoneChunkUint64Into(dst *[]uint64) error {
 		return err
 	}
 	defer d.ascend()
-	h, err := d.readZoneChunkHeader()
+	h, err := d.readZoneChunkHeader(false)
 	if err != nil {
 		return err
 	}

--- a/qpack_zonechunk_test.go
+++ b/qpack_zonechunk_test.go
@@ -2,6 +2,7 @@ package qdf
 
 import (
 	"bytes"
+	"errors"
 	"math"
 	"math/rand"
 	"testing"
@@ -335,6 +336,73 @@ func TestZoneChunkProperty(t *testing.T) {
 			if out[i] != want[i] {
 				t.Fatalf("iter %d [%d] mismatch", iter, i)
 			}
+		}
+	}
+}
+
+// TestZoneChunkProjMatchedViaSibling guards the zone-skip projection path: a
+// projected zone-chunked column whose rows are matched via an OR/NOT sibling on
+// another column must still project the REAL value. The filter pass skips zones
+// the column's own bounds exclude, so projection must follow the final matched
+// set, not the leaf bounds. Regression for the "skipped zone projects zero" bug.
+func TestZoneChunkProjMatchedViaSibling(t *testing.T) {
+	const n = 4096
+	rows := zcRows(n, true) // ordered TS ascending; V=int64(i); U=uint64(i)*7
+	b, err := Marshal(rows, OptBalanced|OptZoneMap|OptColumnIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	check := func(name string, q []QueryOption, pred func(zcRow) bool) {
+		t.Helper()
+		var want []zcRow
+		for _, r := range rows {
+			if pred(r) {
+				want = append(want, r)
+			}
+		}
+		opts := append([]QueryOption{Select("TS", "U", "V")}, q...)
+		var out []zcRow
+		if err := Unmarshal(b, &out, opts...); err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if len(out) != len(want) {
+			t.Fatalf("%s: len %d != %d", name, len(out), len(want))
+		}
+		for i := range want {
+			if out[i] != want[i] {
+				t.Fatalf("%s: [%d] %+v != %+v", name, i, out[i], want[i])
+			}
+		}
+	}
+
+	// OR: TS leaf (GE high) skips the low zones; V leaf (LE 5) matches rows 0..5
+	// which live in those skipped zones. TS must still project the real value.
+	check("or", []QueryOption{Or(WhereCmp("TS", GE, rows[4000].TS), WhereCmp("V", LE, int64(5)))},
+		func(r zcRow) bool { return r.TS >= rows[4000].TS || r.V <= 5 })
+
+	// NOT: leaf bounds intersect only the high zones, but NOT flips the match to
+	// the low zones — the projected TS column must follow the inverted match.
+	check("not", []QueryOption{Not(WhereCmp("TS", GE, rows[4000].TS))},
+		func(r zcRow) bool { return r.TS < rows[4000].TS })
+
+	// OR on the uint zone-chunked column matched via a sibling on TS.
+	check("or-uint", []QueryOption{Or(WhereCmp("U", GE, uint64(4000)*7), WhereCmp("TS", LE, rows[5].TS))},
+		func(r zcRow) bool { return r.U >= 4000*7 || r.TS <= rows[5].TS })
+}
+
+// TestZoneChunkDepthGuard verifies the zone-chunk decoders bound recursion depth
+// (a zone body can itself be a tagZoneChunk, so nested payloads must not overflow
+// the stack). At the depth cap the decoder returns ErrCycleDetected without
+// touching the buffer.
+func TestZoneChunkDepthGuard(t *testing.T) {
+	for _, fn := range []func(d *Decoder) error{
+		func(d *Decoder) error { return d.readZoneChunkInt64Into(new([]int64)) },
+		func(d *Decoder) error { return d.readZoneChunkUint64Into(new([]uint64)) },
+		func(d *Decoder) error { return d.readZoneChunkFloat64Into(new([]float64)) },
+	} {
+		d := &Decoder{maxDepth: DefaultMaxDepth, depth: DefaultMaxDepth}
+		if err := fn(d); !errors.Is(err, ErrCycleDetected) {
+			t.Fatalf("want ErrCycleDetected at depth cap, got %v", err)
 		}
 	}
 }

--- a/qpack_zonechunk_test.go
+++ b/qpack_zonechunk_test.go
@@ -2,6 +2,7 @@ package qdf
 
 import (
 	"bytes"
+	"math"
 	"math/rand"
 	"testing"
 )
@@ -138,6 +139,96 @@ func TestZoneChunkSkipCorrect(t *testing.T) {
 	}
 }
 
+// ---- float64 zone-chunk ----
+
+type zcFRow struct {
+	F   float64 // ordered predicate column
+	K   int64   // payload
+	J   int64   // low-card payload
+	Tag string  // constant string — strong columnar-win signal so the probe transposes
+}
+
+func TestZoneChunkFloat64(t *testing.T) {
+	const n = 4096
+	rng := rand.New(rand.NewSource(9))
+	rows := make([]zcFRow, n)
+	f := 0.0
+	for i := range rows {
+		f += rng.Float64() // monotonically increasing → ordered
+		v := f
+		if i%500 == 0 {
+			v = math.NaN() // sprinkle NaN — must round-trip + never match
+		}
+		rows[i] = zcFRow{F: v, K: int64(i), J: int64(i % 8), Tag: "const"}
+	}
+	b, err := Marshal(rows, OptBalanced|OptZoneMap|OptColumnIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Round-trip incl. NaN (bit-exact).
+	var all []zcFRow
+	if err := Unmarshal(b, &all); err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != n {
+		t.Fatalf("len %d", len(all))
+	}
+	for i := range rows {
+		if math.IsNaN(rows[i].F) {
+			if !math.IsNaN(all[i].F) || all[i].K != rows[i].K {
+				t.Fatalf("[%d] NaN row not preserved: %+v", i, all[i])
+			}
+			continue
+		}
+		if all[i] != rows[i] {
+			t.Fatalf("[%d] %+v != %+v", i, all[i], rows[i])
+		}
+	}
+
+	// Zone-skip range: result == full filter (NaN never matches), zones skipped.
+	lo, hi := rows[1001].F, rows[1099].F
+	zoneSkippedZones = 0
+	var out []zcFRow
+	if err := Unmarshal(b, &out, WhereRange("F", lo, hi), Select("F", "K", "J", "Tag")); err != nil {
+		t.Fatal(err)
+	}
+	var want []zcFRow
+	for _, r := range rows {
+		if r.F >= lo && r.F <= hi { // NaN >= lo is false → excluded, as required
+			want = append(want, r)
+		}
+	}
+	if len(out) != len(want) {
+		t.Fatalf("range len %d != %d", len(out), len(want))
+	}
+	for i := range want {
+		if out[i] != want[i] {
+			t.Fatalf("range [%d] %+v != %+v", i, out[i], want[i])
+		}
+	}
+	if zoneSkippedZones == 0 {
+		t.Fatal("float zone-skip skipped 0 zones")
+	}
+	t.Logf("float64: %d rows, %d zones skipped", len(out), zoneSkippedZones)
+
+	// WhereCmp GE on float.
+	zoneSkippedZones = 0
+	var ge []zcFRow
+	if err := Unmarshal(b, &ge, WhereCmp("F", GE, rows[3997].F), Select("F", "K", "J", "Tag")); err != nil {
+		t.Fatal(err)
+	}
+	cnt := 0
+	for _, r := range rows {
+		if r.F >= rows[3997].F {
+			cnt++
+		}
+	}
+	if len(ge) != cnt {
+		t.Fatalf("ge len %d != %d", len(ge), cnt)
+	}
+}
+
 // ---- no-flag byte-identical ----
 
 func TestZoneChunkNoFlagIdentical(t *testing.T) {
@@ -213,7 +304,7 @@ func FuzzZoneChunkDecode(f *testing.F) {
 
 func TestZoneChunkProperty(t *testing.T) {
 	rng := rand.New(rand.NewSource(123))
-	for iter := 0; iter < 100; iter++ {
+	for iter := range 100 {
 		n := 512 + rng.Intn(4000)
 		ordered := rng.Intn(2) == 0
 		rows := zcRows(n, ordered)

--- a/qpack_zonechunk_test.go
+++ b/qpack_zonechunk_test.go
@@ -1,0 +1,249 @@
+package qdf
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+)
+
+type zcRow struct {
+	TS int64  // ordered predicate column
+	U  uint64 // ordered uint column
+	V  int64  // payload
+}
+
+func zcRows(n int, ordered bool) []zcRow {
+	rng := rand.New(rand.NewSource(5))
+	rows := make([]zcRow, n)
+	ts := int64(1_700_000_000)
+	for i := range rows {
+		if ordered {
+			ts += 1 + rng.Int63n(3)
+		} else {
+			ts = rng.Int63n(1 << 40)
+		}
+		rows[i] = zcRow{TS: ts, U: uint64(i) * 7, V: int64(i)}
+	}
+	return rows
+}
+
+// ---- round-trip (decode-all) ----
+
+func TestZoneChunkRoundtrip(t *testing.T) {
+	for _, ordered := range []bool{true, false} {
+		for _, n := range []int{511, 512, 513, 1000, 4096, 4097} {
+			rows := zcRows(n, ordered)
+			b, err := Marshal(rows, OptBalanced|OptZoneMap|OptColumnIndex)
+			if err != nil {
+				t.Fatalf("n=%d ord=%v marshal: %v", n, ordered, err)
+			}
+			var out []zcRow
+			if err := Unmarshal(b, &out); err != nil {
+				t.Fatalf("n=%d ord=%v unmarshal: %v", n, ordered, err)
+			}
+			if len(out) != n {
+				t.Fatalf("n=%d len %d", n, len(out))
+			}
+			for i := range rows {
+				if out[i] != rows[i] {
+					t.Fatalf("n=%d [%d] %+v != %+v", n, i, out[i], rows[i])
+				}
+			}
+		}
+	}
+}
+
+// ---- zone-skip correctness + actual skipping ----
+
+func TestZoneChunkSkipCorrect(t *testing.T) {
+	const n = 4096
+	rows := zcRows(n, true) // ordered TS → high skip
+	b, err := Marshal(rows, OptBalanced|OptZoneMap|OptColumnIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loTS, hiTS := rows[1000].TS, rows[1100].TS // a narrow range → most zones skippable
+
+	filter := func(pred func(zcRow) bool) []zcRow {
+		var w []zcRow
+		for _, r := range rows {
+			if pred(r) {
+				w = append(w, r)
+			}
+		}
+		return w
+	}
+	eq := func(name string, got, want []zcRow) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("%s: len %d != %d", name, len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("%s: [%d] %+v != %+v", name, i, got[i], want[i])
+			}
+		}
+	}
+	run := func(name string, q []QueryOption, pred func(zcRow) bool, wantSkip bool) {
+		t.Helper()
+		zoneSkippedZones = 0
+		var out []zcRow
+		opts := append([]QueryOption{Select("TS", "U", "V")}, q...)
+		if err := Unmarshal(b, &out, opts...); err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		eq(name, out, filter(pred))
+		if wantSkip && zoneSkippedZones == 0 {
+			t.Fatalf("%s: expected zones skipped, got 0", name)
+		}
+		t.Logf("%s: %d rows, %d zones skipped", name, len(out), zoneSkippedZones)
+	}
+
+	run("range", []QueryOption{WhereRange("TS", loTS, hiTS)},
+		func(r zcRow) bool { return r.TS >= loTS && r.TS <= hiTS }, true)
+	run("ge", []QueryOption{WhereCmp("TS", GE, rows[4000].TS)},
+		func(r zcRow) bool { return r.TS >= rows[4000].TS }, true)
+	run("le", []QueryOption{WhereCmp("TS", LE, rows[100].TS)},
+		func(r zcRow) bool { return r.TS <= rows[100].TS }, true)
+	run("gt", []QueryOption{WhereCmp("TS", GT, rows[4000].TS)},
+		func(r zcRow) bool { return r.TS > rows[4000].TS }, true)
+	run("lt", []QueryOption{WhereCmp("TS", LT, rows[100].TS)},
+		func(r zcRow) bool { return r.TS < rows[100].TS }, true)
+	run("eq-miss", []QueryOption{WhereCmp("TS", EQ, int64(-999))},
+		func(r zcRow) bool { return r.TS == -999 }, true)
+	// uint column
+	run("uint-range", []QueryOption{WhereRange("U", uint64(700), uint64(800))},
+		func(r zcRow) bool { return r.U >= 700 && r.U <= 800 }, true)
+	// AND of two bounds on the SAME column: declines zone-skip (two leaves union
+	// to the whole domain) and full-decodes — correct, just no skip. Use a single
+	// WhereRange to get the skip.
+	run("and-range", []QueryOption{WhereCmp("TS", GE, loTS), WhereCmp("TS", LE, hiTS)},
+		func(r zcRow) bool { return r.TS >= loTS && r.TS <= hiTS }, false)
+	// all-match (no skip expected)
+	run("all", []QueryOption{WhereCmp("TS", GE, int64(0))},
+		func(r zcRow) bool { return r.TS >= 0 }, false)
+
+	// Back-compat: opaque Where(func) over a zone-chunked column → full eval, no
+	// skip, same rows.
+	zoneSkippedZones = 0
+	var out []zcRow
+	if err := Unmarshal(b, &out,
+		Where("TS", func(v int64) bool { return v >= loTS && v <= hiTS }),
+		Select("TS", "U", "V")); err != nil {
+		t.Fatal(err)
+	}
+	eq("opaque-where", out, filter(func(r zcRow) bool { return r.TS >= loTS && r.TS <= hiTS }))
+	if zoneSkippedZones != 0 {
+		t.Fatalf("opaque Where should not zone-skip, skipped %d", zoneSkippedZones)
+	}
+}
+
+// ---- no-flag byte-identical ----
+
+func TestZoneChunkNoFlagIdentical(t *testing.T) {
+	rows := zcRows(4096, true)
+	withFlag, _ := Marshal(rows, OptBalanced|OptColumnIndex|OptZoneMap)
+	noFlag, _ := Marshal(rows, OptBalanced|OptColumnIndex)
+	if bytes.Equal(withFlag, noFlag) {
+		t.Fatal("OptZoneMap produced identical wire — zone-chunk did not fire")
+	}
+	// Without the flag the column must NOT carry the zone-chunk tag.
+	if bytes.IndexByte(noFlag, tagZoneChunk) >= 0 {
+		t.Fatal("no-flag wire contains tagZoneChunk")
+	}
+}
+
+// ---- malformed / fuzz ----
+
+func TestZoneChunkMalformed(t *testing.T) {
+	rows := zcRows(1024, true)
+	good, err := Marshal(rows, OptBalanced|OptZoneMap|OptColumnIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx := bytes.IndexByte(good, tagZoneChunk)
+	if idx < 0 {
+		t.Fatal("no zone-chunk tag")
+	}
+	decode := func(b []byte) { var out []zcRow; _ = Unmarshal(b, &out) }
+	// Deterministic byte-flip fuzz over the zone-chunk region: must error, never
+	// panic / OOM.
+	for off := idx; off < len(good); off++ {
+		for _, bit := range []byte{0x01, 0x80, 0xff} {
+			b := append([]byte(nil), good...)
+			b[off] ^= bit
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("flip off=%d bit=%#x: panic %v", off, bit, r)
+					}
+				}()
+				decode(b)
+			}()
+		}
+	}
+	// Truncations.
+	for cut := idx; cut < len(good); cut += 7 {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("truncate %d: panic %v", cut, r)
+				}
+			}()
+			decode(good[:cut])
+		}()
+	}
+}
+
+func FuzzZoneChunkDecode(f *testing.F) {
+	s := make([]int64, 600)
+	for i := range s {
+		s[i] = int64(i * i)
+	}
+	if b, err := Marshal(s, OptQPack|OptZoneMap); err == nil {
+		f.Add(b)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var out []int64
+		_ = Unmarshal(data, &out)
+	})
+}
+
+// ---- property: skip result == full filter across distributions ----
+
+func TestZoneChunkProperty(t *testing.T) {
+	rng := rand.New(rand.NewSource(123))
+	for iter := 0; iter < 100; iter++ {
+		n := 512 + rng.Intn(4000)
+		ordered := rng.Intn(2) == 0
+		rows := zcRows(n, ordered)
+		b, err := Marshal(rows, OptBalanced|OptZoneMap|OptColumnIndex)
+		if err != nil {
+			t.Fatalf("iter %d marshal: %v", iter, err)
+		}
+		// random range over the TS domain
+		i1, i2 := rng.Intn(n), rng.Intn(n)
+		lo, hi := rows[i1].TS, rows[i2].TS
+		if lo > hi {
+			lo, hi = hi, lo
+		}
+		var out []zcRow
+		if err := Unmarshal(b, &out, WhereRange("TS", lo, hi), Select("TS", "U", "V")); err != nil {
+			t.Fatalf("iter %d unmarshal: %v", iter, err)
+		}
+		var want []zcRow
+		for _, r := range rows {
+			if r.TS >= lo && r.TS <= hi {
+				want = append(want, r)
+			}
+		}
+		if len(out) != len(want) {
+			t.Fatalf("iter %d n=%d ord=%v: len %d != %d", iter, n, ordered, len(out), len(want))
+		}
+		for i := range want {
+			if out[i] != want[i] {
+				t.Fatalf("iter %d [%d] mismatch", iter, i)
+			}
+		}
+	}
+}

--- a/qpack_zonechunk_test.go
+++ b/qpack_zonechunk_test.go
@@ -406,3 +406,150 @@ func TestZoneChunkDepthGuard(t *testing.T) {
 		}
 	}
 }
+
+// firstZoneZmap returns the zmap byte of the first int/uint tagZoneChunk column
+// in buf, or 0xFF if none. Layout: tag, kind, zmap, blkLog, ...
+func firstZoneZmap(buf []byte) byte {
+	for i := 0; i+2 < len(buf); i++ {
+		if buf[i] == tagZoneChunk && (buf[i+1] == zoneKindInt || buf[i+1] == zoneKindUint) {
+			return buf[i+2]
+		}
+	}
+	return 0xFF
+}
+
+type linRow struct {
+	ID  int64  // perfectly linear → linear zmap
+	U   uint64 // perfectly linear
+	V   int64  // payload
+	Tag string // constant → strong columnar-win signal so the probe transposes
+}
+
+// TestZoneChunkLinearChosen: a perfectly linear sorted column picks the linear
+// zonemap (smaller wire) and still zone-skips with exact results.
+func TestZoneChunkLinearChosen(t *testing.T) {
+	const n = 8192
+	rows := make([]linRow, n)
+	for i := range rows {
+		rows[i] = linRow{ID: int64(1_000_000 + i*5), U: uint64(i) * 3, V: int64(i), Tag: "c"}
+	}
+	lin, err := Marshal(rows, OptBalanced|OptZoneMap|OptColumnIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if z := firstZoneZmap(lin); z != zmapLinear {
+		t.Fatalf("expected linear zmap on a linear column, got 0x%02x", z)
+	}
+
+	// Round-trip exact.
+	var out []linRow
+	if err := Unmarshal(lin, &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != n {
+		t.Fatalf("len %d", len(out))
+	}
+	for i := range rows {
+		if out[i] != rows[i] {
+			t.Fatalf("[%d] %+v != %+v", i, out[i], rows[i])
+		}
+	}
+
+	// Range query zone-skips and returns exact rows.
+	zoneSkippedZones = 0
+	lo, hi := rows[2000].ID, rows[2050].ID
+	var q []linRow
+	if err := Unmarshal(lin, &q, WhereRange("ID", lo, hi), Select("ID", "U", "V", "Tag")); err != nil {
+		t.Fatal(err)
+	}
+	var want []linRow
+	for _, r := range rows {
+		if r.ID >= lo && r.ID <= hi {
+			want = append(want, r)
+		}
+	}
+	if len(q) != len(want) {
+		t.Fatalf("range len %d != %d", len(q), len(want))
+	}
+	for i := range want {
+		if q[i] != want[i] {
+			t.Fatalf("range [%d] %+v != %+v", i, q[i], want[i])
+		}
+	}
+	if zoneSkippedZones == 0 {
+		t.Fatal("linear zone-skip skipped no zones")
+	}
+}
+
+// TestZoneChunkLinearFallback: a non-monotonic column falls back to the min/max
+// zonemap (linear undefined for unsorted data) and stays correct.
+func TestZoneChunkLinearFallback(t *testing.T) {
+	const n = 4096
+	rng := rand.New(rand.NewSource(11))
+	rows := make([]linRow, n)
+	for i := range rows {
+		rows[i] = linRow{ID: rng.Int63n(1 << 30), U: uint64(rng.Int63n(1 << 30)), V: int64(i), Tag: "c"}
+	}
+	b, err := Marshal(rows, OptBalanced|OptZoneMap|OptColumnIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if z := firstZoneZmap(b); z != zmapMinMax {
+		t.Fatalf("expected minmax zmap on a random column, got 0x%02x", z)
+	}
+	var out []linRow
+	if err := Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	for i := range rows {
+		if out[i] != rows[i] {
+			t.Fatalf("[%d] %+v != %+v", i, out[i], rows[i])
+		}
+	}
+}
+
+// TestZoneChunkLinearNoFalseSkip is the key correctness guard: over many random
+// monotonic columns and random range/comparison queries, the linear zone-skip
+// result must equal a brute-force filter (no matching row is ever skipped).
+func TestZoneChunkLinearNoFalseSkip(t *testing.T) {
+	rng := rand.New(rand.NewSource(2026))
+	for iter := range 200 {
+		n := 512 + rng.Intn(8000)
+		rows := make([]linRow, n)
+		v := rng.Int63n(1000)
+		for i := range rows {
+			// monotonic non-decreasing with varied step (still often linear-fit)
+			step := int64(rng.Intn(7))
+			if rng.Intn(20) == 0 {
+				step += int64(rng.Intn(500)) // occasional jump
+			}
+			v += step
+			rows[i] = linRow{ID: v, U: uint64(v), V: int64(i), Tag: "c"}
+		}
+		b, err := Marshal(rows, OptBalanced|OptZoneMap|OptColumnIndex)
+		if err != nil {
+			t.Fatalf("iter %d: %v", iter, err)
+		}
+		lo := rows[rng.Intn(n)].ID
+		hi := lo + int64(rng.Intn(2000))
+		var got []linRow
+		if err := Unmarshal(b, &got, WhereRange("ID", lo, hi), Select("ID", "U", "V", "Tag")); err != nil {
+			t.Fatalf("iter %d: %v", iter, err)
+		}
+		var want []linRow
+		for _, r := range rows {
+			if r.ID >= lo && r.ID <= hi {
+				want = append(want, r)
+			}
+		}
+		if len(got) != len(want) {
+			t.Fatalf("iter %d zmap=0x%02x n=%d [%d,%d]: len %d != %d (FALSE SKIP?)",
+				iter, firstZoneZmap(b), n, lo, hi, len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("iter %d [%d]: %+v != %+v", iter, i, got[i], want[i])
+			}
+		}
+	}
+}

--- a/query.go
+++ b/query.go
@@ -25,7 +25,15 @@ type predTerm struct {
 	pStr  func(string) bool
 	pBool func(bool) bool
 	field string
-	want  colKind // 1-byte tail: kept last to avoid padding before the func pointers
+	// Optional comparison bounds, set by the WhereRange/GE/GT/LE/LT/Eq
+	// constructors so a zone-chunked column can skip zones whose [min,max] cannot
+	// intersect [loI64,hiI64] (int) / [loU64,hiU64] (uint). hasBounds is false for
+	// the opaque Where(func) path (no zone-skip) and for float/string in v1.
+	loI64, hiI64 int64
+	loU64, hiU64 uint64
+	loF64, hiF64 float64
+	hasBounds    bool
+	want         colKind // 1-byte tail: kept last to avoid padding before the pointers
 }
 
 // QueryOption configures a filtering/projecting Unmarshal. Construct with Where,
@@ -391,12 +399,13 @@ func matchedIndices(b []uint64, n int, dst []int) []int {
 // indexed by int, avoiding the per-node allocations and pointer hashing a
 // map[*condNode]… would cost on a small tree.
 type cnode struct {
-	term *predTerm // leaf only
-	cv   *colVals  // leaf only: decoded column values (nil until bound)
-	kids []int     // child ids (And/Or: n; Not: 1)
-	col  int       // leaf only: resolved wire column index (-1 until resolved)
-	op   condOp    // 1-byte tails kept last to avoid padding before the pointers above
-	unk  bool      // subtree can produce SQL UNKNOWN (contains a nullable leaf)
+	term     *predTerm // leaf only
+	cv       *colVals  // leaf only: decoded column values (nil until bound)
+	precompT []uint64  // leaf only: precomputed T mask from zone-skip (nil = eval normally)
+	kids     []int     // child ids (And/Or: n; Not: 1)
+	col      int       // leaf only: resolved wire column index (-1 until resolved)
+	op       condOp    // 1-byte tails kept last to avoid padding before the pointers above
+	unk      bool      // subtree can produce SQL UNKNOWN (contains a nullable leaf)
 }
 
 // flattenCond linearises the tree in pre-order (a parent always precedes its
@@ -421,6 +430,26 @@ func flattenCond(root *condNode) []cnode {
 	}
 	walk(root)
 	return flat
+}
+
+// singleBoundedLeafForCol returns the lone leaf resolved to wire column c when
+// EXACTLY ONE leaf references it and that leaf carries comparison bounds — the
+// case zone-skip handles. Multiple leaves on one column are declined (nil): each
+// leaf's bounds are decoded independently (union), so two complementary
+// half-ranges — e.g. WhereGE+WhereLE — would union to the whole domain and skip
+// nothing; expressing a range as a single WhereRange keeps the skip. Returns nil
+// for zero / multiple / unbounded leaves.
+func singleBoundedLeafForCol(flat []cnode, c int) *cnode {
+	var found *cnode
+	for i := range flat {
+		if flat[i].op == condLeaf && flat[i].col == c {
+			if found != nil || !flat[i].term.hasBounds {
+				return nil
+			}
+			found = &flat[i]
+		}
+	}
+	return found
 }
 
 // markUnknown sets unk on every node whose subtree contains a nullable leaf (a
@@ -453,6 +482,11 @@ func evalCond(flat []cnode, id, n int) (t, f []uint64) {
 	nd := &flat[id]
 	switch nd.op {
 	case condLeaf:
+		if nd.precompT != nil {
+			// Zone-skip produced this leaf's T mask directly (skipped zones are
+			// FALSE). The column is non-nullable (zone-chunk), so F is implicit.
+			return nd.precompT, nil
+		}
 		return nd.cv.evalMasks(nd.term, n)
 	case condAnd:
 		return evalAnd(flat, id, n)

--- a/query_bounds.go
+++ b/query_bounds.go
@@ -1,0 +1,187 @@
+package qdf
+
+import (
+	"math"
+
+	"github.com/alex60217101990/qdf/internal/bitflag"
+)
+
+// Bound-carrying predicates. Unlike Where(func) — whose closure is opaque and so
+// cannot drive zone-skip — WhereCmp and WhereRange carry the predicate's
+// comparison bounds, so a zone-chunked column (OptZoneMap) can skip zones whose
+// [min,max] cannot intersect the bounds without decoding them. They evaluate
+// identically to the equivalent Where(func) per row; the bounds are an extra used
+// only by the zone-skip fast path. v1 carries bounds for int/uint columns;
+// float/string get the per-row predicate only (no skip yet) — still correct.
+//
+// Strict comparators (GT/LT) record a CONSERVATIVE inclusive bound (e.g. GT(b)
+// uses [b, +inf]) so a zone is skipped only when provably empty; the exact strict
+// test still runs per row, so the result is exact, just occasionally decoding a
+// zone that contributes no rows.
+
+// CmpOp is a comparison operator for WhereCmp, built from three primitive bits —
+// "accept less-than", "accept equal", "accept greater-than" — so the named
+// operators compose and the per-row test and zone bounds derive directly from the
+// bits (no per-operator switch). Combine bits for custom relations, e.g. NE.
+type CmpOp uint8
+
+const (
+	cmpLT CmpOp = 1 << iota // value <  bound accepted
+	cmpEQ                   // value == bound accepted
+	cmpGT                   // value >  bound accepted
+)
+
+const (
+	LT CmpOp = cmpLT         // field <  val
+	LE CmpOp = cmpLT | cmpEQ // field <= val
+	EQ CmpOp = cmpEQ         // field == val
+	GE CmpOp = cmpGT | cmpEQ // field >= val
+	GT CmpOp = cmpGT         // field >  val
+	NE CmpOp = cmpLT | cmpGT // field != val
+)
+
+// Ordered is Queryable minus bool — the kinds that support <,<=,>,>=.
+type Ordered interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
+		~float32 | ~float64 | ~string
+}
+
+// boundKind classifies a Queryable value into its column kind and the value in
+// the widened form the eval path uses. Boxing happens once, at construction.
+func boundKind(x any) (kind colKind, i int64, u uint64, f float64, s string) {
+	switch v := x.(type) {
+	case int:
+		return colKindInt, int64(v), 0, 0, ""
+	case int8:
+		return colKindInt, int64(v), 0, 0, ""
+	case int16:
+		return colKindInt, int64(v), 0, 0, ""
+	case int32:
+		return colKindInt, int64(v), 0, 0, ""
+	case int64:
+		return colKindInt, v, 0, 0, ""
+	case uint:
+		return colKindUint, 0, uint64(v), 0, ""
+	case uint8:
+		return colKindUint, 0, uint64(v), 0, ""
+	case uint16:
+		return colKindUint, 0, uint64(v), 0, ""
+	case uint32:
+		return colKindUint, 0, uint64(v), 0, ""
+	case uint64:
+		return colKindUint, 0, v, 0, ""
+	case uintptr:
+		return colKindUint, 0, uint64(v), 0, ""
+	case float32:
+		return colKindFloat32, 0, 0, float64(v), ""
+	case float64:
+		return colKindFloat, 0, 0, v, ""
+	case string:
+		return colKindString, 0, 0, 0, v
+	}
+	return 0, 0, 0, 0, ""
+}
+
+func leaf(t *predTerm) QueryOption { return QueryOption{node: &condNode{op: condLeaf, term: t}} }
+
+// WhereCmp keeps rows where (field op val): one of GE / GT / LE / LT / EQ. It is
+// the bound-carrying form of a single comparison, enabling zone-skip on
+// OptZoneMap int/uint columns. For a two-sided range use WhereRange.
+func WhereCmp[T Ordered](field string, op CmpOp, val T) QueryOption {
+	k, vI, vU, vF, vS := boundKind(any(val))
+	t := &predTerm{field: field, want: k}
+	switch k {
+	case colKindInt:
+		t.pI64 = func(v int64) bool {
+			if v < vI {
+				return bitflag.Has(op, cmpLT)
+			}
+			if v > vI {
+				return bitflag.Has(op, cmpGT)
+			}
+			return bitflag.Has(op, cmpEQ)
+		}
+		// Conservative inclusive bounds: open the low side only if "<" is accepted,
+		// the high side only if ">" is accepted; otherwise clamp to val.
+		t.loI64, t.hiI64, t.hasBounds = math.MinInt64, math.MaxInt64, true
+		if !bitflag.Has(op, cmpLT) {
+			t.loI64 = vI
+		}
+		if !bitflag.Has(op, cmpGT) {
+			t.hiI64 = vI
+		}
+	case colKindUint:
+		t.pU64 = func(v uint64) bool {
+			if v < vU {
+				return bitflag.Has(op, cmpLT)
+			}
+			if v > vU {
+				return bitflag.Has(op, cmpGT)
+			}
+			return bitflag.Has(op, cmpEQ)
+		}
+		t.loU64, t.hiU64, t.hasBounds = 0, math.MaxUint64, true
+		if !bitflag.Has(op, cmpLT) {
+			t.loU64 = vU
+		}
+		if !bitflag.Has(op, cmpGT) {
+			t.hiU64 = vU
+		}
+	case colKindFloat, colKindFloat32:
+		t.pF64 = func(v float64) bool {
+			if v != v { // NaN matches nothing
+				return false
+			}
+			if v < vF {
+				return bitflag.Has(op, cmpLT)
+			}
+			if v > vF {
+				return bitflag.Has(op, cmpGT)
+			}
+			return bitflag.Has(op, cmpEQ)
+		}
+		// Float bounds enable zone-skip on float64 zone-chunked columns. An all-NaN
+		// zone stores an empty [+Inf,-Inf] interval, so it is skipped (NaN never
+		// matches), and a partly-NaN zone is governed by its finite min/max.
+		t.loF64, t.hiF64, t.hasBounds = math.Inf(-1), math.Inf(1), true
+		if !bitflag.Has(op, cmpLT) {
+			t.loF64 = vF
+		}
+		if !bitflag.Has(op, cmpGT) {
+			t.hiF64 = vF
+		}
+	case colKindString:
+		t.pStr = func(v string) bool {
+			if v < vS {
+				return bitflag.Has(op, cmpLT)
+			}
+			if v > vS {
+				return bitflag.Has(op, cmpGT)
+			}
+			return bitflag.Has(op, cmpEQ)
+		}
+	}
+	return leaf(t)
+}
+
+// WhereRange keeps rows where lo <= field <= hi (inclusive). Bound-carrying:
+// enables zone-skip on OptZoneMap int/uint columns.
+func WhereRange[T Ordered](field string, lo, hi T) QueryOption {
+	k, loI, loU, loF, loS := boundKind(any(lo))
+	_, hiI, hiU, hiF, hiS := boundKind(any(hi))
+	t := &predTerm{field: field, want: k}
+	switch k {
+	case colKindInt:
+		t.pI64 = func(v int64) bool { return v >= loI && v <= hiI }
+		t.loI64, t.hiI64, t.hasBounds = loI, hiI, true
+	case colKindUint:
+		t.pU64 = func(v uint64) bool { return v >= loU && v <= hiU }
+		t.loU64, t.hiU64, t.hasBounds = loU, hiU, true
+	case colKindFloat, colKindFloat32:
+		t.pF64 = func(v float64) bool { return v >= loF && v <= hiF }
+	case colKindString:
+		t.pStr = func(v string) bool { return v >= loS && v <= hiS }
+	}
+	return leaf(t)
+}

--- a/query_bounds.go
+++ b/query_bounds.go
@@ -179,7 +179,8 @@ func WhereRange[T Ordered](field string, lo, hi T) QueryOption {
 		t.pU64 = func(v uint64) bool { return v >= loU && v <= hiU }
 		t.loU64, t.hiU64, t.hasBounds = loU, hiU, true
 	case colKindFloat, colKindFloat32:
-		t.pF64 = func(v float64) bool { return v >= loF && v <= hiF }
+		t.pF64 = func(v float64) bool { return v >= loF && v <= hiF } // NaN → false
+		t.loF64, t.hiF64, t.hasBounds = loF, hiF, true
 	case colKindString:
 		t.pStr = func(v string) bool { return v >= loS && v <= hiS }
 	}

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -1110,6 +1110,15 @@ func decodeSliceFloat64(d *Decoder, p unsafe.Pointer) error {
 		*(*[]float64)(p) = v
 		return nil
 	}
+	if t == tagZoneChunk {
+		d.i++
+		v, err := d.readZoneChunkFloat64()
+		if err != nil {
+			return err
+		}
+		*(*[]float64)(p) = v
+		return nil
+	}
 	if t == tagPackGorilla {
 		d.i++
 		v, err := d.readPackedGorillaFloat64Slice()

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -321,7 +321,7 @@ func decodeSliceInt(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	switch t {
-	case tagPackRaw, tagPackFor, tagPackDeltaFor, tagPackRLE, tagPackDict, tagPackPFor, tagPackBlock:
+	case tagPackRaw, tagPackFor, tagPackDeltaFor, tagPackRLE, tagPackDict, tagPackPFor, tagPackBlock, tagZoneChunk:
 		if unsafe.Sizeof(int(0)) == 8 {
 			var dest []int64
 			if err := decodeSliceInt64(d, unsafe.Pointer(&dest)); err != nil {
@@ -434,6 +434,8 @@ func (d *Decoder) readQPackUint64(t byte) ([]uint64, error) {
 		return d.readPackedPForUint64Slice()
 	case tagPackBlock:
 		return d.readBlockUint64()
+	case tagZoneChunk:
+		return d.readZoneChunkUint64()
 	}
 	return nil, ErrBadTag
 }
@@ -458,6 +460,8 @@ func (d *Decoder) readQPackInt64(t byte) ([]int64, error) {
 		return d.readPackedPForInt64Slice()
 	case tagPackBlock:
 		return d.readBlockInt64()
+	case tagZoneChunk:
+		return d.readZoneChunkInt64()
 	}
 	return nil, ErrBadTag
 }
@@ -589,6 +593,14 @@ func decodeSliceInt64(d *Decoder, p unsafe.Pointer) error {
 	case tagPackBlock:
 		d.i++
 		v, err := d.readBlockInt64()
+		if err != nil {
+			return err
+		}
+		*(*[]int64)(p) = v
+		return nil
+	case tagZoneChunk:
+		d.i++
+		v, err := d.readZoneChunkInt64()
 		if err != nil {
 			return err
 		}
@@ -769,6 +781,14 @@ func decodeSliceUint64(d *Decoder, p unsafe.Pointer) error {
 	case tagPackBlock:
 		d.i++
 		v, err := d.readBlockUint64()
+		if err != nil {
+			return err
+		}
+		*(*[]uint64)(p) = v
+		return nil
+	case tagZoneChunk:
+		d.i++
+		v, err := d.readZoneChunkUint64()
 		if err != nil {
 			return err
 		}

--- a/wire.go
+++ b/wire.go
@@ -194,7 +194,19 @@ const (
 	//                    predicate query can decode only the blocks covering its
 	//                    matched rows. Selected only when strictly smaller than the
 	//                    whole-column codec (never-larger), so the wire never grows.
-	// 0xF1..0xF2 unassigned (reserved for a future MessagePack-style ext type).
+	tagZoneChunk = 0xF1 // Zone-chunked integer column with a min/max zonemap
+	//                    (OptZoneMap). A column is split into 256-row zones, each an
+	//                    independent QPack int sub-slice, prefixed by a uint32 offset
+	//                    table and a per-zone [min,max] zonemap. Wire:
+	//                       tag, kind(1), zoneLog(1; 8=>256), varuint(n),
+	//                       zoneCount x uint32 LE  (byte offset of each zone body),
+	//                       zoneCount x (min,max)  (zigzag/var-int per kind),
+	//                       zoneCount x <QPack int sub-slice (tag+header+body)>.
+	//                    A bound-carrying predicate (WhereRange/GE/LE/Eq) skips
+	//                    zones whose [min,max] cannot match, without decoding them.
+	//                    Opt-in size-for-query-speed trade; without OptZoneMap the
+	//                    column uses the normal codec and the wire is unchanged.
+	// 0xF2 unassigned (reserved for a future MessagePack-style ext type).
 	tagTimestamp = 0xF3
 
 	// ALP (Adaptive Lossless floating-Point, CWI 2023), decimal path,


### PR DESCRIPTION
## What

Adds **`OptZoneMap`** (Options bit 13, wire tag `tagZoneChunk` 0xF1): an opt-in,
columnar-only encoding that chunks an `int`/`uint`/`float64` column into fixed
**256-row zones**, each prefixed by a `[min,max]` summary (the classic
data-warehouse *zone map* / min-max index). A bound-carrying predicate then
**skips whole zones whose `[min,max]` cannot match — without decoding them**.

This is predicate pushdown one level deeper: plain pushdown never touches the
columns a row is filtered out on, but still decodes each predicate column *whole*
before testing a row. Zone-skip removes that last full-column decode.

## API

Two bound-carrying query constructors (the opaque `Where(func)` closure can't
expose bounds, so it stays full-decode / no-skip — back-compat):

- `WhereCmp[T Ordered](field, op CmpOp, val)` — `op` is a bit-composable
  `CmpOp` (`LT`/`LE`/`EQ`/`GE`/`GT`/`NE`, built from `cmpLT|cmpEQ|cmpGT`).
- `WhereRange[T Ordered](field, lo, hi)` — two-sided inclusive.
- New generic `internal/bitflag` package (`Has/All/Set/Clear/Toggle`).

Produce with `Marshal(rows, OptBalanced|OptZoneMap|OptColumnIndex)`. Without the
flag the wire is **byte-identical** to a normal columnar payload.

## Commits

- `c137182` int/uint zone-chunk + zonemap + zone-skip
- `bd7c152` float64 zone-chunk, NaN-aware (finite min/max; all-NaN zone = empty interval, skipped)
- `3812b43` **audit**: projection-via-OR/NOT-sibling correctness + nested-chunk DoS guard
- `b413fea` **audit**: block-codec decode recursion guard (closes block↔zone cross-recursion)
- `678ffb4` **perf**: selective decode for projected zone columns + skip unused zonemap parse
- `9dfdaf3` **docs**: `docs/ZONEMAP.md` + 2 SVG + cross-links

## Audit findings (fixed in this PR)

1. **Projection via OR/NOT sibling projected zero.** A projected zone-chunked
   column whose rows match through an OR/NOT sibling on another column landed in
   a zone the column's own bounds skipped → value never decoded. Fixed by
   splitting filter (`precompT` mask) from projection (deferred, filled from the
   final matched set via `decodeZoneChunkSelective`).
2. **Nested-chunk recursion DoS.** A zone/block body can itself carry
   `tagZoneChunk`/`tagPackBlock`, so a hostile nested payload recursed unbounded
   → goroutine-stack overflow. Bounded with `descend`/`ascend` in the
   `readZoneChunk*Into` and `readBlock*Into` chokepoints (`ErrCycleDetected` at
   the cap).

## Performance

- Skip rates on ordered columns: **int/uint 87–97 %**, **float64 range 56–63 %**
  of zones never decoded.
- Narrow query projecting 3 zone-chunked columns: **~2.2× faster, −39 % bytes,
  −84 % allocs** (selective projection decodes only zones spanning matched rows).

## Notes

- `string` zone maps were built and **measured-killed** (bounded-prefix summary
  skips ~0 % on the structured IDs/paths people range-scan).
- Explicit size-for-query-speed trade → opt-in, no never-larger gate. Needs
  `OptColumnIndex` for the query-time seek.

All green: build / full suite / race / lint (0 issues) / fuzz (`FuzzZoneChunkDecode`, no crasher).