### PR TITLE
audit: 4 fixes — any-boxed tagPackBlock + codegen any-field lossy round-trip, Gorilla 32-bit DoS, doc

### DIFF
--- a/anypacked_block_test.go
+++ b/anypacked_block_test.go
@@ -1,0 +1,84 @@
+package qdf
+
+import "testing"
+
+// blockRegimeI64 builds an int64 slice that triggers the per-block adaptive
+// codec (tagPackBlock 0xF0): alternating constant and wide-range 256-elem
+// blocks so block-adaptive beats any single whole-column codec.
+func blockRegimeI64() []int64 {
+	const nb, bs = 8, 256
+	s := make([]int64, 0, nb*bs)
+	for b := range nb {
+		for i := range bs {
+			if b%2 == 0 {
+				s = append(s, 0)
+			} else {
+				s = append(s, int64((b*bs+i)*1_000_003%9_000_000))
+			}
+		}
+	}
+	return s
+}
+
+// TestAnyPackBlockRoundTrip guards the schemaless round trip for a numeric
+// slice encoded with the per-block adaptive codec (tagPackBlock 0xF0). decodeAny
+// had cases for tagPackBool and tagPackRaw..tagPackALP but none for tagPackBlock,
+// so a []int64/[]uint64 boxed in an any / map value / struct any-field that
+// happened to pick the block codec under OptBalanced failed to decode with
+// ErrBadTag ("unknown tag"). Same bug-class as the map-any lossy-vec gap: every
+// tag reachable through a schemaless position must be decodeAny-readable.
+func TestAnyPackBlockRoundTrip(t *testing.T) {
+	s := blockRegimeI64()
+	u := make([]uint64, len(s))
+	for i, v := range s {
+		u[i] = uint64(v)
+	}
+
+	t.Run("toplevel_any_int64", func(t *testing.T) {
+		data, err := Marshal(any(s), OptBalanced)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if got := data[5]; got != tagPackBlock {
+			t.Skipf("codec picked 0x%02X, not tagPackBlock — regime did not trigger block path", got)
+		}
+		var out any
+		if err := Unmarshal(data, &out); err != nil {
+			t.Fatalf("unmarshal any([]int64) with tagPackBlock: %v", err)
+		}
+	})
+
+	t.Run("toplevel_any_uint64", func(t *testing.T) {
+		data, err := Marshal(any(u), OptBalanced)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var out any
+		if err := Unmarshal(data, &out); err != nil {
+			t.Fatalf("unmarshal any([]uint64): %v", err)
+		}
+	})
+
+	t.Run("struct_any_field", func(t *testing.T) {
+		type S struct{ Payload any }
+		data, err := Marshal(S{Payload: s}, OptBalanced)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var out S
+		if err := Unmarshal(data, &out); err != nil {
+			t.Fatalf("unmarshal struct any-field: %v", err)
+		}
+	})
+
+	t.Run("map_string_any", func(t *testing.T) {
+		data, err := Marshal(map[string]any{"nums": s}, OptBalanced)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var out map[string]any
+		if err := Unmarshal(data, &out); err != nil {
+			t.Fatalf("unmarshal map[string]any: %v", err)
+		}
+	})
+}

--- a/qpack_gorilla.go
+++ b/qpack_gorilla.go
@@ -270,6 +270,9 @@ func (d *Decoder) readPackedGorillaHeader(expectKind byte) (n int, firstU64 uint
 	if rem := uint64(len(d.buf) - d.i); n64 > rem*8+1 {
 		return 0, 0, nil, ErrShortBuffer
 	}
+	if n64 > uint64(math.MaxInt) { // 32-bit: rem*8 lets n64 exceed MaxInt -> int(n64) wraps negative -> make panics
+		return 0, 0, nil, ErrInvalidLength
+	}
 	n = int(n64)
 	if n == 0 {
 		return n, 0, nil, nil

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -1629,6 +1629,33 @@ func decodeAny(d *Decoder) (any, error) {
 		// decode. Materialise into the matching typed slice (the values
 		// round-trip; the int codecs widen to 64-bit on the wire).
 		return decodeAnyPackedSlice(d)
+	case tagPackBlock:
+		// A long int/uint slice encoded with the per-block adaptive codec.
+		// Emitted by writeQPackInt64/Uint64 for any []int/[]int64/[]uint/[]uint64
+		// (no ifaceDepth gate), so it can reach decodeAny through an any /
+		// map[K]any value / any-typed field; without this case that failed with
+		// ErrBadTag. The block-kind byte after the tag selects int64 vs uint64
+		// (a namespace disjoint from decodeAnyPackedSlice's qpackKind byte, so
+		// it cannot share that path). decodeSliceInt64/Uint64 re-peek the tag.
+		if d.i+1 >= len(d.buf) {
+			return nil, ErrShortBuffer
+		}
+		switch d.buf[d.i+1] {
+		case blockKindInt:
+			var s []int64
+			if err := decodeSliceInt64(d, unsafe.Pointer(&s)); err != nil {
+				return nil, err
+			}
+			return s, nil
+		case blockKindUint:
+			var s []uint64
+			if err := decodeSliceUint64(d, unsafe.Pointer(&s)); err != nil {
+				return nil, err
+			}
+			return s, nil
+		default:
+			return nil, ErrBadTag
+		}
 	}
 	return nil, ErrBadTag
 }


### PR DESCRIPTION
Second/third-pass audit — cross-cutting invariant + behavioral-correctness lenses (tag round-trip, decode-alloc, codegen↔reflect parity, schema-evolution, lifetime, generative diff), find → adversarial-verify. Every confirmed finding re-verified and reproduced by hand (two verifier verdicts were wrong and caught here).

## Fixes

**HIGH — `decodeAny` missing `tagPackBlock` (0xF0)**
A long int/uint slice encoded with the per-block adaptive codec (0xF0) failed to round-trip through any schemaless position (`any` value, `map[K]any` value, `any` field). 0xF0 has no ifaceDepth gate, so it appears on the **default OptBalanced** tier; `decodeAny` had no case → `ErrBadTag`. Decode-only fix. Regression `TestAnyPackBlockRoundTrip`.

**HIGH — codegen any-field emits undecodable OptLossyVec block**
qdfgen emitted `e.EncodeValue` for `any` fields; that runs at `ifaceDepth==0`, so under OptLossyVec a `[]float32/[]float64` or batchable `[]struct` in the field emitted a `tagColVecLossy` (0xFD) / `tagVecBatchStruct` (0xFE) block that `decodeAny` cannot read — codegen-specific corruption the reflect path (which routes any positions through `encodeIface`) does not have. Added `Encoder.EncodeAny` (mirrors `encodeIface`: raises ifaceDepth) and switched the generator to it. `EncodeValue` is left unchanged — it is a top-level entry point where OptLossyVec legitimately fires (e.g. `examples/embeddings`), so gating it would silently disable lossy for direct callers. Regression `TestGenAnyFieldLossyRoundTrip` (generated + reflect decode).

**HIGH (32-bit) — Gorilla decode element count not bounded by MaxInt**
`readPackedGorillaHeader` cast `int(n64)` with no MaxInt guard; on 32-bit a >256MB buffer lets a crafted count wrap negative → `make(...)` panic (decode DoS). Every sibling reader already guards; Gorilla was the outlier. Reject-only.

**LOW — doc:** `UnmarshalT` signature in the package doc comment was stale (missing the `out *T` param).

## Bug-class
Every wire tag reachable through a schemaless position must be `decodeAny`-readable, and every path that reaches a schemaless position (reflect map/slice-any, **and codegen any-fields**) must mark it (ifaceDepth) so undecodable lossy/batch codecs stay suppressed. columnar-only tags (0xF1 zonechunk) are safe — confined to `decodeColumnarAny`.

## Verification
build + vet + golangci-lint (root & qdfgen 0 issues) + full suite + codegen_test module suite + `-race` all green. `go generate` re-run (maps + codegen sample). Fuzz sweep (8 targets) clean.