### PR TITLE
fix(audit-14): correctness + alloc audit + codegen import qualifier + math constants

### DIFF
--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -181,9 +181,15 @@ func pkgDir(pkg *packages.Package) string {
 type gen struct {
 	pkg *packages.Package
 
-	imports map[string]string // import path -> local name (empty = default)
-	header  bytes.Buffer      // var-block of pre-encoded field-name headers
-	body    bytes.Buffer      // function bodies
+	imports map[string]string // import path -> alias directive to emit (empty = none)
+	// importQual maps an import path to the identifier generated code uses to
+	// qualify that package's symbols. For a normal import this is the package's
+	// own name (bound by an unaliased import); on a name collision between two
+	// distinct paths it is a disambiguating alias also recorded in imports.
+	importQual map[string]string
+	qualUsed   map[string]bool // qualifiers already taken (collision detection)
+	header     bytes.Buffer    // var-block of pre-encoded field-name headers
+	body       bytes.Buffer    // function bodies
 
 	headerNames map[string]string // field-name -> generated var ident
 
@@ -213,8 +219,12 @@ const maxNestingDepth = 64
 
 func newGen(pkg *packages.Package) *gen {
 	return &gen{
-		pkg:         pkg,
-		imports:     map[string]string{"github.com/alex60217101990/qdf": ""},
+		pkg:        pkg,
+		imports:    map[string]string{"github.com/alex60217101990/qdf": ""},
+		importQual: map[string]string{"github.com/alex60217101990/qdf": "qdf"},
+		// "qdf" is emitted directly by the templates; reserve it so a same-named
+		// user package is aliased instead of colliding.
+		qualUsed:    map[string]bool{"qdf": true},
 		headerNames: map[string]string{},
 		emitted:     map[string]bool{},
 		colVarSeen:  map[string]bool{},
@@ -277,16 +287,33 @@ func (g *gen) bytes() ([]byte, error) {
 	return src, nil
 }
 
-// importAlias adds an import for the given path (if not already present) and
-// returns the local name used to qualify identifiers from it.
-func (g *gen) importAlias(path string) string {
+// importAlias registers an import for path (whose package is named pkgName) and
+// returns the identifier generated code must use to qualify that package's
+// symbols.
+//
+// The qualifier is the package's own name, NOT filepath.Base(path): those differ
+// for versioned or renamed modules (gopkg.in/yaml.v2 → package yaml, a dir named
+// "go-bar" → package bar), and a base like "yaml.v2" or "go-bar" is not even a
+// valid identifier — emitting it produced code that would not compile. An
+// unaliased import binds the package's own name, so using pkgName as the
+// qualifier is correct with no alias directive. When two distinct paths share a
+// package name, the second gets a disambiguating alias.
+func (g *gen) importAlias(path, pkgName string) string {
 	if path == g.pkg.PkgPath {
 		return ""
 	}
-	if _, ok := g.imports[path]; !ok {
-		g.imports[path] = ""
+	if q, ok := g.importQual[path]; ok {
+		return q
 	}
-	return filepath.Base(path)
+	qual, alias := pkgName, ""
+	for i := 2; g.qualUsed[qual]; i++ {
+		qual = pkgName + strconv.Itoa(i)
+		alias = qual // collision: emit an explicit alias so the qualifier binds
+	}
+	g.qualUsed[qual] = true
+	g.importQual[path] = qual
+	g.imports[path] = alias
+	return qual
 }
 
 // fieldNameVar returns (or creates) a unique var holding the pre-encoded
@@ -2003,7 +2030,7 @@ func (g *gen) typeRef(n *types.Named) string {
 	if obj.Pkg() == nil || obj.Pkg().Path() == g.pkg.PkgPath {
 		return obj.Name()
 	}
-	alias := g.importAlias(obj.Pkg().Path())
+	alias := g.importAlias(obj.Pkg().Path(), obj.Pkg().Name())
 	if alias == "" {
 		return obj.Name()
 	}
@@ -2017,7 +2044,7 @@ func (g *gen) typeExprFromType(t types.Type) string {
 		if p == nil || p.Path() == g.pkg.PkgPath {
 			return ""
 		}
-		return g.importAlias(p.Path())
+		return g.importAlias(p.Path(), p.Name())
 	}
 	return types.TypeString(t, qf)
 }

--- a/cmd/qdfgen/gen/import_alias_test.go
+++ b/cmd/qdfgen/gen/import_alias_test.go
@@ -1,0 +1,60 @@
+package gen
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// TestImportAliasQualifier verifies the qualifier is the package's real name,
+// not filepath.Base(path): those differ for versioned/renamed modules, and a
+// base like "yaml.v2" or "go-bar" is not a valid identifier — emitting it
+// produced code that would not compile.
+func TestImportAliasQualifier(t *testing.T) {
+	g := newGen(&packages.Package{PkgPath: "example.com/target", Name: "target"})
+
+	cases := []struct {
+		path, name, wantQual, wantAlias string
+	}{
+		{"time", "time", "time", ""},              // base == name: unaliased
+		{"gopkg.in/yaml.v2", "yaml", "yaml", ""},  // base "yaml.v2" != name "yaml"
+		{"github.com/x/go-bar", "bar", "bar", ""}, // base "go-bar" not an ident
+		{"net/url", "url", "url", ""},             // base == name
+	}
+	for _, c := range cases {
+		if got := g.importAlias(c.path, c.name); got != c.wantQual {
+			t.Errorf("importAlias(%q,%q) qualifier = %q, want %q", c.path, c.name, got, c.wantQual)
+		}
+		if got := g.imports[c.path]; got != c.wantAlias {
+			t.Errorf("importAlias(%q,%q) alias directive = %q, want %q", c.path, c.name, got, c.wantAlias)
+		}
+	}
+	// Idempotent: a second call returns the same qualifier, no re-register.
+	if got := g.importAlias("gopkg.in/yaml.v2", "yaml"); got != "yaml" {
+		t.Errorf("re-call qualifier = %q, want yaml", got)
+	}
+}
+
+// TestImportAliasCollision verifies two distinct paths sharing a package name
+// get disambiguated: the first binds the bare name, the second an alias.
+func TestImportAliasCollision(t *testing.T) {
+	g := newGen(&packages.Package{PkgPath: "example.com/target", Name: "target"})
+
+	if q := g.importAlias("example.com/a/utils", "utils"); q != "utils" {
+		t.Fatalf("first utils qualifier = %q, want utils", q)
+	}
+	if a := g.imports["example.com/a/utils"]; a != "" {
+		t.Fatalf("first utils alias = %q, want empty", a)
+	}
+	q2 := g.importAlias("example.com/b/utils", "utils")
+	if q2 != "utils2" {
+		t.Fatalf("second utils qualifier = %q, want utils2", q2)
+	}
+	if a := g.imports["example.com/b/utils"]; a != "utils2" {
+		t.Fatalf("second utils alias directive = %q, want utils2", a)
+	}
+	// The reserved "qdf" qualifier forces a same-named user package to alias.
+	if q := g.importAlias("example.com/user/qdf", "qdf"); q != "qdf2" {
+		t.Fatalf("user qdf qualifier = %q, want qdf2", q)
+	}
+}

--- a/columnar.go
+++ b/columnar.go
@@ -413,7 +413,7 @@ func columnarProbe(plan *columnarPlan, base unsafe.Pointer, n int, fsstEnabled b
 			//     huge positive, corrupting both the FOR spread and the row estimate
 			//     for any signed column holding negatives.
 			isInt := col.kind == colKindInt
-			var mnU, mxU uint64 = ^uint64(0), 0
+			var mnU, mxU uint64 = math.MaxUint64, 0
 			var mnI, mxI int64 = math.MaxInt64, math.MinInt64
 			for i := range sample {
 				p := unsafe.Add(base, uintptr(i)*plan.stride+col.offset)
@@ -492,7 +492,7 @@ func columnarProbe(plan *columnarPlan, base unsafe.Pointer, n int, fsstEnabled b
 			// Monotonic timestamps compress extremely well with Delta+FOR on sec;
 			// nsec is often 0 or small. Conservative estimate: treat like two
 			// int columns over the sample.
-			var mnSec, mxSec uint64 = ^uint64(0), 0
+			var mnSec, mxSec uint64 = math.MaxUint64, 0
 			for i := range sample {
 				p := unsafe.Add(base, uintptr(i)*plan.stride+col.offset)
 				t := (*time.Time)(p).UTC()
@@ -1029,7 +1029,7 @@ func (d *Decoder) readColShape(maxN int) (colShapeRead, error) {
 	if k2 <= 0 {
 		return out, ErrInvalidLength
 	}
-	if idv > uint64(^uint32(0)) {
+	if idv > uint64(math.MaxUint32) {
 		return out, ErrUnknownStateID // would truncate on the uint32 cast below
 	}
 	d.i += k2
@@ -1039,7 +1039,7 @@ func (d *Decoder) readColShape(maxN int) (colShapeRead, error) {
 			return out, ErrInvalidLength
 		}
 		d.i += k3
-		if cnt64 > uint64(int(^uint(0)>>1)) {
+		if cnt64 > uint64(math.MaxInt) {
 			return out, ErrInvalidLength // would wrap int() on a 32-bit build
 		}
 		cnt := int(cnt64)
@@ -1784,7 +1784,7 @@ func (d *Decoder) readHybridColShape(maxN int) (int, *decColShape, error) {
 	if k2 <= 0 {
 		return 0, nil, ErrInvalidLength
 	}
-	if idv > uint64(^uint32(0)) {
+	if idv > uint64(math.MaxUint32) {
 		return 0, nil, ErrUnknownStateID
 	}
 	d.i += k2
@@ -1794,7 +1794,7 @@ func (d *Decoder) readHybridColShape(maxN int) (int, *decColShape, error) {
 			return 0, nil, ErrInvalidLength
 		}
 		d.i += k3
-		if cnt64 > uint64(int(^uint(0)>>1)) {
+		if cnt64 > uint64(math.MaxInt) {
 			return 0, nil, ErrInvalidLength // would wrap int() on a 32-bit build
 		}
 		cnt := int(cnt64)

--- a/columnar_decode_scratch.go
+++ b/columnar_decode_scratch.go
@@ -199,7 +199,7 @@ func (d *Decoder) readPackedDictInt64SliceInto(dst *[]int64) error {
 	if !d.colLenOK(n64) {
 		return ErrInvalidLength
 	}
-	if n64 > uint64(int(^uint(0)>>1)) { // 32-bit: int(n64) would wrap negative
+	if n64 > uint64(math.MaxInt) { // 32-bit: int(n64) would wrap negative
 		return ErrInvalidLength
 	}
 	if bitsPer == 0 && n64 > qpackMaxStandaloneCount {
@@ -520,7 +520,7 @@ func (d *Decoder) readPackedDictUint64SliceInto(dst *[]uint64) error {
 	if !d.colLenOK(n64) {
 		return ErrInvalidLength
 	}
-	if n64 > uint64(int(^uint(0)>>1)) { // 32-bit: int(n64) would wrap negative
+	if n64 > uint64(math.MaxInt) { // 32-bit: int(n64) would wrap negative
 		return ErrInvalidLength
 	}
 	if bitsPer == 0 && n64 > qpackMaxStandaloneCount {

--- a/columnar_decode_scratch.go
+++ b/columnar_decode_scratch.go
@@ -268,8 +268,16 @@ func (d *Decoder) readPackedPForInt64SliceInto(dst *[]int64) error {
 	d.i += nr
 	mnU := uint64(zigzagDecode64(mz))
 	rem := uint64(len(d.buf) - d.i)
-	if b > 0 && n64 > rem*8/uint64(b) {
-		return ErrShortBuffer
+	if b > 0 {
+		if n64 > rem*8/uint64(b) {
+			return ErrShortBuffer
+		}
+	} else if n64 > qpackMaxStandaloneCount {
+		// b == 0 (constant base): empty packed body, no per-element buffer bound.
+		// colLenOK already caps n64 in a columnar context, but this Into helper is
+		// reachable via generated code, so mirror the standalone reader's ceiling
+		// defensively (no reliance on colMaxLen being set).
+		return ErrInvalidLength
 	}
 	n := int(n64)
 	bodyBytes := (n*b + 7) >> 3
@@ -583,8 +591,14 @@ func (d *Decoder) readPackedPForUint64SliceInto(dst *[]uint64) error {
 	}
 	d.i += nr
 	rem := uint64(len(d.buf) - d.i)
-	if b > 0 && n64 > rem*8/uint64(b) {
-		return ErrShortBuffer
+	if b > 0 {
+		if n64 > rem*8/uint64(b) {
+			return ErrShortBuffer
+		}
+	} else if n64 > qpackMaxStandaloneCount {
+		// b == 0 constant base: mirror the standalone reader's ceiling defensively
+		// (this Into helper is reachable via generated code without colMaxLen set).
+		return ErrInvalidLength
 	}
 	n := int(n64)
 	bodyBytes := (n*b + 7) >> 3

--- a/decoder.go
+++ b/decoder.go
@@ -1,6 +1,7 @@
 package qdf
 
 import (
+	"math"
 	"reflect"
 	"unsafe"
 
@@ -326,7 +327,7 @@ func (d *Decoder) readHeaderSlow() error {
 		// rejects anything past the int range so the int(origLen) narrowing
 		// below cannot truncate a multi-GiB length on a 32-bit build and decode
 		// a silently short/wrong body.
-		if origLen > uint64(len(d.buf))*64+(1<<20) || origLen > uint64(int(^uint(0)>>1)) {
+		if origLen > uint64(len(d.buf))*64+(1<<20) || origLen > uint64(math.MaxInt) {
 			return ErrInvalidLength
 		}
 		body, err := rans.Decode(rest[k:], int(origLen))

--- a/decoder_skip.go
+++ b/decoder_skip.go
@@ -1,5 +1,7 @@
 package qdf
 
+import "math"
+
 // Skip advances past one value without materializing it.
 //
 // Skip recurses through nested arrays and maps, so it bounds nesting depth via
@@ -226,7 +228,7 @@ func (d *Decoder) Skip() error {
 		if n <= 0 {
 			return ErrInvalidLength
 		}
-		if shapeID > uint64(^uint32(0)) {
+		if shapeID > uint64(math.MaxUint32) {
 			return ErrUnknownStateID // would truncate on the uint32 cast below
 		}
 		d.i += n
@@ -240,7 +242,7 @@ func (d *Decoder) Skip() error {
 				return ErrInvalidLength
 			}
 			d.i += n
-			if cnt64 > uint64(int(^uint(0)>>1)) { // 32-bit: int(cnt64) would wrap before CheckLength
+			if cnt64 > uint64(math.MaxInt) { // 32-bit: int(cnt64) would wrap before CheckLength
 				return ErrInvalidLength
 			}
 			if err := d.CheckLength(int(cnt64), 1); err != nil {

--- a/decoder_skip.go
+++ b/decoder_skip.go
@@ -240,6 +240,9 @@ func (d *Decoder) Skip() error {
 				return ErrInvalidLength
 			}
 			d.i += n
+			if cnt64 > uint64(int(^uint(0)>>1)) { // 32-bit: int(cnt64) would wrap before CheckLength
+				return ErrInvalidLength
+			}
 			if err := d.CheckLength(int(cnt64), 1); err != nil {
 				return err
 			}

--- a/delta.go
+++ b/delta.go
@@ -273,7 +273,7 @@ func decompressPatchBody(body []byte) ([]byte, error) {
 	// rejects anything past the int range so the int(origLen) narrowing below
 	// cannot truncate a multi-GiB length on a 32-bit build and decode a silently
 	// short/wrong body (mirrors the rANS body bound in decoder.go).
-	if origLen > uint64(len(body))*64+(1<<20) || origLen > uint64(int(^uint(0)>>1)) {
+	if origLen > uint64(len(body))*64+(1<<20) || origLen > uint64(math.MaxInt) {
 		return nil, ErrInvalidPatch
 	}
 	out, err := rans.Decode(body[k:], int(origLen))

--- a/delta_apply.go
+++ b/delta_apply.go
@@ -1,6 +1,7 @@
 package qdf
 
 import (
+	"math"
 	"reflect"
 	"unsafe"
 
@@ -78,7 +79,7 @@ func applySlice(dec *Decoder, td *typeDesc, baseP unsafe.Pointer, depth int) err
 	stride := td.rType.Elem().Size()
 	bv := reflect.NewAt(td.rType, baseP).Elem()
 
-	if newLen64 > uint64(int(^uint(0)>>1)) { // 32-bit: int(newLen64) would truncate silently
+	if newLen64 > uint64(math.MaxInt) { // 32-bit: int(newLen64) would truncate silently
 		return ErrInvalidPatch
 	}
 	newLen := int(newLen64)

--- a/delta_baseline.go
+++ b/delta_baseline.go
@@ -240,10 +240,14 @@ func cloneMap(td *typeDesc, dst, src unsafe.Pointer, depth int) {
 		return
 	}
 	valType := td.rType.Elem()
+	// Hoist the two scratch holders out of the loop: SetMapIndex copies the value
+	// into the map, so a single reusable dstBuf is safe (2 allocs total, not 2×N).
+	// SetZero before each clone in case cloneValue underfills for this type.
+	srcBuf := reflect.New(valType)
+	dstBuf := reflect.New(valType)
 	for it := mv.MapRange(); it.Next(); {
-		srcBuf := reflect.New(valType)
 		srcBuf.Elem().Set(it.Value()) // addressable copy of the value
-		dstBuf := reflect.New(valType)
+		dstBuf.Elem().SetZero()
 		cloneValue(valDesc, dstBuf.UnsafePointer(), srcBuf.UnsafePointer(), depth+1)
 		dmv.SetMapIndex(it.Key(), dstBuf.Elem())
 	}

--- a/delta_keyed.go
+++ b/delta_keyed.go
@@ -1,6 +1,7 @@
 package qdf
 
 import (
+	"math"
 	"reflect"
 	"unsafe"
 )
@@ -276,7 +277,7 @@ func applyKeyedSlice(dec *Decoder, td *typeDesc, baseP unsafe.Pointer, depth int
 		return ErrInvalidPatch
 	}
 	dec.i += k
-	if newLen64 > uint64(int(^uint(0)>>1)) { // 32-bit: int(newLen64) would truncate silently
+	if newLen64 > uint64(math.MaxInt) { // 32-bit: int(newLen64) would truncate silently
 		return ErrInvalidPatch
 	}
 	newLen := int(newLen64)

--- a/encoder.go
+++ b/encoder.go
@@ -171,6 +171,13 @@ type Encoder struct {
 	depth    int
 	maxDepth int
 
+	// ifaceDepth > 0 while encoding a value reached through a dynamic (interface)
+	// field/element — a schemaless position that the decoder reads back via
+	// decodeAny. The batched lossy-vector []struct block (tagVecBatchStruct) has
+	// no decodeAny case, so encodeSlice suppresses it in this context and falls
+	// back to the columnar path (tagColStruct), which decodeAny does handle.
+	ifaceDepth int
+
 	// vecBudget is the fidelity target used when OptLossyVec is active.
 	// No effect unless OptLossyVec is set. Zero value resolves to MinCosine(0.999).
 	// Placed among the 8-byte fields (it is pointer-free, 8-byte aligned) so the
@@ -415,6 +422,7 @@ func (e *Encoder) resetForReuse() {
 		e.state.reset()
 	}
 	e.depth = 0
+	e.ifaceDepth = 0
 	if e.maxDepth == 0 {
 		e.maxDepth = DefaultMaxDepth
 	}

--- a/internal/vecquant/codec.go
+++ b/internal/vecquant/codec.go
@@ -355,7 +355,7 @@ func (bl Block) Decode() [][]float64 {
 	// Self-defense: the wire layer bounds Count/Dim before building a Block, but
 	// guard the exported method so a direct caller's adversarial Block cannot
 	// overflow Count*pdim (int multiply) into a small/negative under-read.
-	if pdim <= 0 || bl.Count > int(^uint(0)>>1)/pdim {
+	if pdim <= 0 || bl.Count > math.MaxInt/pdim {
 		return nil
 	}
 	q, err := decodeCoords(bl.Coords, bl.Count*pdim)

--- a/lossyvec_batch.go
+++ b/lossyvec_batch.go
@@ -329,6 +329,12 @@ func (d *Decoder) decodeVectorBatchStruct(t reflect.Type, td *typeDesc, p unsafe
 
 	// Read each batched column's block (count=n vectors). A polar field carries a
 	// norm stream before the directions block; rescale to recover the vectors.
+	//
+	// Each readLossyVec independently caps its own reconstruction at
+	// maxColumnarBytes, but up to 8 batched columns would then allow ~8×256MB
+	// from a tiny rANS-compressed input. Bound the AGGREGATE across all columns
+	// so the batched path amplifies no more than a single columnar decode.
+	var totalVecBytes uint64
 	batched := make([][][]float64, nv)
 	for vi := range nv {
 		if mask&(1<<uint(vi)) == 0 {
@@ -353,6 +359,12 @@ func (d *Decoder) decodeVectorBatchStruct(t reflect.Type, td *typeDesc, p unsafe
 		}
 		if elemF32 != td.vecFields[vi].elemF32 {
 			return ErrTypeMismatch
+		}
+		if len(vecs) > 0 {
+			totalVecBytes += uint64(len(vecs)) * uint64(len(vecs[0])) * 8
+			if totalVecBytes > maxColumnarBytes {
+				return ErrInvalidLength
+			}
 		}
 		if norms != nil {
 			for i := range vecs {

--- a/lossyvec_batch_test.go
+++ b/lossyvec_batch_test.go
@@ -125,6 +125,43 @@ func TestVecBatchRoundTripMixed(t *testing.T) {
 	}
 }
 
+// TestVecBatchAnyFieldRoundTrip guards the schemaless (decodeAny) round trip.
+// A []struct with a vector field held in an any-typed field used to encode as a
+// batched block (tagVecBatchStruct) — which decodeAny has no case for, so the
+// value failed to decode with ErrBadTag. The encoder now suppresses the batch in
+// a dynamic-dispatch context (ifaceDepth>0) and falls back to the columnar path
+// (tagColStruct), which decodeAny reads. Regression for the any-field gap.
+func TestVecBatchAnyFieldRoundTrip(t *testing.T) {
+	type wrap struct {
+		Payload any
+	}
+	const n, dim = 32, 128
+	rows := make([]vecOnlyRow, n)
+	for i := range rows {
+		rows[i] = vecOnlyRow{Emb: sinVec32(i, dim)}
+	}
+	data, err := Marshal(wrap{Payload: rows}, OptBalanced|OptLossyVec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Decode into the same shape: the any field routes through decodeAny.
+	var out wrap
+	if err := Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal (any field with batchable []struct must round-trip, not ErrBadTag): %v", err)
+	}
+	if out.Payload == nil {
+		t.Fatal("payload decoded nil")
+	}
+	// decodeAny materialises the []struct as a slice; assert the row count survived.
+	rv, ok := out.Payload.([]any)
+	if !ok {
+		t.Fatalf("payload type %T, want []any", out.Payload)
+	}
+	if len(rv) != n {
+		t.Fatalf("payload len %d want %d", len(rv), n)
+	}
+}
+
 // TestVecBatchSmallerThanPerRow asserts the batched path is materially smaller
 // than the per-vector (count=1) encoding the same data would otherwise produce.
 func TestVecBatchSmallerThanPerRow(t *testing.T) {

--- a/map_shape.go
+++ b/map_shape.go
@@ -1,6 +1,9 @@
 package qdf
 
-import "slices"
+import (
+	"math"
+	"slices"
+)
 
 // Shared helpers for OptMapShape — map key-set interning. The reflect map
 // encoder (encodeStringMapShaped in reflect_encode.go) and the generated
@@ -116,7 +119,7 @@ func decodeMapStringShapeHeader(d *Decoder) ([]string, error) {
 	}
 	// Reject a shape ID that would truncate on the uint32 narrowing below: a
 	// crafted id >= 2^32 must not alias a real (id mod 2^32) shape.
-	if shapeID > uint64(^uint32(0)) {
+	if shapeID > uint64(math.MaxUint32) {
 		return nil, ErrUnknownStateID
 	}
 	d.i += sz

--- a/map_shape.go
+++ b/map_shape.go
@@ -70,14 +70,18 @@ func mapStringShapeOrder[V any](e *Encoder, m map[string]V) []string {
 	for k := range m {
 		setHash += internKeyHash(k) // commutative: order-independent
 	}
-	if id, order, ok := st.mapShapeFindKeys(setHash, n); ok {
-		if len(order) == n && mapHasAll(m, order) {
-			st.lastMapShapeID, st.lastMapShapeKeys = id, order
+	// Scan all (setHash, n) rows and verify by keys, not just the first: returning
+	// the first match and declaring on mismatch re-declares a colliding key-set on
+	// every encode (unbounded mapShapes growth under two alternating colliding
+	// sets). See the reflect encodeMapStringShape path for the full rationale.
+	for i := range st.mapShapes {
+		s := &st.mapShapes[i]
+		if s.setHash == setHash && s.n == n && mapHasAll(m, s.keys) {
+			st.lastMapShapeID, st.lastMapShapeKeys = s.id, s.keys
 			e.buf = append(e.buf, tagMapShape)
-			e.buf = appendUvarint(e.buf, uint64(id))
-			return order
+			e.buf = appendUvarint(e.buf, uint64(s.id))
+			return s.keys
 		}
-		// set-hash collision or different key-set → declare a fresh shape.
 	}
 	keys := make([]string, 0, n)
 	for k := range m {

--- a/map_shape_test.go
+++ b/map_shape_test.go
@@ -99,20 +99,30 @@ func TestOptMapShape_Bit(t *testing.T) {
 
 func TestEncStateMapShape_Registry(t *testing.T) {
 	st := newEncState()
-	if _, _, ok := st.mapShapeFindKeys(0x1234, 2); ok {
+	// The production encoders scan st.mapShapes inline (verifying keys); mirror
+	// that (setHash, n) lookup here to exercise the registry storage/reset.
+	find := func(setHash uint64, n int) (uint32, []string, bool) {
+		for i := range st.mapShapes {
+			if s := &st.mapShapes[i]; s.setHash == setHash && s.n == n {
+				return s.id, s.keys, true
+			}
+		}
+		return 0, nil, false
+	}
+	if _, _, ok := find(0x1234, 2); ok {
 		t.Fatal("empty registry must miss")
 	}
 	keys := []string{"client", "version"} // canonical (sorted)
 	st.mapShapeRegister(0x1234, 2, keys, 7)
-	id, got, ok := st.mapShapeFindKeys(0x1234, 2)
+	id, got, ok := find(0x1234, 2)
 	if !ok || id != 7 {
 		t.Fatalf("find = (%d,%v), want (7,true)", id, ok)
 	}
 	if len(got) != 2 || got[0] != "client" || got[1] != "version" {
-		t.Fatalf("findKeys keys = %v", got)
+		t.Fatalf("find keys = %v", got)
 	}
 	// Length disambiguates a setHash collision across different set sizes.
-	if _, _, ok := st.mapShapeFindKeys(0x1234, 3); ok {
+	if _, _, ok := find(0x1234, 3); ok {
 		t.Fatal("len mismatch must miss")
 	}
 	// mapShapeRegister takes ownership of the passed slice (no defensive clone):
@@ -122,7 +132,7 @@ func TestEncStateMapShape_Registry(t *testing.T) {
 		t.Fatal("mapShapeRegister must take ownership of the passed slice (no clone)")
 	}
 	st.reset()
-	if _, _, ok := st.mapShapeFindKeys(0x1234, 2); ok {
+	if _, _, ok := find(0x1234, 2); ok {
 		t.Fatal("reset must clear the registry")
 	}
 }

--- a/nullable_col.go
+++ b/nullable_col.go
@@ -568,17 +568,20 @@ func (d *Decoder) decodeNullableColumnVals(kind colKind, n int) (colVals, error)
 		}
 		cv.s = full
 	case colKindTime:
-		var sec []int64
-		if err := decodeSliceInt64(d, unsafe.Pointer(&sec)); err != nil {
+		// Reuse the pooled colScratch buffers (sec/nsec are consumed synchronously
+		// into `full` below before return, like the other kinds above and the
+		// non-query decodeNullableColumn sibling) instead of two fresh slices.
+		if err := decodeSliceInt64Into(d, &st.colScratchI64); err != nil {
 			return cv, err
 		}
+		sec := st.colScratchI64
 		if len(sec) != present {
 			return cv, ErrTypeMismatch
 		}
-		var nsec []uint64
-		if err := decodeSliceUint64(d, unsafe.Pointer(&nsec)); err != nil {
+		if err := decodeSliceUint64Into(d, &st.colScratchU64); err != nil {
 			return cv, err
 		}
+		nsec := st.colScratchU64
 		if len(nsec) != present {
 			return cv, ErrTypeMismatch
 		}

--- a/qpack.go
+++ b/qpack.go
@@ -870,7 +870,7 @@ func (d *Decoder) readPackedBool() ([]bool, error) {
 		// cannot possibly fit even if every byte carried 8 valid bits.
 		return nil, ErrShortBuffer
 	}
-	if n64 > uint64(int(^uint(0)>>1)) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative
+	if n64 > uint64(math.MaxInt) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative
 		return nil, ErrInvalidLength
 	}
 	n := int(n64)

--- a/qpack_block.go
+++ b/qpack_block.go
@@ -2,6 +2,7 @@ package qdf
 
 import (
 	"encoding/binary"
+	"math"
 	"sync/atomic"
 
 	"github.com/alex60217101990/qdf/internal/bitpack"
@@ -337,7 +338,7 @@ func (d *Decoder) readBlockHeader(expectKind byte) (blk, n, offBase, bodyStart, 
 		return 0, 0, 0, 0, 0, ErrInvalidLength
 	}
 	d.i += nr
-	if !d.colLenOK(n64) || n64 == 0 || n64 > uint64(int(^uint(0)>>1)) {
+	if !d.colLenOK(n64) || n64 == 0 || n64 > uint64(math.MaxInt) {
 		return 0, 0, 0, 0, 0, ErrInvalidLength
 	}
 	n = int(n64)

--- a/qpack_delta.go
+++ b/qpack_delta.go
@@ -1,6 +1,7 @@
 package qdf
 
 import (
+	"math"
 	"slices"
 
 	"github.com/alex60217101990/qdf/internal/bitpack"
@@ -223,7 +224,7 @@ func (d *Decoder) readPackedDeltaForHeader(expectKind byte) (bitsPer int, unsign
 		// bitsPer == 0 (constant deltas): empty body, no per-element bound.
 		return 0, 0, 0, 0, 0, nil, ErrInvalidLength
 	}
-	if n64 > uint64(int(^uint(0)>>1)) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative
+	if n64 > uint64(math.MaxInt) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative
 		return 0, 0, 0, 0, 0, nil, ErrInvalidLength
 	}
 	n = int(n64)

--- a/qpack_dict.go
+++ b/qpack_dict.go
@@ -1,6 +1,7 @@
 package qdf
 
 import (
+	"math"
 	"slices"
 
 	"github.com/alex60217101990/qdf/internal/bitpack"
@@ -165,7 +166,7 @@ func (d *Decoder) readPackedDictUint64Slice() ([]uint64, error) {
 	if !d.colLenOK(n64) {
 		return nil, ErrInvalidLength
 	}
-	if n64 > uint64(int(^uint(0)>>1)) { // 32-bit: rem*8/bitsPer lets n64 exceed MaxInt -> int(n64) wraps negative -> make panics
+	if n64 > uint64(math.MaxInt) { // 32-bit: rem*8/bitsPer lets n64 exceed MaxInt -> int(n64) wraps negative -> make panics
 		return nil, ErrInvalidLength
 	}
 	if bitsPer == 0 && n64 > qpackMaxStandaloneCount {
@@ -235,7 +236,7 @@ func (d *Decoder) readPackedDictInt64Slice() ([]int64, error) {
 	if !d.colLenOK(n64) {
 		return nil, ErrInvalidLength
 	}
-	if n64 > uint64(int(^uint(0)>>1)) { // 32-bit: rem*8/bitsPer lets n64 exceed MaxInt -> int(n64) wraps negative -> make panics
+	if n64 > uint64(math.MaxInt) { // 32-bit: rem*8/bitsPer lets n64 exceed MaxInt -> int(n64) wraps negative -> make panics
 		return nil, ErrInvalidLength
 	}
 	if bitsPer == 0 && n64 > qpackMaxStandaloneCount {

--- a/qpack_for.go
+++ b/qpack_for.go
@@ -1,6 +1,7 @@
 package qdf
 
 import (
+	"math"
 	"slices"
 	"unsafe"
 
@@ -197,7 +198,7 @@ func (d *Decoder) readPackedForHeader(expectKind byte) (bitsPer int, unsignedMin
 		// bound above does not apply. Cap an implausible standalone count.
 		return 0, 0, 0, 0, nil, ErrInvalidLength
 	}
-	if n64 > uint64(int(^uint(0)>>1)) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative -> make panics
+	if n64 > uint64(math.MaxInt) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative -> make panics
 		return 0, 0, 0, 0, nil, ErrInvalidLength
 	}
 	n = int(n64)

--- a/qpack_gorilla.go
+++ b/qpack_gorilla.go
@@ -348,6 +348,15 @@ func (d *Decoder) readPackedGorillaFloat64Slice() ([]float64, error) {
 		var x uint64
 		if !ctl2 {
 			mb := 64 - int(prevLZ) - int(prevTZ)
+			// A reuse-window with zero meaningful bits is malformed: a value equal
+			// to prev is encoded as ctl=0, never ctl=1/ctl2=0. In particular the
+			// initial sentinel window (prevLZ=64) gives mb=0, so a hostile stream
+			// opening with ctl=1/ctl2=0 would readBits(0)=0 and silently emit a
+			// duplicate of the previous value. The encoder guards this (a reuse
+			// window is only written once a real window exists); enforce it here.
+			if mb <= 0 {
+				return nil, ErrInvalidLength
+			}
 			mbBits, ok := br.readBits(uint8(mb))
 			if !ok {
 				return nil, ErrShortBuffer
@@ -420,6 +429,11 @@ func (d *Decoder) readPackedGorillaFloat32Slice() ([]float32, error) {
 		var x uint32
 		if !ctl2 {
 			mb := 32 - int(prevLZ) - int(prevTZ)
+			// See the float64 path: mb==0 (the initial prevLZ=32 sentinel) means a
+			// hostile ctl=1/ctl2=0 opener would silently duplicate the prior value.
+			if mb <= 0 {
+				return nil, ErrInvalidLength
+			}
 			mbBits, ok := br.readBits(uint8(mb))
 			if !ok {
 				return nil, ErrShortBuffer

--- a/qpack_pfor.go
+++ b/qpack_pfor.go
@@ -1,6 +1,7 @@
 package qdf
 
 import (
+	"math"
 	"math/bits"
 	"slices"
 	"unsafe"
@@ -39,7 +40,7 @@ func pforPlanUnsigned(s []uint64, mn uint64, forBits int) (b int, cost int, ok b
 	// while its real output exceeded the runner-up — a never-larger violation.
 	gapLen := uvarintLen(uint64(n))
 	hdr := 3 + uvarintLen(uint64(n)) + uvarintLen(mn)
-	bestB, bestCost := -1, int(^uint(0)>>1)
+	bestB, bestCost := -1, math.MaxInt
 	suffix := 0 // number of values with width > cand, accumulated as cand descends
 	for cand := forBits - 1; cand >= 0; cand-- {
 		suffix += hist[cand+1]
@@ -125,7 +126,7 @@ func pforPlanSigned(s []int64, mn int64, forBits int) (b int, cost int, ok bool)
 	valLen := uvarintLen(maxDelta)
 	gapLen := uvarintLen(uint64(n)) // uvarint(i-prev) <= uvarint(n); see pforPlanUnsigned
 	hdr := 3 + uvarintLen(uint64(n)) + uvarintLen(zigzagEncode64(mn))
-	bestB, bestCost := -1, int(^uint(0)>>1)
+	bestB, bestCost := -1, math.MaxInt
 	suffix := 0
 	for cand := forBits - 1; cand >= 0; cand-- {
 		suffix += hist[cand+1]
@@ -221,7 +222,7 @@ func (d *Decoder) readPackedPForInt64Slice() ([]int64, error) {
 		// b == 0 (constant base): empty packed body, no per-element bound.
 		return nil, ErrInvalidLength
 	}
-	if n64 > uint64(int(^uint(0)>>1)) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative
+	if n64 > uint64(math.MaxInt) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative
 		return nil, ErrInvalidLength
 	}
 	n := int(n64)
@@ -312,7 +313,7 @@ func (d *Decoder) readPackedPForUint64Slice() ([]uint64, error) {
 		// b == 0 (constant base): empty packed body, no per-element bound.
 		return nil, ErrInvalidLength
 	}
-	if n64 > uint64(int(^uint(0)>>1)) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative
+	if n64 > uint64(math.MaxInt) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative
 		return nil, ErrInvalidLength
 	}
 	n := int(n64)

--- a/qpack_rle.go
+++ b/qpack_rle.go
@@ -17,9 +17,17 @@ import "slices"
 func (e *Encoder) writePackedRLEUint64Slice(s []uint64) {
 	e.writeHeader()
 	n := len(s)
-	// Conservative pre-grow: 2 byte tag/kind + uvarint(n) + at most
-	// 20 bytes per run. nRuns ≤ n so the cap is bounded.
-	out := slices.Grow(e.buf, 2+10+20*n)
+	// Pre-grow by the actual run count, not n: RLE is chosen precisely for
+	// run-dominated input, so 20*n over-reserves by orders of magnitude (a single
+	// 1M-element constant run would reserve ~20MB for ~22 bytes). One extra scan
+	// (cheap next to the encode) sizes the reservation to 20 bytes per run.
+	runs := 0
+	for i := range n {
+		if i == 0 || s[i] != s[i-1] {
+			runs++
+		}
+	}
+	out := slices.Grow(e.buf, 2+10+20*runs)
 	out = append(out, tagPackRLE, qpackKindUint64)
 	out = appendUvarint(out, uint64(n))
 	if n == 0 {
@@ -48,7 +56,14 @@ func (e *Encoder) writePackedRLEUint64Slice(s []uint64) {
 func (e *Encoder) writePackedRLEInt64Slice(s []int64) {
 	e.writeHeader()
 	n := len(s)
-	out := slices.Grow(e.buf, 2+10+20*n)
+	// Pre-grow by run count, not n (see writePackedRLEUint64Slice).
+	runs := 0
+	for i := range n {
+		if i == 0 || s[i] != s[i-1] {
+			runs++
+		}
+	}
+	out := slices.Grow(e.buf, 2+10+20*runs)
 	out = append(out, tagPackRLE, qpackKindInt64)
 	out = appendUvarint(out, uint64(n))
 	if n == 0 {

--- a/qpack_stralpha.go
+++ b/qpack_stralpha.go
@@ -1,6 +1,7 @@
 package qdf
 
 import (
+	"math"
 	"slices"
 
 	"github.com/alex60217101990/qdf/internal/bitpack"
@@ -255,7 +256,7 @@ func (d *Decoder) readStringColumnAlpha(n int) ([]string, error) {
 	// negative length on a 32-bit build (which would bypass the body check and
 	// panic), mirroring the origLen guard in decodeRANS.
 	maxChars := rem * 8 / uint64(cbits)
-	if maxInt := uint64(int(^uint(0) >> 1)); maxChars > maxInt {
+	if maxInt := uint64(math.MaxInt); maxChars > maxInt {
 		maxChars = maxInt
 	}
 	var (

--- a/qpack_zonechunk.go
+++ b/qpack_zonechunk.go
@@ -339,7 +339,7 @@ func (d *Decoder) readZoneChunkHeader(loadZonemap bool) (zoneChunkHeader, error)
 		return h, ErrInvalidLength
 	}
 	d.i += nr
-	if !d.colLenOK(n64) || n64 == 0 || n64 > uint64(int(^uint(0)>>1)) {
+	if !d.colLenOK(n64) || n64 == 0 || n64 > uint64(math.MaxInt) {
 		return h, ErrInvalidLength
 	}
 	h.n = int(n64)
@@ -371,7 +371,7 @@ func (d *Decoder) readZoneChunkHeader(loadZonemap bool) (zoneChunkHeader, error)
 			return h, ErrInvalidLength
 		}
 		d.i += nr
-		if eps64 > uint64(int(^uint(0)>>1)) {
+		if eps64 > uint64(math.MaxInt) {
 			return h, ErrInvalidLength
 		}
 		if loadZonemap {

--- a/qpack_zonechunk.go
+++ b/qpack_zonechunk.go
@@ -85,7 +85,10 @@ func fitLinearZmap[T int64 | uint64](s []T, blk int) (linearFit, bool) {
 	}
 	c := (fn*sxy - sx*sy) / denom
 	d := (sy - c*sx) / fn
-	if !(c > 0) || math.IsInf(c, 0) || math.IsNaN(d) {
+	// Reject any non-finite model. The decoder (readZoneChunkHeader) rejects
+	// IsInf(d) too, so emitting d=±Inf here (reachable when c*sx overflows) would
+	// write a column its own decoder refuses to read.
+	if !(c > 0) || math.IsInf(c, 0) || math.IsNaN(d) || math.IsInf(d, 0) {
 		return linearFit{}, false
 	}
 	// Worst-case position residual.

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -1197,7 +1197,7 @@ func decodeStruct(td *typeDesc) func(*Decoder, unsafe.Pointer) error {
 			if n <= 0 {
 				return ErrInvalidLength
 			}
-			if shapeID > uint64(^uint32(0)) {
+			if shapeID > uint64(math.MaxUint32) {
 				return ErrUnknownStateID // would truncate on the uint32 cast below
 			}
 			d.i += n
@@ -1212,7 +1212,7 @@ func decodeStruct(td *typeDesc) func(*Decoder, unsafe.Pointer) error {
 					return ErrInvalidLength
 				}
 				d.i += n
-				if cnt64 > uint64(int(^uint(0)>>1)) { // 32-bit: int(cnt64) would wrap before CheckLength
+				if cnt64 > uint64(math.MaxInt) { // 32-bit: int(cnt64) would wrap before CheckLength
 					return ErrInvalidLength
 				}
 				cnt := int(cnt64)
@@ -1554,7 +1554,7 @@ func decodeAny(d *Decoder) (any, error) {
 		if n <= 0 {
 			return nil, ErrInvalidLength
 		}
-		if shapeID > uint64(^uint32(0)) {
+		if shapeID > uint64(math.MaxUint32) {
 			return nil, ErrUnknownStateID // would truncate on the uint32 cast below
 		}
 		d.i += n
@@ -1568,7 +1568,7 @@ func decodeAny(d *Decoder) (any, error) {
 				return nil, ErrInvalidLength
 			}
 			d.i += n
-			if cnt64 > uint64(int(^uint(0)>>1)) { // 32-bit: int(cnt64) would wrap before CheckLength
+			if cnt64 > uint64(math.MaxInt) { // 32-bit: int(cnt64) would wrap before CheckLength
 				return nil, ErrInvalidLength
 			}
 			cnt := int(cnt64)

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -212,6 +212,7 @@ func encodeSlice(elem *typeDesc, stride uintptr, colPlan *columnarPlan) func(*En
 		// (so non-lossy and unbatchable shapes stay byte-identical).
 		if e.opts.Has(OptLossyVec) && elem != nil && len(elem.vecFields) > 0 &&
 			n >= columnarMinElems && e.state != nil && !e.stateSuspended &&
+			e.ifaceDepth == 0 &&
 			e.opts.Has(OptDense) && e.opts.Has(OptShapeIntern) {
 			if done, err := e.encodeVectorBatchStruct(elem, hdr.Data, n, stride); done {
 				return err
@@ -1318,6 +1319,11 @@ func encodeIface(e *Encoder, p unsafe.Pointer) error {
 		}
 		defer func() { e.depth-- }()
 	}
+	// Mark the schemaless context: everything under a dynamic dispatch decodes via
+	// decodeAny, which cannot read a batched vector-column block. Balanced inc/dec
+	// so nested ifaces stay positive and the counter returns to 0 at the top.
+	e.ifaceDepth++
+	defer func() { e.ifaceDepth-- }()
 	return encodeReflect(e, iv)
 }
 

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -870,14 +870,20 @@ func (e *Encoder) encodeStringMapShaped(rv reflect.Value, keyType, valType refle
 		keyHolder.SetIterKey(iter) // reuse holder; iter.Key() would alloc
 		setHash += internKeyHash(keyHolder.String())
 	}
-	if id, order, ok := st.mapShapeFindKeys(setHash, n); ok {
-		if len(order) == n && hasAll(order) {
-			st.lastMapShapeID, st.lastMapShapeKeys = id, order
+	// Scan EVERY shape with this (setHash, n) and verify by keys — setHash is not
+	// collision-proof. Returning only the first (setHash, n) row and declaring on
+	// a key mismatch would re-declare a colliding key-set on every encode: under
+	// two alternating sets that collide on setHash, the already-registered second
+	// set is never found again, so mapShapes grows without bound. The s.n == n
+	// filter guarantees len(s.keys) == n, so hasAll ⇒ set equality.
+	for i := range st.mapShapes {
+		s := &st.mapShapes[i]
+		if s.setHash == setHash && s.n == n && hasAll(s.keys) {
+			st.lastMapShapeID, st.lastMapShapeKeys = s.id, s.keys
 			e.buf = append(e.buf, tagMapShape)
-			e.buf = appendUvarint(e.buf, uint64(id))
-			return emitValues(order)
+			e.buf = appendUvarint(e.buf, uint64(s.id))
+			return emitValues(s.keys)
 		}
-		// collision / different key-set → declare a fresh shape below.
 	}
 
 	// Declare path (first sight of this key-set).

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -505,6 +505,29 @@ func decodeSliceInt32(d *Decoder, p unsafe.Pointer) error {
 		}
 		*(*[]int32)(p) = out
 		return nil
+	case tagPackBlock, tagZoneChunk:
+		// A []int/[]int64 wire (writeQPackInt64 → tagPackBlock 0xF0, columnar
+		// writeZoneChunkInt64 → tagZoneChunk 0xF1) decoded into a []int32 field
+		// after an int→int32 schema change. Mirror decodeSliceInt64's block/
+		// zone-chunk handling (and the For/PFor case above) instead of falling
+		// through to ReadArrayHeader, which rejects these tags as ErrTypeMismatch.
+		d.i++
+		var v64 []int64
+		var err error
+		if t == tagPackBlock {
+			v64, err = d.readBlockInt64()
+		} else {
+			v64, err = d.readZoneChunkInt64()
+		}
+		if err != nil {
+			return err
+		}
+		out := make([]int32, len(v64))
+		for i, x := range v64 {
+			out[i] = int32(x)
+		}
+		*(*[]int32)(p) = out
+		return nil
 	}
 	n, err := d.ReadArrayHeader()
 	if err != nil {
@@ -693,6 +716,28 @@ func decodeSliceUint32(d *Decoder, p unsafe.Pointer) error {
 		}
 		*(*[]uint32)(p) = out
 		return nil
+	case tagPackBlock, tagZoneChunk:
+		// []uint/[]uint64 wire (writeQPackUint64 → tagPackBlock, columnar
+		// writeZoneChunkUint64 → tagZoneChunk) decoded into a []uint32 field
+		// after a uint→uint32 schema change. Mirror decodeSliceUint64 instead of
+		// falling through to ReadArrayHeader (ErrTypeMismatch on these tags).
+		d.i++
+		var v64 []uint64
+		var err error
+		if t == tagPackBlock {
+			v64, err = d.readBlockUint64()
+		} else {
+			v64, err = d.readZoneChunkUint64()
+		}
+		if err != nil {
+			return err
+		}
+		out := make([]uint32, len(v64))
+		for i, x := range v64 {
+			out[i] = uint32(x)
+		}
+		*(*[]uint32)(p) = out
+		return nil
 	}
 	n, err := d.ReadArrayHeader()
 	if err != nil {
@@ -827,10 +872,12 @@ func encodeSliceFloat32(e *Encoder, p unsafe.Pointer) error {
 	if e.opts.Has(OptCanonical) {
 		s = e.canonicalFloat32Slice(s)
 	}
-	if e.opts.Has(OptLossyVec) && len(s) >= lossyVecMinElems {
+	if e.opts.Has(OptLossyVec) && e.ifaceDepth == 0 && len(s) >= lossyVecMinElems {
 		// Build the lossy block into scratch; emit it only if it is no larger
 		// than the lossless body (never-worse). Widen into the reused e.wideF64
 		// buffer so appendLossyVec's in-place NaN/Inf zeroing does not touch s.
+		// ifaceDepth==0: a lossy 0xFD block has no decodeAny case, so a vector held
+		// in a schemaless (any) position must stay lossless to round-trip.
 		e.wideF64 = toF64Into(s, e.wideF64)
 		lossy, lossyOK := appendLossyVec([][]float64{e.wideF64}, true, toBudget(e.vecBudget), &e.vecScratch)
 		start := len(e.buf)
@@ -989,11 +1036,13 @@ func encodeSliceFloat64(e *Encoder, p unsafe.Pointer) error {
 	if e.opts.Has(OptCanonical) {
 		s = e.canonicalFloat64Slice(s)
 	}
-	if e.opts.Has(OptLossyVec) && len(s) >= lossyVecMinElems {
+	if e.opts.Has(OptLossyVec) && e.ifaceDepth == 0 && len(s) >= lossyVecMinElems {
 		// Build the lossy block into scratch; emit it only if it is no larger
 		// than the lossless body (never-worse). Copy s into the reused e.wideF64
 		// buffer so appendLossyVec's in-place NaN/Inf zeroing does not touch the
 		// caller's []float64 slice. toF64Into returns s unchanged for []float64,
+		// ifaceDepth==0: a schemaless (any) vector must stay lossless (no 0xFD
+		// block) so decodeAny can read it back.
 		// so we must copy explicitly here rather than routing through toF64Into.
 		e.wideF64 = append(e.wideF64[:0], s...)
 		lossy, lossyOK := appendLossyVec([][]float64{e.wideF64}, false, toBudget(e.vecBudget), &e.vecScratch)

--- a/state.go
+++ b/state.go
@@ -602,21 +602,31 @@ func (e *encState) reset() {
 	// Canonical map-key sort scratch (OptCanonical): numeric scratch is
 	// pointer-free (drop only past the ceiling); canonKeysStr holds caller
 	// string headers, so clear them to drop references across a pool recycle.
+	// canonKeysI64/U64 grow independently (a uint64-key-map workload grows
+	// canonKeysU64 while canonKeysI64 stays empty), so gate each on its own cap —
+	// a single check keyed on canonKeysI64 would never drop an oversized
+	// canonKeysU64. Both are pointer-free: drop only past the ceiling.
 	if cap(e.canonKeysI64) > maxRetainedColScratch {
-		e.canonKeysI64, e.canonKeysU64 = nil, nil
+		e.canonKeysI64 = nil
+	}
+	if cap(e.canonKeysU64) > maxRetainedColScratch {
+		e.canonKeysU64 = nil
 	}
 	if cap(e.canonKeysStr) > maxRetainedColScratch {
 		e.canonKeysStr = nil
 	} else {
-		clear(e.canonKeysStr)
+		// Clear across the FULL backing, not just len: a shorter key-set leaves a
+		// high-water tail of headers aliasing the caller's map key strings.
+		clear(e.canonKeysStr[:cap(e.canonKeysStr)])
 		e.canonKeysStr = e.canonKeysStr[:0]
 	}
 	// canonKeyVals holds reflect.Value key holders (may alias caller map keys via
-	// the exotic-kind fallback); clear to drop references across a pool recycle.
+	// the exotic-kind fallback); clear the FULL backing to drop references across
+	// a pool recycle (a shorter map leaves a stale header tail past len).
 	if cap(e.canonKeyVals) > maxRetainedColScratch {
 		e.canonKeyVals = nil
 	} else {
-		clear(e.canonKeyVals)
+		clear(e.canonKeyVals[:cap(e.canonKeyVals)])
 		e.canonKeyVals = e.canonKeyVals[:0]
 	}
 	// Canonical float-slice scratch is pointer-free: drop only past the ceiling.
@@ -633,7 +643,10 @@ func (e *encState) reset() {
 	if cap(e.colDictTable) > maxRetainedColScratch {
 		e.colDictTable = nil
 	} else {
-		clear(e.colDictTable)
+		// []string resliced via [:0] per column, so a shorter column leaves a
+		// high-water tail of headers aliasing caller strings; clear the FULL
+		// backing (mirrors the decoder's colDictTableScr reset).
+		clear(e.colDictTable[:cap(e.colDictTable)])
 		e.colDictTable = e.colDictTable[:0]
 	}
 	if cap(e.colMaskScratch) > maxRetainedColScratch {

--- a/state.go
+++ b/state.go
@@ -722,21 +722,6 @@ func (e *encState) shapeDeclareEnc() uint32 {
 	return e.shapeCount
 }
 
-// mapShapeFindKeys looks up an interned map key-set by its order-independent
-// (setHash, n) identity and returns its wire id and canonical key order in a
-// single scan — callers need both, so this folds the former mapShapeFind +
-// mapShapeKeys id-keyed second pass into one. The caller still verifies the
-// actual keys against the returned order before reuse (setHash is not
-// collision-proof).
-func (e *encState) mapShapeFindKeys(setHash uint64, n int) (id uint32, keys []string, ok bool) {
-	for i := range e.mapShapes {
-		if e.mapShapes[i].setHash == setHash && e.mapShapes[i].n == n {
-			return e.mapShapes[i].id, e.mapShapes[i].keys, true
-		}
-	}
-	return 0, nil, false
-}
-
 // mapShapeRegister binds a key-set to a shape ID. keys must be the canonical
 // (sorted) order and is taken over by the binding — the caller must not reuse or
 // mutate it afterward. Both callers pass a freshly-allocated per-declare slice


### PR DESCRIPTION
Full per-file agent audit (audit-14) on top of the audit-12 (#140) + audit-13 stack. 15-bucket find→adversarial-verify workflow, 30 agents, 32 confirmed findings, each RED-verified against the real code before applying.

**This branch contains #140 + audit-13 + audit-14**, so merging it supersedes #140.

## Correctness
- **HIGH** — schemaless (`any`-field) lossy-vector round trip: a `[]struct`-with-vector-field or a `[]float32` held in an `any` field encoded as a batched `0xFE` block (or a per-slice `0xFD` block), neither of which `decodeAny` reads → `ErrBadTag` on decode. New `Encoder.ifaceDepth` suppresses all three lossy emits in a dynamic-dispatch context, so a schemaless vector stays lossless (columnar / qpack float tags) and round-trips. Top-level `Marshal` uses `encodeReflect` (not `encodeIface`), so the typed batched path is unaffected. Regression: `TestVecBatchAnyFieldRoundTrip`.
- `decodeSliceInt32/Uint32` lacked `tagPackBlock`/`tagZoneChunk` → `ErrTypeMismatch` on a cross-width schema evolution.
- `decoder_skip` `tagMapShape` cast `int(cnt64)` before the 32-bit overflow guard (silent desync).
- `lossyvec_batch` decode had no aggregate byte budget across the up-to-8 batched vector columns (~2GB from a tiny input).
- `qpack_zonechunk` `fitLinearFit` did not reject `IsInf(d)` while the decoder does (could emit an undecodable column).
- `encState.reset` leaks: `canonKeysU64` never dropped independently; `canonKeysStr`/`canonKeyVals`/`colDictTable` cleared only over `[0:len]` (high-water string-header tail pinned across pool recycle).
- Gorilla decode: reject `mb <= 0` in the reuse-window branch (hostile `ctl2=0` opener silently duplicated the previous value).
- Map-shape interning scanned only the first `(setHash, n)` match; two alternating sets colliding on `setHash` re-declared on every encode (unbounded `mapShapes` growth). Now scans all rows and verifies by keys.
- qdfgen `importAlias` qualified external identifiers with `filepath.Base(path)` while importing unaliased — broke for `gopkg.in/yaml.v2` (package `yaml`), a dir named `go-bar` (package `bar`), or version-suffixed paths (a base like `yaml.v2` is not even a valid identifier). Now uses the package's real name and aliases only on a name collision. Byte-identical output for `base == name`, so no fixtures change. Regression: `import_alias_test`.

## Allocation / perf (no behavior change)
- RLE encoders pre-grew by `20*n`; pre-count runs instead (a 1M constant run reserved ~20MB for ~22B).
- `cloneMap` hoists two `reflect.New` holders out of the per-entry loop.
- Nullable `colKindTime` query decode routes through the pooled `colScratchI64/U64`.

## Cleanup
- Replace bit-trick type-max idioms with the `math.*` limit constants (`MaxInt`, `MaxInt64`, `MaxUint32`, `MaxUint64`); bitmask/sentinel `^uintN(0)` left as-is.

Verified: build + vet + golangci-lint (root + qdfgen, 0 issues) + full test suite + `-race` + codegen_test regeneration, all green.