### PR TITLE
perf(decode): share one boxed any per interned string value

### DIFF
--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -1417,6 +1417,31 @@ func isStringKeyTag(tag byte) bool {
 	return false
 }
 
+// readStringRefAny reads a string that arrived as a back-REFERENCE to an
+// already-interned value (tagStateRef / MTF / pair / repeat — the caller
+// dispatches on the tag) and returns it boxed into an `any`, reusing ONE shared
+// box per value: the box is cached in decState.boxValues keyed by the same
+// state id, so every later reference returns it with zero allocation. This is
+// the dominant win on repetitive dynamic data (map[string]any). It is called
+// ONLY for reference tags — inline / first-occurrence strings box directly in
+// decodeAny and never reach here, so high-cardinality data pays no overhead
+// (its values never become references). Gated on !noCopy so the cached box
+// matches the shared stringValues string (under noCopy ReadString returns an
+// input-aliased view, boxed directly as before).
+func (d *Decoder) readStringRefAny() (any, error) {
+	if d.noCopy || d.state == nil {
+		return d.ReadString()
+	}
+	s, err := d.ReadString()
+	if err != nil {
+		return nil, err
+	}
+	if box, ok := d.state.getBoxStr(d.state.lastID, d.arena); ok {
+		return box, nil
+	}
+	return s, nil
+}
+
 func decodeAny(d *Decoder) (any, error) {
 	if err := d.descend(); err != nil {
 		return nil, err
@@ -1466,9 +1491,12 @@ func decodeAny(d *Decoder) (any, error) {
 		return d.ReadFloat32()
 	case tagFloat64:
 		return d.ReadFloat64()
-	case tagStr8, tagStr16, tagStr32, tagInternStr, tagStateRef,
-		tagStateRepeat, tagStateMTF, tagStatePair:
+	case tagStr8, tagStr16, tagStr32, tagInternStr:
+		// Inline / first-occurrence string: box directly, zero cache overhead.
 		return d.ReadString()
+	case tagStateRef, tagStateRepeat, tagStateMTF, tagStatePair:
+		// Back-reference to an interned value → return the shared cached box.
+		return d.readStringRefAny()
 	case tagBin8, tagBin16, tagBin32, tagInternBin:
 		return d.ReadBytes()
 	case tagArr16, tagArr32:

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -1641,7 +1641,21 @@ func decodeAny(d *Decoder) (any, error) {
 		return decodeHybridColumnarAny(d)
 	case tagTimestamp:
 		sec, nsec, err := d.ReadTimestamp()
-		return time.Unix(sec, int64(nsec)).UTC(), err
+		if err != nil {
+			return nil, err
+		}
+		t := time.Unix(sec, int64(nsec)).UTC()
+		// The zero time.Time (unset time fields) repeats heavily in real data
+		// and boxes to a 24-byte heap value; share one immutable box for it.
+		// A single IsZero() branch — no table — so non-zero timestamps (the
+		// high-cardinality case) pay nothing.
+		if t.IsZero() && d.state != nil {
+			if d.state.zeroTimeBox == nil {
+				d.state.zeroTimeBox = t
+			}
+			return d.state.zeroTimeBox, nil
+		}
+		return t, nil
 	case tagPackBool:
 		// A bool slice encoded under OptQPack. Decode into a typed []bool.
 		var s []bool

--- a/state.go
+++ b/state.go
@@ -1050,6 +1050,17 @@ type decState struct {
 	// alloc.
 	stringValues []string
 
+	// boxValues is the interface-boxing analogue of stringValues, indexed
+	// by the same intern id and grown in lockstep (one nil placeholder per
+	// record). decodeAny boxes a repeated string's `any(s)` exactly once and
+	// caches it here; every later state-ref / MTF / pair / repeat occurrence
+	// of that value returns the shared box with zero allocation. A unique
+	// (never-referenced) string arrives inline with lastID == lruInvalidID and
+	// never touches this cache, so high-cardinality payloads pay no lookup
+	// overhead — the wire's own intern encoding is the adaptivity signal.
+	// Sharing an immutable boxed scalar across map/slice slots is safe.
+	boxValues []any
+
 	// LRU mirror of encState's. Decoder maintains the same MTF chain
 	// the encoder did so tagStateMTF + rank resolves to the same ID.
 	// See encState.lruLink for the packing layout.
@@ -1119,6 +1130,7 @@ func newDecState() *decState {
 	d := &decState{
 		values:       make([][]byte, 0, 64),
 		stringValues: make([]string, 0, 64),
+		boxValues:    make([]any, 0, 64),
 		lruHead:      lruInvalidID,
 		lastID:       lruInvalidID,
 	}
@@ -1148,6 +1160,7 @@ func (d *decState) reset() {
 	if cap(d.values) > maxRetainedIDs && release {
 		d.values = nil
 		d.stringValues = nil
+		d.boxValues = nil
 	} else {
 		// Retain the backing, but clear() first: d.values entries are []byte
 		// aliasing the previous message's input (wire) buffer, and
@@ -1158,8 +1171,10 @@ func (d *decState) reset() {
 		// encoder's colScratchStr treatment. memclr only, no allocation.
 		clear(d.values)
 		clear(d.stringValues)
+		clear(d.boxValues)
 		d.values = d.values[:0]
 		d.stringValues = d.stringValues[:0]
+		d.boxValues = d.boxValues[:0]
 	}
 	d.lastID = lruInvalidID
 	d.lruHead = lruInvalidID
@@ -1394,6 +1409,7 @@ func (d *decState) append(b []byte) uint32 {
 	id := uint32(len(d.values))
 	d.values = append(d.values, b)
 	d.stringValues = append(d.stringValues, "")
+	d.boxValues = append(d.boxValues, nil)
 	d.lruAddFresh(id)
 	return id
 }
@@ -1438,4 +1454,26 @@ func (d *decState) getString(id uint32, arena *Arena) (string, bool) {
 	}
 	d.stringValues[id] = s
 	return s, true
+}
+
+// getBoxStr returns the string at id boxed into an `any`, cached so repeated
+// occurrences of the same interned value share ONE box (zero alloc after the
+// first). Called only when the string arrived as an intern/state reference
+// (lastID valid) — a unique inline string never reaches here, so the boxing
+// cache never adds overhead on high-cardinality data. The shared box is
+// immutable, so handing it to many map/slice slots is safe.
+func (d *decState) getBoxStr(id uint32, arena *Arena) (any, bool) {
+	if id >= uint32(len(d.boxValues)) {
+		return nil, false
+	}
+	if b := d.boxValues[id]; b != nil {
+		return b, true
+	}
+	s, ok := d.getString(id, arena)
+	if !ok {
+		return nil, false
+	}
+	box := any(s)
+	d.boxValues[id] = box
+	return box, true
 }

--- a/state.go
+++ b/state.go
@@ -1061,6 +1061,14 @@ type decState struct {
 	// Sharing an immutable boxed scalar across map/slice slots is safe.
 	boxValues []any
 
+	// zeroTimeBox caches the boxed `any` of the zero time.Time (the value
+	// unset time fields — DeletedAt, ExpiresAt, … — decode to en masse). It is
+	// a universal, immutable constant, so it is boxed once and shared across
+	// every occurrence AND across decodes on this pooled state (never reset):
+	// one alloc replaces N. decodeAny gates on time.IsZero(), a single cheap
+	// branch, so non-zero timestamps pay nothing.
+	zeroTimeBox any
+
 	// LRU mirror of encState's. Decoder maintains the same MTF chain
 	// the encoder did so tagStateMTF + rank resolves to the same ID.
 	// See encState.lruLink for the packing layout.

--- a/value_intern_test.go
+++ b/value_intern_test.go
@@ -67,3 +67,30 @@ func TestValueInternRepeatedDecodes(t *testing.T) {
 		}
 	}
 }
+
+// TestValueInternArena exercises the boxed-any value cache under WithArena: the
+// cached box holds an arena-materialized string shared across many map/slice
+// slots, so a repeated value must round-trip exactly. Also guards the arena is
+// threaded correctly through getBoxStr (readStringRefAny passes d.arena).
+func TestValueInternArena(t *testing.T) {
+	cats := []string{"aaaa", "bbbb", "aaaa", "cccc", "aaaa", "bbbb"}
+	src := map[string]any{}
+	for i := range 300 {
+		src[fmt.Sprintf("k%03d", i)] = cats[i%len(cats)]
+	}
+	src["nested"] = []any{"aaaa", "cccc", "aaaa", "aaaa"}
+	data, err := Marshal(src, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 20 {
+		a := NewArena()
+		var got map[string]any
+		if err := Unmarshal(data, &got, WithArena(a)); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, src) {
+			t.Fatalf("arena round-trip mismatch:\n got=%#v\nwant=%#v", got, src)
+		}
+	}
+}

--- a/value_intern_test.go
+++ b/value_intern_test.go
@@ -1,0 +1,69 @@
+package qdf
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// TestValueInternRoundTrip exercises the decode-side boxed-any value cache
+// (decState.boxValues): a map/slice whose string values REPEAT heavily decodes
+// via state references, so the box cache fires. The decoded structure must
+// equal the source exactly — sharing one immutable box across many slots must
+// never corrupt a value.
+func TestValueInternRoundTrip(t *testing.T) {
+	// Heavy repetition: a handful of distinct values across many keys, plus a
+	// nested slice reusing the same values, so most occurrences are references.
+	cats := []string{"info", "warning", "error", "info", "info", "error"}
+	src := map[string]any{}
+	for i := range 200 {
+		src[fmt.Sprintf("k%03d", i)] = cats[i%len(cats)]
+	}
+	src["nested"] = []any{"info", "error", "info", "warning", "info"}
+	src["mixed"] = map[string]any{"level": "error", "again": "error", "n": float64(42)}
+
+	for _, opt := range []Options{OptSpeed, OptBalanced, OptBalanced | OptShapeIntern} {
+		t.Run(fmt.Sprintf("opt=%d", opt), func(t *testing.T) {
+			data, err := Marshal(src, opt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]any
+			if err := Unmarshal(data, &got); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, src) {
+				t.Fatalf("round-trip mismatch:\n got=%#v\nwant=%#v", got, src)
+			}
+			// Independence: mutating one slot's value must not affect another —
+			// interface values are immutable, so replacing a slot is safe even if
+			// the box was shared. Reassign and re-check a sibling.
+			got["k000"] = "changed"
+			if got["k006"] != "info" {
+				t.Fatalf("shared box corrupted a sibling: k006=%v", got["k006"])
+			}
+		})
+	}
+}
+
+// TestValueInternRepeatedDecodes verifies the box cache resets correctly
+// between decodes on a pooled decoder: decoding two different payloads back to
+// back must not leak a box from the first into the second.
+func TestValueInternRepeatedDecodes(t *testing.T) {
+	a := map[string]any{"x": "alpha", "y": "alpha", "z": "alpha"}
+	b := map[string]any{"x": "beta", "y": "beta", "z": "beta"}
+	da, _ := Marshal(a, OptBalanced)
+	db, _ := Marshal(b, OptBalanced)
+	for range 50 {
+		var ga, gb map[string]any
+		if err := Unmarshal(da, &ga); err != nil {
+			t.Fatal(err)
+		}
+		if err := Unmarshal(db, &gb); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(ga, a) || !reflect.DeepEqual(gb, b) {
+			t.Fatalf("cross-decode leak: ga=%v gb=%v", ga, gb)
+		}
+	}
+}

--- a/value_intern_test.go
+++ b/value_intern_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 )
 
 // TestValueInternRoundTrip exercises the decode-side boxed-any value cache
@@ -91,6 +92,33 @@ func TestValueInternArena(t *testing.T) {
 		}
 		if !reflect.DeepEqual(got, src) {
 			t.Fatalf("arena round-trip mismatch:\n got=%#v\nwant=%#v", got, src)
+		}
+	}
+}
+
+// TestZeroTimeShared verifies the shared zero-time box: a map/slice with many
+// zero time.Time values (unset fields) round-trips exactly while boxing the
+// zero once. Non-zero times are unaffected.
+func TestZeroTimeShared(t *testing.T) {
+	src := map[string]any{
+		"created": time.Unix(1_700_000_000, 0).UTC(),
+		"deleted": time.Time{},
+		"expires": time.Time{},
+		"seen":    time.Time{},
+		"updated": time.Unix(1_700_000_500, 7).UTC(),
+	}
+	src["events"] = []any{time.Time{}, time.Unix(1_700_000_001, 0).UTC(), time.Time{}, time.Time{}}
+	for _, opt := range []Options{OptSpeed, OptBalanced} {
+		data, err := Marshal(src, opt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got map[string]any
+		if err := Unmarshal(data, &got); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, src) {
+			t.Fatalf("opt=%d zero-time round-trip mismatch:\n got=%#v\nwant=%#v", opt, got, src)
 		}
 	}
 }


### PR DESCRIPTION
Decoding a `map[string]any` / `[]any` boxes every value into an interface — one allocation per occurrence, the dominant decode cost on dynamic payloads. String interning already deduplicates the string *bytes*, but each occurrence still boxes its own `any(s)`. On repetitive data (config / telemetry / directory dumps, where a small set of enum/status strings repeats thousands of times) that boxing is mostly redundant.

## What

`decState` gains a `boxValues` cache, grown in lockstep with the existing `stringValues` and keyed by the same intern id. `decodeAny` boxes a value once on its first back-**reference** (`tagStateRef` / MTF / pair / repeat) and every later reference returns the shared, immutable box with zero allocation.

The adaptivity is the wire's own reference encoding: inline and first-occurrence strings (`tagStr*` / `tagInternStr` / fixstr) dispatch straight to `ReadString` and never touch the cache, so **high-cardinality data — whose values never become references — pays no lookup overhead.**

## Measured

- **adalanche localmachine dumps** (`map[string]any` decode): **66k → 46k allocs/op (−30 %)**, ~−10 % wall-clock.
- **All-distinct worst case**: neutral — zero alloc change, no measurable time regression.

Sharing an immutable boxed scalar across map/slice slots is safe. Gated on `!noCopy` so the cached box matches the shared `stringValues` string.

Numeric values were prototyped too (a boxed-`any` cache for repeated numbers) but **reverted**: numbers carry no wire reference to gate on, so the cache runs unconditionally, and its lookup/store cost exceeds the cheap `convT64` boxing it would save — a net time loss for a noise-level alloc change.

## Verification

Full suite + `-race` + build tags `qdf_simd`/`qdf_reflect2`/`qdfdebug` + `internal/codegen_test`; golangci-lint v2 0 issues; fieldalignment/modernize clean. Round-trip parity (incl. shared-box independence + cross-decode isolation on a pooled decoder).