### PR TITLE
audit-15: fix map[K]any lossy-vec round-trip + 2 encode perf wins

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -144,6 +144,13 @@ type Encoder struct {
 	blkPlanI64 []blockPlanI64
 	blkPlanU64 []blockPlanU64
 
+	// zoneMM caches the per-zone (min,max) pairs — already reduced to their
+	// uvarint payload (zigzag for int64, raw for uint64) — computed while
+	// costing the min/max zonemap against the linear one in writeZoneChunk*.
+	// When the linear map wins it is unused; when it loses the emit pass reuses
+	// these instead of a second minMaxI64/minMaxU64 scan. Reused across columns.
+	zoneMM []uint64
+
 	// vecScratch reuses the lossy vector codec's rotate/row/coord buffers across
 	// encodes, retained between batches and dropped past the ceiling in
 	// resetForReuse. Mirrors alpScratch. Placed last among the pointer-bearing

--- a/floats_simd.go
+++ b/floats_simd.go
@@ -12,7 +12,10 @@
 // decode, UTF-8 validation, intern-table hashing).
 package qdf
 
-import "math"
+import (
+	"math"
+	"slices"
+)
 
 func encodeSliceFloat32Impl(e *Encoder, s []float32) error {
 	n := len(s)
@@ -20,6 +23,7 @@ func encodeSliceFloat32Impl(e *Encoder, s []float32) error {
 	if n == 0 {
 		return nil
 	}
+	e.buf = slices.Grow(e.buf, n*5) // tag + 4-byte body per element
 	for i := 0; i < n; i++ {
 		e.buf = appendU32(append(e.buf, tagFloat32), math.Float32bits(s[i]))
 	}
@@ -32,6 +36,7 @@ func encodeSliceFloat64Impl(e *Encoder, s []float64) error {
 	if n == 0 {
 		return nil
 	}
+	e.buf = slices.Grow(e.buf, n*9) // tag + 8-byte body per element
 	for i := 0; i < n; i++ {
 		e.buf = appendU64(append(e.buf, tagFloat64), math.Float64bits(s[i]))
 	}

--- a/internal/mapsgen/main.go
+++ b/internal/mapsgen/main.go
@@ -219,14 +219,18 @@ d.i++
 	},
 }
 
-// kindAny — generic any value. Dispatches through the reflect path
-// so heterogeneous values keep round-trip parity with the existing
-// reflect encoder.
+// kindAny — generic any value. Dispatches through encodeIface (not
+// encodeReflect) so the value is encoded in a dynamic-dispatch context:
+// encodeIface raises e.ifaceDepth, which suppresses the lossy-vector /
+// batched-struct codecs (gated on ifaceDepth==0). A map[K]any value is always
+// read back via decodeAny, which cannot decode a tagColVecLossy (0xFD) or
+// tagVecBatchStruct (0xFE) block, so those tags must never be emitted here.
+// This matches the []any element path (encodeSliceAny → encodeIface).
 var kindAny = kind{
 	suffix: "Any",
 	goType: "any",
 	writeBlock: func(v string) string {
-		return fmt.Sprintf("if err := encodeReflect(e, %s); err != nil {\nreturn err\n}", v)
+		return fmt.Sprintf("if err := encodeIface(e, unsafe.Pointer(&%s)); err != nil {\nreturn err\n}", v)
 	},
 	readBlock: func(v string) string {
 		return fmt.Sprintf("%s, err := decodeAny(d)\nif err != nil {\nreturn err\n}", v)

--- a/lossyvec_mapany_test.go
+++ b/lossyvec_mapany_test.go
@@ -1,0 +1,102 @@
+package qdf
+
+import "testing"
+
+// TestMapAnyLossyVecRoundTrip guards the schemaless map[K]any round trip under
+// OptLossyVec. A []float32/[]float64 value (>= lossyVecMinElems) held in a
+// map[K]any value slot used to be encoded through encodeReflect, which — unlike
+// encodeIface — never raised e.ifaceDepth. With ifaceDepth==0 the lossy-vector
+// gate fired and emitted a tagColVecLossy (0xFD) / tagVecBatchStruct (0xFE)
+// block that decodeAny has no case for, so the value failed to decode with
+// ErrBadTag ("unknown tag"). The generator now routes map-any values through
+// encodeIface, matching the []any element path. Regression for the map-any gap.
+func TestMapAnyLossyVecRoundTrip(t *testing.T) {
+	const dim = 64
+	vec32 := make([]float32, dim)
+	vec64 := make([]float64, dim)
+	for i := range vec32 {
+		vec32[i] = float32(i) * 0.01
+		vec64[i] = float64(i) * 0.01
+	}
+	opts := OptBalanced | OptLossyVec
+
+	t.Run("map_string_any_f64", func(t *testing.T) {
+		in := map[string]any{"v": vec64}
+		data, err := Marshal(in, opts)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var out map[string]any
+		if err := Unmarshal(data, &out); err != nil {
+			t.Fatalf("unmarshal (map[string]any lossy value must round-trip): %v", err)
+		}
+		if _, ok := out["v"]; !ok {
+			t.Fatalf("key v lost: %#v", out)
+		}
+	})
+
+	t.Run("map_string_any_f32", func(t *testing.T) {
+		in := map[string]any{"v": vec32}
+		data, err := Marshal(in, opts)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var out map[string]any
+		if err := Unmarshal(data, &out); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+	})
+
+	t.Run("map_int_any", func(t *testing.T) {
+		in := map[int]any{7: vec64}
+		data, err := Marshal(in, opts)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var out map[int]any
+		if err := Unmarshal(data, &out); err != nil {
+			t.Fatalf("unmarshal (map[int]any): %v", err)
+		}
+	})
+
+	t.Run("map_int64_any", func(t *testing.T) {
+		in := map[int64]any{9: vec64}
+		data, err := Marshal(in, opts)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var out map[int64]any
+		if err := Unmarshal(data, &out); err != nil {
+			t.Fatalf("unmarshal (map[int64]any): %v", err)
+		}
+	})
+
+	t.Run("map_uint64_any", func(t *testing.T) {
+		in := map[uint64]any{11: vec64}
+		data, err := Marshal(in, opts)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var out map[uint64]any
+		if err := Unmarshal(data, &out); err != nil {
+			t.Fatalf("unmarshal (map[uint64]any): %v", err)
+		}
+	})
+
+	// Batchable []struct-with-vector held as a map value (0xFE path).
+	t.Run("map_string_any_batch_struct", func(t *testing.T) {
+		rows := make([]vecOnlyRow, 32)
+		for i := range rows {
+			rows[i] = vecOnlyRow{Emb: sinVec32(i, 128)}
+		}
+		in := map[string]any{"rows": rows}
+		data, err := Marshal(in, opts)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var out map[string]any
+		if err := Unmarshal(data, &out); err != nil {
+			t.Fatalf("unmarshal (map value batchable []struct): %v", err)
+		}
+	})
+}

--- a/maps_fast_generated.go
+++ b/maps_fast_generated.go
@@ -1695,7 +1695,7 @@ func encodeMapStringAny(e *Encoder, p unsafe.Pointer) error {
 	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
-			if err := encodeReflect(e, v); err != nil {
+			if err := encodeIface(e, unsafe.Pointer(&v)); err != nil {
 				return err
 			}
 		}
@@ -1723,7 +1723,7 @@ func encodeMapStringAny(e *Encoder, p unsafe.Pointer) error {
 		for _, sk := range keys {
 			v := m[sk]
 			e.WriteString(sk)
-			if err := encodeReflect(e, v); err != nil {
+			if err := encodeIface(e, unsafe.Pointer(&v)); err != nil {
 				return err
 			}
 		}
@@ -1731,7 +1731,7 @@ func encodeMapStringAny(e *Encoder, p unsafe.Pointer) error {
 	}
 	for k, v := range m {
 		e.WriteString(k)
-		if err := encodeReflect(e, v); err != nil {
+		if err := encodeIface(e, unsafe.Pointer(&v)); err != nil {
 			return err
 		}
 	}
@@ -2048,7 +2048,7 @@ func encodeMapIntAny(e *Encoder, p unsafe.Pointer) error {
 			k := int(sk)
 			v := m[k]
 			e.WriteInt(int64(k))
-			if err := encodeReflect(e, v); err != nil {
+			if err := encodeIface(e, unsafe.Pointer(&v)); err != nil {
 				return err
 			}
 		}
@@ -2056,7 +2056,7 @@ func encodeMapIntAny(e *Encoder, p unsafe.Pointer) error {
 	}
 	for k, v := range m {
 		e.WriteInt(int64(k))
-		if err := encodeReflect(e, v); err != nil {
+		if err := encodeIface(e, unsafe.Pointer(&v)); err != nil {
 			return err
 		}
 	}
@@ -2275,7 +2275,7 @@ func encodeMapInt64Any(e *Encoder, p unsafe.Pointer) error {
 		for _, sk := range keys {
 			v := m[sk]
 			e.WriteInt(int64(sk))
-			if err := encodeReflect(e, v); err != nil {
+			if err := encodeIface(e, unsafe.Pointer(&v)); err != nil {
 				return err
 			}
 		}
@@ -2283,7 +2283,7 @@ func encodeMapInt64Any(e *Encoder, p unsafe.Pointer) error {
 	}
 	for k, v := range m {
 		e.WriteInt(int64(k))
-		if err := encodeReflect(e, v); err != nil {
+		if err := encodeIface(e, unsafe.Pointer(&v)); err != nil {
 			return err
 		}
 	}
@@ -2501,7 +2501,7 @@ func encodeMapUint64Any(e *Encoder, p unsafe.Pointer) error {
 		for _, sk := range keys {
 			v := m[sk]
 			e.WriteUint(uint64(sk))
-			if err := encodeReflect(e, v); err != nil {
+			if err := encodeIface(e, unsafe.Pointer(&v)); err != nil {
 				return err
 			}
 		}
@@ -2509,7 +2509,7 @@ func encodeMapUint64Any(e *Encoder, p unsafe.Pointer) error {
 	}
 	for k, v := range m {
 		e.WriteUint(uint64(k))
-		if err := encodeReflect(e, v); err != nil {
+		if err := encodeIface(e, unsafe.Pointer(&v)); err != nil {
 			return err
 		}
 	}

--- a/qdf.go
+++ b/qdf.go
@@ -431,6 +431,9 @@ func putEnc(enc *Encoder, pool *sync.Pool) {
 	if cap(enc.blkPlanU64) > maxRetainedWideScratch {
 		enc.blkPlanU64 = nil
 	}
+	if cap(enc.zoneMM) > maxRetainedWideScratch {
+		enc.zoneMM = nil
+	}
 	pool.Put(enc)
 }
 

--- a/qpack_zonechunk.go
+++ b/qpack_zonechunk.go
@@ -167,13 +167,20 @@ func (e *Encoder) writeZoneChunkInt64(s []int64) {
 	// Pick the learned linear zonemap over per-zone min/max only when it is both
 	// valid (monotonic, tight fit) and strictly smaller (never-worse).
 	fit, linOK := fitLinearZmap(s, blockSizeSmall)
+	// zmm holds the per-zone zigzag(min),zigzag(max) payload, computed here only
+	// when the linear map is a candidate; reused by the else branch below so the
+	// min/max pass runs once even when the linear map loses the never-worse test.
+	zmm := e.zoneMM[:0]
 	if linOK {
 		var mmBytes int
 		for i := 0; i < n; i += blockSizeSmall {
 			j := min(i+blockSizeSmall, n)
 			mn, mx := minMaxI64(s[i:j])
-			mmBytes += uvarintLen(zigzagEncode64(mn)) + uvarintLen(zigzagEncode64(mx))
+			zmn, zmx := zigzagEncode64(mn), zigzagEncode64(mx)
+			zmm = append(zmm, zmn, zmx)
+			mmBytes += uvarintLen(zmn) + uvarintLen(zmx)
 		}
+		e.zoneMM = zmm
 		linOK = linearZmapBytes(fit) < mmBytes
 	}
 
@@ -181,12 +188,18 @@ func (e *Encoder) writeZoneChunkInt64(s []int64) {
 	e.buf = appendUvarint(e.buf, uint64(n))
 	offAt := len(e.buf)
 	e.buf = append(e.buf, make([]byte, 4*zoneCount)...)
-	if linOK {
+	switch {
+	case linOK:
 		e.buf = binary.LittleEndian.AppendUint64(e.buf, math.Float64bits(fit.c))
 		e.buf = binary.LittleEndian.AppendUint64(e.buf, math.Float64bits(fit.d))
 		e.buf = appendUvarint(e.buf, uint64(fit.epsP))
-	} else {
-		// zonemap: per-zone min,max as zigzag-varint (variable length), before bodies.
+	case len(zmm) == 2*zoneCount:
+		// zonemap: per-zone min,max as zigzag-varint, reusing the pass above.
+		for _, z := range zmm {
+			e.buf = appendUvarint(e.buf, z)
+		}
+	default:
+		// linear was never a candidate: single min/max pass here.
 		for i := 0; i < n; i += blockSizeSmall {
 			j := min(i+blockSizeSmall, n)
 			mn, mx := minMaxI64(s[i:j])
@@ -215,13 +228,18 @@ func (e *Encoder) writeZoneChunkUint64(s []uint64) {
 	plans := e.blkPlanU64[:zoneCount]
 
 	fit, linOK := fitLinearZmap(s, blockSizeSmall)
+	// zmm holds the per-zone min,max payload (raw uvarint), reused by the else
+	// branch so the min/max pass runs once when the linear map loses.
+	zmm := e.zoneMM[:0]
 	if linOK {
 		var mmBytes int
 		for i := 0; i < n; i += blockSizeSmall {
 			j := min(i+blockSizeSmall, n)
 			mn, mx := minMaxU64(s[i:j])
+			zmm = append(zmm, mn, mx)
 			mmBytes += uvarintLen(mn) + uvarintLen(mx)
 		}
+		e.zoneMM = zmm
 		linOK = linearZmapBytes(fit) < mmBytes
 	}
 
@@ -229,11 +247,16 @@ func (e *Encoder) writeZoneChunkUint64(s []uint64) {
 	e.buf = appendUvarint(e.buf, uint64(n))
 	offAt := len(e.buf)
 	e.buf = append(e.buf, make([]byte, 4*zoneCount)...)
-	if linOK {
+	switch {
+	case linOK:
 		e.buf = binary.LittleEndian.AppendUint64(e.buf, math.Float64bits(fit.c))
 		e.buf = binary.LittleEndian.AppendUint64(e.buf, math.Float64bits(fit.d))
 		e.buf = appendUvarint(e.buf, uint64(fit.epsP))
-	} else {
+	case len(zmm) == 2*zoneCount:
+		for _, z := range zmm {
+			e.buf = appendUvarint(e.buf, z)
+		}
+	default:
 		for i := 0; i < n; i += blockSizeSmall {
 			j := min(i+blockSizeSmall, n)
 			mn, mx := minMaxU64(s[i:j])


### PR DESCRIPTION
Full-codebase audit (logic bugs + alloc reduction + CPU perf), multi-agent find → adversarial-verify, each confirmed finding re-verified by hand.

## Fixes

**HIGH bug — `map[K]any` values must encode via `encodeIface`, not `encodeReflect`**
A `[]float32`/`[]float64` (≥32 elems) or a batchable `[]struct`-with-vector held in a `map[K]any` value slot was encoded through `encodeReflect`, which — unlike `encodeIface` — never raised `e.ifaceDepth`. With `ifaceDepth==0` the lossy-vector / batched-struct gate fired under `OptLossyVec` and emitted a `tagColVecLossy` (0xFD) / `tagVecBatchStruct` (0xFE) block. Those tags are only decodable on the typed path; a `map[K]any` value is always read back via `decodeAny`, which has no case for them, so the round trip failed with `ErrBadTag` ("unknown tag"). Fixed at the generator (`kindAny` → `encodeIface`) and regenerated `maps_fast_generated.go`; affects all four map-any encoders (string/int/int64/uint64 keys). Byte-identical for every previously-decodable value. Regression: `TestMapAnyLossyVecRoundTrip`.

**MED perf — reuse per-zone min/max pass in zone-chunk encode**
`writeZoneChunkInt64/Uint64` scanned every zone to cost the min/max zonemap, then scanned again to emit it when the linear zonemap lost. Cache the pairs in a reused `Encoder` scratch. Byte-identical, opt-in `OptZoneMap` path only, alloc-free.

**LOW perf — reserve buffer capacity once in the `qdf_simd` bulk float encoders**
`encodeSliceFloat32/64Impl` appended per element with no upfront `slices.Grow`, unlike every sibling codec. Byte-identical; `qdf_simd` build tag only.

## Verification
build + vet + golangci-lint (0 issues, incl `--build-tags qdf_simd`) + full test suite + `-race` all green. `go generate ./...` re-run for the map fix.