### PR TITLE
ci(fuzz): tolerate -fuzztime boundary flake, gate on written reproducer

### DIFF
--- a/.github/workflows/fuzz-extended.yml
+++ b/.github/workflows/fuzz-extended.yml
@@ -52,10 +52,34 @@ jobs:
       # (the "hung or terminated unexpectedly" failure mode — an environmental
       # OOM, not an input crash). -parallel caps worker processes so their
       # aggregate footprint stays well under the runner's RAM.
+      # Native Go fuzzing is nondeterministic discovery, and the corpus replay
+      # (plain `go test -run=<Fuzz>`) is the deterministic gate: a REAL finding
+      # is always written to testdata/fuzz/<target>/ with a "Failing input
+      # written to" line. At the -fuzztime boundary the engine can instead
+      # spuriously print "0 execs/sec" then "context deadline exceeded" and exit
+      # non-zero WITHOUT finding anything (golang/go#51484). So we gate on the
+      # reproducer, not the raw exit code: fail iff a reproducer was written,
+      # tolerate the bare boundary flake, and still fail on any other non-zero
+      # exit we don't recognize.
       - name: ${{ matrix.target }} (10m)
         env:
           GOMEMLIMIT: 2GiB
-        run: go test -run=^$ -fuzz=${{ matrix.target }} -fuzztime=10m -timeout=15m -parallel=2
+        run: |
+          set +e
+          out="$(go test -run='^$' -fuzz='${{ matrix.target }}' -fuzztime=10m -timeout=15m -parallel=2 2>&1)"
+          code=$?
+          echo "$out"
+          [ $code -eq 0 ] && exit 0
+          if echo "$out" | grep -q 'Failing input written to'; then
+            echo "::error::${{ matrix.target }}: reproducer written — real fuzz finding"
+            exit 1
+          fi
+          if echo "$out" | grep -q 'context deadline exceeded'; then
+            echo "::warning::${{ matrix.target }}: fuzztime-boundary flake (golang/go#51484), no reproducer written — tolerated"
+            exit 0
+          fi
+          echo "::error::${{ matrix.target }}: fuzz failed (exit $code) with no reproducer and no known-flake signature"
+          exit $code
 
       - name: Upload new corpus on failure
         if: failure()


### PR DESCRIPTION
## Problem

The nightly `fuzz-extended` job failed on `FuzzRoundTrip_StringSlice` with:

```
fuzz: elapsed: 10m0s, execs: 7676096 (0/sec), new interesting: 10 (total: 1261)
--- FAIL: FuzzRoundTrip_StringSlice (600.13s)
    context deadline exceeded
```

This is **not a qdf bug** — it is the known Go fuzzing engine flake at the `-fuzztime` boundary ([golang/go#51484](https://github.com/golang/go/issues/51484)): the engine reports `0 execs/sec` then `context deadline exceeded` and exits non-zero **without finding anything**. Evidence:

- 7.6M executions, **zero reproducers written** (a real finding prints `Failing input written to testdata/fuzz/...`).
- The sibling target `FuzzDecoder_NeverPanics` passed under the identical config.
- The `ci` corpus replay on the same main commit was green.

## Fix

Follow the [go.dev](https://go.dev/doc/security/fuzz/) model: **fuzzing is nondeterministic discovery; the corpus replay is the deterministic gate.** A real finding always writes a reproducer, so gate on that instead of the raw exit code:

- **Reproducer written** (`Failing input written to`) → fail (real bug).
- **Bare `context deadline exceeded`, no reproducer** → tolerate (boundary flake).
- **Any other unrecognized non-zero exit** → still fail (conservative).

The failure-artifact upload is unchanged, so a genuine reproducer is still captured. Not a blind `|| true` — pass/fail is re-derived from the deterministic reproducer signal, the same discriminator the community [jidicula/go-fuzz-action](https://github.com/jidicula/go-fuzz-action) uses.