### PR TITLE
audit: reject malformed E8 lossy-vec block with pdim < 8 (fail closed)

### DIFF
--- a/lossyvec.go
+++ b/lossyvec.go
@@ -245,6 +245,14 @@ func readLossyVec(src []byte) (vectors [][]float64, elemF32 bool, used int, err 
 	var cosets []byte
 	if variant == vecquant.VariantE8 {
 		pdim := nextPow2Int(int(dim))
+		// E8 quantizes in 8-D blocks; ReconstructE8 walks nb = n/8 blocks and
+		// silently leaves the tail zero when n is not a multiple of 8. The honest
+		// encoder only emits E8 at pdim>=16 (e8Eligible), so a pdim<8 block can
+		// only come from a corrupt/hostile wire — reject it so E8 decode fails
+		// closed instead of returning partially zero-filled vectors.
+		if pdim%8 != 0 {
+			return nil, false, 0, errors.New("qdf: E8 requires pdim multiple of 8")
+		}
 		blocks := int(count) * pdim / 8
 		wantCoset := (blocks + 7) / 8
 		cs, used2, cerr := vecquant.ReadCosets(src[off:], wantCoset)

--- a/lossyvec_e8_guard_test.go
+++ b/lossyvec_e8_guard_test.go
@@ -1,0 +1,33 @@
+package qdf
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/alex60217101990/qdf/internal/vecquant"
+)
+
+// TestReadLossyVecE8RejectsSmallPdim guards against a hostile/corrupt E8
+// lossy-vec block whose padded dimension is < 8. ReconstructE8 walks nb = n/8
+// blocks and silently leaves the tail zero when n is not a multiple of 8, so a
+// pdim<8 block (dim in 1..7 → pdim in {1,2,4}) would decode to partially
+// zero-filled vectors instead of erroring. The honest encoder only emits E8 at
+// pdim>=16 (e8Eligible), so readLossyVec must fail closed on pdim<8.
+func TestReadLossyVecE8RejectsSmallPdim(t *testing.T) {
+	// Build a minimal E8 block with dim=4 (pdim=4) that passes every prior
+	// bound check and reaches the E8 branch.
+	var b []byte
+	b = append(b, tagColVecLossy)
+	b = append(b, vecquant.VariantE8<<1)                           // flags: elemF32=0, variant=E8
+	b = binary.AppendUvarint(b, 4)                                 // dim=4 -> pdim=4 (< 8)
+	b = binary.AppendUvarint(b, 1)                                 // count=1
+	b = append(b, make([]byte, 8)...)                              // seed
+	b = binary.LittleEndian.AppendUint64(b, math.Float64bits(1.0)) // delta
+	b = binary.AppendUvarint(b, 0)                                 // coords len = 0
+
+	_, _, _, err := readLossyVec(b)
+	if err == nil {
+		t.Fatal("readLossyVec accepted an E8 block with pdim<8 (should fail closed, not zero-fill)")
+	}
+}


### PR DESCRIPTION
Full per-file codebase scan (audit-16), logic + alloc + CPU perf, find → adversarial-verify. Every finding re-verified and measured by hand.

## Fix

**MED (robustness) — E8 lossy-vec decode failed open on pdim < 8**
`readLossyVec` accepted any `VariantE8` block after only validating the variant enum and the dim/count bounds. E8 quantizes in 8-D blocks and `ReconstructE8` walks `nb = n/8` blocks, silently leaving the output tail zero when `n = count*pdim` is not a multiple of 8. A corrupt/hostile wire blob with `dim` in 1..7 (`pdim` in {1,2,4}) therefore decoded to **partially zero-filled vectors instead of erroring** — failing open, unlike every other malformed-input path in the file. The honest encoder only emits E8 at `pdim>=16` (`e8Eligible`), so this is unreachable from valid output.

Reject any E8 block whose `pdim` is not a multiple of 8. Byte-identical for all valid input; no honest E8 block is ever rejected. Regression `TestReadLossyVecE8RejectsSmallPdim`.

## Rejected findings (measured, not fixed)
- **PFOR `append(out, make([]byte, n)...)` "redundant alloc"** — FALSE. `go build -gcflags=-m` shows `make([]byte, bodyBytes) does not escape` at both sites: the compiler's isAppendOfMake optimization already lowers it to grow-in-place + memclr with no intermediate allocation. The proposed sibling-idiom rewrite would be a byte-identical no-op with zero alloc benefit. (A prior audit pass reached the same conclusion; a second verifier re-raised it — measurement settles it.)
- **E8 `cosets` re-alloc across the encode verify loop** — real but marginal (opt-in E8 lossy path, a ~1/256-of-coords slice, ≤3 tiny allocs per encode) and the naive reuse is a stale-bit hazard requiring an explicit clear. Not worth the risk for a cold opt-in path (measure-first).

## Verification
build + vet + golangci-lint (0) + full suite + internal packages + `-race` all green.