### PR TITLE
ci: retry go mod download to stop Dependabot PRs flaking on proxy errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,25 @@ jobs:
           go version
           go env GOMODCACHE GOCACHE
 
+      # Warm every module's download cache with retries up front. A Dependabot
+      # bump misses setup-go's go.sum-keyed cache, so the first build/test would
+      # fetch the new module mid-step where a transient proxy.golang.org stream
+      # error fails the job with no retry. Pre-downloading here absorbs that flake.
+      - name: Warm module cache (all modules, retry transient errors)
+        run: |
+          for dir in . bench cmd/qdfgen cmd/qdf-bench internal/codegen_test; do
+            ok=
+            for i in 1 2 3 4 5; do
+              if ( cd "$dir" && go mod download ); then ok=1; break; fi
+              echo "go mod download in $dir failed (attempt $i/5); retrying in $((i * 5))s"
+              sleep $((i * 5))
+            done
+            if [ -z "$ok" ]; then
+              echo "::error::go mod download in $dir failed after 5 attempts"
+              exit 1
+            fi
+          done
+
       - name: vet
         run: go vet ./...
 
@@ -137,6 +156,24 @@ jobs:
             cmd/qdfgen/go.sum
             cmd/qdf-bench/go.sum
             internal/codegen_test/go.sum
+
+      # Warm the module download cache with retries BEFORE golangci-lint.
+      # On a Dependabot bump the go.sum changes, so setup-go's cache misses and
+      # golangci-lint downloads the new module on the fly during typecheck — where
+      # a transient proxy.golang.org stream error ("INTERNAL_ERROR; received from
+      # peer") fails the whole lint with no retry. Pre-downloading here with a
+      # retry loop makes that fetch resilient; golangci-lint then reuses the warm
+      # GOMODCACHE and never touches the network.
+      - name: Warm module cache (retry transient proxy errors)
+        working-directory: ${{ matrix.working-directory }}
+        run: |
+          for i in 1 2 3 4 5; do
+            if go mod download; then exit 0; fi
+            echo "go mod download failed (attempt $i/5); retrying in $((i * 5))s"
+            sleep $((i * 5))
+          done
+          echo "::error::go mod download failed after 5 attempts (transient proxy/network)"
+          exit 1
 
       - name: golangci-lint (${{ matrix.module }})
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9


### PR DESCRIPTION
## Problem

Dependabot PR #136 (bump `golang.org/x/tools` 0.46→0.47 in `/cmd/qdfgen`) failed CI on a **transient module-download error**, not a code/config problem:

```
golang.org/x/tools@v0.47.0: read "https://proxy.golang.org/.../v0.47.0.zip":
  stream error: stream ID 1; INTERNAL_ERROR; received from peer (typecheck)
```

A Dependabot bump changes `go.sum`, so `setup-go`'s go.sum-keyed cache **misses** and the new module is fetched on the fly. In the lint job that fetch happens *inside* golangci-lint's typecheck, where a transient `proxy.golang.org` HTTP/2 stream error fails the whole job with **no retry**.

## Fix

Warm the module download cache with a retry loop before the network-sensitive steps, so a flaky proxy fetch is retried instead of failing the build, and golangci-lint then reuses a warm `GOMODCACHE` (no network at lint time):

- **lint job**: `go mod download` (per-module `working-directory`) before golangci-lint.
- **test job**: `go mod download` across all modules up front.

5 attempts, linear backoff. No untrusted input in the run scripts. YAML + actionlint clean.

Once merged, new Dependabot PRs (branched off `main`) pick this up automatically; re-running #136 after rebase will also benefit.