### PR TITLE
chore: gitignore docs/promo/ (local promotion drafts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ dev-to-qdf.md
 PR_DESCRIPTION.md
 docs/PAGES-SETUP.md
 docs/PERF-NEXT.md
+
+# Local-only promotion drafts (article/post markdown, launch notes). Never
+# committed — published to dev.to / HN / reddit by hand.
+docs/promo/
 # Claude Code local session/worktree state (never commit)
 .claude/
 cmd/qdf-bench/qdf-bench


### PR DESCRIPTION
Adds `docs/promo/` to .gitignore — a local-only home for article/post drafts (dev.to / HN / reddit), published by hand. Matches the existing local-draft ignore pattern (dev-to-qdf.md, golangnews-submission.md). One-line change; the drafts themselves are never committed.