### PR TITLE
docs: When-to-use fit guide + "qdf loses" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/qdf_loses.md
+++ b/.github/ISSUE_TEMPLATE/qdf_loses.md
@@ -1,0 +1,40 @@
+---
+name: A payload where qdf loses
+about: A data shape where qdf is bigger or slower than it should be
+title: '[perf] qdf loses on '
+labels: perf
+---
+
+<!-- The deep-dive posts invite this on purpose: if you found a payload
+     where qdf is larger or slower than json / msgpack / protobuf and you
+     think it shouldn't be, this is the place. Measured beats anecdotal. -->
+
+## The data shape
+
+<!-- Fields and their types, string cardinality (how repetitive), batch
+     size (records per message / messages per stream). A struct definition
+     is ideal. -->
+
+## The numbers
+
+<!-- qdf vs the baseline you're comparing against: wire bytes and/or ns/op,
+     which qdf option tier (OptSpeed / OptBalanced / OptCompression), and
+     whether it was streaming. State how you measured. -->
+
+| codec | wire bytes | encode | decode |
+| --- | ---: | ---: | ---: |
+| qdf (`Opt...`) |  |  |  |
+| baseline (`...`) |  |  |  |
+
+## Reproducer
+
+```go
+// A runnable snippet, or a fixture / generator for the data.
+```
+
+## Environment
+
+- qdf commit: `...`
+- Go version: `go version`
+- GOOS / GOARCH:
+- Build tags (`qdf_simd`, `qdf_reflect2`, both, none):

--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ decode. Full tables + reproduction recipe: **[docs/COMPETITIVE.md](docs/COMPETIT
 
 ---
 
+## When to use qdf
+
+| Reach for qdf when… | Consider something else when… |
+| --- | --- |
+| You batch or stream **structured records** — logs, traces, spans, metrics, events, rows — where strings and keys repeat across the batch. | You send **one tiny message at a time** with no repetition: protobuf / flatbuffers carry less fixed per-message overhead. |
+| You want **`encoding/json` ergonomics** (struct tags, no IDL, no codegen step) at a fraction of the size and decode cost. | You need a **cross-language schema contract** with generated stubs in many languages: reach for protobuf / an IDL. |
+| Your workload is **decode-heavy** and dominated by materialising strings — pair it with a decode arena / no-copy. | You need **random access into a huge mmap'd file** without decoding: flatbuffers / capnproto are built for that. |
+| You want to **filter columnar batches without a full decode** (predicate pushdown, selective columns). | You need **maximum encode throughput** on high-cardinality data with no repetition: msgpack can edge qdf on encode there. |
+| You store **AI embeddings** and can trade bit-exactness for size (lossy vector codec at a fidelity budget). | You require a **frozen, versioned wire spec today**: qdf is alpha and the format still moves (see [Status](#status)). |
+
+qdf is Go-only and pure-Go (zero dependencies). One `Unmarshal` reads any output
+`Marshal` produces regardless of the encode-side option bits, so you can turn
+codecs on later without a migration.
+
+---
+
 ## Design philosophy — from "data as bytes" to "data as a model"
 
 qdf treats a message not as a tree to serialize byte-for-byte, but as a


### PR DESCRIPTION
Phase-0 conversion-surface follow-ups.

- **README "When to use qdf"** — an honest fit guide (reach-for-qdf vs consider-something-else) placed right after the hero, so evaluators self-select fast. Names the real trade-offs: single-tiny-message → protobuf/flatbuffers, cross-language contract → IDL, mmap random-access → flatbuffers/capnproto, max encode throughput on high-cardinality → msgpack, frozen spec → not yet (alpha).
- **New issue template `qdf_loses.md`** — turns the deep-dive posts' "open an issue if you find a payload where qdf loses" CTA into a structured perf/size report (data shape, numbers table, reproducer, env). Matches the existing bug/feature/PR template style.

Docs only.