### PR TITLE
docs: rebrand to Quick Data Format + benchmark-first README + SVG logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,27 +11,47 @@
 ![Status](https://img.shields.io/badge/status-alpha-orange)
 
 <p align="center">
-  <img src="images/qdf-logo-new.png" alt="qdf — Quantum Density Format" width="640">
+  <img src="images/qdf-logo.svg" alt="qdf — Quick Data Format" width="560">
 </p>
 
-**Quantum-inspired data serialization format designed for ultra-fast
-and lightweight data exchange.**
+<p align="center">
+  <b>Fast, compact binary serialization for Go.</b><br>
+  <code>encoding/json</code>-style API · columnar per-column codecs · up to <b>68% smaller than Protobuf</b>, <b>6× smaller than JSON</b>
+</p>
 
-qdf gives you `encoding/json`-style ergonomics (`Marshal` / `Unmarshal` /
-`NewEncoder` / `NewDecoder`) and a compact tagged binary wire format
-with an optional inline string-interning table. The reflect path ships
-with specialised encoders for the common slice / map shapes. A
-`go:generate` tool emits reflection-free `MarshalQDF` / `UnmarshalQDF`
-methods when you need the last 10–15 %.
+qdf is a single-pass, streaming binary format with `encoding/json`
+ergonomics (`Marshal` / `Unmarshal` / `NewEncoder` / `NewDecoder`) — no
+IDL, no schema registry, types picked up from struct tags. It dedups
+repeated strings and keys inline and columnar-compresses slices of
+structs with per-column codecs (frame-of-reference, delta, RLE,
+dictionary, Gorilla XOR, FSST, rANS), so it shrinks *across* records
+where per-record formats can't. A `go:generate` tool emits
+reflection-free `MarshalQDF` / `UnmarshalQDF` for the last 10–15 %.
+
+### 5 000 Active-Directory records · one machine (i7-9750H · Go 1.26)
+
+| | wire | encode | decode |
+| --- | ---: | ---: | ---: |
+| `encoding/json` | 3 833 KB | 14.1 ms | 57.8 ms |
+| `vmihailenco/msgpack` | 3 370 KB | 8.7 ms | 16.7 ms |
+| **qdf** · `OptBalanced` (default) | **1 830 KB** | **6.6 ms** | **7.9 ms** |
+| **qdf** · `OptCompression` | **616 KB** | 32.1 ms | 13.2 ms |
+
+`OptBalanced` is smaller **and** faster than json and msgpack on every
+axis (decode ≈ 7× faster than json, ≈ 2× faster than msgpack, ~half the
+allocations). Wire is **smaller than Protobuf on every fixture** we test
+(−21 … −68 %). Full json / msgpack / protobuf / flatbuffers tables and
+the reproduction recipe: **[docs/COMPETITIVE.md](docs/COMPETITIVE.md)**.
 
 ---
 
-## Where the name comes from
+## Design philosophy — from "data as bytes" to "data as a model"
 
-**Quantum Density Format** is a borrowed metaphor, not physics. A
-classical CPU cannot store qubits; what qdf borrows from quantum
-information theory is a way of thinking about repetitive structured
-data.
+qdf treats a message not as a tree to serialize byte-for-byte, but as a
+small set of distinct values plus a stream of references and residuals
+against the context already seen. (The original working name, *Quantum
+Density Format*, was a borrowed metaphor for this state/collapse view —
+not physics; the engineering below is what actually ships.)
 
 The starting observation: in a payload like
 
@@ -53,7 +73,7 @@ treat data as `tree → bytes`. qdf treats it as
 position onto one of them. The wire dialect that ships today realises
 the practical subset of that idea:
 
-| Quantum-inspired concept | What it maps to in qdf today |
+| Concept | What it maps to in qdf today |
 | ------------------------ | ---------------------------- |
 | **State set** — the discrete values a position can take. | The Dense-mode intern table. The first occurrence of a string or `[]byte` value writes it in full and assigns it a stable ID. |
 | **Wavefunction collapse** — a single observation picks one state. | Every subsequent occurrence emits a `state_ref` tag plus a varint ID. Decoding "collapses" the reference back to its stored value. |

--- a/README.md
+++ b/README.md
@@ -28,20 +28,25 @@ dictionary, Gorilla XOR, FSST, rANS), so it shrinks *across* records
 where per-record formats can't. A `go:generate` tool emits
 reflection-free `MarshalQDF` / `UnmarshalQDF` for the last 10–15 %.
 
-### 5 000 Active-Directory records · one machine (i7-9750H · Go 1.26)
+### Wire size on real telemetry batches · GitHub Actions `ubuntu-latest` · Go 1.26
 
-| | wire | encode | decode |
-| --- | ---: | ---: | ---: |
-| `encoding/json` | 3 833 KB | 14.1 ms | 57.8 ms |
-| `vmihailenco/msgpack` | 3 370 KB | 8.7 ms | 16.7 ms |
-| **qdf** · `OptBalanced` (default) | **1 830 KB** | **6.6 ms** | **7.9 ms** |
-| **qdf** · `OptCompression` | **616 KB** | 32.1 ms | 13.2 ms |
+| batch | `encoding/json` | protobuf | **qdf** balanced | **qdf** compression |
+| --- | ---: | ---: | ---: | ---: |
+| OTLP traces | 1 027 KB | 562 KB | **138 KB** | **130 KB** |
+| logs        |   245 KB | 156 KB |  **44 KB** |  **44 KB** |
+| RTB bids    |   559 KB | 328 KB | **244 KB** | **201 KB** |
+| events      |   123 KB |  65 KB |  **40 KB** |  **40 KB** |
+| IoT floats  |   469 KB | 208 KB | **158 KB** | **148 KB** |
 
-`OptBalanced` is smaller **and** faster than json and msgpack on every
-axis (decode ≈ 7× faster than json, ≈ 2× faster than msgpack, ~half the
-allocations). Wire is **smaller than Protobuf on every fixture** we test
-(−21 … −68 %). Full json / msgpack / protobuf / flatbuffers tables and
-the reproduction recipe: **[docs/COMPETITIVE.md](docs/COMPETITIVE.md)**.
+qdf's wire is **smaller than Protobuf on every fixture (−24 … −77 %)** and
+**2.3–7.5× smaller than JSON** — it interns repeated strings and
+columnar-compresses *across* records, where per-record formats can't. On a
+real Active-Directory host dump it also decodes **≈6× faster than JSON**
+and **~1.5× faster than msgpack** at **~40 % of the allocations**, and encodes
+faster than both on telemetry-shaped batches (msgpack edges encode on some
+high-cardinality sets). Honest trade-offs: `OptCompression` spends encode CPU
+for the smallest wire, and protobuf/flatbuffers still win raw single-tiny-message
+decode. Full tables + reproduction recipe: **[docs/COMPETITIVE.md](docs/COMPETITIVE.md)**.
 
 **Deep dives:**
 [qdf — decodes less, packs harder, and lets you query the bytes](https://dev.to/alex_602/qdf-a-go-serializer-that-decodes-less-packs-harder-and-lets-you-query-the-bytes-2a39)
@@ -135,42 +140,41 @@ are picked up via Go struct tags (`qdf:"name"`, falling back to
 
 ### Measured against the field
 
-On realistic batch payloads (i7-9750H · Go 1.26), qdf's wire is **smaller
-than protobuf on every fixture** — because it dedups and columnar-compresses
-across records, while json/msgpack/protobuf/flatbuffers encode each record
-independently:
+On realistic batch payloads (GitHub Actions `ubuntu-latest` · Go 1.26), qdf's
+wire is **smaller than protobuf on every fixture** — because it dedups and
+columnar-compresses across records, while json/msgpack/protobuf/flatbuffers
+encode each record independently:
 
 | wire size vs protobuf | OTLP traces | logs | RTB | events | IoT floats |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| `qdf_balanced` | −57 % | −43 % | −21 % | −39 % | −24 % |
-| `qdf_compression` | **−68 %** | **−60 %** | −38 % | −39 % | −29 % |
+| `qdf_balanced` | **−75 %** | **−72 %** | −25 % | −39 % | −24 % |
+| `qdf_compression` | **−77 %** | **−72 %** | −39 % | −39 % | −29 % |
 
 It also allocates far less under load (IoT encode: `qdf_balanced` 3 allocs/op
 vs protobuf 385). Honest trade-offs: `qdf_speed` wire ≈ msgpack;
 `qdf_compression` encode trades CPU for bytes; protobuf and flatbuffers win
-raw decode throughput and single-tiny-message size. Full tables (json /
-msgpack / protobuf / flatbuffers × five fixtures, wire + memory) and the
-reproduction recipe are in **[docs/COMPETITIVE.md](docs/COMPETITIVE.md)**.
+raw single-tiny-message decode. Full tables (json / msgpack / protobuf /
+flatbuffers × five fixtures, wire + memory) and the reproduction recipe are in
+**[docs/COMPETITIVE.md](docs/COMPETITIVE.md)**.
 
-A concrete head-to-head on a realistic **Active-Directory export** (5 000
-mixed `ADUser` records — unique GUID/UPN/email, occasionally-repeating
-names, moderately-repeating groups/departments; i7-9750H, same data through
-each library):
+A concrete head-to-head on a real **Active-Directory host dump** (adalanche
+`localmachine` data — unique GUID/SID identifiers alongside repeating group,
+department, and object-class strings; same data through each library, typed
+structs):
 
-| 5 000 AD users | wire | encode | decode |
-| --- | ---: | ---: | ---: |
-| `encoding/json` | 3 833 KB | 14.1 ms | 57.8 ms |
-| `msgpack` | 3 370 KB | 8.7 ms | 16.7 ms |
-| **qdf — `OptBalanced`** (default) | **1 830 KB** | **6.6 ms** | **7.9 ms** |
-| **qdf — `OptCompression`** | **616 KB** | 32.1 ms | 13.2 ms |
+| AD host dump | wire | encode | decode | decode allocs |
+| --- | ---: | ---: | ---: | ---: |
+| `encoding/json` | 532 KB | 1.5 ms | 4.9 ms | 15 851 |
+| `vmihailenco/msgpack` | 500 KB | **0.65 ms** | 1.2 ms | 13 261 |
+| **qdf — `OptBalanced`** (default) | **209 KB** | 0.77 ms | **0.79 ms** | **6 413** |
+| **qdf — `OptCompression`** | **127 KB** | 5.7 ms | 1.6 ms | **5 597** |
 
-`OptBalanced` is a clean sweep — smaller **and** faster than both json and
-msgpack on every axis (decode ≈ **7× faster than json**, ≈ 2× faster than
-msgpack; ≈ half the allocations). `OptCompression` is **6.2× smaller than
-json / 5.5× smaller than msgpack** and still decodes faster than both, paying
-encode CPU for it. The mixed-struct shape (a map + a slice field amid the
-scalars) is exactly what **hybrid columnar** (`OptCompression`) unlocks —
-without it those records would never have been transposed at all.
+`OptBalanced` is **2.5× smaller than json / 2.4× smaller than msgpack**, decodes
+**≈6× faster than json** and **~1.5× faster than msgpack**, at ~40 % of json's
+allocations. msgpack edges it on encode wall-time for this high-cardinality set
+(qdf wins encode on the telemetry fixtures above); `OptCompression` trades encode
+CPU for the smallest wire. Protobuf/flatbuffers still win raw single-message
+decode.
 
 ### Wire layout
 
@@ -248,6 +252,15 @@ go get github.com/alex60217101990/qdf
 ```
 
 Requires Go 1.26.
+
+**Runnable examples** (`go run ./examples/<name>`):
+[`telemetry`](examples/telemetry) (dedup vs json) ·
+[`query`](examples/query) (predicate pushdown) ·
+[`embeddings`](examples/embeddings) (lossy vector codec) ·
+[`streaming`](examples/streaming) (shared-dict stream) ·
+[`decodealloc`](examples/decodealloc) (arena zero-alloc decode).
+More runnable snippets — arena, no-copy, options, delta, columns — render on
+[**pkg.go.dev**](https://pkg.go.dev/github.com/alex60217101990/qdf#pkg-examples).
 
 ```go
 package main

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ allocations). Wire is **smaller than Protobuf on every fixture** we test
 (−21 … −68 %). Full json / msgpack / protobuf / flatbuffers tables and
 the reproduction recipe: **[docs/COMPETITIVE.md](docs/COMPETITIVE.md)**.
 
+**Deep dives:**
+[qdf — decodes less, packs harder, and lets you query the bytes](https://dev.to/alex_602/qdf-a-go-serializer-that-decodes-less-packs-harder-and-lets-you-query-the-bytes-2a39)
+· [Shrinking AI embeddings on the wire — a lossy vector codec that beats Google's TurboQuant at equal recall](https://dev.to/alex_602/shrinking-ai-embeddings-on-the-wire-a-lossy-vector-codec-that-beats-googles-turboquant-at-equal-4hme)
+
 ---
 
 ## Design philosophy — from "data as bytes" to "data as a model"

--- a/images/qdf-icon.svg
+++ b/images/qdf-icon.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" role="img" aria-label="qdf">
+  <defs>
+    <radialGradient id="bg" cx="42%" cy="34%" r="80%"><stop offset="0" stop-color="#15214a"/><stop offset="0.6" stop-color="#0a0e22"/><stop offset="1" stop-color="#05070f"/></radialGradient>
+    <linearGradient id="cTable" x1="0" y1="0" x2="0.4" y2="1"><stop offset="0" stop-color="#f0fbff"/><stop offset="1" stop-color="#8fe3f9"/></linearGradient>
+    <linearGradient id="cCrownL" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#bde9fb"/><stop offset="1" stop-color="#38bdf8"/></linearGradient>
+    <linearGradient id="cCrownR" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#5cc6f5"/><stop offset="1" stop-color="#0e8fd6"/></linearGradient>
+    <linearGradient id="cPavL" x1="0.2" y1="0" x2="0.5" y2="1"><stop offset="0" stop-color="#2f77e6"/><stop offset="1" stop-color="#122a6b"/></linearGradient>
+    <linearGradient id="cPavR" x1="0.8" y1="0" x2="0.5" y2="1"><stop offset="0" stop-color="#1e5bd6"/><stop offset="1" stop-color="#0b1f52"/></linearGradient>
+    <linearGradient id="cPavC" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#eaf7ff"/><stop offset="0.5" stop-color="#4aa8f0"/><stop offset="1" stop-color="#0a1c4d"/></linearGradient>
+    <radialGradient id="caustic" cx="50%" cy="44%" r="60%"><stop offset="0" stop-color="#7dd3fc" stop-opacity="0.9"/><stop offset="1" stop-color="#7dd3fc" stop-opacity="0"/></radialGradient>
+    <filter id="glow" x="-70%" y="-70%" width="240%" height="240%"><feGaussianBlur stdDeviation="1.6" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="spec" x="-100%" y="-100%" width="300%" height="300%"><feGaussianBlur stdDeviation="1.6"/></filter>
+  </defs>
+
+  <rect x="0" y="0" width="128" height="128" rx="28" fill="url(#bg)"/>
+  <ellipse cx="64" cy="66" rx="52" ry="50" fill="url(#caustic)"/>
+
+  <g transform="translate(64,60) scale(1.55)">
+    <polygon points="-32,-14 0,-14 0,36" fill="url(#cPavL)"/>
+    <polygon points="32,-14 0,-14 0,36" fill="url(#cPavR)"/>
+    <polygon points="-9,-14 9,-14 0,36" fill="url(#cPavC)" opacity="0.9"/>
+    <polygon points="-32,-14 32,-14 24,-8 -24,-8" fill="#bfe6fb" opacity="0.55"/>
+    <polygon points="-15,-32 -20,-14 -32,-14" fill="url(#cCrownL)"/>
+    <polygon points="15,-32 20,-14 32,-14" fill="url(#cCrownR)"/>
+    <polygon points="-15,-32 15,-32 20,-14 -20,-14" fill="url(#cTable)"/>
+    <polygon points="-15,-32 15,-32 0,-24" fill="#ffffff" opacity="0.35"/>
+    <polygon points="-20,-14 0,-24 20,-14 0,-14" fill="#dff4ff" opacity="0.45"/>
+    <g stroke="#eaf7ff" stroke-width="0.7" opacity="0.5"><line x1="-20" y1="-14" x2="0" y2="36"/><line x1="20" y1="-14" x2="0" y2="36"/><line x1="0" y1="-24" x2="0" y2="36"/></g>
+    <path d="M -15,-32 L -32,-14 L 0,36" fill="none" stroke="#eaf7ff" stroke-width="1.2" opacity="0.7" stroke-linejoin="round"/>
+    <polygon points="-15,-32 15,-32 32,-14 0,36 -32,-14" fill="none" stroke="#0a1830" stroke-width="1" stroke-linejoin="round"/>
+    <ellipse cx="-6" cy="-25" rx="7" ry="3" fill="#ffffff" opacity="0.85" filter="url(#spec)"/>
+    <g transform="translate(13,-15)" fill="#ffffff" filter="url(#glow)"><path d="M 0,-7 L 1.3,-1.3 L 7,0 L 1.3,1.3 L 0,7 L -1.3,1.3 L -7,0 L -1.3,-1.3 Z"/></g>
+  </g>
+</svg>

--- a/images/qdf-logo.svg
+++ b/images/qdf-logo.svg
@@ -1,34 +1,83 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="660" height="200" viewBox="0 0 660 200" role="img" aria-label="qdf — Quick Data Format">
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="260" viewBox="0 0 760 260" role="img" aria-label="qdf — Quick Data Format">
   <defs>
-    <linearGradient id="tile" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4f46e5"/>
-      <stop offset="1" stop-color="#06b6d4"/>
+    <radialGradient id="bg" cx="30%" cy="30%" r="90%">
+      <stop offset="0" stop-color="#141833"/>
+      <stop offset="0.55" stop-color="#0b0e1f"/>
+      <stop offset="1" stop-color="#05060d"/>
+    </radialGradient>
+    <linearGradient id="fTop" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#22d3ee"/>
+      <stop offset="0.5" stop-color="#818cf8"/>
+      <stop offset="1" stop-color="#e879f9"/>
     </linearGradient>
-    <linearGradient id="word" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#4f46e5"/>
-      <stop offset="1" stop-color="#0891b2"/>
+    <linearGradient id="fRight" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#6366f1"/>
+      <stop offset="1" stop-color="#3730a3"/>
     </linearGradient>
+    <linearGradient id="fLeft" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#3730a3"/>
+      <stop offset="1" stop-color="#1e1b4b"/>
+    </linearGradient>
+    <linearGradient id="word" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#5eead4"/>
+      <stop offset="0.45" stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#c084fc"/>
+    </linearGradient>
+    <linearGradient id="sheen" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.9"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
+    </linearGradient>
+    <filter id="glow" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="5" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur stdDeviation="18"/>
+    </filter>
   </defs>
 
-  <!-- Icon tile -->
-  <rect x="20" y="20" width="160" height="160" rx="34" fill="url(#tile)"/>
+  <!-- Backplate -->
+  <rect x="2" y="2" width="756" height="256" rx="30" fill="url(#bg)" stroke="#2a3157" stroke-opacity="0.6"/>
 
-  <!-- Columnar bars collapsing into a dense block: per-column codecs + dedup -->
-  <g fill="#ffffff">
-    <rect x="52"  y="70"  width="16" height="76" rx="6" opacity="0.55"/>
-    <rect x="78"  y="54"  width="16" height="92" rx="6" opacity="0.72"/>
-    <rect x="104" y="86"  width="16" height="60" rx="6" opacity="0.72"/>
-    <!-- dense compressed block -->
-    <rect x="130" y="62"  width="20" height="84" rx="6"/>
+  <!-- Ambient neon glow behind the mark -->
+  <ellipse cx="150" cy="140" rx="120" ry="96" fill="#6d28d9" opacity="0.45" filter="url(#softglow)"/>
+  <ellipse cx="120" cy="120" rx="80" ry="70" fill="#0ea5e9" opacity="0.35" filter="url(#softglow)"/>
+
+  <!-- 3D isometric data stack: raw (wide) → compressed (narrow) -->
+  <g filter="url(#glow)">
+    <!-- bottom slab -->
+    <polygon points="76,150 150,181 150,205 76,174" fill="url(#fLeft)"/>
+    <polygon points="150,181 224,150 224,174 150,205" fill="url(#fRight)"/>
+    <polygon points="150,119 224,150 150,181 76,150" fill="url(#fTop)"/>
+    <polygon points="150,119 224,150 150,181 76,150" fill="none" stroke="#a5f3fc" stroke-opacity="0.9" stroke-width="1.5"/>
+    <!-- middle slab -->
+    <polygon points="98,126 150,148 150,172 98,150" fill="url(#fLeft)"/>
+    <polygon points="150,148 202,126 202,150 150,172" fill="url(#fRight)"/>
+    <polygon points="150,104 202,126 150,148 98,126" fill="url(#fTop)"/>
+    <polygon points="150,104 202,126 150,148 98,126" fill="none" stroke="#a5f3fc" stroke-opacity="0.9" stroke-width="1.5"/>
+    <!-- top slab (most compressed) -->
+    <polygon points="118,102 150,115 150,139 118,126" fill="url(#fLeft)"/>
+    <polygon points="150,115 182,102 182,126 150,139" fill="url(#fRight)"/>
+    <polygon points="150,89 182,102 150,115 118,102" fill="url(#fTop)"/>
+    <polygon points="150,89 182,102 150,115 118,102" fill="none" stroke="#e9d5ff" stroke-opacity="0.95" stroke-width="1.5"/>
+    <!-- glossy sheen on the top faces -->
+    <polygon points="150,119 224,150 150,181 76,150" fill="url(#sheen)" opacity="0.16"/>
   </g>
-  <!-- baseline -->
-  <rect x="48" y="150" width="106" height="6" rx="3" fill="#ffffff" opacity="0.85"/>
 
-  <!-- Wordmark -->
-  <text x="212" y="118" font-family="ui-sans-serif, Segoe UI, Helvetica, Arial, sans-serif"
-        font-size="96" font-weight="800" letter-spacing="-4" fill="url(#word)">qdf</text>
+  <!-- Floating accent particles -->
+  <g fill="#67e8f9">
+    <circle cx="243" cy="86" r="3" opacity="0.9"/>
+    <circle cx="62" cy="196" r="2.5" opacity="0.7"/>
+    <circle cx="236" cy="206" r="2" opacity="0.6"/>
+  </g>
+
+  <!-- Wordmark: extruded 3D + neon -->
+  <g font-family="ui-sans-serif, Segoe UI, Helvetica, Arial, sans-serif" font-weight="900" letter-spacing="-6">
+    <text x="304" y="160" font-size="128" fill="#0a0a1f" opacity="0.9">qdf</text>
+    <text x="300" y="156" font-size="128" fill="url(#word)" filter="url(#glow)">qdf</text>
+  </g>
 
   <!-- Tagline -->
-  <text x="216" y="152" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
-        font-size="21" letter-spacing="1.5" fill="#64748b">Quick Data Format</text>
+  <text x="306" y="196" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+        font-size="21" letter-spacing="3" fill="#8b93c9">QUICK · DATA · FORMAT</text>
 </svg>

--- a/images/qdf-logo.svg
+++ b/images/qdf-logo.svg
@@ -1,144 +1,142 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="820" height="280" viewBox="0 0 820 280" role="img" aria-label="qdf — Quick Data Format">
   <defs>
-    <radialGradient id="bg" cx="30%" cy="24%" r="100%">
-      <stop offset="0" stop-color="#1a2148"/><stop offset="0.5" stop-color="#0b0f26"/><stop offset="1" stop-color="#040610"/>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#03040c"/>
+      <stop offset="0.34" stop-color="#0a1030"/>
+      <stop offset="0.5" stop-color="#3b1f4e"/>
+      <stop offset="0.6" stop-color="#8a3d1a"/>
+      <stop offset="0.66" stop-color="#b45309"/>
+      <stop offset="0.72" stop-color="#3a1a0f"/>
+      <stop offset="1" stop-color="#120a08"/>
+    </linearGradient>
+    <radialGradient id="sun" cx="50%" cy="50%" r="50%">
+      <stop offset="0" stop-color="#fde68a"/><stop offset="0.5" stop-color="#f59e0b"/><stop offset="1" stop-color="#b45309"/>
+    </radialGradient>
+    <radialGradient id="sunhaze" cx="50%" cy="50%" r="50%">
+      <stop offset="0" stop-color="#f59e0b" stop-opacity="0.7"/><stop offset="1" stop-color="#f59e0b" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="moon" cx="42%" cy="38%" r="60%">
+      <stop offset="0" stop-color="#e7e9ff"/><stop offset="1" stop-color="#7c86b8"/>
     </radialGradient>
     <linearGradient id="neon" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0" stop-color="#2dd4bf"/><stop offset="0.5" stop-color="#6366f1"/><stop offset="1" stop-color="#e879f9"/>
-    </linearGradient>
-    <linearGradient id="beam" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0" stop-color="#a5f3fc"/><stop offset="1" stop-color="#e879f9"/>
+      <stop offset="0" stop-color="#2dd4bf"/><stop offset="0.5" stop-color="#38bdf8"/><stop offset="1" stop-color="#818cf8"/>
     </linearGradient>
     <radialGradient id="coreglow" cx="50%" cy="45%" r="55%">
       <stop offset="0" stop-color="#7dd3fc" stop-opacity="0.95"/><stop offset="1" stop-color="#7dd3fc" stop-opacity="0"/>
     </radialGradient>
     <linearGradient id="wFront" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#5eead4"/><stop offset="0.45" stop-color="#38bdf8"/><stop offset="1" stop-color="#c084fc"/>
+      <stop offset="0" stop-color="#5eead4"/><stop offset="0.5" stop-color="#38bdf8"/><stop offset="1" stop-color="#a5b4fc"/>
     </linearGradient>
-    <linearGradient id="grid" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#38bdf8"/><stop offset="1" stop-color="#a855f7"/>
+    <linearGradient id="scrim" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#05060f" stop-opacity="0"/><stop offset="0.5" stop-color="#05060f" stop-opacity="0.55"/><stop offset="1" stop-color="#05060f" stop-opacity="0"/>
     </linearGradient>
-    <linearGradient id="fog" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#0b0f26" stop-opacity="0.95"/><stop offset="0.35" stop-color="#0b0f26" stop-opacity="0"/>
-    </linearGradient>
-    <radialGradient id="vignette" cx="50%" cy="48%" r="62%">
-      <stop offset="0.55" stop-color="#000000" stop-opacity="0"/><stop offset="1" stop-color="#000000" stop-opacity="0.55"/>
+    <radialGradient id="vignette" cx="50%" cy="46%" r="65%">
+      <stop offset="0.5" stop-color="#000" stop-opacity="0"/><stop offset="1" stop-color="#000" stop-opacity="0.6"/>
     </radialGradient>
-    <linearGradient id="horizon" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0" stop-color="#22d3ee" stop-opacity="0"/><stop offset="0.5" stop-color="#818cf8" stop-opacity="0.9"/><stop offset="1" stop-color="#e879f9" stop-opacity="0"/>
-    </linearGradient>
     <filter id="glow" x="-70%" y="-70%" width="240%" height="240%">
       <feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
-    <filter id="soft" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="22"/></filter>
-    <filter id="hglow" x="-50%" y="-400%" width="200%" height="900%"><feGaussianBlur stdDeviation="4"/></filter>
+    <filter id="soft" x="-150%" y="-150%" width="400%" height="400%"><feGaussianBlur stdDeviation="26"/></filter>
+    <filter id="blur6" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="6"/></filter>
     <clipPath id="card"><rect x="2" y="2" width="816" height="276" rx="32"/></clipPath>
   </defs>
 
-  <rect x="2" y="2" width="816" height="276" rx="32" fill="url(#bg)" stroke="#2a3157" stroke-opacity="0.55"/>
+  <rect x="2" y="2" width="816" height="276" rx="32" fill="url(#sky)" stroke="#2a2140" stroke-opacity="0.6"/>
 
-  <!-- 3D perspective scene -->
   <g clip-path="url(#card)">
-    <!-- far wireframe prisms (depth) -->
-    <g stroke="#3b4a8a" stroke-opacity="0.25" fill="none" stroke-width="1">
-      <polygon points="640,70 690,58 720,78 670,90"/>
-      <polygon points="690,58 690,88 720,108 720,78"/>
-      <polygon points="120,52 150,44 168,58 138,66"/>
-    </g>
-    <!-- perspective floor grid (vanishing point at 410,168) -->
-    <g stroke="url(#grid)" stroke-opacity="0.5" stroke-width="1">
-      <!-- verticals fanning from the horizon -->
-      <line x1="410" y1="168" x2="-140" y2="290"/>
-      <line x1="410" y1="168" x2="60"  y2="290"/>
-      <line x1="410" y1="168" x2="200" y2="290"/>
-      <line x1="410" y1="168" x2="310" y2="290"/>
-      <line x1="410" y1="168" x2="410" y2="290"/>
-      <line x1="410" y1="168" x2="510" y2="290"/>
-      <line x1="410" y1="168" x2="620" y2="290"/>
-      <line x1="410" y1="168" x2="760" y2="290"/>
-      <line x1="410" y1="168" x2="960" y2="290"/>
-      <!-- horizontals, gaps widen toward the viewer -->
-      <line x1="0" y1="172" x2="820" y2="172"/>
-      <line x1="0" y1="178" x2="820" y2="178"/>
-      <line x1="0" y1="187" x2="820" y2="187"/>
-      <line x1="0" y1="200" x2="820" y2="200"/>
-      <line x1="0" y1="219" x2="820" y2="219"/>
-      <line x1="0" y1="244" x2="820" y2="244"/>
-      <line x1="0" y1="276" x2="820" y2="276"/>
-    </g>
-    <!-- fog fading the far grid into the horizon -->
-    <rect x="2" y="150" width="816" height="70" fill="url(#fog)"/>
-    <!-- glowing horizon line -->
-    <rect x="120" y="167" width="580" height="2" fill="url(#horizon)" filter="url(#hglow)"/>
+    <!-- nebula clouds -->
+    <ellipse cx="560" cy="60" rx="150" ry="60" fill="#7c3aed" opacity="0.18" filter="url(#soft)"/>
+    <ellipse cx="300" cy="40" rx="120" ry="46" fill="#0e7490" opacity="0.16" filter="url(#soft)"/>
+    <ellipse cx="700" cy="120" rx="120" ry="50" fill="#b45309" opacity="0.14" filter="url(#soft)"/>
 
-    <!-- depth particles (near = bigger/brighter, far = small/dim) -->
-    <g fill="#a5b4fc">
-      <circle cx="600" cy="60" r="1.6" opacity="0.5"/><circle cx="700" cy="96" r="1.4" opacity="0.4"/>
-      <circle cx="520" cy="44" r="1.2" opacity="0.35"/><circle cx="756" cy="210" r="3" opacity="0.7"/>
-      <circle cx="470" cy="236" r="2.4" opacity="0.6"/><circle cx="360" cy="60" r="1.5" opacity="0.4"/>
+    <!-- starfield -->
+    <g fill="#eef2ff">
+      <circle cx="70" cy="34" r="1.1" opacity="0.8"/><circle cx="140" cy="60" r="0.8" opacity="0.6"/>
+      <circle cx="230" cy="28" r="1.3" opacity="0.9"/><circle cx="300" cy="72" r="0.7" opacity="0.5"/>
+      <circle cx="380" cy="40" r="1" opacity="0.7"/><circle cx="450" cy="24" r="0.8" opacity="0.6"/>
+      <circle cx="520" cy="66" r="1.2" opacity="0.85"/><circle cx="600" cy="34" r="0.7" opacity="0.5"/>
+      <circle cx="670" cy="70" r="1" opacity="0.7"/><circle cx="740" cy="40" r="1.3" opacity="0.9"/>
+      <circle cx="785" cy="90" r="0.8" opacity="0.6"/><circle cx="110" cy="96" r="0.7" opacity="0.5"/>
+      <circle cx="420" cy="88" r="0.9" opacity="0.6"/><circle cx="250" cy="104" r="0.8" opacity="0.5"/>
+      <circle cx="560" cy="100" r="0.7" opacity="0.5"/><circle cx="330" cy="20" r="0.9" opacity="0.7"/>
+    </g>
+
+    <!-- twin celestial bodies -->
+    <circle cx="690" cy="128" r="70" fill="url(#sunhaze)"/>
+    <circle cx="690" cy="128" r="40" fill="url(#sun)"/>
+    <circle cx="236" cy="52" r="14" fill="url(#moon)" opacity="0.92"/>
+    <circle cx="286" cy="38" r="7" fill="url(#moon)" opacity="0.6"/>
+
+    <!-- horizon haze -->
+    <rect x="2" y="150" width="816" height="26" fill="#f59e0b" opacity="0.28" filter="url(#blur6)"/>
+
+    <!-- desert dune ridges (back → front, hazy → dark) -->
+    <path d="M -20,168 C 160,150 340,176 520,160 C 660,148 760,166 840,158 L 840,290 L -20,290 Z" fill="#7c3a12" opacity="0.55"/>
+    <path d="M -20,190 C 180,168 300,198 470,184 C 640,170 770,196 840,186 L 840,290 L -20,290 Z" fill="#4a2310" opacity="0.85"/>
+    <path d="M -20,222 C 140,200 360,232 560,214 C 700,202 780,224 840,220 L 840,290 L -20,290 Z" fill="#1c0f08"/>
+
+    <!-- windblown sand streaks -->
+    <g stroke="#f59e0b" stroke-width="1" opacity="0.14" fill="none">
+      <path d="M 40,204 C 120,200 200,206 300,202"/>
+      <path d="M 380,214 C 480,210 560,216 660,211"/>
     </g>
   </g>
 
-  <!-- ambient glow behind the crystal -->
-  <ellipse cx="158" cy="146" rx="120" ry="110" fill="#7c3aed" opacity="0.38" filter="url(#soft)"/>
-  <ellipse cx="158" cy="146" rx="66" ry="66" fill="#0891b2" opacity="0.45" filter="url(#soft)"/>
+  <!-- ambient blue glow behind the crystal (spice contrast) -->
+  <ellipse cx="150" cy="150" rx="96" ry="90" fill="#0891b2" opacity="0.4" filter="url(#soft)"/>
 
   <!-- redundant streams IN -->
-  <g stroke="url(#neon)" stroke-width="2.4" fill="none" opacity="0.5" stroke-linecap="round">
-    <path d="M 34,96  C 82,106 104,120 126,140"/>
-    <path d="M 26,121 C 78,127 98,133 122,144"/>
-    <path d="M 24,146 C 76,146 98,146 120,146"/>
-    <path d="M 26,171 C 78,165 98,159 122,150"/>
-    <path d="M 34,196 C 82,186 104,172 126,152"/>
+  <g stroke="url(#neon)" stroke-width="2.4" fill="none" opacity="0.55" stroke-linecap="round">
+    <path d="M 34,104 C 80,112 100,124 122,142"/>
+    <path d="M 28,126 C 76,131 96,137 118,146"/>
+    <path d="M 26,150 C 74,150 96,150 116,150"/>
+    <path d="M 28,174 C 76,168 96,162 118,154"/>
   </g>
   <g fill="#7dd3fc" opacity="0.85">
-    <circle cx="34" cy="96" r="2.6"/><circle cx="26" cy="121" r="2.6"/><circle cx="24" cy="146" r="2.6"/>
-    <circle cx="26" cy="171" r="2.6"/><circle cx="34" cy="196" r="2.6"/>
-  </g>
-
-  <g fill="none" opacity="0.25" filter="url(#glow)">
-    <ellipse cx="158" cy="146" rx="60" ry="52" stroke="url(#neon)" stroke-width="1.6" stroke-dasharray="6 10"/>
+    <circle cx="34" cy="104" r="2.4"/><circle cx="28" cy="126" r="2.4"/><circle cx="26" cy="150" r="2.4"/><circle cx="28" cy="174" r="2.4"/>
   </g>
 
   <!-- compressed output -->
   <g filter="url(#glow)">
-    <path d="M 190,146 L 252,146" stroke="url(#beam)" stroke-width="9" stroke-linecap="round"/>
-    <polygon points="254,132 270,146 254,160 248,146" fill="#a5f3fc"/>
-    <polygon points="254,146 270,146 254,160" fill="#6366f1"/>
-    <circle cx="288" cy="146" r="3.2" fill="#f0abfc"/><circle cx="302" cy="146" r="2.1" fill="#f0abfc" opacity="0.7"/>
+    <path d="M 188,150 L 248,150" stroke="url(#neon)" stroke-width="8" stroke-linecap="round"/>
+    <polygon points="250,138 264,150 250,162 245,150" fill="#a5f3fc"/>
+    <polygon points="250,150 264,150 250,162" fill="#6366f1"/>
+    <circle cx="282" cy="150" r="2.8" fill="#a5f3fc" opacity="0.8"/>
   </g>
-  <circle cx="158" cy="146" r="30" fill="url(#coreglow)"/>
+  <circle cx="152" cy="150" r="30" fill="url(#coreglow)"/>
 
-  <!-- 3D faceted density crystal -->
-  <g filter="url(#glow)" stroke="#0a0f2a" stroke-width="0.8" stroke-linejoin="round">
-    <polygon points="144,120 172,120 158,134" fill="#e0f2fe"/>
-    <polygon points="144,120 128,142 158,134" fill="#7dd3fc"/>
-    <polygon points="172,120 188,142 158,134" fill="#38bdf8"/>
-    <polygon points="128,142 158,134 188,142 158,150" fill="#4f46e5"/>
-    <polygon points="128,142 158,150 158,184" fill="#3730a3"/>
-    <polygon points="188,142 158,150 158,184" fill="#1e1b4b"/>
-    <polygon points="158,134 161,150 158,184 155,150" fill="#ffffff" opacity="0.5"/>
-    <polygon points="144,120 172,120 158,134" fill="#ffffff" opacity="0.35"/>
+  <!-- 3D faceted density crystal (the monolith on the horizon) -->
+  <g filter="url(#glow)" stroke="#06121f" stroke-width="0.8" stroke-linejoin="round">
+    <polygon points="138,124 166,124 152,138" fill="#e0f2fe"/>
+    <polygon points="138,124 122,146 152,138" fill="#7dd3fc"/>
+    <polygon points="166,124 182,146 152,138" fill="#38bdf8"/>
+    <polygon points="122,146 152,138 182,146 152,154" fill="#3b82f6"/>
+    <polygon points="122,146 152,154 152,188" fill="#1d4ed8"/>
+    <polygon points="182,146 152,154 152,188" fill="#172554"/>
+    <polygon points="152,138 155,154 152,188 149,154" fill="#ffffff" opacity="0.5"/>
+    <polygon points="138,124 166,124 152,138" fill="#ffffff" opacity="0.35"/>
   </g>
+
+  <!-- legibility scrim under wordmark -->
+  <rect x="316" y="96" width="470" height="150" fill="url(#scrim)" filter="url(#blur6)"/>
 
   <!-- 3D extruded wordmark -->
   <g font-family="ui-sans-serif, Segoe UI, Helvetica, Arial, sans-serif" font-weight="900" letter-spacing="-6" font-size="120">
-    <text x="356.6" y="169.2" fill="#0b0f24">qdf</text>
-    <text x="356.0" y="168.6" fill="#0d1230">qdf</text>
-    <text x="355.4" y="168.0" fill="#101642">qdf</text>
-    <text x="354.8" y="167.4" fill="#141a52">qdf</text>
-    <text x="354.2" y="166.8" fill="#182061">qdf</text>
-    <text x="353.6" y="166.2" fill="#1c2570">qdf</text>
-    <text x="353.0" y="165.6" fill="#212b80">qdf</text>
-    <text x="352.4" y="165.0" fill="#263191">qdf</text>
-    <text x="351.8" y="164.4" fill="#2c38a3">qdf</text>
-    <text x="351.2" y="163.8" fill="#333fb5">qdf</text>
-    <text x="350.6" y="163.2" fill="#3a46c7">qdf</text>
+    <text x="356.6" y="169.2" fill="#07101f">qdf</text>
+    <text x="356.0" y="168.6" fill="#0a1628">qdf</text>
+    <text x="355.4" y="168.0" fill="#0d1c34">qdf</text>
+    <text x="354.8" y="167.4" fill="#102340">qdf</text>
+    <text x="354.2" y="166.8" fill="#132a4d">qdf</text>
+    <text x="353.6" y="166.2" fill="#16325a">qdf</text>
+    <text x="353.0" y="165.6" fill="#1a3b68">qdf</text>
+    <text x="352.4" y="165.0" fill="#1e4477">qdf</text>
+    <text x="351.8" y="164.4" fill="#234e88">qdf</text>
+    <text x="351.2" y="163.8" fill="#285799">qdf</text>
+    <text x="350.6" y="163.2" fill="#2e62ab">qdf</text>
     <text x="350" y="162" fill="url(#wFront)" filter="url(#glow)">qdf</text>
   </g>
   <text x="356" y="220" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
-        font-size="20" letter-spacing="6.5" fill="#8b93c9">QUICK · DATA · FORMAT</text>
+        font-size="20" letter-spacing="6.5" fill="#b8a58a">QUICK · DATA · FORMAT</text>
 
-  <!-- vignette for depth -->
   <rect x="2" y="2" width="816" height="276" rx="32" fill="url(#vignette)"/>
 </svg>

--- a/images/qdf-logo.svg
+++ b/images/qdf-logo.svg
@@ -1,142 +1,123 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="820" height="280" viewBox="0 0 820 280" role="img" aria-label="qdf — Quick Data Format">
   <defs>
     <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#03040c"/>
-      <stop offset="0.34" stop-color="#0a1030"/>
-      <stop offset="0.5" stop-color="#3b1f4e"/>
-      <stop offset="0.6" stop-color="#8a3d1a"/>
-      <stop offset="0.66" stop-color="#b45309"/>
-      <stop offset="0.72" stop-color="#3a1a0f"/>
-      <stop offset="1" stop-color="#120a08"/>
+      <stop offset="0" stop-color="#03040c"/><stop offset="0.34" stop-color="#0a1030"/><stop offset="0.5" stop-color="#3b1f4e"/>
+      <stop offset="0.6" stop-color="#8a3d1a"/><stop offset="0.66" stop-color="#b45309"/><stop offset="0.72" stop-color="#3a1a0f"/><stop offset="1" stop-color="#120a08"/>
     </linearGradient>
-    <radialGradient id="sun" cx="50%" cy="50%" r="50%">
-      <stop offset="0" stop-color="#fde68a"/><stop offset="0.5" stop-color="#f59e0b"/><stop offset="1" stop-color="#b45309"/>
-    </radialGradient>
-    <radialGradient id="sunhaze" cx="50%" cy="50%" r="50%">
-      <stop offset="0" stop-color="#f59e0b" stop-opacity="0.7"/><stop offset="1" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="moon" cx="42%" cy="38%" r="60%">
-      <stop offset="0" stop-color="#e7e9ff"/><stop offset="1" stop-color="#7c86b8"/>
-    </radialGradient>
-    <linearGradient id="neon" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0" stop-color="#2dd4bf"/><stop offset="0.5" stop-color="#38bdf8"/><stop offset="1" stop-color="#818cf8"/>
-    </linearGradient>
-    <radialGradient id="coreglow" cx="50%" cy="45%" r="55%">
-      <stop offset="0" stop-color="#7dd3fc" stop-opacity="0.95"/><stop offset="1" stop-color="#7dd3fc" stop-opacity="0"/>
-    </radialGradient>
-    <linearGradient id="wFront" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#5eead4"/><stop offset="0.5" stop-color="#38bdf8"/><stop offset="1" stop-color="#a5b4fc"/>
-    </linearGradient>
-    <linearGradient id="scrim" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#05060f" stop-opacity="0"/><stop offset="0.5" stop-color="#05060f" stop-opacity="0.55"/><stop offset="1" stop-color="#05060f" stop-opacity="0"/>
-    </linearGradient>
-    <radialGradient id="vignette" cx="50%" cy="46%" r="65%">
-      <stop offset="0.5" stop-color="#000" stop-opacity="0"/><stop offset="1" stop-color="#000" stop-opacity="0.6"/>
-    </radialGradient>
-    <filter id="glow" x="-70%" y="-70%" width="240%" height="240%">
-      <feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
-    </filter>
+    <radialGradient id="sun" cx="50%" cy="50%" r="50%"><stop offset="0" stop-color="#fde68a"/><stop offset="0.5" stop-color="#f59e0b"/><stop offset="1" stop-color="#b45309"/></radialGradient>
+    <radialGradient id="sunhaze" cx="50%" cy="50%" r="50%"><stop offset="0" stop-color="#f59e0b" stop-opacity="0.7"/><stop offset="1" stop-color="#f59e0b" stop-opacity="0"/></radialGradient>
+    <radialGradient id="moon" cx="42%" cy="38%" r="60%"><stop offset="0" stop-color="#e7e9ff"/><stop offset="1" stop-color="#7c86b8"/></radialGradient>
+
+    <!-- crystal facet gradients (glassy, graded) -->
+    <linearGradient id="cTable" x1="0" y1="0" x2="0.4" y2="1"><stop offset="0" stop-color="#f0fbff"/><stop offset="1" stop-color="#8fe3f9"/></linearGradient>
+    <linearGradient id="cCrownL" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#bde9fb"/><stop offset="1" stop-color="#38bdf8"/></linearGradient>
+    <linearGradient id="cCrownR" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#5cc6f5"/><stop offset="1" stop-color="#0e8fd6"/></linearGradient>
+    <linearGradient id="cPavL" x1="0.2" y1="0" x2="0.5" y2="1"><stop offset="0" stop-color="#2f77e6"/><stop offset="1" stop-color="#122a6b"/></linearGradient>
+    <linearGradient id="cPavR" x1="0.8" y1="0" x2="0.5" y2="1"><stop offset="0" stop-color="#1e5bd6"/><stop offset="1" stop-color="#0b1f52"/></linearGradient>
+    <linearGradient id="cPavC" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#eaf7ff"/><stop offset="0.5" stop-color="#4aa8f0"/><stop offset="1" stop-color="#0a1c4d"/></linearGradient>
+    <radialGradient id="caustic" cx="50%" cy="42%" r="60%"><stop offset="0" stop-color="#7dd3fc" stop-opacity="0.95"/><stop offset="1" stop-color="#7dd3fc" stop-opacity="0"/></radialGradient>
+
+    <linearGradient id="ray" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#22d3ee" stop-opacity="0"/><stop offset="0.7" stop-color="#67e8f9" stop-opacity="0.55"/><stop offset="1" stop-color="#a5f3fc" stop-opacity="0.95"/></linearGradient>
+    <linearGradient id="wFront" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#5eead4"/><stop offset="0.5" stop-color="#38bdf8"/><stop offset="1" stop-color="#a5b4fc"/></linearGradient>
+    <linearGradient id="scrim" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#05060f" stop-opacity="0"/><stop offset="0.5" stop-color="#05060f" stop-opacity="0.55"/><stop offset="1" stop-color="#05060f" stop-opacity="0"/></linearGradient>
+    <radialGradient id="vignette" cx="50%" cy="46%" r="66%"><stop offset="0.52" stop-color="#000" stop-opacity="0"/><stop offset="1" stop-color="#000" stop-opacity="0.6"/></radialGradient>
+
+    <filter id="glow" x="-70%" y="-70%" width="240%" height="240%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="rayglow" x="-40%" y="-200%" width="180%" height="500%"><feGaussianBlur stdDeviation="2.2" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
     <filter id="soft" x="-150%" y="-150%" width="400%" height="400%"><feGaussianBlur stdDeviation="26"/></filter>
     <filter id="blur6" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="6"/></filter>
+    <filter id="spec" x="-100%" y="-100%" width="300%" height="300%"><feGaussianBlur stdDeviation="2.4"/></filter>
     <clipPath id="card"><rect x="2" y="2" width="816" height="276" rx="32"/></clipPath>
   </defs>
 
   <rect x="2" y="2" width="816" height="276" rx="32" fill="url(#sky)" stroke="#2a2140" stroke-opacity="0.6"/>
 
   <g clip-path="url(#card)">
-    <!-- nebula clouds -->
     <ellipse cx="560" cy="60" rx="150" ry="60" fill="#7c3aed" opacity="0.18" filter="url(#soft)"/>
     <ellipse cx="300" cy="40" rx="120" ry="46" fill="#0e7490" opacity="0.16" filter="url(#soft)"/>
     <ellipse cx="700" cy="120" rx="120" ry="50" fill="#b45309" opacity="0.14" filter="url(#soft)"/>
-
-    <!-- starfield -->
     <g fill="#eef2ff">
-      <circle cx="70" cy="34" r="1.1" opacity="0.8"/><circle cx="140" cy="60" r="0.8" opacity="0.6"/>
-      <circle cx="230" cy="28" r="1.3" opacity="0.9"/><circle cx="300" cy="72" r="0.7" opacity="0.5"/>
-      <circle cx="380" cy="40" r="1" opacity="0.7"/><circle cx="450" cy="24" r="0.8" opacity="0.6"/>
-      <circle cx="520" cy="66" r="1.2" opacity="0.85"/><circle cx="600" cy="34" r="0.7" opacity="0.5"/>
-      <circle cx="670" cy="70" r="1" opacity="0.7"/><circle cx="740" cy="40" r="1.3" opacity="0.9"/>
-      <circle cx="785" cy="90" r="0.8" opacity="0.6"/><circle cx="110" cy="96" r="0.7" opacity="0.5"/>
-      <circle cx="420" cy="88" r="0.9" opacity="0.6"/><circle cx="250" cy="104" r="0.8" opacity="0.5"/>
-      <circle cx="560" cy="100" r="0.7" opacity="0.5"/><circle cx="330" cy="20" r="0.9" opacity="0.7"/>
+      <circle cx="70" cy="34" r="1.1" opacity="0.8"/><circle cx="150" cy="70" r="0.8" opacity="0.6"/><circle cx="360" cy="30" r="1.3" opacity="0.9"/>
+      <circle cx="330" cy="86" r="0.7" opacity="0.5"/><circle cx="420" cy="46" r="1" opacity="0.7"/><circle cx="470" cy="26" r="0.8" opacity="0.6"/>
+      <circle cx="560" cy="70" r="1.2" opacity="0.85"/><circle cx="620" cy="36" r="0.7" opacity="0.5"/><circle cx="680" cy="74" r="1" opacity="0.7"/>
+      <circle cx="760" cy="44" r="1.3" opacity="0.9"/><circle cx="790" cy="96" r="0.8" opacity="0.6"/><circle cx="110" cy="100" r="0.7" opacity="0.5"/>
+      <circle cx="440" cy="92" r="0.9" opacity="0.6"/><circle cx="600" cy="104" r="0.7" opacity="0.5"/><circle cx="510" cy="112" r="0.8" opacity="0.55"/>
     </g>
-
-    <!-- twin celestial bodies -->
-    <circle cx="690" cy="128" r="70" fill="url(#sunhaze)"/>
-    <circle cx="690" cy="128" r="40" fill="url(#sun)"/>
-    <circle cx="236" cy="52" r="14" fill="url(#moon)" opacity="0.92"/>
-    <circle cx="286" cy="38" r="7" fill="url(#moon)" opacity="0.6"/>
-
-    <!-- horizon haze -->
+    <circle cx="690" cy="128" r="70" fill="url(#sunhaze)"/><circle cx="690" cy="128" r="40" fill="url(#sun)"/>
+    <circle cx="236" cy="52" r="14" fill="url(#moon)" opacity="0.92"/><circle cx="286" cy="38" r="7" fill="url(#moon)" opacity="0.6"/>
     <rect x="2" y="150" width="816" height="26" fill="#f59e0b" opacity="0.28" filter="url(#blur6)"/>
-
-    <!-- desert dune ridges (back → front, hazy → dark) -->
     <path d="M -20,168 C 160,150 340,176 520,160 C 660,148 760,166 840,158 L 840,290 L -20,290 Z" fill="#7c3a12" opacity="0.55"/>
     <path d="M -20,190 C 180,168 300,198 470,184 C 640,170 770,196 840,186 L 840,290 L -20,290 Z" fill="#4a2310" opacity="0.85"/>
     <path d="M -20,222 C 140,200 360,232 560,214 C 700,202 780,224 840,220 L 840,290 L -20,290 Z" fill="#1c0f08"/>
+  </g>
 
-    <!-- windblown sand streaks -->
-    <g stroke="#f59e0b" stroke-width="1" opacity="0.14" fill="none">
-      <path d="M 40,204 C 120,200 200,206 300,202"/>
-      <path d="M 380,214 C 480,210 560,216 660,211"/>
+  <!-- spice-blue caustic glow behind crystal -->
+  <ellipse cx="150" cy="150" rx="92" ry="88" fill="#0891b2" opacity="0.4" filter="url(#soft)"/>
+
+  <!-- data-flow rays: tapered glowing beams, fade at source, packets in transit -->
+  <g filter="url(#rayglow)" fill="none" stroke-linecap="round">
+    <path d="M 40,102 Q 96,112 128,144" stroke="url(#ray)" stroke-width="2.4"/>
+    <path d="M 34,126 Q 92,132 124,148" stroke="url(#ray)" stroke-width="3"/>
+    <path d="M 32,150 Q 92,150 122,150" stroke="url(#ray)" stroke-width="3.2"/>
+    <path d="M 34,174 Q 92,168 124,152" stroke="url(#ray)" stroke-width="3"/>
+    <path d="M 40,198 Q 96,188 128,156" stroke="url(#ray)" stroke-width="2.4"/>
+  </g>
+  <!-- data packets travelling along the rays -->
+  <g fill="#c7f7ff">
+    <circle cx="92" cy="123" r="2.3" opacity="0.9"/><circle cx="86" cy="139" r="2.1" opacity="0.85"/>
+    <circle cx="90" cy="150" r="2.4" opacity="0.95"/><circle cx="86" cy="161" r="2.1" opacity="0.85"/><circle cx="92" cy="177" r="2.3" opacity="0.9"/>
+    <circle cx="58" cy="112" r="1.5" opacity="0.6"/><circle cx="60" cy="188" r="1.5" opacity="0.6"/>
+  </g>
+  <!-- convergence flare where the rays enter the crystal -->
+  <circle cx="126" cy="150" r="16" fill="url(#caustic)"/>
+
+  <!-- compressed output beam + dense packet -->
+  <g filter="url(#glow)">
+    <path d="M 186,150 L 246,150" stroke="url(#ray)" stroke-width="7" stroke-linecap="round"/>
+    <polygon points="248,139 262,150 248,161 244,150" fill="#a5f3fc"/><polygon points="248,150 262,150 248,161" fill="#3b82f6"/>
+    <circle cx="280" cy="150" r="2.6" fill="#a5f3fc" opacity="0.8"/>
+  </g>
+  <circle cx="152" cy="150" r="30" fill="url(#caustic)"/>
+
+  <!-- REALISTIC faceted brilliant-cut crystal -->
+  <g transform="translate(152,150)">
+    <!-- pavilion (lower) -->
+    <polygon points="-32,-14 0,-14 0,36" fill="url(#cPavL)"/>
+    <polygon points="32,-14 0,-14 0,36" fill="url(#cPavR)"/>
+    <polygon points="-9,-14 9,-14 0,36" fill="url(#cPavC)" opacity="0.9"/>
+    <!-- girdle band -->
+    <polygon points="-32,-14 32,-14 24,-8 -24,-8" fill="#bfe6fb" opacity="0.55"/>
+    <!-- crown (upper) -->
+    <polygon points="-15,-32 -20,-14 -32,-14" fill="url(#cCrownL)"/>
+    <polygon points="15,-32 20,-14 32,-14" fill="url(#cCrownR)"/>
+    <polygon points="-15,-32 15,-32 20,-14 -20,-14" fill="url(#cTable)"/>
+    <!-- table star split + inner facets -->
+    <polygon points="-15,-32 15,-32 0,-24" fill="#ffffff" opacity="0.35"/>
+    <polygon points="-20,-14 0,-24 20,-14 0,-14" fill="#dff4ff" opacity="0.45"/>
+    <!-- refraction lines -->
+    <g stroke="#eaf7ff" stroke-width="0.7" opacity="0.5"><line x1="-20" y1="-14" x2="0" y2="36"/><line x1="20" y1="-14" x2="0" y2="36"/><line x1="0" y1="-24" x2="0" y2="36"/></g>
+    <!-- rim light on the lit (left) edge -->
+    <path d="M -15,-32 L -32,-14 L 0,36" fill="none" stroke="#eaf7ff" stroke-width="1.2" opacity="0.7" stroke-linejoin="round"/>
+    <!-- outline -->
+    <polygon points="-15,-32 15,-32 32,-14 0,36 -32,-14" fill="none" stroke="#0a1830" stroke-width="1" stroke-linejoin="round"/>
+    <!-- specular highlight -->
+    <ellipse cx="-6" cy="-25" rx="7" ry="3" fill="#ffffff" opacity="0.85" filter="url(#spec)"/>
+    <!-- sparkle star -->
+    <g transform="translate(13,-15)" fill="#ffffff" filter="url(#glow)">
+      <path d="M 0,-7 L 1.3,-1.3 L 7,0 L 1.3,1.3 L 0,7 L -1.3,1.3 L -7,0 L -1.3,-1.3 Z"/>
     </g>
   </g>
 
-  <!-- ambient blue glow behind the crystal (spice contrast) -->
-  <ellipse cx="150" cy="150" rx="96" ry="90" fill="#0891b2" opacity="0.4" filter="url(#soft)"/>
-
-  <!-- redundant streams IN -->
-  <g stroke="url(#neon)" stroke-width="2.4" fill="none" opacity="0.55" stroke-linecap="round">
-    <path d="M 34,104 C 80,112 100,124 122,142"/>
-    <path d="M 28,126 C 76,131 96,137 118,146"/>
-    <path d="M 26,150 C 74,150 96,150 116,150"/>
-    <path d="M 28,174 C 76,168 96,162 118,154"/>
-  </g>
-  <g fill="#7dd3fc" opacity="0.85">
-    <circle cx="34" cy="104" r="2.4"/><circle cx="28" cy="126" r="2.4"/><circle cx="26" cy="150" r="2.4"/><circle cx="28" cy="174" r="2.4"/>
-  </g>
-
-  <!-- compressed output -->
-  <g filter="url(#glow)">
-    <path d="M 188,150 L 248,150" stroke="url(#neon)" stroke-width="8" stroke-linecap="round"/>
-    <polygon points="250,138 264,150 250,162 245,150" fill="#a5f3fc"/>
-    <polygon points="250,150 264,150 250,162" fill="#6366f1"/>
-    <circle cx="282" cy="150" r="2.8" fill="#a5f3fc" opacity="0.8"/>
-  </g>
-  <circle cx="152" cy="150" r="30" fill="url(#coreglow)"/>
-
-  <!-- 3D faceted density crystal (the monolith on the horizon) -->
-  <g filter="url(#glow)" stroke="#06121f" stroke-width="0.8" stroke-linejoin="round">
-    <polygon points="138,124 166,124 152,138" fill="#e0f2fe"/>
-    <polygon points="138,124 122,146 152,138" fill="#7dd3fc"/>
-    <polygon points="166,124 182,146 152,138" fill="#38bdf8"/>
-    <polygon points="122,146 152,138 182,146 152,154" fill="#3b82f6"/>
-    <polygon points="122,146 152,154 152,188" fill="#1d4ed8"/>
-    <polygon points="182,146 152,154 152,188" fill="#172554"/>
-    <polygon points="152,138 155,154 152,188 149,154" fill="#ffffff" opacity="0.5"/>
-    <polygon points="138,124 166,124 152,138" fill="#ffffff" opacity="0.35"/>
-  </g>
-
-  <!-- legibility scrim under wordmark -->
+  <!-- legibility scrim + wordmark -->
   <rect x="316" y="96" width="470" height="150" fill="url(#scrim)" filter="url(#blur6)"/>
-
-  <!-- 3D extruded wordmark -->
   <g font-family="ui-sans-serif, Segoe UI, Helvetica, Arial, sans-serif" font-weight="900" letter-spacing="-6" font-size="120">
-    <text x="356.6" y="169.2" fill="#07101f">qdf</text>
-    <text x="356.0" y="168.6" fill="#0a1628">qdf</text>
-    <text x="355.4" y="168.0" fill="#0d1c34">qdf</text>
-    <text x="354.8" y="167.4" fill="#102340">qdf</text>
-    <text x="354.2" y="166.8" fill="#132a4d">qdf</text>
-    <text x="353.6" y="166.2" fill="#16325a">qdf</text>
-    <text x="353.0" y="165.6" fill="#1a3b68">qdf</text>
-    <text x="352.4" y="165.0" fill="#1e4477">qdf</text>
-    <text x="351.8" y="164.4" fill="#234e88">qdf</text>
-    <text x="351.2" y="163.8" fill="#285799">qdf</text>
-    <text x="350.6" y="163.2" fill="#2e62ab">qdf</text>
+    <text x="356.6" y="169.2" fill="#07101f">qdf</text><text x="356.0" y="168.6" fill="#0a1628">qdf</text><text x="355.4" y="168.0" fill="#0d1c34">qdf</text>
+    <text x="354.8" y="167.4" fill="#102340">qdf</text><text x="354.2" y="166.8" fill="#132a4d">qdf</text><text x="353.6" y="166.2" fill="#16325a">qdf</text>
+    <text x="353.0" y="165.6" fill="#1a3b68">qdf</text><text x="352.4" y="165.0" fill="#1e4477">qdf</text><text x="351.8" y="164.4" fill="#234e88">qdf</text>
+    <text x="351.2" y="163.8" fill="#285799">qdf</text><text x="350.6" y="163.2" fill="#2e62ab">qdf</text>
     <text x="350" y="162" fill="url(#wFront)" filter="url(#glow)">qdf</text>
   </g>
-  <text x="356" y="220" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
-        font-size="20" letter-spacing="6.5" fill="#b8a58a">QUICK · DATA · FORMAT</text>
+  <text x="356" y="220" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="20" letter-spacing="6.5" fill="#b8a58a">QUICK · DATA · FORMAT</text>
 
   <rect x="2" y="2" width="816" height="276" rx="32" fill="url(#vignette)"/>
 </svg>

--- a/images/qdf-logo.svg
+++ b/images/qdf-logo.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="820" height="280" viewBox="0 0 820 280" role="img" aria-label="qdf — Quick Data Format">
   <defs>
-    <radialGradient id="bg" cx="26%" cy="28%" r="98%">
-      <stop offset="0" stop-color="#161c3d"/><stop offset="0.55" stop-color="#0a0d20"/><stop offset="1" stop-color="#04050c"/>
+    <radialGradient id="bg" cx="30%" cy="24%" r="100%">
+      <stop offset="0" stop-color="#1a2148"/><stop offset="0.5" stop-color="#0b0f26"/><stop offset="1" stop-color="#040610"/>
     </radialGradient>
     <linearGradient id="neon" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0" stop-color="#2dd4bf"/><stop offset="0.5" stop-color="#6366f1"/><stop offset="1" stop-color="#e879f9"/>
@@ -15,18 +15,75 @@
     <linearGradient id="wFront" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#5eead4"/><stop offset="0.45" stop-color="#38bdf8"/><stop offset="1" stop-color="#c084fc"/>
     </linearGradient>
+    <linearGradient id="grid" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#38bdf8"/><stop offset="1" stop-color="#a855f7"/>
+    </linearGradient>
+    <linearGradient id="fog" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0b0f26" stop-opacity="0.95"/><stop offset="0.35" stop-color="#0b0f26" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="vignette" cx="50%" cy="48%" r="62%">
+      <stop offset="0.55" stop-color="#000000" stop-opacity="0"/><stop offset="1" stop-color="#000000" stop-opacity="0.55"/>
+    </radialGradient>
+    <linearGradient id="horizon" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#22d3ee" stop-opacity="0"/><stop offset="0.5" stop-color="#818cf8" stop-opacity="0.9"/><stop offset="1" stop-color="#e879f9" stop-opacity="0"/>
+    </linearGradient>
     <filter id="glow" x="-70%" y="-70%" width="240%" height="240%">
       <feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
     <filter id="soft" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="22"/></filter>
+    <filter id="hglow" x="-50%" y="-400%" width="200%" height="900%"><feGaussianBlur stdDeviation="4"/></filter>
+    <clipPath id="card"><rect x="2" y="2" width="816" height="276" rx="32"/></clipPath>
   </defs>
 
   <rect x="2" y="2" width="816" height="276" rx="32" fill="url(#bg)" stroke="#2a3157" stroke-opacity="0.55"/>
 
+  <!-- 3D perspective scene -->
+  <g clip-path="url(#card)">
+    <!-- far wireframe prisms (depth) -->
+    <g stroke="#3b4a8a" stroke-opacity="0.25" fill="none" stroke-width="1">
+      <polygon points="640,70 690,58 720,78 670,90"/>
+      <polygon points="690,58 690,88 720,108 720,78"/>
+      <polygon points="120,52 150,44 168,58 138,66"/>
+    </g>
+    <!-- perspective floor grid (vanishing point at 410,168) -->
+    <g stroke="url(#grid)" stroke-opacity="0.5" stroke-width="1">
+      <!-- verticals fanning from the horizon -->
+      <line x1="410" y1="168" x2="-140" y2="290"/>
+      <line x1="410" y1="168" x2="60"  y2="290"/>
+      <line x1="410" y1="168" x2="200" y2="290"/>
+      <line x1="410" y1="168" x2="310" y2="290"/>
+      <line x1="410" y1="168" x2="410" y2="290"/>
+      <line x1="410" y1="168" x2="510" y2="290"/>
+      <line x1="410" y1="168" x2="620" y2="290"/>
+      <line x1="410" y1="168" x2="760" y2="290"/>
+      <line x1="410" y1="168" x2="960" y2="290"/>
+      <!-- horizontals, gaps widen toward the viewer -->
+      <line x1="0" y1="172" x2="820" y2="172"/>
+      <line x1="0" y1="178" x2="820" y2="178"/>
+      <line x1="0" y1="187" x2="820" y2="187"/>
+      <line x1="0" y1="200" x2="820" y2="200"/>
+      <line x1="0" y1="219" x2="820" y2="219"/>
+      <line x1="0" y1="244" x2="820" y2="244"/>
+      <line x1="0" y1="276" x2="820" y2="276"/>
+    </g>
+    <!-- fog fading the far grid into the horizon -->
+    <rect x="2" y="150" width="816" height="70" fill="url(#fog)"/>
+    <!-- glowing horizon line -->
+    <rect x="120" y="167" width="580" height="2" fill="url(#horizon)" filter="url(#hglow)"/>
+
+    <!-- depth particles (near = bigger/brighter, far = small/dim) -->
+    <g fill="#a5b4fc">
+      <circle cx="600" cy="60" r="1.6" opacity="0.5"/><circle cx="700" cy="96" r="1.4" opacity="0.4"/>
+      <circle cx="520" cy="44" r="1.2" opacity="0.35"/><circle cx="756" cy="210" r="3" opacity="0.7"/>
+      <circle cx="470" cy="236" r="2.4" opacity="0.6"/><circle cx="360" cy="60" r="1.5" opacity="0.4"/>
+    </g>
+  </g>
+
+  <!-- ambient glow behind the crystal -->
   <ellipse cx="158" cy="146" rx="120" ry="110" fill="#7c3aed" opacity="0.38" filter="url(#soft)"/>
   <ellipse cx="158" cy="146" rx="66" ry="66" fill="#0891b2" opacity="0.45" filter="url(#soft)"/>
 
-  <!-- redundant streams flow IN, converge on the crystal -->
+  <!-- redundant streams IN -->
   <g stroke="url(#neon)" stroke-width="2.4" fill="none" opacity="0.5" stroke-linecap="round">
     <path d="M 34,96  C 82,106 104,120 126,140"/>
     <path d="M 26,121 C 78,127 98,133 122,144"/>
@@ -39,12 +96,11 @@
     <circle cx="26" cy="171" r="2.6"/><circle cx="34" cy="196" r="2.6"/>
   </g>
 
-  <!-- faint energy rings behind the gem -->
   <g fill="none" opacity="0.25" filter="url(#glow)">
     <ellipse cx="158" cy="146" rx="60" ry="52" stroke="url(#neon)" stroke-width="1.6" stroke-dasharray="6 10"/>
   </g>
 
-  <!-- compressed output: beam → dense gem packet -->
+  <!-- compressed output -->
   <g filter="url(#glow)">
     <path d="M 190,146 L 252,146" stroke="url(#beam)" stroke-width="9" stroke-linecap="round"/>
     <polygon points="254,132 270,146 254,160 248,146" fill="#a5f3fc"/>
@@ -53,18 +109,14 @@
   </g>
   <circle cx="158" cy="146" r="30" fill="url(#coreglow)"/>
 
-  <!-- 3D faceted diamond (density crystal) -->
+  <!-- 3D faceted density crystal -->
   <g filter="url(#glow)" stroke="#0a0f2a" stroke-width="0.8" stroke-linejoin="round">
-    <!-- crown (top, lit) -->
     <polygon points="144,120 172,120 158,134" fill="#e0f2fe"/>
     <polygon points="144,120 128,142 158,134" fill="#7dd3fc"/>
     <polygon points="172,120 188,142 158,134" fill="#38bdf8"/>
-    <!-- girdle band -->
     <polygon points="128,142 158,134 188,142 158,150" fill="#4f46e5"/>
-    <!-- pavilion (bottom, shadow) -->
     <polygon points="128,142 158,150 158,184" fill="#3730a3"/>
     <polygon points="188,142 158,150 158,184" fill="#1e1b4b"/>
-    <!-- center highlight ridge -->
     <polygon points="158,134 161,150 158,184 155,150" fill="#ffffff" opacity="0.5"/>
     <polygon points="144,120 172,120 158,134" fill="#ffffff" opacity="0.35"/>
   </g>
@@ -86,4 +138,7 @@
   </g>
   <text x="356" y="220" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
         font-size="20" letter-spacing="6.5" fill="#8b93c9">QUICK · DATA · FORMAT</text>
+
+  <!-- vignette for depth -->
+  <rect x="2" y="2" width="816" height="276" rx="32" fill="url(#vignette)"/>
 </svg>

--- a/images/qdf-logo.svg
+++ b/images/qdf-logo.svg
@@ -71,12 +71,21 @@
   <!-- convergence flare where the rays enter the crystal -->
   <circle cx="126" cy="150" r="16" fill="url(#caustic)"/>
 
-  <!-- compressed output beam + dense packet -->
-  <g filter="url(#glow)">
-    <path d="M 186,150 L 246,150" stroke="url(#ray)" stroke-width="7" stroke-linecap="round"/>
-    <polygon points="248,139 262,150 248,161 244,150" fill="#a5f3fc"/><polygon points="248,150 262,150 248,161" fill="#3b82f6"/>
-    <circle cx="280" cy="150" r="2.6" fill="#a5f3fc" opacity="0.8"/>
+  <!-- compressed output beam → a smaller crystal receding in perspective -->
+  <path d="M 186,150 L 236,150" stroke="url(#ray)" stroke-width="6" stroke-linecap="round" filter="url(#glow)"/>
+  <ellipse cx="252" cy="150" rx="20" ry="19" fill="url(#caustic)" opacity="0.7"/>
+  <g transform="translate(252,150) scale(0.34)" opacity="0.72">
+    <polygon points="-32,-14 0,-14 0,36" fill="url(#cPavL)"/>
+    <polygon points="32,-14 0,-14 0,36" fill="url(#cPavR)"/>
+    <polygon points="-9,-14 9,-14 0,36" fill="url(#cPavC)" opacity="0.9"/>
+    <polygon points="-32,-14 32,-14 24,-8 -24,-8" fill="#bfe6fb" opacity="0.55"/>
+    <polygon points="-15,-32 -20,-14 -32,-14" fill="url(#cCrownL)"/>
+    <polygon points="15,-32 20,-14 32,-14" fill="url(#cCrownR)"/>
+    <polygon points="-15,-32 15,-32 20,-14 -20,-14" fill="url(#cTable)"/>
+    <polygon points="-15,-32 15,-32 0,-24" fill="#ffffff" opacity="0.35"/>
+    <polygon points="-15,-32 15,-32 32,-14 0,36 -32,-14" fill="none" stroke="#0a1830" stroke-width="1.6" stroke-linejoin="round"/>
   </g>
+  <circle cx="292" cy="150" r="2" fill="#a5f3fc" opacity="0.5" filter="url(#glow)"/>
   <circle cx="152" cy="150" r="30" fill="url(#caustic)"/>
 
   <!-- REALISTIC faceted brilliant-cut crystal -->

--- a/images/qdf-logo.svg
+++ b/images/qdf-logo.svg
@@ -1,83 +1,90 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="760" height="260" viewBox="0 0 760 260" role="img" aria-label="qdf — Quick Data Format">
   <defs>
-    <radialGradient id="bg" cx="30%" cy="30%" r="90%">
-      <stop offset="0" stop-color="#141833"/>
-      <stop offset="0.55" stop-color="#0b0e1f"/>
-      <stop offset="1" stop-color="#05060d"/>
+    <radialGradient id="bg" cx="28%" cy="30%" r="95%">
+      <stop offset="0" stop-color="#151a38"/>
+      <stop offset="0.55" stop-color="#0a0d20"/>
+      <stop offset="1" stop-color="#04050c"/>
     </radialGradient>
-    <linearGradient id="fTop" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#22d3ee"/>
-      <stop offset="0.5" stop-color="#818cf8"/>
+    <linearGradient id="neon" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#2dd4bf"/>
+      <stop offset="0.5" stop-color="#6366f1"/>
       <stop offset="1" stop-color="#e879f9"/>
     </linearGradient>
-    <linearGradient id="fRight" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#6366f1"/>
-      <stop offset="1" stop-color="#3730a3"/>
+    <linearGradient id="beam" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#a5f3fc"/>
+      <stop offset="1" stop-color="#e879f9"/>
     </linearGradient>
-    <linearGradient id="fLeft" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#3730a3"/>
-      <stop offset="1" stop-color="#1e1b4b"/>
-    </linearGradient>
+    <radialGradient id="core" cx="42%" cy="38%" r="70%">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="0.45" stop-color="#a5f3fc"/>
+      <stop offset="1" stop-color="#4f46e5"/>
+    </radialGradient>
+    <radialGradient id="coreglow" cx="50%" cy="50%" r="50%">
+      <stop offset="0" stop-color="#7dd3fc" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#7dd3fc" stop-opacity="0"/>
+    </radialGradient>
     <linearGradient id="word" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#5eead4"/>
       <stop offset="0.45" stop-color="#38bdf8"/>
       <stop offset="1" stop-color="#c084fc"/>
     </linearGradient>
-    <linearGradient id="sheen" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#ffffff" stop-opacity="0.9"/>
-      <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
-    </linearGradient>
-    <filter id="glow" x="-60%" y="-60%" width="220%" height="220%">
-      <feGaussianBlur stdDeviation="5" result="b"/>
+    <filter id="glow" x="-70%" y="-70%" width="240%" height="240%">
+      <feGaussianBlur stdDeviation="3" result="b"/>
       <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
-    <filter id="softglow" x="-80%" y="-80%" width="260%" height="260%">
-      <feGaussianBlur stdDeviation="18"/>
+    <filter id="soft" x="-120%" y="-120%" width="340%" height="340%">
+      <feGaussianBlur stdDeviation="20"/>
     </filter>
   </defs>
 
-  <!-- Backplate -->
-  <rect x="2" y="2" width="756" height="256" rx="30" fill="url(#bg)" stroke="#2a3157" stroke-opacity="0.6"/>
+  <rect x="2" y="2" width="756" height="256" rx="30" fill="url(#bg)" stroke="#2a3157" stroke-opacity="0.55"/>
 
-  <!-- Ambient neon glow behind the mark -->
-  <ellipse cx="150" cy="140" rx="120" ry="96" fill="#6d28d9" opacity="0.45" filter="url(#softglow)"/>
-  <ellipse cx="120" cy="120" rx="80" ry="70" fill="#0ea5e9" opacity="0.35" filter="url(#softglow)"/>
+  <!-- ambient glow around the core -->
+  <ellipse cx="150" cy="130" rx="110" ry="100" fill="#7c3aed" opacity="0.38" filter="url(#soft)"/>
+  <ellipse cx="150" cy="130" rx="60" ry="58" fill="#0891b2" opacity="0.45" filter="url(#soft)"/>
 
-  <!-- 3D isometric data stack: raw (wide) → compressed (narrow) -->
+  <!-- many redundant streams flow IN from the left -->
+  <g stroke="url(#neon)" stroke-width="2.4" fill="none" opacity="0.55" stroke-linecap="round">
+    <path d="M 30,86  C 76,96  96,108 120,124"/>
+    <path d="M 22,108 C 72,114 92,120 116,128"/>
+    <path d="M 20,130 C 70,130 92,130 114,130"/>
+    <path d="M 22,152 C 72,146 92,140 116,132"/>
+    <path d="M 30,174 C 76,164 96,152 120,136"/>
+  </g>
+  <g fill="#7dd3fc" opacity="0.85">
+    <circle cx="30" cy="86" r="2.6"/><circle cx="22" cy="108" r="2.6"/><circle cx="20" cy="130" r="2.6"/>
+    <circle cx="22" cy="152" r="2.6"/><circle cx="30" cy="174" r="2.6"/>
+  </g>
+
+  <!-- compression funnel: arcs opening toward the output (right) -->
+  <g fill="none" filter="url(#glow)" stroke-linecap="round">
+    <path d="M 185.2,91.4 A 46 46 0 1 0 185.2,168.6" stroke="url(#neon)" stroke-width="3" opacity="0.85"/>
+    <path d="M 175.3,108.8 A 33 33 0 1 0 175.3,151.2" stroke="url(#neon)" stroke-width="3.8"/>
+    <path d="M 166.9,125.9 A 22 22 0 1 0 166.9,134.1" stroke="#a5f3fc" stroke-width="4.6"/>
+  </g>
+
+  <!-- compressed output: bright beam → dense packet -->
   <g filter="url(#glow)">
-    <!-- bottom slab -->
-    <polygon points="76,150 150,181 150,205 76,174" fill="url(#fLeft)"/>
-    <polygon points="150,181 224,150 224,174 150,205" fill="url(#fRight)"/>
-    <polygon points="150,119 224,150 150,181 76,150" fill="url(#fTop)"/>
-    <polygon points="150,119 224,150 150,181 76,150" fill="none" stroke="#a5f3fc" stroke-opacity="0.9" stroke-width="1.5"/>
-    <!-- middle slab -->
-    <polygon points="98,126 150,148 150,172 98,150" fill="url(#fLeft)"/>
-    <polygon points="150,148 202,126 202,150 150,172" fill="url(#fRight)"/>
-    <polygon points="150,104 202,126 150,148 98,126" fill="url(#fTop)"/>
-    <polygon points="150,104 202,126 150,148 98,126" fill="none" stroke="#a5f3fc" stroke-opacity="0.9" stroke-width="1.5"/>
-    <!-- top slab (most compressed) -->
-    <polygon points="118,102 150,115 150,139 118,126" fill="url(#fLeft)"/>
-    <polygon points="150,115 182,102 182,126 150,139" fill="url(#fRight)"/>
-    <polygon points="150,89 182,102 150,115 118,102" fill="url(#fTop)"/>
-    <polygon points="150,89 182,102 150,115 118,102" fill="none" stroke="#e9d5ff" stroke-opacity="0.95" stroke-width="1.5"/>
-    <!-- glossy sheen on the top faces -->
-    <polygon points="150,119 224,150 150,181 76,150" fill="url(#sheen)" opacity="0.16"/>
+    <path d="M 172,130 L 236,130" stroke="url(#beam)" stroke-width="9" stroke-linecap="round"/>
+    <polygon points="252,130 238,116 224,130 238,144" fill="url(#core)"/>
+    <circle cx="270" cy="130" r="3.4" fill="#f0abfc"/>
+    <circle cx="284" cy="130" r="2.3" fill="#f0abfc" opacity="0.7"/>
   </g>
 
-  <!-- Floating accent particles -->
-  <g fill="#67e8f9">
-    <circle cx="243" cy="86" r="3" opacity="0.9"/>
-    <circle cx="62" cy="196" r="2.5" opacity="0.7"/>
-    <circle cx="236" cy="206" r="2" opacity="0.6"/>
+  <!-- dense core crystal -->
+  <circle cx="150" cy="130" r="24" fill="url(#coreglow)"/>
+  <g filter="url(#glow)">
+    <polygon points="150,110 168,130 150,150 132,130" fill="url(#core)"/>
+    <polygon points="150,110 150,150 132,130" fill="#c7d2fe" opacity="0.7"/>
+    <polygon points="150,110 168,130 150,130" fill="#ffffff" opacity="0.55"/>
+    <circle cx="144" cy="124" r="3" fill="#ffffff"/>
   </g>
 
-  <!-- Wordmark: extruded 3D + neon -->
+  <!-- wordmark -->
   <g font-family="ui-sans-serif, Segoe UI, Helvetica, Arial, sans-serif" font-weight="900" letter-spacing="-6">
-    <text x="304" y="160" font-size="128" fill="#0a0a1f" opacity="0.9">qdf</text>
-    <text x="300" y="156" font-size="128" fill="url(#word)" filter="url(#glow)">qdf</text>
+    <text x="326" y="158" font-size="126" fill="#090a1c" opacity="0.9">qdf</text>
+    <text x="322" y="154" font-size="126" fill="url(#word)" filter="url(#glow)">qdf</text>
   </g>
-
-  <!-- Tagline -->
-  <text x="306" y="196" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
-        font-size="21" letter-spacing="3" fill="#8b93c9">QUICK · DATA · FORMAT</text>
+  <text x="328" y="194" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+        font-size="20" letter-spacing="4" fill="#8b93c9">QUICK · DATA · FORMAT</text>
 </svg>

--- a/images/qdf-logo.svg
+++ b/images/qdf-logo.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="660" height="200" viewBox="0 0 660 200" role="img" aria-label="qdf — Quick Data Format">
+  <defs>
+    <linearGradient id="tile" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4f46e5"/>
+      <stop offset="1" stop-color="#06b6d4"/>
+    </linearGradient>
+    <linearGradient id="word" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#4f46e5"/>
+      <stop offset="1" stop-color="#0891b2"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Icon tile -->
+  <rect x="20" y="20" width="160" height="160" rx="34" fill="url(#tile)"/>
+
+  <!-- Columnar bars collapsing into a dense block: per-column codecs + dedup -->
+  <g fill="#ffffff">
+    <rect x="52"  y="70"  width="16" height="76" rx="6" opacity="0.55"/>
+    <rect x="78"  y="54"  width="16" height="92" rx="6" opacity="0.72"/>
+    <rect x="104" y="86"  width="16" height="60" rx="6" opacity="0.72"/>
+    <!-- dense compressed block -->
+    <rect x="130" y="62"  width="20" height="84" rx="6"/>
+  </g>
+  <!-- baseline -->
+  <rect x="48" y="150" width="106" height="6" rx="3" fill="#ffffff" opacity="0.85"/>
+
+  <!-- Wordmark -->
+  <text x="212" y="118" font-family="ui-sans-serif, Segoe UI, Helvetica, Arial, sans-serif"
+        font-size="96" font-weight="800" letter-spacing="-4" fill="url(#word)">qdf</text>
+
+  <!-- Tagline -->
+  <text x="216" y="152" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+        font-size="21" letter-spacing="1.5" fill="#64748b">Quick Data Format</text>
+</svg>

--- a/images/qdf-logo.svg
+++ b/images/qdf-logo.svg
@@ -1,90 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="760" height="260" viewBox="0 0 760 260" role="img" aria-label="qdf — Quick Data Format">
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="280" viewBox="0 0 820 280" role="img" aria-label="qdf — Quick Data Format">
   <defs>
-    <radialGradient id="bg" cx="28%" cy="30%" r="95%">
-      <stop offset="0" stop-color="#151a38"/>
-      <stop offset="0.55" stop-color="#0a0d20"/>
-      <stop offset="1" stop-color="#04050c"/>
+    <radialGradient id="bg" cx="26%" cy="28%" r="98%">
+      <stop offset="0" stop-color="#161c3d"/><stop offset="0.55" stop-color="#0a0d20"/><stop offset="1" stop-color="#04050c"/>
     </radialGradient>
     <linearGradient id="neon" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0" stop-color="#2dd4bf"/>
-      <stop offset="0.5" stop-color="#6366f1"/>
-      <stop offset="1" stop-color="#e879f9"/>
+      <stop offset="0" stop-color="#2dd4bf"/><stop offset="0.5" stop-color="#6366f1"/><stop offset="1" stop-color="#e879f9"/>
     </linearGradient>
     <linearGradient id="beam" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0" stop-color="#a5f3fc"/>
-      <stop offset="1" stop-color="#e879f9"/>
+      <stop offset="0" stop-color="#a5f3fc"/><stop offset="1" stop-color="#e879f9"/>
     </linearGradient>
-    <radialGradient id="core" cx="42%" cy="38%" r="70%">
-      <stop offset="0" stop-color="#ffffff"/>
-      <stop offset="0.45" stop-color="#a5f3fc"/>
-      <stop offset="1" stop-color="#4f46e5"/>
+    <radialGradient id="coreglow" cx="50%" cy="45%" r="55%">
+      <stop offset="0" stop-color="#7dd3fc" stop-opacity="0.95"/><stop offset="1" stop-color="#7dd3fc" stop-opacity="0"/>
     </radialGradient>
-    <radialGradient id="coreglow" cx="50%" cy="50%" r="50%">
-      <stop offset="0" stop-color="#7dd3fc" stop-opacity="0.95"/>
-      <stop offset="1" stop-color="#7dd3fc" stop-opacity="0"/>
-    </radialGradient>
-    <linearGradient id="word" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#5eead4"/>
-      <stop offset="0.45" stop-color="#38bdf8"/>
-      <stop offset="1" stop-color="#c084fc"/>
+    <linearGradient id="wFront" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#5eead4"/><stop offset="0.45" stop-color="#38bdf8"/><stop offset="1" stop-color="#c084fc"/>
     </linearGradient>
     <filter id="glow" x="-70%" y="-70%" width="240%" height="240%">
-      <feGaussianBlur stdDeviation="3" result="b"/>
-      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+      <feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
-    <filter id="soft" x="-120%" y="-120%" width="340%" height="340%">
-      <feGaussianBlur stdDeviation="20"/>
-    </filter>
+    <filter id="soft" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="22"/></filter>
   </defs>
 
-  <rect x="2" y="2" width="756" height="256" rx="30" fill="url(#bg)" stroke="#2a3157" stroke-opacity="0.55"/>
+  <rect x="2" y="2" width="816" height="276" rx="32" fill="url(#bg)" stroke="#2a3157" stroke-opacity="0.55"/>
 
-  <!-- ambient glow around the core -->
-  <ellipse cx="150" cy="130" rx="110" ry="100" fill="#7c3aed" opacity="0.38" filter="url(#soft)"/>
-  <ellipse cx="150" cy="130" rx="60" ry="58" fill="#0891b2" opacity="0.45" filter="url(#soft)"/>
+  <ellipse cx="158" cy="146" rx="120" ry="110" fill="#7c3aed" opacity="0.38" filter="url(#soft)"/>
+  <ellipse cx="158" cy="146" rx="66" ry="66" fill="#0891b2" opacity="0.45" filter="url(#soft)"/>
 
-  <!-- many redundant streams flow IN from the left -->
-  <g stroke="url(#neon)" stroke-width="2.4" fill="none" opacity="0.55" stroke-linecap="round">
-    <path d="M 30,86  C 76,96  96,108 120,124"/>
-    <path d="M 22,108 C 72,114 92,120 116,128"/>
-    <path d="M 20,130 C 70,130 92,130 114,130"/>
-    <path d="M 22,152 C 72,146 92,140 116,132"/>
-    <path d="M 30,174 C 76,164 96,152 120,136"/>
+  <!-- redundant streams flow IN, converge on the crystal -->
+  <g stroke="url(#neon)" stroke-width="2.4" fill="none" opacity="0.5" stroke-linecap="round">
+    <path d="M 34,96  C 82,106 104,120 126,140"/>
+    <path d="M 26,121 C 78,127 98,133 122,144"/>
+    <path d="M 24,146 C 76,146 98,146 120,146"/>
+    <path d="M 26,171 C 78,165 98,159 122,150"/>
+    <path d="M 34,196 C 82,186 104,172 126,152"/>
   </g>
   <g fill="#7dd3fc" opacity="0.85">
-    <circle cx="30" cy="86" r="2.6"/><circle cx="22" cy="108" r="2.6"/><circle cx="20" cy="130" r="2.6"/>
-    <circle cx="22" cy="152" r="2.6"/><circle cx="30" cy="174" r="2.6"/>
+    <circle cx="34" cy="96" r="2.6"/><circle cx="26" cy="121" r="2.6"/><circle cx="24" cy="146" r="2.6"/>
+    <circle cx="26" cy="171" r="2.6"/><circle cx="34" cy="196" r="2.6"/>
   </g>
 
-  <!-- compression funnel: arcs opening toward the output (right) -->
-  <g fill="none" filter="url(#glow)" stroke-linecap="round">
-    <path d="M 185.2,91.4 A 46 46 0 1 0 185.2,168.6" stroke="url(#neon)" stroke-width="3" opacity="0.85"/>
-    <path d="M 175.3,108.8 A 33 33 0 1 0 175.3,151.2" stroke="url(#neon)" stroke-width="3.8"/>
-    <path d="M 166.9,125.9 A 22 22 0 1 0 166.9,134.1" stroke="#a5f3fc" stroke-width="4.6"/>
+  <!-- faint energy rings behind the gem -->
+  <g fill="none" opacity="0.25" filter="url(#glow)">
+    <ellipse cx="158" cy="146" rx="60" ry="52" stroke="url(#neon)" stroke-width="1.6" stroke-dasharray="6 10"/>
   </g>
 
-  <!-- compressed output: bright beam → dense packet -->
+  <!-- compressed output: beam → dense gem packet -->
   <g filter="url(#glow)">
-    <path d="M 172,130 L 236,130" stroke="url(#beam)" stroke-width="9" stroke-linecap="round"/>
-    <polygon points="252,130 238,116 224,130 238,144" fill="url(#core)"/>
-    <circle cx="270" cy="130" r="3.4" fill="#f0abfc"/>
-    <circle cx="284" cy="130" r="2.3" fill="#f0abfc" opacity="0.7"/>
+    <path d="M 190,146 L 252,146" stroke="url(#beam)" stroke-width="9" stroke-linecap="round"/>
+    <polygon points="254,132 270,146 254,160 248,146" fill="#a5f3fc"/>
+    <polygon points="254,146 270,146 254,160" fill="#6366f1"/>
+    <circle cx="288" cy="146" r="3.2" fill="#f0abfc"/><circle cx="302" cy="146" r="2.1" fill="#f0abfc" opacity="0.7"/>
+  </g>
+  <circle cx="158" cy="146" r="30" fill="url(#coreglow)"/>
+
+  <!-- 3D faceted diamond (density crystal) -->
+  <g filter="url(#glow)" stroke="#0a0f2a" stroke-width="0.8" stroke-linejoin="round">
+    <!-- crown (top, lit) -->
+    <polygon points="144,120 172,120 158,134" fill="#e0f2fe"/>
+    <polygon points="144,120 128,142 158,134" fill="#7dd3fc"/>
+    <polygon points="172,120 188,142 158,134" fill="#38bdf8"/>
+    <!-- girdle band -->
+    <polygon points="128,142 158,134 188,142 158,150" fill="#4f46e5"/>
+    <!-- pavilion (bottom, shadow) -->
+    <polygon points="128,142 158,150 158,184" fill="#3730a3"/>
+    <polygon points="188,142 158,150 158,184" fill="#1e1b4b"/>
+    <!-- center highlight ridge -->
+    <polygon points="158,134 161,150 158,184 155,150" fill="#ffffff" opacity="0.5"/>
+    <polygon points="144,120 172,120 158,134" fill="#ffffff" opacity="0.35"/>
   </g>
 
-  <!-- dense core crystal -->
-  <circle cx="150" cy="130" r="24" fill="url(#coreglow)"/>
-  <g filter="url(#glow)">
-    <polygon points="150,110 168,130 150,150 132,130" fill="url(#core)"/>
-    <polygon points="150,110 150,150 132,130" fill="#c7d2fe" opacity="0.7"/>
-    <polygon points="150,110 168,130 150,130" fill="#ffffff" opacity="0.55"/>
-    <circle cx="144" cy="124" r="3" fill="#ffffff"/>
+  <!-- 3D extruded wordmark -->
+  <g font-family="ui-sans-serif, Segoe UI, Helvetica, Arial, sans-serif" font-weight="900" letter-spacing="-6" font-size="120">
+    <text x="356.6" y="169.2" fill="#0b0f24">qdf</text>
+    <text x="356.0" y="168.6" fill="#0d1230">qdf</text>
+    <text x="355.4" y="168.0" fill="#101642">qdf</text>
+    <text x="354.8" y="167.4" fill="#141a52">qdf</text>
+    <text x="354.2" y="166.8" fill="#182061">qdf</text>
+    <text x="353.6" y="166.2" fill="#1c2570">qdf</text>
+    <text x="353.0" y="165.6" fill="#212b80">qdf</text>
+    <text x="352.4" y="165.0" fill="#263191">qdf</text>
+    <text x="351.8" y="164.4" fill="#2c38a3">qdf</text>
+    <text x="351.2" y="163.8" fill="#333fb5">qdf</text>
+    <text x="350.6" y="163.2" fill="#3a46c7">qdf</text>
+    <text x="350" y="162" fill="url(#wFront)" filter="url(#glow)">qdf</text>
   </g>
-
-  <!-- wordmark -->
-  <g font-family="ui-sans-serif, Segoe UI, Helvetica, Arial, sans-serif" font-weight="900" letter-spacing="-6">
-    <text x="326" y="158" font-size="126" fill="#090a1c" opacity="0.9">qdf</text>
-    <text x="322" y="154" font-size="126" fill="url(#word)" filter="url(#glow)">qdf</text>
-  </g>
-  <text x="328" y="194" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
-        font-size="20" letter-spacing="4" fill="#8b93c9">QUICK · DATA · FORMAT</text>
+  <text x="356" y="220" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+        font-size="20" letter-spacing="6.5" fill="#8b93c9">QUICK · DATA · FORMAT</text>
 </svg>


### PR DESCRIPTION
Positioning + presentation refresh to make the repo land with the Go / systems audience (the crowd that stars serialization libs).

**What changed (docs/assets only — no code):**
- Drops the "Quantum-inspired / Quantum Density Format" headline. The wire magic is literally `'Q','D','F'`, so the letters stay and the expansion becomes **Quick Data Format**. The state/collapse metaphor is kept as an honest origin note under a new **Design philosophy** section — not the lead.
- **Benchmark-first hero**: one-line value prop + a real numbers table (5 000 AD records, i7-9750H · Go 1.26) on the first screen — smaller *and* faster than json/msgpack, −21…−68% vs Protobuf.
- New **vector logo** `images/qdf-logo.svg` (columnar-compression mark + `qdf` wordmark + tagline), crisp on GitHub at any size.

Also set on the repo: description (de-quantumed) + 12 discoverability topics.

Rendering note: eyeball the SVG + hero table in the GitHub preview before merge.