### PR TITLE
perf(batch): row-major-direct decode + FSST direct-into-slab

### DIFF
--- a/batch_alpha_test.go
+++ b/batch_alpha_test.go
@@ -1,0 +1,161 @@
+package qdf
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// alphaSrc encodes the wire; alphaDoc is the pointer-free batch target. Span is
+// a high-cardinality restricted-alphabet (lowercase-hex, 16 symbols) column the
+// alpha codec packs (tagColStrAlpha); ID/At keep the struct columnar so the
+// batch fast path — decodeBatchColumnar -> scatterBatchColumn(bfStr) ->
+// readStringColumnHandles — reaches the direct-into-slab alpha arm under test.
+type alphaSrc struct {
+	At   time.Time `qdf:"at"`
+	Span string    `qdf:"span"`
+	ID   int64     `qdf:"id"`
+}
+
+type alphaDoc struct {
+	ID   int64 `qdf:"id"`
+	At   Time  `qdf:"at"`
+	Span Str   `qdf:"span"`
+}
+
+// mkAlphaSrc builds n rows. fixed=true gives a uniform 16-char span (the
+// fixed-length + a==16 SIMD DecodeHex4 path); fixed=false varies the length
+// 8..23 (the variable-length lenStart re-scan path). Both use the 16-symbol
+// hex alphabet so the column alpha-packs either way.
+func mkAlphaSrc(n int, fixed bool) []alphaSrc {
+	const hexChars = "0123456789abcdef"
+	r := rand.New(rand.NewSource(1)) //nolint:gosec // deterministic test corpus
+	out := make([]alphaSrc, n)
+	for i := range out {
+		ln := 16
+		if !fixed {
+			ln = 8 + r.Intn(16)
+		}
+		b := make([]byte, ln)
+		for j := range b {
+			// Random over the 16-symbol hex alphabet: high cardinality (so dict
+			// can't dedup it) restricted to <= 64 distinct chars (so alpha packs it).
+			b[j] = hexChars[r.Intn(16)]
+		}
+		out[i] = alphaSrc{
+			ID:   int64(i),
+			At:   time.Unix(1_700_000_000+int64(i), 0).UTC(),
+			Span: string(b),
+		}
+	}
+	return out
+}
+
+// TestBatchAlphaDirectParity checks readStringColumnAlphaInto decodes
+// byte-identically to the source across an alpha-packed columnar batch, on both
+// the fixed- and variable-length span layouts. For n large enough to pack it
+// also asserts the wire is a columnar struct carrying an alpha column (0xFB),
+// so the test genuinely exercises the new arm.
+func TestBatchAlphaDirectParity(t *testing.T) {
+	for _, fixed := range []bool{true, false} {
+		for _, n := range []int{0, 1, 64, 1000} {
+			t.Run(fmt.Sprintf("fixed=%v/n=%d", fixed, n), func(t *testing.T) {
+				src := mkAlphaSrc(n, fixed)
+				data, err := Marshal(src, OptBalanced)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if n >= 64 {
+					d := &Decoder{buf: data}
+					tag, perr := d.peekTag()
+					if perr != nil {
+						t.Fatalf("peekTag: %v", perr)
+					}
+					if tag != tagColStruct {
+						t.Fatalf("want columnar wire (tagColStruct %#x), got %#x", tagColStruct, tag)
+					}
+					// Printable-ASCII bodies never contain 0xFB, so its presence
+					// marks the alpha column tag (same discriminator alphapack_test uses).
+					if bytes.IndexByte(data, tagColStrAlpha) < 0 {
+						t.Fatalf("Span did not alpha-pack (no %#x tag) — would not exercise readStringColumnAlphaInto", tagColStrAlpha)
+					}
+				}
+
+				b, err := UnmarshalBatch[alphaDoc](data)
+				if err != nil {
+					t.Fatalf("UnmarshalBatch: %v", err)
+				}
+				defer b.Release()
+				if len(b.Rows) != n {
+					t.Fatalf("rows = %d, want %d", len(b.Rows), n)
+				}
+				for i, r := range b.Rows {
+					if r.ID != src[i].ID {
+						t.Fatalf("row %d id = %d, want %d", i, r.ID, src[i].ID)
+					}
+					if got := b.Str(r.Span); got != src[i].Span {
+						t.Fatalf("row %d span = %q, want %q", i, got, src[i].Span)
+					}
+					if !b.TimeOf(r.At).Equal(src[i].At) {
+						t.Fatalf("row %d at = %v, want %v", i, b.TimeOf(r.At), src[i].At)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestBatchAlphaDirectTruncated feeds every prefix of an alpha-packed batch wire
+// through UnmarshalBatch: each must error, never panic (readStringColumnAlphaInto
+// parses an alphabet + per-row lengths + a bit-packed body off attacker-controlled
+// bytes and writes unpacked chars into the slab — every bound must hold).
+func TestBatchAlphaDirectTruncated(t *testing.T) {
+	for _, fixed := range []bool{true, false} {
+		src := mkAlphaSrc(128, fixed)
+		data, err := Marshal(src, OptBalanced)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for k := range len(data) {
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("fixed=%v prefix %d panicked: %v", fixed, k, r)
+					}
+				}()
+				if b, err := UnmarshalBatch[alphaDoc](data[:k]); err == nil {
+					b.Release()
+					t.Fatalf("fixed=%v prefix %d decoded without error", fixed, k)
+				}
+			}()
+		}
+	}
+}
+
+// BenchmarkBatchAlphaDecode measures the alpha batch decode after the
+// direct-into-slab change: the temp make([]byte, totalChars) scratch + one copy
+// pass the general readStringColumnHandles arm used to pay are gone.
+func BenchmarkBatchAlphaDecode(b *testing.B) {
+	src := mkAlphaSrc(1000, true)
+	data, err := Marshal(src, OptBalanced)
+	if err != nil {
+		b.Fatal(err)
+	}
+	warm, err := UnmarshalBatch[alphaDoc](data)
+	if err != nil {
+		b.Fatal(err)
+	}
+	warm.Release()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		bat, err := UnmarshalBatch[alphaDoc](data)
+		if err != nil {
+			b.Fatal(err)
+		}
+		bat.Release()
+	}
+}

--- a/batch_decode.go
+++ b/batch_decode.go
@@ -986,11 +986,15 @@ func readStringColumnHandles(d *Decoder, n int, slab *batchSlab, out []Str) erro
 		// copy). readStringColumnFSSTInto mirrors readStringColumnFSST's header
 		// parse and every bounds guard verbatim.
 		return readStringColumnFSSTInto(d, n, slab, out)
+	case tagColStrAlpha:
+		// Alpha unpacks its characters straight onto the slab's backing (no temp
+		// scratch + no second copy), the same shape as the FSST arm above.
+		return d.readStringColumnAlphaInto(n, slab, out)
 	default:
-		// tagColStrRaw / alpha / per-row inline: reuse the general materializer,
-		// then copy each body into the slab (distinct strings, so there is no
-		// dedup to lose). readStringColumn's result aliases decoder scratch —
-		// copy before it is recycled by the next column.
+		// tagColStrRaw / per-row inline: reuse the general materializer, then
+		// copy each body into the slab (distinct strings, so there is no dedup
+		// to lose). readStringColumn's result aliases decoder scratch — copy
+		// before it is recycled by the next column.
 		strs, err := d.readStringColumn(n)
 		if err != nil {
 			return err

--- a/batch_decode.go
+++ b/batch_decode.go
@@ -69,14 +69,13 @@ func unmarshalBatchCore(data []byte, plan *batchPlan, slab *batchSlab, rows func
 }
 
 // unmarshalBatchMirror is unmarshalBatchCore's fallback strategy, factored out
-// so it can be driven directly — bypassing both fast-path attempts above — by
-// a benchmark control that measures what EVERY wire paid before the row-major-
-// direct fast path existed (Phase A's baseline) without needing to check out
-// an earlier commit. unmarshalBatchCore's normal call path reaches it only
-// after both tryDecodeBatchColumnar and tryDecodeBatchRowMajor return ok=false
-// (hybrid, batched-vector, tagNil, a nullable columnar column, or — for the
-// benchmark control — a row-major wire decoded on purpose without the direct
-// path).
+// so it can also be driven directly — bypassing both fast-path attempts above —
+// by a benchmark control that measures the reflect-mirror cost of a wire the
+// direct paths would otherwise handle. unmarshalBatchCore's normal call path
+// reaches it only after both tryDecodeBatchColumnar and tryDecodeBatchRowMajor
+// return ok=false (hybrid, batched-vector, tagNil, a nullable columnar column,
+// or — for the benchmark control — a row-major wire decoded on purpose without
+// the direct path).
 func unmarshalBatchMirror(data []byte, plan *batchPlan, slab *batchSlab, rows func(n int) unsafe.Pointer) (int, error) {
 	slot := plan.mirrorSlicePtr.Get().(*mirrorSlot)
 	defer plan.mirrorSlicePtr.Put(slot)

--- a/batch_decode.go
+++ b/batch_decode.go
@@ -982,11 +982,16 @@ func readStringColumnHandles(d *Decoder, n int, slab *batchSlab, out []Str) erro
 			out[i] = th[j]
 		}
 		return nil
+	case tagColStrFSST:
+		// FSST decompresses straight into the slab (no temp scratch + no second
+		// copy). readStringColumnFSSTInto mirrors readStringColumnFSST's header
+		// parse and every bounds guard verbatim.
+		return readStringColumnFSSTInto(d, n, slab, out)
 	default:
-		// tagColStrRaw / FSST / alpha / per-row inline: reuse the general
-		// materializer, then copy each body into the slab (distinct strings,
-		// so there is no dedup to lose). readStringColumn's result aliases
-		// decoder scratch — copy before it is recycled by the next column.
+		// tagColStrRaw / alpha / per-row inline: reuse the general materializer,
+		// then copy each body into the slab (distinct strings, so there is no
+		// dedup to lose). readStringColumn's result aliases decoder scratch —
+		// copy before it is recycled by the next column.
 		strs, err := d.readStringColumn(n)
 		if err != nil {
 			return err

--- a/batch_decode.go
+++ b/batch_decode.go
@@ -65,6 +65,19 @@ func unmarshalBatchCore(data []byte, plan *batchPlan, slab *batchSlab, rows func
 		return n, err
 	}
 
+	return unmarshalBatchMirror(data, plan, slab, rows)
+}
+
+// unmarshalBatchMirror is unmarshalBatchCore's fallback strategy, factored out
+// so it can be driven directly — bypassing both fast-path attempts above — by
+// a benchmark control that measures what EVERY wire paid before the row-major-
+// direct fast path existed (Phase A's baseline) without needing to check out
+// an earlier commit. unmarshalBatchCore's normal call path reaches it only
+// after both tryDecodeBatchColumnar and tryDecodeBatchRowMajor return ok=false
+// (hybrid, batched-vector, tagNil, a nullable columnar column, or — for the
+// benchmark control — a row-major wire decoded on purpose without the direct
+// path).
+func unmarshalBatchMirror(data []byte, plan *batchPlan, slab *batchSlab, rows func(n int) unsafe.Pointer) (int, error) {
 	slot := plan.mirrorSlicePtr.Get().(*mirrorSlot)
 	defer plan.mirrorSlicePtr.Put(slot)
 
@@ -300,10 +313,22 @@ func tryDecodeBatchRowMajor(data []byte, plan *batchPlan, slab *batchSlab, rows 
 	if err != nil {
 		return 0, true, err
 	}
-	// Bound the OUTPUT allocation like the columnar path: a hostile array count
-	// must not drive a huge rows(n) region. ReadArrayHeader already rejects a
-	// count over the remaining bytes (each element is a struct header >= 1
-	// byte); this additionally caps n*stride at maxColumnarBytes.
+	// Bound n by the INPUT before it drives any allocation: ReadArrayHeader's
+	// tagArr32 arm already rejects a count over the remaining bytes, but its
+	// tagArr16 arm does not (only 2 header bytes are checked, not the claimed
+	// count) — a 3-byte hostile wire can claim up to 65535 rows with zero
+	// bytes left to decode them from. Each row is a struct header of >= 1 wire
+	// byte, so CheckLength(n, 1) rejects that up front, matching the row-major
+	// reflect decoder's identical guard (emitDecodeSliceRowMajorBody,
+	// cmd/qdfgen/gen/gen.go) and go-fuzz-oom-triage's "bound every decode
+	// allocation by the input" rule.
+	if err := d.CheckLength(n, 1); err != nil {
+		return 0, true, err
+	}
+	// Bound the OUTPUT allocation like the columnar path: a wide-struct T with
+	// a still-plausible (input-bounded) n could otherwise amplify a modest
+	// wire into a very large rows(n) region; this caps n*stride at
+	// maxColumnarBytes on top of the input-proportional guard above.
 	if err = checkColumnarBytes(n, plan.stride); err != nil {
 		return 0, true, err
 	}

--- a/batch_decode.go
+++ b/batch_decode.go
@@ -56,11 +56,11 @@ func unmarshalBatchCore(data []byte, plan *batchPlan, slab *batchSlab, rows func
 		return n, err
 	}
 
-	// Row-major-direct fast path: detects a plain row-major struct-slice wire
-	// (an array header, as opposed to the tagColStruct/tagHybridColStruct
-	// container tags) but this skeleton always returns ok=false — the direct
-	// decode body ships in a follow-up change, so behavior here is unchanged
-	// (falls through to the mirror fallback below).
+	// Row-major-direct fast path: a plain row-major struct-slice wire (an array
+	// header, as opposed to the tagColStruct/tagHybridColStruct container tags)
+	// is decoded straight into the T rows + slab — no mirror, no per-row owned
+	// string. Any other wire (hybrid, batched-vector, tagNil, …) returns
+	// ok=false and drops through to the mirror fallback below.
 	if n, ok, err := tryDecodeBatchRowMajor(data, plan, slab, rows); ok {
 		return n, err
 	}
@@ -235,13 +235,25 @@ func tryDecodeBatchColumnar(data []byte, plan *batchPlan, slab *batchSlab, rows 
 // never array-header tags, so checking "is this an array-header tag" alone
 // is sufficient to rule them both out — no need to peek past the outer tag.
 //
-// This is presently a SKELETON: detection runs, but the function always
-// returns ok=false ("not this fast path, use the mirror fallback"), so
-// unmarshalBatchCore's behavior is unchanged. A follow-up change gives it a
-// direct decode body (mirroring decodeBatchColumnar's contract: ok=true on
-// success or hard error, ok=false only for a non-row-major wire).
+// On detection it decodes the array of per-row structs directly into the T
+// rows (obtained from rows(n)) plus the slab, with NO reflect mirror and NO
+// per-row owned-string allocation: each row is read via ReadStructHeader
+// (shape-interned or plain map) and every wire field is matched by name
+// against plan.fields and scattered through unsafe offsets, mirroring the
+// generated DecodeQDF discipline. String/bytes bodies alias the input buffer
+// (noCopy) and are copied once into the slab as Str/Bytes handles.
 //
-//nolint:unparam // plan/slab/rows are unused by this detection-only skeleton; a follow-up change adds the decode body that consumes them (signature is fixed now to match that body's contract).
+// Contract (same as tryDecodeBatchColumnar's real-decode branch):
+//   - ok=false, nil → not this fast path (non-array-header tag, or a peek
+//     error before any byte is consumed) → the caller's mirror fallback
+//     re-decodes the ORIGINAL data.
+//   - ok=true, nil → decoded successfully.
+//   - ok=true, err → a hard decode error AFTER the header was consumed. The
+//     cursor is spent, so the caller must NOT fall back to the mirror (that
+//     would double-decode); the error is surfaced. Every d.Read* error is
+//     propagated and a per-field wire/plan type mismatch surfaces as the
+//     value reader's ErrTypeMismatch — the outer array tag proves nothing
+//     about the element types, so nothing is scattered without validation.
 func tryDecodeBatchRowMajor(data []byte, plan *batchPlan, slab *batchSlab, rows func(n int) unsafe.Pointer) (n int, ok bool, err error) {
 	d := decPool.Get().(*Decoder)
 	d.buf = data
@@ -281,12 +293,199 @@ func tryDecodeBatchRowMajor(data []byte, plan *batchPlan, slab *batchSlab, rows 
 		return 0, false, nil // columnar / hybrid / tagNil / anything else → mirror fallback
 	}
 
-	// Detected a row-major struct-slice wire. plan/slab/rows are threaded
-	// through only for parity with tryDecodeBatchColumnar's signature — this
-	// skeleton proves detection compiles and the unmarshalBatchCore wiring is
-	// inert; a follow-up change adds the direct decode body that consumes
-	// them for real.
-	return 0, false, nil
+	// Detected a row-major struct-slice wire. From here every error is HANDLED
+	// (ok=true): ReadArrayHeader consumes the peeked array tag, so the cursor is
+	// spent and a mid-stream fall back to the mirror would double-decode.
+	n, err = d.ReadArrayHeader()
+	if err != nil {
+		return 0, true, err
+	}
+	// Bound the OUTPUT allocation like the columnar path: a hostile array count
+	// must not drive a huge rows(n) region. ReadArrayHeader already rejects a
+	// count over the remaining bytes (each element is a struct header >= 1
+	// byte); this additionally caps n*stride at maxColumnarBytes.
+	if err = checkColumnarBytes(n, plan.stride); err != nil {
+		return 0, true, err
+	}
+	if n == 0 {
+		rows(0)
+		return 0, true, nil
+	}
+	base := rows(n)
+
+	// Plan fields absent from a row keep their zero value: takeRows hands back
+	// a zeroed region, so a field never scattered stays Time{0,0}/0/"" — the
+	// same schema-evolution semantics as the columnar and mirror paths.
+	for i := range n {
+		rowDst := unsafe.Add(base, uintptr(i)*plan.stride)
+		names, plainN, shaped, herr := d.ReadStructHeader()
+		if herr != nil {
+			return 0, true, herr
+		}
+		if shaped {
+			// Shape-interned struct: values follow positionally in names order,
+			// no per-value key on the wire.
+			for _, name := range names {
+				nb := unsafe.Slice(unsafe.StringData(name), len(name))
+				if ferr := scatterBatchRowMajorField(d, plan, slab, rowDst, nb); ferr != nil {
+					return 0, true, ferr
+				}
+			}
+			continue
+		}
+		// Plain map: plainN (key, value) pairs. The key bytes alias the input;
+		// comparing them against a plan-field name (string(b) == name) does not
+		// allocate.
+		for range plainN {
+			kb, kerr := d.ReadStringBytes()
+			if kerr != nil {
+				return 0, true, kerr
+			}
+			if ferr := scatterBatchRowMajorField(d, plan, slab, rowDst, kb); ferr != nil {
+				return 0, true, ferr
+			}
+		}
+	}
+	return n, true, nil
+}
+
+// batchPlanFieldByName returns the plan field whose wire key equals name, or
+// nil when name is not a plan field (a forward-compat wire field to skip). The
+// name argument aliases the input buffer / an interned shape name; the
+// string(name) == f.name comparison is compiled to a zero-alloc byte compare.
+func batchPlanFieldByName(plan *batchPlan, name []byte) *batchField {
+	for i := range plan.fields {
+		if plan.fields[i].name == string(name) {
+			return &plan.fields[i]
+		}
+	}
+	return nil
+}
+
+// scatterBatchRowMajorField reads one wire field value for the row at rowDst,
+// matched by name against plan.fields, and scatters it through the field's
+// unsafe offset. An unmatched name is skipped (forward compat). Type safety is
+// enforced by the value reader: ReadInt/ReadUint/ReadFloat*/ReadBool/
+// ReadTimestamp/ReadString each return ErrTypeMismatch when the wire tag does
+// not match the field's expected kind, so a mismatched element cannot scatter
+// garbage — the outer array-header tag never implies the element types.
+func scatterBatchRowMajorField(d *Decoder, plan *batchPlan, slab *batchSlab, rowDst unsafe.Pointer, name []byte) error {
+	f := batchPlanFieldByName(plan, name)
+	if f == nil {
+		return d.Skip() // wire field not in plan → skip its single value
+	}
+	dst := unsafe.Add(rowDst, f.off)
+	switch f.kind {
+	case bfStr:
+		// noCopy → s aliases the input buffer; slab.append copies it (the sole
+		// owner), so the alias never escapes.
+		s, err := d.ReadString()
+		if err != nil {
+			return err
+		}
+		off, ln, err := slab.append(unsafe.Slice(unsafe.StringData(s), len(s)))
+		if err != nil {
+			return err
+		}
+		*(*Str)(dst) = Str{off: off, len: ln}
+	case bfBytes:
+		// A nil []byte encodes as tagNil (distinct from an empty bin); the mirror
+		// path (decodeBytes → decodeNilSlice) consumes it as a nil slice. Mirror
+		// that: consume the tag and leave the zeroed handle (BytesOf resolves
+		// Bytes{0,0} to nil), matching batchCopyRows which stores (0,0) for both
+		// a nil and an empty []byte.
+		t, terr := d.peekTag()
+		if terr != nil {
+			return terr
+		}
+		if t == tagNil {
+			d.i++
+			return nil
+		}
+		b, err := d.ReadBytes() // noCopy → aliases input; copied into the slab
+		if err != nil {
+			return err
+		}
+		off, ln, err := slab.append(b)
+		if err != nil {
+			return err
+		}
+		*(*Bytes)(dst) = Bytes{off: off, len: ln}
+	case bfTime:
+		// The wire carries sec/nsec directly (unlike the mirror path, which
+		// decodes a Go time.Time and must guard its zero value): a schema-absent
+		// time is never read here — it stays the zeroed Time{0,0} takeRows left,
+		// matching the columnar path.
+		sec, nsec, err := d.ReadTimestamp()
+		if err != nil {
+			return err
+		}
+		*(*Time)(dst) = Time{Sec: sec, Nsec: nsec}
+	default: // bfScalar
+		return scatterBatchRowMajorScalar(d, dst, f.scalarKind)
+	}
+	return nil
+}
+
+// scatterBatchRowMajorScalar reads one scalar value per the field's Go kind and
+// stores it width-narrowed at dst, reusing scatterBatchScalar's width-store
+// logic for a single value. The chosen reader validates the wire tag: a wire
+// value whose type does not match sk yields ErrTypeMismatch instead of a
+// silent reinterpretation of the bits.
+func scatterBatchRowMajorScalar(d *Decoder, dst unsafe.Pointer, sk reflect.Kind) error {
+	switch sk {
+	case reflect.Bool:
+		v, err := d.ReadBool()
+		if err != nil {
+			return err
+		}
+		*(*bool)(dst) = v
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v, err := d.ReadInt()
+		if err != nil {
+			return err
+		}
+		switch scalarKindSize(sk) {
+		case 1: // int8
+			*(*int8)(dst) = int8(v)
+		case 2: // int16
+			*(*int16)(dst) = int16(v)
+		case 4: // int32
+			*(*int32)(dst) = int32(v)
+		default: // 8: int, int64
+			*(*int64)(dst) = v
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		v, err := d.ReadUint()
+		if err != nil {
+			return err
+		}
+		switch scalarKindSize(sk) {
+		case 1: // uint8/byte
+			*(*uint8)(dst) = uint8(v)
+		case 2: // uint16
+			*(*uint16)(dst) = uint16(v)
+		case 4: // uint32
+			*(*uint32)(dst) = uint32(v)
+		default: // 8: uint, uint64, uintptr
+			*(*uint64)(dst) = v
+		}
+	case reflect.Float32:
+		v, err := d.ReadFloat32()
+		if err != nil {
+			return err
+		}
+		*(*float32)(dst) = v
+	case reflect.Float64:
+		v, err := d.ReadFloat64()
+		if err != nil {
+			return err
+		}
+		*(*float64)(dst) = v
+	default:
+		return ErrTypeMismatch
+	}
+	return nil
 }
 
 // decodeBatchColumnar decodes a pure columnar (tagColStruct) payload straight

--- a/batch_decode.go
+++ b/batch_decode.go
@@ -56,6 +56,15 @@ func unmarshalBatchCore(data []byte, plan *batchPlan, slab *batchSlab, rows func
 		return n, err
 	}
 
+	// Row-major-direct fast path: detects a plain row-major struct-slice wire
+	// (an array header, as opposed to the tagColStruct/tagHybridColStruct
+	// container tags) but this skeleton always returns ok=false — the direct
+	// decode body ships in a follow-up change, so behavior here is unchanged
+	// (falls through to the mirror fallback below).
+	if n, ok, err := tryDecodeBatchRowMajor(data, plan, slab, rows); ok {
+		return n, err
+	}
+
 	slot := plan.mirrorSlicePtr.Get().(*mirrorSlot)
 	defer plan.mirrorSlicePtr.Put(slot)
 
@@ -215,6 +224,69 @@ func tryDecodeBatchColumnar(data []byte, plan *batchPlan, slab *batchSlab, rows 
 		return 0, true, derr
 	}
 	return n, true, nil
+}
+
+// tryDecodeBatchRowMajor sets up a pooled decoder exactly like
+// tryDecodeBatchColumnar and peeks the top tag to DETECT a pure row-major
+// struct-slice wire: a plain array header (the tagFixarr range, tagArr16, or
+// tagArr32 — the same tag set ReadArrayHeader accepts) whose elements are
+// struct-headers, as opposed to the tagColStruct (columnar) or
+// tagHybridColStruct (hybrid) container tags. Those two container tags are
+// never array-header tags, so checking "is this an array-header tag" alone
+// is sufficient to rule them both out — no need to peek past the outer tag.
+//
+// This is presently a SKELETON: detection runs, but the function always
+// returns ok=false ("not this fast path, use the mirror fallback"), so
+// unmarshalBatchCore's behavior is unchanged. A follow-up change gives it a
+// direct decode body (mirroring decodeBatchColumnar's contract: ok=true on
+// success or hard error, ok=false only for a non-row-major wire).
+//
+//nolint:unparam // plan/slab/rows are unused by this detection-only skeleton; a follow-up change adds the decode body that consumes them (signature is fixed now to match that body's contract).
+func tryDecodeBatchRowMajor(data []byte, plan *batchPlan, slab *batchSlab, rows func(n int) unsafe.Pointer) (n int, ok bool, err error) {
+	d := decPool.Get().(*Decoder)
+	d.buf = data
+	d.i = 0
+	d.depth = 0
+	d.headerRead = false
+	d.mode = Fast
+	d.colIndex = false
+	d.colMaxLen = 0
+	// noCopy mirrors tryDecodeBatchColumnar's setup: any string reads this
+	// path eventually does must alias-then-copy into the slab, never
+	// materialize an owned per-value string.
+	d.noCopy = true
+	d.arena = nil
+	d.selectFields = nil
+	d.query = nil
+	if d.state != nil {
+		d.state.reset()
+	}
+	defer func() {
+		d.buf = nil
+		d.colMaxLen = 0
+		d.noCopy = false
+		decPool.Put(d)
+	}()
+
+	tag, perr := d.peekTag()
+	if perr != nil {
+		return 0, false, nil // header/peek error: let the mirror re-decode and surface it
+	}
+
+	// isRowMajor is true only for a plain array-header tag. tagColStruct and
+	// tagHybridColStruct are distinct, non-array-header tag values, so this
+	// single check is enough to exclude both.
+	isRowMajor := tag >= tagFixarr && tag <= tagFixarr|tagFixarrMask || tag == tagArr16 || tag == tagArr32
+	if !isRowMajor {
+		return 0, false, nil // columnar / hybrid / tagNil / anything else → mirror fallback
+	}
+
+	// Detected a row-major struct-slice wire. plan/slab/rows are threaded
+	// through only for parity with tryDecodeBatchColumnar's signature — this
+	// skeleton proves detection compiles and the unmarshalBatchCore wiring is
+	// inert; a follow-up change adds the direct decode body that consumes
+	// them for real.
+	return 0, false, nil
 }
 
 // decodeBatchColumnar decodes a pure columnar (tagColStruct) payload straight

--- a/batch_fsst_test.go
+++ b/batch_fsst_test.go
@@ -1,0 +1,142 @@
+package qdf
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// fsstSrc encodes the wire; fsstDoc is the pointer-free batch target. Body
+// carries high-cardinality, heavy-shared-substring URLs so the columnar string
+// codec picks FSST (tagColStrFSST); At is a narrow-range timestamp that keeps
+// the struct columnar (so the batch fast path — decodeBatchColumnar ->
+// scatterBatchColumn(bfStr) -> readStringColumnHandles — is reached, exercising
+// the direct-into-slab FSST arm this test covers).
+type fsstSrc struct {
+	At   time.Time `qdf:"at"`
+	Body string    `qdf:"body"`
+	ID   int64     `qdf:"id"`
+}
+
+type fsstDoc struct {
+	ID   int64 `qdf:"id"`
+	At   Time  `qdf:"at"`
+	Body Str   `qdf:"body"`
+}
+
+func mkFSSTSrc(n int) []fsstSrc {
+	out := make([]fsstSrc, n)
+	for i := range out {
+		out[i] = fsstSrc{
+			ID:   int64(i),
+			At:   time.Unix(1_700_000_000+int64(i), 0).UTC(),
+			Body: fmt.Sprintf("https://example.com/api/v1/users/%d/profile?ref=%d&session=abcdef0123456789", i, i*7),
+		}
+	}
+	return out
+}
+
+// TestBatchFSSTDirectParity checks the direct-into-slab FSST arm
+// (readStringColumnFSSTInto) decodes byte-identically to the source, across an
+// FSST-coded columnar batch. For n large enough to compress, it also asserts
+// the wire is a columnar struct carrying an FSST string column, so the test
+// genuinely exercises the new arm rather than a raw/row-major fallback.
+func TestBatchFSSTDirectParity(t *testing.T) {
+	for _, n := range []int{0, 1, 64, 1000} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			src := mkFSSTSrc(n)
+			data, err := Marshal(src, OptBalanced|OptFSST)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if n >= 64 {
+				// Columnar wire (batch fast path) carrying an FSST string column.
+				d := &Decoder{buf: data}
+				tag, perr := d.peekTag()
+				if perr != nil {
+					t.Fatalf("peekTag: %v", perr)
+				}
+				if tag != tagColStruct {
+					t.Fatalf("want columnar wire (tagColStruct %#x) so the batch FSST arm runs, got %#x", tagColStruct, tag)
+				}
+				if bytes.IndexByte(data, tagColStrFSST) < 0 {
+					t.Fatalf("Body column did not FSST-code (no %#x tag in wire) — test would not exercise readStringColumnFSSTInto", tagColStrFSST)
+				}
+			}
+
+			b, err := UnmarshalBatch[fsstDoc](data)
+			if err != nil {
+				t.Fatalf("UnmarshalBatch: %v", err)
+			}
+			defer b.Release()
+			if len(b.Rows) != n {
+				t.Fatalf("rows = %d, want %d", len(b.Rows), n)
+			}
+			for i, r := range b.Rows {
+				if r.ID != src[i].ID {
+					t.Fatalf("row %d id = %d, want %d", i, r.ID, src[i].ID)
+				}
+				if got := b.Str(r.Body); got != src[i].Body {
+					t.Fatalf("row %d body = %q, want %q", i, got, src[i].Body)
+				}
+				if !b.TimeOf(r.At).Equal(src[i].At) {
+					t.Fatalf("row %d at = %v, want %v", i, b.TimeOf(r.At), src[i].At)
+				}
+			}
+		})
+	}
+}
+
+// TestBatchFSSTDirectTruncated feeds every prefix of an FSST-coded batch wire
+// through UnmarshalBatch: each must return an error, never panic (the
+// direct-into-slab path parses a symbol table + per-row compressed lengths off
+// attacker-controlled bytes; every bound must hold).
+func TestBatchFSSTDirectTruncated(t *testing.T) {
+	src := mkFSSTSrc(128)
+	data, err := Marshal(src, OptBalanced|OptFSST)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for k := range len(data) {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("prefix len %d panicked: %v", k, r)
+				}
+			}()
+			if b, err := UnmarshalBatch[fsstDoc](data[:k]); err == nil {
+				b.Release()
+				t.Fatalf("prefix len %d decoded without error", k)
+			}
+		}()
+	}
+}
+
+// BenchmarkBatchFSSTDecode measures the FSST batch decode after the
+// direct-into-slab change: the temp make([]byte,0,dt64) scratch + one full copy
+// pass the general readStringColumnHandles arm used to pay are gone, so allocs/op
+// and B/op should sit well below the pre-change ~14 allocs / ~112 KB the headroom
+// probe recorded (the residual is the FSST symbol-table decode, out of scope).
+func BenchmarkBatchFSSTDecode(b *testing.B) {
+	src := mkFSSTSrc(1000)
+	data, err := Marshal(src, OptBalanced|OptFSST)
+	if err != nil {
+		b.Fatal(err)
+	}
+	warm, err := UnmarshalBatch[fsstDoc](data)
+	if err != nil {
+		b.Fatal(err)
+	}
+	warm.Release()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		bat, err := UnmarshalBatch[fsstDoc](data)
+		if err != nil {
+			b.Fatal(err)
+		}
+		bat.Release()
+	}
+}

--- a/batch_multicol_test.go
+++ b/batch_multicol_test.go
@@ -1,0 +1,150 @@
+package qdf
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// multiSrc encodes a batch with FOUR string columns that the encoder codes
+// differently — a URL column (FSST), a hex column (alpha), a high-entropy
+// random column (raw), and a low-cardinality category column (dict) — so the
+// batch decode runs its FSST/alpha/raw/dict arms in the SAME slab, each 2nd+
+// column starting at a non-zero slab base. This is the coverage the
+// single-string-column tests miss: it catches any base/offset error in
+// readStringColumnFSSTInto / readStringColumnAlphaInto where a handle would
+// otherwise resolve against the wrong slab region.
+type multiSrc struct {
+	At  time.Time `qdf:"at"`
+	URL string    `qdf:"url"` // FSST: shared-substring URLs
+	Hex string    `qdf:"hex"` // alpha: 16-symbol hex
+	Rnd string    `qdf:"rnd"` // raw: high-entropy ASCII
+	Cat string    `qdf:"cat"` // dict: few distinct values
+	ID  int64     `qdf:"id"`
+}
+
+type multiDoc struct {
+	ID  int64 `qdf:"id"`
+	At  Time  `qdf:"at"`
+	URL Str   `qdf:"url"`
+	Hex Str   `qdf:"hex"`
+	Rnd Str   `qdf:"rnd"`
+	Cat Str   `qdf:"cat"`
+}
+
+func mkMultiSrc(n int) []multiSrc {
+	const hexChars = "0123456789abcdef"
+	const asciiChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
+	cats := []string{"info", "warn", "error", "debug"}
+	r := rand.New(rand.NewSource(7)) //nolint:gosec // deterministic test corpus
+	out := make([]multiSrc, n)
+	for i := range out {
+		hx := make([]byte, 16)
+		for j := range hx {
+			hx[j] = hexChars[r.Intn(16)]
+		}
+		rn := make([]byte, 24)
+		for j := range rn {
+			rn[j] = asciiChars[r.Intn(len(asciiChars))]
+		}
+		out[i] = multiSrc{
+			ID:  int64(i),
+			At:  time.Unix(1_700_000_000+int64(i), 0).UTC(),
+			URL: fmt.Sprintf("https://example.com/api/v1/resource/%d/detail?ref=%d", i, i*3),
+			Hex: string(hx),
+			Rnd: string(rn),
+			Cat: cats[i%len(cats)],
+		}
+	}
+	return out
+}
+
+// TestBatchMultiColumnParity round-trips a four-string-column batch and asserts
+// every field decodes byte-identically via UnmarshalBatch — against the source
+// AND against the authoritative reflect Unmarshal into the string-twin. Because
+// the columns share one slab, columns 2..4 exercise the FSST/alpha direct-into-
+// slab arms at a non-zero base; a base/offset bug corrupts a later column's
+// strings, which this catches.
+func TestBatchMultiColumnParity(t *testing.T) {
+	for _, n := range []int{0, 1, 64, 1000} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			src := mkMultiSrc(n)
+			data, err := Marshal(src, OptBalanced|OptFSST)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if n >= 64 {
+				// Confirm the two direct-into-slab arms are actually exercised:
+				// FSST (0xF6) and alpha (0xFB) tags both present in the columnar wire.
+				if bytes.IndexByte(data, tagColStrFSST) < 0 {
+					t.Fatalf("URL column did not FSST-code (no %#x) — FSST arm not exercised", tagColStrFSST)
+				}
+				if bytes.IndexByte(data, tagColStrAlpha) < 0 {
+					t.Fatalf("Hex column did not alpha-pack (no %#x) — alpha arm not exercised", tagColStrAlpha)
+				}
+			}
+
+			// Authoritative baseline: reflect Unmarshal into the string-twin.
+			var want []multiSrc
+			if err := Unmarshal(data, &want); err != nil {
+				t.Fatalf("reflect Unmarshal: %v", err)
+			}
+
+			b, err := UnmarshalBatch[multiDoc](data)
+			if err != nil {
+				t.Fatalf("UnmarshalBatch: %v", err)
+			}
+			defer b.Release()
+			if len(b.Rows) != n || len(want) != n {
+				t.Fatalf("rows batch=%d reflect=%d want=%d", len(b.Rows), len(want), n)
+			}
+			for i, r := range b.Rows {
+				// Compare every string field against BOTH the source and the
+				// reflect decode — a base/offset bug shows as a wrong or shifted
+				// body in exactly one of the later columns.
+				if b.Str(r.URL) != src[i].URL || b.Str(r.URL) != want[i].URL {
+					t.Fatalf("row %d URL: batch=%q src=%q reflect=%q", i, b.Str(r.URL), src[i].URL, want[i].URL)
+				}
+				if b.Str(r.Hex) != src[i].Hex || b.Str(r.Hex) != want[i].Hex {
+					t.Fatalf("row %d Hex: batch=%q src=%q reflect=%q", i, b.Str(r.Hex), src[i].Hex, want[i].Hex)
+				}
+				if b.Str(r.Rnd) != src[i].Rnd || b.Str(r.Rnd) != want[i].Rnd {
+					t.Fatalf("row %d Rnd: batch=%q src=%q reflect=%q", i, b.Str(r.Rnd), src[i].Rnd, want[i].Rnd)
+				}
+				if b.Str(r.Cat) != src[i].Cat || b.Str(r.Cat) != want[i].Cat {
+					t.Fatalf("row %d Cat: batch=%q src=%q reflect=%q", i, b.Str(r.Cat), src[i].Cat, want[i].Cat)
+				}
+				if r.ID != src[i].ID {
+					t.Fatalf("row %d ID: batch=%d src=%d", i, r.ID, src[i].ID)
+				}
+			}
+		})
+	}
+}
+
+// TestBatchMultiColumnTruncated: every prefix of the four-column wire errors,
+// never panics — the FSST/alpha arms write into the slab off attacker-controlled
+// lengths at a non-zero base, so bounds must hold there too.
+func TestBatchMultiColumnTruncated(t *testing.T) {
+	src := mkMultiSrc(96)
+	data, err := Marshal(src, OptBalanced|OptFSST)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for k := range len(data) {
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					t.Fatalf("prefix %d panicked: %v", k, rec)
+				}
+			}()
+			if b, err := UnmarshalBatch[multiDoc](data[:k]); err == nil {
+				b.Release()
+				t.Fatalf("prefix %d decoded without error", k)
+			}
+		}()
+	}
+}

--- a/batch_rowmajor_test.go
+++ b/batch_rowmajor_test.go
@@ -60,35 +60,169 @@ func TestBatchRowMajorDirectParity(t *testing.T) {
 	}
 }
 
-// TestTryDecodeBatchRowMajorSkeletonAlwaysDefers is a whitebox test asserting
-// this task's contract directly: even for a wire tryDecodeBatchRowMajor
-// detects as row-major, the skeleton returns ok=false (delegates to the
-// mirror fallback) rather than ok=true. A later change that implements the
-// real decode body is expected to flip this to ok=true on success — at that
-// point this test should be updated/replaced, not left asserting the
-// skeleton's inert behavior.
-func TestTryDecodeBatchRowMajorSkeletonAlwaysDefers(t *testing.T) {
+// TestTryDecodeBatchRowMajorDecodes is a whitebox test asserting this task's
+// contract directly: on a row-major struct-slice wire, tryDecodeBatchRowMajor
+// returns ok=true with n rows decoded straight into T + slab (no mirror), and
+// every row matches the source.
+func TestTryDecodeBatchRowMajorDecodes(t *testing.T) {
+	for _, n := range []int{0, 1, 64, 1000} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			src := mkBatSrc(n)
+			data, err := Marshal(src, OptBalanced&^OptDense)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			plan, err := batchPlanOf(reflect.TypeFor[batDoc]())
+			if err != nil {
+				t.Fatalf("batchPlanOf: %v", err)
+			}
+			slab := newBatchSlab()
+			defer slab.release()
+			var base unsafe.Pointer
+			rows := func(m int) unsafe.Pointer {
+				base = slab.takeRows(m * int(plan.stride))
+				return base
+			}
+
+			gotN, ok, err := tryDecodeBatchRowMajor(data, plan, slab, rows)
+			if err != nil {
+				t.Fatalf("tryDecodeBatchRowMajor: unexpected err %v", err)
+			}
+			if !ok {
+				t.Fatalf("tryDecodeBatchRowMajor: ok = false, want true (direct path must handle a row-major wire)")
+			}
+			if gotN != n {
+				t.Fatalf("tryDecodeBatchRowMajor: n = %d, want %d", gotN, n)
+			}
+			if n == 0 {
+				return
+			}
+			b := Batch[batDoc]{Rows: unsafe.Slice((*batDoc)(base), n), slab: slab, epoch: slab.epoch}
+			for i, r := range b.Rows {
+				if r.ID != int64(i) || b.Str(r.Name) != src[i].Name || r.Val != src[i].Val {
+					t.Fatalf("row %d = %+v (name=%q), want id=%d name=%q val=%v",
+						i, r, b.Str(r.Name), src[i].ID, src[i].Name, src[i].Val)
+				}
+				if !b.TimeOf(r.At).Equal(src[i].At) {
+					t.Fatalf("row %d time = %v, want %v", i, b.TimeOf(r.At), src[i].At)
+				}
+			}
+		})
+	}
+}
+
+// TestBatchRowMajorTruncated asserts every prefix of a marshaled row-major wire
+// returns an error (never panics) — the unsafe per-field scatter must guard
+// every offset so a truncated/hostile payload cannot read past the buffer.
+func TestBatchRowMajorTruncated(t *testing.T) {
 	src := mkBatSrc(64)
 	data, err := Marshal(src, OptBalanced&^OptDense)
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
-	plan, err := batchPlanOf(reflect.TypeFor[batDoc]())
-	if err != nil {
-		t.Fatalf("batchPlanOf: %v", err)
+	for k := range len(data) {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("prefix len %d panicked: %v", k, r)
+				}
+			}()
+			b, err := UnmarshalBatch[batDoc](data[:k])
+			if err == nil {
+				// A truncated struct-slice may occasionally decode to a valid
+				// SHORTER batch (a whole-row prefix boundary); that is fine as
+				// long as it did not panic and the rows it did produce resolve.
+				for _, r := range b.Rows {
+					_ = b.Str(r.Name)
+				}
+				b.Release()
+			}
+		}()
 	}
-	slab := newBatchSlab()
-	defer slab.release()
-	rows := func(n int) unsafe.Pointer { return slab.takeRows(n * int(plan.stride)) }
+}
 
-	n, ok, err := tryDecodeBatchRowMajor(data, plan, slab, rows)
+// TestBatchRowMajorKindMismatch corrupts a field's value tag on the wire and
+// asserts the direct path rejects it (a decode error) rather than scattering a
+// reinterpreted value — the outer array-header tag does not prove the element
+// field types.
+func TestBatchRowMajorKindMismatch(t *testing.T) {
+	src := mkBatSrc(4)
+	data, err := Marshal(src, OptBalanced&^OptDense)
 	if err != nil {
-		t.Fatalf("tryDecodeBatchRowMajor: unexpected err %v", err)
+		t.Fatalf("Marshal: %v", err)
 	}
-	if ok {
-		t.Fatalf("tryDecodeBatchRowMajor: ok = true, want false (skeleton must still delegate to mirror)")
+	// Find the first "val" (float64) value byte on the wire and overwrite its
+	// float64 tag with a bool tag: ReadFloat64 must then return ErrTypeMismatch.
+	d := &Decoder{buf: data}
+	if _, err := d.peekTag(); err != nil {
+		t.Fatalf("peekTag: %v", err)
 	}
-	if n != 0 {
-		t.Fatalf("tryDecodeBatchRowMajor: n = %d, want 0 when ok=false", n)
+	if _, err := d.ReadArrayHeader(); err != nil {
+		t.Fatalf("ReadArrayHeader: %v", err)
+	}
+	// Walk the first row to the "val" field's value tag.
+	names, plainN, shaped, err := d.ReadStructHeader()
+	if err != nil {
+		t.Fatalf("ReadStructHeader: %v", err)
+	}
+	pos := -1
+	read1 := func(name string) {
+		switch name {
+		case "id":
+			_, _ = d.ReadInt()
+		case "val":
+			pos = d.i // tag byte of the float64 value
+			_, _ = d.ReadFloat64()
+		case "name":
+			_, _ = d.ReadString()
+		case "at":
+			_, _, _ = d.ReadTimestamp()
+		default:
+			_ = d.Skip()
+		}
+	}
+	if shaped {
+		for _, name := range names {
+			read1(name)
+		}
+	} else {
+		for range plainN {
+			kb, _ := d.ReadStringBytes()
+			read1(string(kb))
+		}
+	}
+	if pos < 0 {
+		t.Fatalf("could not locate the val field on the wire")
+	}
+	corrupt := make([]byte, len(data))
+	copy(corrupt, data)
+	corrupt[pos] = byte(tagFalse) // was tagFloat64
+	if _, err := UnmarshalBatch[batDoc](corrupt); err == nil {
+		t.Fatalf("expected a decode error for a bool where a float64 is required, got nil")
+	}
+}
+
+// BenchmarkBatchRowMajorDecode measures the direct path: decode a 1000-row
+// row-major wire + Release, steady-state (pools warmed). Compare its allocs/ns
+// against the mirror fallback that decoded the same wire before this change.
+func BenchmarkBatchRowMajorDecode(b *testing.B) {
+	src := mkBatSrc(1000)
+	data, err := Marshal(src, OptBalanced&^OptDense)
+	if err != nil {
+		b.Fatalf("Marshal: %v", err)
+	}
+	// Warm the decoder/slab/mirror pools.
+	if bb, err := UnmarshalBatch[batDoc](data); err != nil {
+		b.Fatalf("warm: %v", err)
+	} else {
+		bb.Release()
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		bb, err := UnmarshalBatch[batDoc](data)
+		if err != nil {
+			b.Fatalf("decode: %v", err)
+		}
+		bb.Release()
 	}
 }

--- a/batch_rowmajor_test.go
+++ b/batch_rowmajor_test.go
@@ -259,8 +259,8 @@ func BenchmarkBatchRowMajorDecode(b *testing.B) {
 // bypassing tryDecodeBatchColumnar/tryDecodeBatchRowMajor entirely. It mirrors
 // UnmarshalBatch's structure (batch.go) exactly but calls the mirror strategy
 // directly — the benchmark control for BenchmarkBatchRowMajorDecodeMirror,
-// reproducing exactly what a row-major wire paid before Phase A added the
-// direct fast path (A2's measured baseline).
+// reproducing what a row-major wire costs through the reflect-mirror fallback
+// instead of the direct fast path.
 func unmarshalBatchForceMirror[T any](data []byte) (Batch[T], error) {
 	plan, err := batchPlanOf(reflect.TypeFor[T]())
 	if err != nil {
@@ -287,8 +287,9 @@ func unmarshalBatchForceMirror[T any](data []byte) (Batch[T], error) {
 // BenchmarkBatchRowMajorDecodeMirror is BenchmarkBatchRowMajorDecode's control:
 // the IDENTICAL row-major wire, forced through the mirror fallback via
 // unmarshalBatchForceMirror instead of tryDecodeBatchRowMajor. benchstat-diffing
-// this against BenchmarkBatchRowMajorDecode is the Phase-A gate measurement,
-// reproducible in-repo without checking out a pre-Phase-A commit.
+// this against BenchmarkBatchRowMajorDecode isolates the direct path's win (the
+// per-row string allocation and copy the reflect mirror pays), reproducible
+// in-repo without checking out an earlier commit.
 func BenchmarkBatchRowMajorDecodeMirror(b *testing.B) {
 	src := mkBatSrc(1000)
 	data, err := Marshal(src, OptBalanced&^OptDense)

--- a/batch_rowmajor_test.go
+++ b/batch_rowmajor_test.go
@@ -1,0 +1,94 @@
+package qdf
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"unsafe"
+)
+
+// TestBatchRowMajorDirectParity locks Batch decode parity for a row-major
+// wire BEFORE tryDecodeBatchRowMajor grows a real decode body, so a later
+// change to it cannot silently regress correctness.
+//
+// OptBalanced includes OptDense, which transposes a []struct slice at
+// len >= columnarMinElems (16) into the columnar tagColStruct wire.
+// Stripping OptDense forces a row-major wire at every n, including n >= 16 —
+// unlike TestUnmarshalBatchRowMajor (n=4, naturally below the columnar
+// threshold), this exercises the row-major path across the full size range
+// the batch fast path cares about.
+func TestBatchRowMajorDirectParity(t *testing.T) {
+	for _, n := range []int{0, 1, 64, 1000} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			src := mkBatSrc(n)
+			data, err := Marshal(src, OptBalanced&^OptDense)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+
+			// Whitebox check that the wire really is row-major (not columnar
+			// or hybrid) — trusting the flag alone would let this test pass
+			// even if a future encoder change re-triggered columnar transpose
+			// for some n despite OptDense being stripped.
+			d := &Decoder{buf: data}
+			tag, err := d.peekTag()
+			if err != nil {
+				t.Fatalf("peekTag: %v", err)
+			}
+			if tag == tagColStruct || tag == tagHybridColStruct {
+				t.Fatalf("n=%d: expected row-major wire, got columnar/hybrid tag %#x", n, tag)
+			}
+
+			b, err := UnmarshalBatch[batDoc](data)
+			if err != nil {
+				t.Fatalf("UnmarshalBatch: %v", err)
+			}
+			defer b.Release()
+			if len(b.Rows) != n {
+				t.Fatalf("rows = %d, want %d", len(b.Rows), n)
+			}
+			for i, r := range b.Rows {
+				if r.ID != int64(i) || b.Str(r.Name) != src[i].Name || r.Val != src[i].Val {
+					t.Fatalf("row %d = %+v (name=%q), want id=%d name=%q val=%v",
+						i, r, b.Str(r.Name), src[i].ID, src[i].Name, src[i].Val)
+				}
+				if !b.TimeOf(r.At).Equal(src[i].At) {
+					t.Fatalf("row %d time = %v, want %v", i, b.TimeOf(r.At), src[i].At)
+				}
+			}
+		})
+	}
+}
+
+// TestTryDecodeBatchRowMajorSkeletonAlwaysDefers is a whitebox test asserting
+// this task's contract directly: even for a wire tryDecodeBatchRowMajor
+// detects as row-major, the skeleton returns ok=false (delegates to the
+// mirror fallback) rather than ok=true. A later change that implements the
+// real decode body is expected to flip this to ok=true on success — at that
+// point this test should be updated/replaced, not left asserting the
+// skeleton's inert behavior.
+func TestTryDecodeBatchRowMajorSkeletonAlwaysDefers(t *testing.T) {
+	src := mkBatSrc(64)
+	data, err := Marshal(src, OptBalanced&^OptDense)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	plan, err := batchPlanOf(reflect.TypeFor[batDoc]())
+	if err != nil {
+		t.Fatalf("batchPlanOf: %v", err)
+	}
+	slab := newBatchSlab()
+	defer slab.release()
+	rows := func(n int) unsafe.Pointer { return slab.takeRows(n * int(plan.stride)) }
+
+	n, ok, err := tryDecodeBatchRowMajor(data, plan, slab, rows)
+	if err != nil {
+		t.Fatalf("tryDecodeBatchRowMajor: unexpected err %v", err)
+	}
+	if ok {
+		t.Fatalf("tryDecodeBatchRowMajor: ok = true, want false (skeleton must still delegate to mirror)")
+	}
+	if n != 0 {
+		t.Fatalf("tryDecodeBatchRowMajor: n = %d, want 0 when ok=false", n)
+	}
+}

--- a/batch_rowmajor_test.go
+++ b/batch_rowmajor_test.go
@@ -1,9 +1,11 @@
 package qdf
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 	"unsafe"
 )
 
@@ -57,6 +59,32 @@ func TestBatchRowMajorDirectParity(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestBatchRowMajorHostileLength is the A2-review hardening regression
+// (go-fuzz-oom-triage bug class): a tiny 3-byte wire claims a tagArr16 (0xD3)
+// array header of n=65535 backed by ZERO remaining bytes. Unlike ReadArrayHeader's
+// tagArr32 arm, its tagArr16 arm does not bound n against the remaining
+// buffer (only the 2 header bytes are checked, not the claimed count) — before
+// the CheckLength(n, 1) guard, checkColumnarBytes(n, plan.stride) was the only
+// bound left, and it caps the OUTPUT allocation at 256 MB, not at the input
+// size: n=65535 * batDoc's ~40-byte stride is ~2.6 MB, far under that ceiling,
+// so rows(65535) would actually run — a transient multi-MB allocation driven
+// by a 3-byte hostile input — before the first ReadStructHeader (0 bytes left)
+// finally errors. CheckLength(n, 1) now rejects it immediately, before rows(n)
+// is ever called.
+func TestBatchRowMajorHostileLength(t *testing.T) {
+	// tagArr16 = 0xD3 (wire.go); readU16 is little-endian, but 0xff/0xff makes
+	// the byte order irrelevant here: n = 65535.
+	hostile := []byte{0xd3, 0xff, 0xff}
+	b, err := UnmarshalBatch[batDoc](hostile)
+	if err == nil {
+		b.Release()
+		t.Fatal("expected an error for a hostile 65535-row header backed by 0 bytes, got nil")
+	}
+	if !errors.Is(err, ErrShortBuffer) {
+		t.Fatalf("error = %v, want ErrShortBuffer", err)
 	}
 }
 
@@ -224,5 +252,193 @@ func BenchmarkBatchRowMajorDecode(b *testing.B) {
 			b.Fatalf("decode: %v", err)
 		}
 		bb.Release()
+	}
+}
+
+// unmarshalBatchForceMirror decodes data via ONLY unmarshalBatchMirror,
+// bypassing tryDecodeBatchColumnar/tryDecodeBatchRowMajor entirely. It mirrors
+// UnmarshalBatch's structure (batch.go) exactly but calls the mirror strategy
+// directly — the benchmark control for BenchmarkBatchRowMajorDecodeMirror,
+// reproducing exactly what a row-major wire paid before Phase A added the
+// direct fast path (A2's measured baseline).
+func unmarshalBatchForceMirror[T any](data []byte) (Batch[T], error) {
+	plan, err := batchPlanOf(reflect.TypeFor[T]())
+	if err != nil {
+		return Batch[T]{}, err
+	}
+	slab := newBatchSlab()
+	var rowsPtr unsafe.Pointer
+	takeRows := func(n int) unsafe.Pointer {
+		rowsPtr = slab.takeRows(n * int(plan.stride))
+		return rowsPtr
+	}
+	n, err := unmarshalBatchMirror(data, plan, slab, takeRows)
+	if err != nil {
+		slab.release()
+		return Batch[T]{}, err
+	}
+	var rows []T
+	if n > 0 {
+		rows = unsafe.Slice((*T)(rowsPtr), n)
+	}
+	return Batch[T]{Rows: rows, slab: slab, epoch: slab.epoch}, nil
+}
+
+// BenchmarkBatchRowMajorDecodeMirror is BenchmarkBatchRowMajorDecode's control:
+// the IDENTICAL row-major wire, forced through the mirror fallback via
+// unmarshalBatchForceMirror instead of tryDecodeBatchRowMajor. benchstat-diffing
+// this against BenchmarkBatchRowMajorDecode is the Phase-A gate measurement,
+// reproducible in-repo without checking out a pre-Phase-A commit.
+func BenchmarkBatchRowMajorDecodeMirror(b *testing.B) {
+	src := mkBatSrc(1000)
+	data, err := Marshal(src, OptBalanced&^OptDense)
+	if err != nil {
+		b.Fatalf("Marshal: %v", err)
+	}
+	if bb, err := unmarshalBatchForceMirror[batDoc](data); err != nil {
+		b.Fatalf("warm: %v", err)
+	} else {
+		bb.Release()
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		bb, err := unmarshalBatchForceMirror[batDoc](data)
+		if err != nil {
+			b.Fatalf("decode: %v", err)
+		}
+		bb.Release()
+	}
+}
+
+// hybSrc mirrors batSrc's 4 columnar-eligible fields and adds Extra, a
+// map field: classifyColKind (columnar.go) has no case for reflect.Map (its
+// switch covers Int/Uint/Float32/Float64/Bool/String/Slice-of-byte only, and
+// falls to `default: return 0, 0, false, false` for anything else), so Extra
+// is always residual while ID/Name/Val/At stay columnar-eligible —
+// buildColumnarPlan (columnar.go) then produces a HYBRID plan (residual !=
+// nil), not a pure one. This is the realistic hybrid trigger buildColumnarPlan
+// itself documents ("mostly-scalar struct with one map/slice field", AD/log/
+// RTB records) — the same shape TestHybridResidualLongerThanRowCount exercises
+// for the general (non-batch) decode path.
+//
+// batDoc (batch_test.go) is used AS-IS for T: it has no Extra field at all, so
+// decoding into it is unambiguous schema evolution ("a residual wire field the
+// target struct lacks" — decodeHybridColumnar's own documented behavior,
+// columnar.go) rather than the OTHER residual-matching case decodeHybridColumnar
+// implements (a wire-residual field whose name DOES match a target field, but
+// the target's OWN classification of that field disagrees with the wire's —
+// e.g. a batch mirror's plain-scalar reconstruction of a source field the
+// encoder classified residual for an unrelated reason, such as a per-field
+// custom Marshaler on the SOURCE struct only). decodeHybridColumnar matches a
+// wire-residual field by NAME AND by the TARGET's OWN classification
+// (findResidual only searches plan.residual), not by name alone, so that other
+// case decodes as the target's zero value instead of an error — batDoc sidesteps
+// it entirely by simply not declaring the field, which is the shape every
+// batch-eligible T is restricted to anyway (batchPlanOf rejects the map/slice/
+// custom-Marshaler types that could ever trigger the mismatched case).
+type hybSrc struct {
+	Extra map[string]int `qdf:"extra"`
+	At    time.Time      `qdf:"at"`
+	Name  string         `qdf:"name"`
+	ID    int64          `qdf:"id"`
+	Val   float64        `qdf:"val"`
+}
+
+func mkHybSrc(n int) []hybSrc {
+	out := make([]hybSrc, n)
+	for i := range out {
+		out[i] = hybSrc{
+			ID:    int64(i),
+			Name:  []string{"alpha", "beta", "gamma"}[i%3],
+			Val:   float64(i) * 1.5,
+			At:    time.Unix(1_700_000_000+int64(i), 500).UTC(),
+			Extra: map[string]int{"i": i}, // residual: batDoc has no matching field
+		}
+	}
+	return out
+}
+
+// TestBatchHybridFallback proves the mirror fallback still fires — and stays
+// correct — for the ONE non-row-major/non-pure-columnar wire a batch-eligible
+// T can actually encode: tagHybridColStruct.
+//
+// Reachability accounting for every wire shape NEITHER tryDecodeBatchColumnar
+// NOR tryDecodeBatchRowMajor claims (batch_decode.go):
+//
+//   - Hybrid (tagHybridColStruct): REACHABLE — this test. Requires a
+//     columnar-INELIGIBLE field (classifyColKind, columnar.go) alongside at
+//     least one eligible one. hybSrc's Extra (map[string]int) field is exactly
+//     that; a batch-eligible T (scalars + Str/Bytes/Time only, per
+//     batchPlanOf/appendBatchFields, batch_desc.go) simply never declares the
+//     residual field, which is fine — schema evolution already handles a wire
+//     field the target lacks.
+//   - Nullable column: UNREACHABLE for a legitimately-typed Batch[T] wire —
+//     no test needed. A nullable column requires a *U source field
+//     (buildColumnarPlan's `if fd.kind == reflect.Pointer` branch, columnar.go);
+//     appendBatchFields (batch_desc.go) rejects ANY pointer field on T outright
+//     (`case reflect.Map, reflect.Pointer, reflect.Interface, reflect.Chan,
+//     reflect.Func: return fmt.Errorf(...not pointer-free...)`), so
+//     batchPlanOf fails before UnmarshalBatch touches a single wire byte for
+//     any T with a matching pointer field — there is no batch-eligible T a
+//     nullable-column wire could legitimately decode into. (The existing,
+//     separate errBatchNeedFallback guard in decodeBatchColumnar already
+//     defends a HOSTILE columnar wire that merely declares a nullable column
+//     under a matching field name — pre-existing, out of this task's scope.)
+//   - Batched-vector (tagVecBatchStruct): UNREACHABLE — no test needed. Per
+//     wire.go's tag doc it requires a []float32/[]float64 struct field;
+//     appendBatchFields's `case reflect.Slice: return fmt.Errorf(...is a
+//     slice — use qdf.Bytes...)` rejects every slice field except via the
+//     Bytes handle ([]byte only), so batchPlanOf fails before decode for any T
+//     with a vector field — no batch-eligible T can pair with this wire.
+func TestBatchHybridFallback(t *testing.T) {
+	const n = 64 // >= columnarMinElems
+	src := mkHybSrc(n)
+	data, err := Marshal(src, OptBalanced|OptDense|OptShapeIntern)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	d := &Decoder{buf: data}
+	tag, err := d.peekTag()
+	if err != nil {
+		t.Fatalf("peekTag: %v", err)
+	}
+	if tag != tagHybridColStruct {
+		t.Fatalf("expected a tagHybridColStruct wire (%#x), got tag %#x — the columnar probe did not choose hybrid for this fixture", tagHybridColStruct, tag)
+	}
+
+	// Whitebox: neither fast path claims a hybrid wire — unmarshalBatchCore
+	// must fall through to unmarshalBatchMirror.
+	plan, err := batchPlanOf(reflect.TypeFor[batDoc]())
+	if err != nil {
+		t.Fatalf("batchPlanOf: %v", err)
+	}
+	slab := newBatchSlab()
+	defer slab.release()
+	rows := func(m int) unsafe.Pointer { return slab.takeRows(m * int(plan.stride)) }
+	if _, ok, _ := tryDecodeBatchColumnar(data, plan, slab, rows); ok {
+		t.Fatal("tryDecodeBatchColumnar: ok = true, want false (a hybrid wire is not this fast path)")
+	}
+	if _, ok, _ := tryDecodeBatchRowMajor(data, plan, slab, rows); ok {
+		t.Fatal("tryDecodeBatchRowMajor: ok = true, want false (a hybrid wire is not this fast path)")
+	}
+
+	b, err := UnmarshalBatch[batDoc](data)
+	if err != nil {
+		t.Fatalf("UnmarshalBatch: %v", err)
+	}
+	defer b.Release()
+	if len(b.Rows) != n {
+		t.Fatalf("rows = %d, want %d", len(b.Rows), n)
+	}
+	for i, r := range b.Rows {
+		want := src[i]
+		if r.ID != want.ID || b.Str(r.Name) != want.Name || r.Val != want.Val {
+			t.Fatalf("row %d = %+v (name=%q), want id=%d name=%q val=%v",
+				i, r, b.Str(r.Name), want.ID, want.Name, want.Val)
+		}
+		if !b.TimeOf(r.At).Equal(want.At) {
+			t.Fatalf("row %d time = %v, want %v", i, b.TimeOf(r.At), want.At)
+		}
 	}
 }

--- a/docs/BATCH-HANDLES.md
+++ b/docs/BATCH-HANDLES.md
@@ -85,10 +85,12 @@ don't cover — each is its own benchmark (same i7-9750H):
 |---|---|---|---|
 | **Row-major** batch (1000 rows) — small-n or a string-heavy struct the columnar probe drops to row-major | 1000 allocs, ~156 µs (mirror) | **0 allocs, ~115 µs** | `-bench BenchmarkBatchRowMajorDecode` |
 | **FSST** string column (1000 rows) — decompress straight into the slab | 111,925 B, 14 allocs, ~138 µs | **29,864 B, 13 allocs, ~105 µs** | `-bench BenchmarkBatchFSSTDecode` |
+| **Alpha** string column (1000 × 16-char hex) — unpack straight into the slab | 16,445 B, 2 allocs, ~24 µs | **24 B, 1 alloc, ~15 µs** | `-bench BenchmarkBatchAlphaDecode` |
 
 The row-major path removes the per-row string allocation the reflect mirror
-paid (1000 → 0); the FSST path removes the decompress scratch buffer and one
-copy pass (−82 KB/op, −24 %). Both are in *How it works* below.
+paid (1000 → 0); the FSST and alpha paths each remove a decode scratch buffer
+and one copy pass (−82 KB / −16 KB per op, −24 % / −37 %). All are in *How it
+works* below.
 
 ---
 
@@ -216,13 +218,16 @@ referencing another block, `decodeBatchColumnar` decodes **directly into the
      Every bound the general FSST reader enforces (decompressed-size caps,
      per-row compressed-length checks, the slab's `uint32` offset guard) is
      preserved, so a hostile column still errors rather than over-allocating.
-   - **Everything else** (`tagColStrRaw`, alpha, or per-row inline strings)
-     has no such structure to exploit: `readStringColumnHandles` decodes each
-     value via the general string-column machinery and copies its bytes into
-     the slab, one `slab.append` per row. (Raw/inline already alias the wire
-     under `noCopy`, so that single copy is the necessary one; `alpha`, which
-     still decompresses into a temp, is the one remaining direct-into-slab
-     candidate — not yet wired in.)
+   - **Alpha** (`tagColStrAlpha`, the restricted-alphabet packer used for
+     hex/ID columns) unpacks its characters straight onto the slab's backing
+     the same way (`readStringColumnAlphaInto`) — again no temp scratch, no
+     second copy. On a 1000-row 16-char hex column that is one fewer alloc,
+     **−16 KB/op**, −37 %.
+   - **Everything else** (`tagColStrRaw` or per-row inline strings) has no such
+     structure to exploit: `readStringColumnHandles` decodes each value via the
+     general string-column machinery and copies its bytes into the slab, one
+     `slab.append` per row. Raw/inline already alias the wire under `noCopy`,
+     so that single copy is the necessary one — nothing to eliminate.
 
    All of this runs with the pooled decoder's `noCopy` mode on
    (`tryDecodeBatchColumnar` sets `d.noCopy = true`): every intermediate

--- a/docs/BATCH-HANDLES.md
+++ b/docs/BATCH-HANDLES.md
@@ -78,6 +78,18 @@ Three separate claims, three separate benchmarks:
 
 ![Bar chart: GC scan time per cycle, 907 microseconds for held strings versus 233 microseconds for held handles, 3.89x reduction.](assets/batch-handles-gc.svg)
 
+Two further decode-path wins land on the shapes the columnar numbers above
+don't cover — each is its own benchmark (same i7-9750H):
+
+| Decode path | Before | After | Repro |
+|---|---|---|---|
+| **Row-major** batch (1000 rows) — small-n or a string-heavy struct the columnar probe drops to row-major | 1000 allocs, ~156 µs (mirror) | **0 allocs, ~115 µs** | `-bench BenchmarkBatchRowMajorDecode` |
+| **FSST** string column (1000 rows) — decompress straight into the slab | 111,925 B, 14 allocs, ~138 µs | **29,864 B, 13 allocs, ~105 µs** | `-bench BenchmarkBatchFSSTDecode` |
+
+The row-major path removes the per-row string allocation the reflect mirror
+paid (1000 → 0); the FSST path removes the decompress scratch buffer and one
+copy pass (−82 KB/op, −24 %). Both are in *How it works* below.
+
 ---
 
 ## Quick start
@@ -152,9 +164,10 @@ struct needs one, flatten it (embed instead of name) or split it out.
 
 ## How it works
 
-`UnmarshalBatch` has two decode strategies. Both populate the same `Batch[T]`
-result; which one runs depends on the wire shape, not on anything the caller
-chooses.
+`UnmarshalBatch` has three decode strategies — two allocation-free fast paths
+(one per wire shape it decodes directly) and a correctness-first fallback. All
+populate the same `Batch[T]` result; which one runs depends on the wire shape,
+not on anything the caller chooses.
 
 ### 1. Columnar fast path (the common case)
 
@@ -192,10 +205,24 @@ referencing another block, `decodeBatchColumnar` decodes **directly into the
      something a plain `Unmarshal` into `[]string` cannot give you (every row
      still gets its own Go string, even if the runtime string data happens
      to be shared).
-   - **Everything else** (`tagColStrRaw`, FSST, alpha, or per-row inline
-     strings) has no such structure to exploit: `readStringColumnHandles`
-     decodes each value via the general string-column machinery and copies
-     its bytes into the slab, one `slab.append` per row.
+   - **FSST** (`tagColStrFSST`) — the bytes are compressed, so they can't be
+     aliased and *must* be decompressed. `readStringColumnFSSTInto`
+     decompresses each row **straight onto the slab's backing** (the FSST
+     decoder appends in place), so the column is materialized with **no
+     intermediate scratch buffer and no second copy** — the temp
+     `make([]byte, decompressedTotal)` the general path used to allocate, plus
+     one full copy pass, are gone. On a 1000-row FSST column that is one fewer
+     alloc and **−82 KB/op** (≈ −73 % of the decode's bytes), −24 % wall-clock.
+     Every bound the general FSST reader enforces (decompressed-size caps,
+     per-row compressed-length checks, the slab's `uint32` offset guard) is
+     preserved, so a hostile column still errors rather than over-allocating.
+   - **Everything else** (`tagColStrRaw`, alpha, or per-row inline strings)
+     has no such structure to exploit: `readStringColumnHandles` decodes each
+     value via the general string-column machinery and copies its bytes into
+     the slab, one `slab.append` per row. (Raw/inline already alias the wire
+     under `noCopy`, so that single copy is the necessary one; `alpha`, which
+     still decompresses into a temp, is the one remaining direct-into-slab
+     candidate — not yet wired in.)
 
    All of this runs with the pooled decoder's `noCopy` mode on
    (`tryDecodeBatchColumnar` sets `d.noCopy = true`): every intermediate
@@ -212,13 +239,45 @@ referencing another block, `decodeBatchColumnar` decodes **directly into the
    consuming bytes, the caller can cleanly re-decode from the start via the
    fallback path below — no partial-decode state to unwind.
 
-### 2. Mirror fallback (row-major, hybrid, or nullable wire)
+### 2. Row-major-direct fast path
 
-Anything the fast path doesn't handle — row-major wire, a hybrid
-columnar/row-major payload, a batched-vector column, or a columnar payload
-with a nullable column — falls back to a **correctness-first** strategy that
-reuses the existing reflect-driven decoder instead of teaching the batch path
-every wire variant:
+Not every batch is columnar. A slice below `columnarMinElems` rows, or one
+encoded without `OptDense`, is a plain **row-major** struct-slice (an array
+header whose elements are struct headers). More subtly, a struct with a
+dominant high-cardinality string column that doesn't compress fails the
+columnar gain gate (`columnarMinGainPct`) and the encoder drops the *whole
+struct* to row-major even under `OptDense` — so string/bytes-heavy record
+types (logs, events, audit rows) routinely land here.
+
+`tryDecodeBatchRowMajor` decodes such a wire **straight into the `T` rows and
+the slab**, the row-major analogue of the columnar fast path:
+
+1. **Detection.** The top tag is one of the array-header tags
+   (`isRowMajorArrayTag`) — distinct from `tagColStruct`/`tagHybridColStruct`,
+   so a single tag check routes the wire without peeking further. The row
+   count is bounded by the input (`CheckLength(n, 1)` — each row is ≥ 1 wire
+   byte) before any allocation, and by `n * sizeof(T)` before `takeRows`.
+2. **Per-row scatter.** For each row it reads the struct header and, per
+   field, matches the wire key against the plan and writes the value directly
+   into `base + i*stride + field.offset`: scalars are a width-switched store,
+   `qdf.Str`/`qdf.Bytes` decode under `noCopy` and materialize into the slab
+   as handles, `qdf.Time` reads its sec/nsec directly. Every value reader
+   validates its own wire tag, so a name match never scatters a wrong-typed
+   value — a malformed wire errors (it does **not** silently fall through to
+   the mirror mid-stream, which would double-decode).
+
+This replaces what used to be the mirror path's single largest client: a
+row-major batch that once paid a full reflect `Unmarshal` into a `[]mirror`
+(**one owned string alloc per row**) plus a copy pass now decodes with **0
+allocs** and ~1.36× less wall-clock (`BatchRowMajorDecode`: 1000 allocs → 0).
+No code generation, so every batch caller gets it.
+
+### 3. Mirror fallback (hybrid, batched-vector, or nullable wire)
+
+Anything neither fast path handles — a hybrid columnar/row-major payload, a
+batched-vector column, or a columnar payload with a nullable column — falls
+back to a **correctness-first** strategy that reuses the existing
+reflect-driven decoder instead of teaching the batch path every wire variant:
 
 1. `batchPlanOf` built a **mirror type**: a `reflect.StructOf` with the same
    wire field names/tags as `T`, but with `qdf.Str`→`string`,
@@ -236,15 +295,16 @@ every wire variant:
 
 The mirror path pays for one intermediate `[]mirror` decode most of what a
 plain `Unmarshal` would, plus the copy pass — it exists so `UnmarshalBatch`
-never has a wire shape it silently can't handle, not to be fast. Real traffic
-above `columnarMinElems` rows under `OptDense` takes the columnar fast path;
-the mirror path is what makes small batches, row-major wire, and future wire
-extensions correct without extending the fast path's scope.
+never has a wire shape it silently can't handle, not to be fast. Columnar and
+row-major wires — the overwhelming majority of real batch traffic — take one
+of the two direct fast paths above; the mirror path is what keeps hybrid,
+nullable, batched-vector, and future wire extensions correct without extending
+either fast path's scope.
 
 ### Pooled slab + rows: how `Release` gets you to 2 allocs/op
 
-Both paths draw their memory from two `sync.Pool`-backed structures owned by
-`batchSlab`:
+All three paths draw their memory from two `sync.Pool`-backed structures owned
+by `batchSlab`:
 
 - **`buf []byte`** — the string/bytes slab itself. Handles store *offsets*,
   not pointers, so growing the buffer (`append`, which may reallocate) does

--- a/qpack_fsst.go
+++ b/qpack_fsst.go
@@ -158,3 +158,93 @@ func (d *Decoder) readStringColumnFSST(n int) ([]string, error) {
 	}
 	return out, nil
 }
+
+// readStringColumnFSSTInto decodes a tagColStrFSST block (tag at d.i) DIRECTLY
+// into the batch slab, writing a per-row Str handle into out[0:n]. It mirrors
+// readStringColumnFSST's header parse and EVERY bounds guard verbatim (the
+// dt64 caps, per-row compressed-length checks, and DecompressN's absolute-length
+// limit), but instead of a temp scratch buffer it decompresses each row straight
+// onto slab.buf — DecompressN appends in place — eliminating the ~dt64-byte temp
+// alloc and the redundant second copy the general readStringColumnHandles path
+// pays for FSST columns.
+//
+// Bounds parity is load-bearing here (this is decompress + unsafe slab writes):
+// the slab reservation is bounded by dt64, which is itself bounded by the input;
+// the slab's uint32 offset overflow guard (maxBatchSlabBytes, matching
+// slab.append) is honored BEFORE any reservation. A malformed/hostile column
+// errors — never OOM, never OOB write into the slab.
+func readStringColumnFSSTInto(d *Decoder, n int, slab *batchSlab, out []Str) error {
+	d.i++ // consume tagColStrFSST
+	tbl, used, err := fsst.UnmarshalSymbolTable(d.buf[d.i:])
+	if err != nil {
+		return err
+	}
+	d.i += used
+
+	n64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return ErrInvalidLength
+	}
+	d.i += nr
+	if int(n64) != n {
+		return ErrTypeMismatch
+	}
+
+	dt64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return ErrInvalidLength
+	}
+	d.i += nr
+	rem := uint64(len(d.buf) - d.i)
+	if dt64 > rem*fsstMaxDecompPerByte {
+		return ErrShortBuffer
+	}
+	// Hard cap: decompTotal must not exceed maxColumnarElems * maxSymLen (8).
+	// This prevents a hostile varint from driving a huge slab reservation.
+	if dt64 > uint64(maxColumnarElems)*8 {
+		return ErrShortBuffer
+	}
+
+	// Honor the slab's uint32 offset cap BEFORE reserving: the reserved region
+	// grows slab.buf by dt64, and a Str handle's offset must fit uint32. This is
+	// the same overflow guard slab.append enforces (maxBatchSlabBytes) — a direct
+	// write that would exceed it errors instead of silently wrapping the offset.
+	base := len(slab.buf)
+	if uint64(base)+dt64 > maxBatchSlabBytes {
+		return ErrInvalidLength
+	}
+	// Reserve dt64 bytes ONCE so per-row DecompressN appends land in place with
+	// no mid-column reallocation (offsets stay stable). limit is the ABSOLUTE
+	// len(dst) cap DecompressN enforces; base+dt64 mirrors readStringColumnFSST's
+	// int(dt64) cap on a slab that started empty.
+	slab.grow(int(dt64))
+	limit := base + int(dt64)
+	for i := range n {
+		cl64, nr := readUvarint(d.buf[d.i:])
+		if nr <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += nr
+		if cl64 > uint64(len(d.buf)-d.i) {
+			return ErrShortBuffer
+		}
+		cl := int(cl64)
+		start := len(slab.buf)
+		var ok bool
+		// Bounded decode: never let slab.buf grow past base+dt64, so a malformed
+		// row cannot trigger a transient over-allocation or an OOB slab write.
+		slab.buf, ok = tbl.DecompressN(d.buf[d.i:d.i+cl], slab.buf, limit)
+		if !ok {
+			return ErrShortBuffer
+		}
+		d.i += cl
+		ln := len(slab.buf) - start
+		if ln == 0 {
+			// Match slab.append's empty-string convention: the zero handle.
+			out[i] = Str{}
+			continue
+		}
+		out[i] = Str{off: uint32(start), len: uint32(ln)}
+	}
+	return nil
+}

--- a/qpack_stralpha.go
+++ b/qpack_stralpha.go
@@ -376,3 +376,171 @@ func (d *Decoder) readStringColumnAlpha(n int) ([]string, error) {
 	}
 	return out, nil
 }
+
+// readStringColumnAlphaInto decodes a tagColStrAlpha column (tag at d.i) DIRECTLY
+// into the batch slab, writing a per-row Str handle into out[0:n]. It mirrors
+// readStringColumnAlpha's header parse and body-unpack verbatim, but unpacks the
+// alphabet characters straight onto the slab's backing instead of a fresh
+// make([]byte, totalChars) scratch, and emits (off,len) handles instead of
+// []string views — eliminating the temp allocation and the second copy the
+// general readStringColumnHandles path pays for an alpha column. Every bound
+// readStringColumnAlpha enforces is preserved (alphabet range, totalChars/body
+// caps, per-row length re-scan), plus the slab's uint32 offset-overflow guard
+// before the reservation. readStringColumnAlpha itself is unchanged — the reflect
+// Unmarshal path still uses it.
+func (d *Decoder) readStringColumnAlphaInto(n int, bs *batchSlab, out []Str) error {
+	d.i++ // consume tagColStrAlpha
+	a64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return ErrInvalidLength
+	}
+	d.i += nr
+	if a64 < 2 || a64 > qpackStrAlphaMaxAlphabet {
+		return ErrBadTag
+	}
+	a := int(a64)
+	if a > len(d.buf)-d.i {
+		return ErrShortBuffer
+	}
+	alphabet := d.buf[d.i : d.i+a]
+	d.i += a
+
+	n64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return ErrInvalidLength
+	}
+	d.i += nr
+	if int(n64) != n {
+		return ErrTypeMismatch
+	}
+	if d.i >= len(d.buf) {
+		return ErrShortBuffer
+	}
+	flags := d.buf[d.i]
+	d.i++
+	fixedLen := flags&1 != 0
+	cbits := bitsForDistinct(a)
+
+	rem := uint64(len(d.buf) - d.i)
+	maxChars := rem * 8 / uint64(cbits)
+	if maxInt := uint64(math.MaxInt); maxChars > maxInt {
+		maxChars = maxInt
+	}
+	var (
+		totalChars int
+		fixedL     int
+		lenStart   int
+	)
+	if fixedLen {
+		l64, k := readUvarint(d.buf[d.i:])
+		if k <= 0 {
+			return ErrInvalidLength
+		}
+		d.i += k
+		tc := uint64(n) * l64
+		if l64 != 0 && tc/l64 != uint64(n) {
+			return ErrInvalidLength
+		}
+		if tc > maxChars {
+			return ErrShortBuffer
+		}
+		totalChars = int(tc)
+		fixedL = int(l64)
+	} else {
+		lenStart = d.i
+		var tc uint64
+		for range n {
+			l64, k := readUvarint(d.buf[d.i:])
+			if k <= 0 {
+				return ErrInvalidLength
+			}
+			d.i += k
+			tc += l64
+			if tc > maxChars {
+				return ErrShortBuffer
+			}
+		}
+		totalChars = int(tc)
+	}
+
+	bodyBytes := int((uint64(totalChars)*uint64(cbits) + 7) >> 3)
+	if bodyBytes > len(d.buf)-d.i {
+		return ErrShortBuffer
+	}
+	body := d.buf[d.i : d.i+bodyBytes]
+	d.i += bodyBytes
+
+	// Reserve totalChars on the slab's backing and unpack straight into it. The
+	// uint32 offset-overflow guard (matching slab.append/maxBatchSlabBytes) runs
+	// BEFORE the reservation so a direct write can never wrap a handle offset.
+	base := len(bs.buf)
+	if uint64(base)+uint64(totalChars) > maxBatchSlabBytes {
+		return ErrInvalidLength
+	}
+	bs.grow(totalChars)
+	dst := bs.buf[base : base+totalChars]
+	if cbits == 4 {
+		if a64 == 16 {
+			bitpack.DecodeHex4(dst, body, (*[16]byte)(alphabet))
+		} else {
+			full := totalChars &^ 1
+			k := 0
+			for ; k < full; k += 2 {
+				b := body[k>>1]
+				lo, hi := b&0xf, b>>4
+				if uint64(lo) >= a64 || uint64(hi) >= a64 {
+					return ErrBadTag
+				}
+				dst[k] = alphabet[lo]
+				dst[k+1] = alphabet[hi]
+			}
+			if k < totalChars {
+				lo := body[k>>1] & 0xf
+				if uint64(lo) >= a64 {
+					return ErrBadTag
+				}
+				dst[k] = alphabet[lo]
+			}
+		}
+	} else {
+		if cap(d.deltaScratch) < totalChars {
+			d.deltaScratch = make([]uint64, totalChars)
+		}
+		codes := d.deltaScratch[:totalChars]
+		bitpack.Unpack(codes, body, cbits)
+		for k, c := range codes {
+			if c >= a64 {
+				return ErrBadTag
+			}
+			dst[k] = alphabet[c]
+		}
+	}
+
+	// Commit the unpacked bytes onto the slab and emit per-row handles.
+	bs.buf = bs.buf[:base+totalChars]
+	off := 0
+	if fixedLen {
+		for i := range n {
+			if fixedL == 0 {
+				out[i] = Str{}
+				continue
+			}
+			out[i] = Str{off: uint32(base + off), len: uint32(fixedL)}
+			off += fixedL
+		}
+	} else {
+		j := lenStart
+		for i := range n {
+			l64, k := readUvarint(d.buf[j:])
+			j += k
+			l := int(l64)
+			if l == 0 {
+				out[i] = Str{}
+				continue
+			}
+			out[i] = Str{off: uint32(base + off), len: uint32(l)}
+			off += l
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Three decode-side wins for the pointer-free `Batch[T]` path (v1 covered columnar batches; these cover the wire shapes and string codecs it left to the slower fallback / to a temp-buffer copy). All are allocation-lean fast paths that populate the same `Batch[T]` — no API change, no wire change, no code generation.

## Row-major-direct decode

A batch below `columnarMinElems` rows, one encoded without `OptDense`, or a string/bytes-heavy struct the columnar probe drops to row-major (logs, events, audit rows) is a plain row-major struct-slice. Previously that decoded through a reflect `Unmarshal` into a mirror `[]struct` — **one owned string allocation per row** — then a copy into the slab.

`tryDecodeBatchRowMajor` decodes such a wire straight into the `T` rows + slab (strings alias the buffer under `noCopy` and land in the slab as handles), added ahead of the reflect fallback, which still handles hybrid, nullable, and batched-vector wires. The row count is input-bounded before any allocation; every per-field value reader validates its own wire tag, so a malformed wire errors rather than scattering a wrong-typed value.

**Measured (1000-row row-major wire):** 1000 allocs → **0**, ~1.36× faster.

## FSST + alpha string columns: decompress straight into the slab

When a batch's columnar string column is coded (not raw), materializing it used to decompress the whole column into a fresh temp buffer, then copy each string a second time into the slab. Two codecs now write straight onto the slab's backing instead:

- **FSST** (`readStringColumnFSSTInto`) — decompresses each row in place. **1000-row FSST column: 111,925 B / 14 allocs / ~138 µs → 29,864 B / 13 allocs / ~105 µs** (−82 KB, −1 alloc, −24 %).
- **Alpha** (`readStringColumnAlphaInto`, the restricted-alphabet packer for hex/ID columns) — unpacks its characters in place, same SIMD/scalar kernels. **1000-row 16-char hex column: 16,445 B / 2 allocs / ~24 µs → 24 B / 1 alloc / ~15 µs** (−16 KB, −1 alloc, −37 %).

Each preserves every bound of its original reader verbatim, plus the slab's `uint32` offset-overflow guard, so a hostile column still errors instead of over-allocating. The plain `Unmarshal` path keeps the original readers. (`const`/dict columns already materialize each distinct value once; `raw` already aliases the buffer — nothing to eliminate there.)

## Docs & verification

`docs/BATCH-HANDLES.md` updated with the three decode strategies and all three string-column wins. Full suite + `-race` + build tags `qdf_simd`/`qdf_reflect2`/`qdfdebug` + `internal/codegen_test`; golangci-lint v2 0 issues; fieldalignment/modernize clean. Row-major, FSST, and alpha truncation tests (every input prefix errors, never panics); parity vs reflect `UnmarshalBatch` across n ∈ {0, 1, 64, 1000}, fixed and variable string lengths.