### PR TITLE
perf/fix: 3 correctness bugs + 5 perf wins (adaptive-alloc)

### DIFF
--- a/batch_desc.go
+++ b/batch_desc.go
@@ -34,10 +34,16 @@ type batchField struct {
 // same wire field order the normal encoder uses for the equivalent struct
 // (flattened embedded, tag-named) — see appendBatchFields.
 type batchPlan struct {
+
+	// mirrorSlicePtr pools *mirrorSlot values so repeated UnmarshalBatch calls
+	// for the same T neither reallocate the *[]mirror box nor touch
+	// reflect.Value on the hot path (the slot caches the raw slice-header
+	// pointer alongside the any box Unmarshal needs).
+	mirrorSlicePtr sync.Pool
+
 	// Pointer-bearing fields lead, scalars trail (fieldalignment: trims the
 	// GC-scanned prefix 128 -> 104 bytes). Constructed with named fields only.
-	rt     reflect.Type
-	fields []batchField
+	rt reflect.Type
 
 	// mirror is a runtime-built struct type with the same field names/tags
 	// as rt, with handle types swapped back to their decodable wire
@@ -47,14 +53,10 @@ type batchPlan struct {
 	// mirror row into a T row plus slab bytes. Since batchPlanOf only
 	// accepts flat (non-nested) field sets, mirror's field offsets align
 	// 1:1 with plan.fields via mirrorOff.
-	mirror    reflect.Type
-	mirrorOff []uintptr // parallel to fields: byte offset within mirror
+	mirror reflect.Type
+	fields []batchField
 
-	// mirrorSlicePtr pools *mirrorSlot values so repeated UnmarshalBatch calls
-	// for the same T neither reallocate the *[]mirror box nor touch
-	// reflect.Value on the hot path (the slot caches the raw slice-header
-	// pointer alongside the any box Unmarshal needs).
-	mirrorSlicePtr sync.Pool
+	mirrorOff []uintptr // parallel to fields: byte offset within mirror
 
 	// stride is rt.Size() — scalar tail (see the field-order note above).
 	stride uintptr

--- a/batch_fsst_test.go
+++ b/batch_fsst_test.go
@@ -114,6 +114,43 @@ func TestBatchFSSTDirectTruncated(t *testing.T) {
 	}
 }
 
+// BenchmarkBatchFSSTStream measures the FSST encode cost when the same Encoder
+// is reused across consecutive batches (the "streaming" pattern: one encoder,
+// many batches). Unlike BenchmarkFSSTEncodeCompressible which pulls a fresh
+// encoder from the pool each iteration, this bench keeps one encoder warm so
+// the fsstCachedTbl optimisation can eliminate Build() training on batches 1–7
+// out of every 8.
+//
+// Run this bench interleaved against the baseline (before adding fsstCachedTbl)
+// to measure the training-avoidance gain.
+func BenchmarkBatchFSSTStream(b *testing.B) {
+	rows := mkFSSTSrc(512)
+	// Verify the wire actually carries an FSST string column before benching.
+	{
+		data, err := Marshal(rows, OptBalanced|OptFSST)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if bytes.IndexByte(data, tagColStrFSST) < 0 {
+			b.Skip("Body column did not FSST-code: bench would not exercise fsstCachedTbl")
+		}
+	}
+
+	// One dedicated encoder per bench run: resetForReuse preserves fsstCachedTbl
+	// across iterations so the cache warms up after the first iteration.
+	enc := NewEncoderWith(OptBalanced | OptFSST)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		enc.resetForReuse() // partial reset: fsstCachedTbl survives
+		if err := enc.EncodeValue(rows); err != nil {
+			b.Fatal(err)
+		}
+		_ = enc.Bytes()
+	}
+}
+
 // BenchmarkBatchFSSTDecode measures the FSST batch decode after the
 // direct-into-slab change: the temp make([]byte,0,dt64) scratch + one full copy
 // pass the general readStringColumnHandles arm used to pay are gone, so allocs/op

--- a/columnar_decode_scratch.go
+++ b/columnar_decode_scratch.go
@@ -164,7 +164,7 @@ func (d *Decoder) readPackedRLEInt64SliceInto(dst *[]int64) error {
 			return ErrInvalidLength
 		}
 		d.i += nr
-		if runLen == 0 || uint64(idx)+runLen > uint64(n) {
+		if runLen == 0 || runLen > uint64(n-idx) {
 			return ErrInvalidLength
 		}
 		v := zigzagDecode64(v64)
@@ -490,7 +490,7 @@ func (d *Decoder) readPackedRLEUint64SliceInto(dst *[]uint64) error {
 			return ErrInvalidLength
 		}
 		d.i += nr
-		if runLen == 0 || uint64(idx)+runLen > uint64(n) {
+		if runLen == 0 || runLen > uint64(n-idx) {
 			return ErrInvalidLength
 		}
 		end := idx + int(runLen)

--- a/columnar_decode_scratch.go
+++ b/columnar_decode_scratch.go
@@ -169,8 +169,9 @@ func (d *Decoder) readPackedRLEInt64SliceInto(dst *[]int64) error {
 		}
 		v := zigzagDecode64(v64)
 		end := idx + int(runLen)
-		for i := idx; i < end; i++ {
-			out[i] = v
+		out[idx] = v
+		for size := 1; idx+size < end; size <<= 1 {
+			copy(out[idx+size:end], out[idx:idx+size])
 		}
 		idx = end
 	}
@@ -493,8 +494,9 @@ func (d *Decoder) readPackedRLEUint64SliceInto(dst *[]uint64) error {
 			return ErrInvalidLength
 		}
 		end := idx + int(runLen)
-		for i := idx; i < end; i++ {
-			out[i] = v
+		out[idx] = v
+		for size := 1; idx+size < end; size <<= 1 {
+			copy(out[idx+size:end], out[idx:idx+size])
 		}
 		idx = end
 	}

--- a/delta_columnar.go
+++ b/delta_columnar.go
@@ -31,12 +31,14 @@ const (
 
 // diffColumnarEligible reports whether a slice's columnar plan can use the
 // column-level diff: pure columnar (every field is a column, no residual) with
-// fewer than 128 columns. The 128 cap keeps the nChangedCols count a single
-// uvarint byte (nChanged <= len(cols) < 128 < 0x80), so the placeholder-patch
-// in diffColumnar is always valid; a struct with >=128 columns (pathological)
-// declines to the positional path.
+// fewer than 16384 columns. The 16384 cap (2-byte uvarint max) ensures the
+// nChangedCols placeholder in diffColumnar always fits in the reserved space.
+// For structs with <128 columns nChanged fits in a single byte (backward-
+// compatible wire format). For structs with 128..16383 columns diffColumnar
+// reserves a 2-byte padded uvarint placeholder. Structs with >=16384 columns
+// are pathological and decline to the positional path.
 func diffColumnarEligible(colPlan *columnarPlan) bool {
-	return colPlan != nil && colPlan.residual == nil && len(colPlan.cols) < 128
+	return colPlan != nil && colPlan.residual == nil && len(colPlan.cols) < 16384
 }
 
 // colKindColumnDiffSupported reports whether a column's kind has a column-diff
@@ -150,7 +152,17 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 	body = append(body, tagColSlicePatch)
 	body = appendUvarint(body, uint64(n))
 	colCountPos := len(body)
-	body = appendUvarint(body, 0) // nChangedCols placeholder (single byte for <128 cols)
+	// Reserve space for nChangedCols. Structs with <128 columns guarantee
+	// nChanged < 128, so a single byte suffices (backward-compatible wire
+	// format). Structs with >=128 columns may have nChanged >=128, so reserve
+	// two bytes (padded uvarint encoding of 0: 0x80, 0x00) to accommodate up to
+	// 16383 changed columns. The apply side always uses readUvarint, so both
+	// sizes decode correctly.
+	if len(plan.cols) < 128 {
+		body = append(body, 0) // 1-byte uvarint placeholder
+	} else {
+		body = append(body, 0x80, 0) // 2-byte padded uvarint placeholder for 0
+	}
 	nChanged := 0
 	// Column codecs write through enc.buf; swap it to point at our scratch body,
 	// restore enc.buf afterward.
@@ -209,8 +221,16 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 		body = enc.buf
 	}
 	enc.buf = savedBuf
-	// Patch the nChangedCols count (always < 128 columns → single uvarint byte).
-	body[colCountPos] = byte(nChanged)
+	// Patch the nChangedCols count into the reserved placeholder bytes.
+	// For structs with <128 columns nChanged <128, so single byte is valid
+	// (backward-compatible wire format). For structs with >=128 columns two
+	// bytes were reserved; write a padded 2-byte uvarint (covers 0..16383).
+	if len(plan.cols) < 128 {
+		body[colCountPos] = byte(nChanged) // nChanged < 128, single byte valid
+	} else {
+		body[colCountPos] = byte(nChanged) | 0x80   // low 7 bits + continuation
+		body[colCountPos+1] = byte(nChanged >> 7)   // high bits
+	}
 	st.deltaColBuf = body
 
 	// Never-larger: keep the column body only if it strictly beats positional.

--- a/delta_columnar.go
+++ b/delta_columnar.go
@@ -228,8 +228,8 @@ func diffColumnar(enc *Encoder, elem *typeDesc, plan *columnarPlan, stride uintp
 	if len(plan.cols) < 128 {
 		body[colCountPos] = byte(nChanged) // nChanged < 128, single byte valid
 	} else {
-		body[colCountPos] = byte(nChanged) | 0x80   // low 7 bits + continuation
-		body[colCountPos+1] = byte(nChanged >> 7)   // high bits
+		body[colCountPos] = byte(nChanged) | 0x80 // low 7 bits + continuation
+		body[colCountPos+1] = byte(nChanged >> 7) // high bits
 	}
 	st.deltaColBuf = body
 

--- a/delta_columnar_test.go
+++ b/delta_columnar_test.go
@@ -651,3 +651,112 @@ func TestColDiffHybridFallsBack(t *testing.T) {
 		t.Fatal("hybrid round-trip mismatch")
 	}
 }
+
+// big130Row is a struct with 130 int64 fields — exactly 2 more than the old
+// 128-column cap — used to exercise the nChangedCols >=128 varint path.
+type big130Row struct {
+	F000, F001, F002, F003, F004, F005, F006, F007, F008, F009 int64
+	F010, F011, F012, F013, F014, F015, F016, F017, F018, F019 int64
+	F020, F021, F022, F023, F024, F025, F026, F027, F028, F029 int64
+	F030, F031, F032, F033, F034, F035, F036, F037, F038, F039 int64
+	F040, F041, F042, F043, F044, F045, F046, F047, F048, F049 int64
+	F050, F051, F052, F053, F054, F055, F056, F057, F058, F059 int64
+	F060, F061, F062, F063, F064, F065, F066, F067, F068, F069 int64
+	F070, F071, F072, F073, F074, F075, F076, F077, F078, F079 int64
+	F080, F081, F082, F083, F084, F085, F086, F087, F088, F089 int64
+	F090, F091, F092, F093, F094, F095, F096, F097, F098, F099 int64
+	F100, F101, F102, F103, F104, F105, F106, F107, F108, F109 int64
+	F110, F111, F112, F113, F114, F115, F116, F117, F118, F119 int64
+	F120, F121, F122, F123, F124, F125, F126, F127, F128, F129 int64
+}
+
+// TestColDiff128ColsRoundTrip encodes a slice of big130Row where all 130
+// columns change, so nChangedCols = 130 >= 128. Before the fix,
+// diffColumnarEligible declined structs with >=128 cols (the patch would use
+// positional encoding and patchTag would not be tagColSlicePatch). After the
+// fix, the columnar path is used with a 2-byte padded uvarint for nChangedCols,
+// and the round-trip must produce the original values.
+func TestColDiff128ColsRoundTrip(t *testing.T) {
+	const n = 500
+	old := make([]big130Row, n)
+	neu := make([]big130Row, n)
+
+	// Initialise: field Fxxx = int64(xxx) for every row.
+	for i := range old {
+		r := &old[i]
+		r.F000, r.F001, r.F002, r.F003, r.F004 = 0, 1, 2, 3, 4
+		r.F005, r.F006, r.F007, r.F008, r.F009 = 5, 6, 7, 8, 9
+		r.F010, r.F011, r.F012, r.F013, r.F014 = 10, 11, 12, 13, 14
+		r.F015, r.F016, r.F017, r.F018, r.F019 = 15, 16, 17, 18, 19
+		r.F020, r.F021, r.F022, r.F023, r.F024 = 20, 21, 22, 23, 24
+		r.F025, r.F026, r.F027, r.F028, r.F029 = 25, 26, 27, 28, 29
+		r.F030, r.F031, r.F032, r.F033, r.F034 = 30, 31, 32, 33, 34
+		r.F035, r.F036, r.F037, r.F038, r.F039 = 35, 36, 37, 38, 39
+		r.F040, r.F041, r.F042, r.F043, r.F044 = 40, 41, 42, 43, 44
+		r.F045, r.F046, r.F047, r.F048, r.F049 = 45, 46, 47, 48, 49
+		r.F050, r.F051, r.F052, r.F053, r.F054 = 50, 51, 52, 53, 54
+		r.F055, r.F056, r.F057, r.F058, r.F059 = 55, 56, 57, 58, 59
+		r.F060, r.F061, r.F062, r.F063, r.F064 = 60, 61, 62, 63, 64
+		r.F065, r.F066, r.F067, r.F068, r.F069 = 65, 66, 67, 68, 69
+		r.F070, r.F071, r.F072, r.F073, r.F074 = 70, 71, 72, 73, 74
+		r.F075, r.F076, r.F077, r.F078, r.F079 = 75, 76, 77, 78, 79
+		r.F080, r.F081, r.F082, r.F083, r.F084 = 80, 81, 82, 83, 84
+		r.F085, r.F086, r.F087, r.F088, r.F089 = 85, 86, 87, 88, 89
+		r.F090, r.F091, r.F092, r.F093, r.F094 = 90, 91, 92, 93, 94
+		r.F095, r.F096, r.F097, r.F098, r.F099 = 95, 96, 97, 98, 99
+		r.F100, r.F101, r.F102, r.F103, r.F104 = 100, 101, 102, 103, 104
+		r.F105, r.F106, r.F107, r.F108, r.F109 = 105, 106, 107, 108, 109
+		r.F110, r.F111, r.F112, r.F113, r.F114 = 110, 111, 112, 113, 114
+		r.F115, r.F116, r.F117, r.F118, r.F119 = 115, 116, 117, 118, 119
+		r.F120, r.F121, r.F122, r.F123, r.F124 = 120, 121, 122, 123, 124
+		r.F125, r.F126, r.F127, r.F128, r.F129 = 125, 126, 127, 128, 129
+	}
+	// new: every field += 1000. All 130 columns change → nChangedCols = 130.
+	for i := range neu {
+		r := &old[i]
+		w := &neu[i]
+		w.F000, w.F001, w.F002, w.F003, w.F004 = r.F000+1000, r.F001+1000, r.F002+1000, r.F003+1000, r.F004+1000
+		w.F005, w.F006, w.F007, w.F008, w.F009 = r.F005+1000, r.F006+1000, r.F007+1000, r.F008+1000, r.F009+1000
+		w.F010, w.F011, w.F012, w.F013, w.F014 = r.F010+1000, r.F011+1000, r.F012+1000, r.F013+1000, r.F014+1000
+		w.F015, w.F016, w.F017, w.F018, w.F019 = r.F015+1000, r.F016+1000, r.F017+1000, r.F018+1000, r.F019+1000
+		w.F020, w.F021, w.F022, w.F023, w.F024 = r.F020+1000, r.F021+1000, r.F022+1000, r.F023+1000, r.F024+1000
+		w.F025, w.F026, w.F027, w.F028, w.F029 = r.F025+1000, r.F026+1000, r.F027+1000, r.F028+1000, r.F029+1000
+		w.F030, w.F031, w.F032, w.F033, w.F034 = r.F030+1000, r.F031+1000, r.F032+1000, r.F033+1000, r.F034+1000
+		w.F035, w.F036, w.F037, w.F038, w.F039 = r.F035+1000, r.F036+1000, r.F037+1000, r.F038+1000, r.F039+1000
+		w.F040, w.F041, w.F042, w.F043, w.F044 = r.F040+1000, r.F041+1000, r.F042+1000, r.F043+1000, r.F044+1000
+		w.F045, w.F046, w.F047, w.F048, w.F049 = r.F045+1000, r.F046+1000, r.F047+1000, r.F048+1000, r.F049+1000
+		w.F050, w.F051, w.F052, w.F053, w.F054 = r.F050+1000, r.F051+1000, r.F052+1000, r.F053+1000, r.F054+1000
+		w.F055, w.F056, w.F057, w.F058, w.F059 = r.F055+1000, r.F056+1000, r.F057+1000, r.F058+1000, r.F059+1000
+		w.F060, w.F061, w.F062, w.F063, w.F064 = r.F060+1000, r.F061+1000, r.F062+1000, r.F063+1000, r.F064+1000
+		w.F065, w.F066, w.F067, w.F068, w.F069 = r.F065+1000, r.F066+1000, r.F067+1000, r.F068+1000, r.F069+1000
+		w.F070, w.F071, w.F072, w.F073, w.F074 = r.F070+1000, r.F071+1000, r.F072+1000, r.F073+1000, r.F074+1000
+		w.F075, w.F076, w.F077, w.F078, w.F079 = r.F075+1000, r.F076+1000, r.F077+1000, r.F078+1000, r.F079+1000
+		w.F080, w.F081, w.F082, w.F083, w.F084 = r.F080+1000, r.F081+1000, r.F082+1000, r.F083+1000, r.F084+1000
+		w.F085, w.F086, w.F087, w.F088, w.F089 = r.F085+1000, r.F086+1000, r.F087+1000, r.F088+1000, r.F089+1000
+		w.F090, w.F091, w.F092, w.F093, w.F094 = r.F090+1000, r.F091+1000, r.F092+1000, r.F093+1000, r.F094+1000
+		w.F095, w.F096, w.F097, w.F098, w.F099 = r.F095+1000, r.F096+1000, r.F097+1000, r.F098+1000, r.F099+1000
+		w.F100, w.F101, w.F102, w.F103, w.F104 = r.F100+1000, r.F101+1000, r.F102+1000, r.F103+1000, r.F104+1000
+		w.F105, w.F106, w.F107, w.F108, w.F109 = r.F105+1000, r.F106+1000, r.F107+1000, r.F108+1000, r.F109+1000
+		w.F110, w.F111, w.F112, w.F113, w.F114 = r.F110+1000, r.F111+1000, r.F112+1000, r.F113+1000, r.F114+1000
+		w.F115, w.F116, w.F117, w.F118, w.F119 = r.F115+1000, r.F116+1000, r.F117+1000, r.F118+1000, r.F119+1000
+		w.F120, w.F121, w.F122, w.F123, w.F124 = r.F120+1000, r.F121+1000, r.F122+1000, r.F123+1000, r.F124+1000
+		w.F125, w.F126, w.F127, w.F128, w.F129 = r.F125+1000, r.F126+1000, r.F127+1000, r.F128+1000, r.F129+1000
+	}
+
+	patch, err := Diff(old, neu, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify the columnar path was chosen (nChangedCols = 130 requires the
+	// 2-byte varint fix; positional would have been chosen before the fix).
+	if tag, ok := patchTag(patch); !ok || tag != tagColSlicePatch {
+		t.Fatalf("expected tagColSlicePatch for 130-col struct, got tag=%#x ok=%v", tag, ok)
+	}
+	got := append([]big130Row(nil), old...)
+	if err := Apply(&got, patch); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, neu) {
+		t.Fatal("128-col round-trip mismatch")
+	}
+}

--- a/delta_keyed.go
+++ b/delta_keyed.go
@@ -6,10 +6,6 @@ import (
 	"unsafe"
 )
 
-// noopRelease is a package-level no-op release function used by buildKeyLookup
-// on the linear path to avoid allocating a closure on the heap.
-var noopRelease = func() {}
-
 // keyToken returns a string usable as a Go map key that uniquely identifies the
 // element's key field value WITHOUT allocating. elemP points at an element of a
 // keyed struct type td; td.keyOff/td.keyDesc locate the key field. Delegates to
@@ -390,7 +386,7 @@ type keyLookup struct {
 // keyed slice), it allocates a fresh local map so the parent's lookup is never
 // clobbered. release() returns the borrow (no-op for the linear / nested cases).
 func buildKeyLookup(m *map[string]int, busy *bool, keyAt func(int) string, n int) (lk keyLookup, dup bool, release func()) {
-	noop := noopRelease
+	noop := func() {}
 	if n <= keyedLinearMax {
 		for i := range n {
 			ki := keyAt(i)

--- a/delta_keyed.go
+++ b/delta_keyed.go
@@ -6,6 +6,10 @@ import (
 	"unsafe"
 )
 
+// noopRelease is a package-level no-op release function used by buildKeyLookup
+// on the linear path to avoid allocating a closure on the heap.
+var noopRelease = func() {}
+
 // keyToken returns a string usable as a Go map key that uniquely identifies the
 // element's key field value WITHOUT allocating. elemP points at an element of a
 // keyed struct type td; td.keyOff/td.keyDesc locate the key field. Delegates to
@@ -386,7 +390,7 @@ type keyLookup struct {
 // keyed slice), it allocates a fresh local map so the parent's lookup is never
 // clobbered. release() returns the borrow (no-op for the linear / nested cases).
 func buildKeyLookup(m *map[string]int, busy *bool, keyAt func(int) string, n int) (lk keyLookup, dup bool, release func()) {
-	noop := func() {}
+	noop := noopRelease
 	if n <= keyedLinearMax {
 		for i := range n {
 			ki := keyAt(i)

--- a/encoder.go
+++ b/encoder.go
@@ -77,7 +77,7 @@ const preInternUnseen = ^uint32(0)
 // 8-byte counters first, then the 1-byte flags (mode + the many bools) last
 // so the interspersed bools do not each force a padding word (200 bytes vs
 // 232 for the source order).
-type Encoder struct {
+type Encoder struct { // betteralign:ignore — hand-tuned for SIZE (200 vs 232 bytes); bools packed last
 	state *encState
 
 	// fsstDict, when non-nil, is a pre-trained FSST symbol table supplied via

--- a/encoder.go
+++ b/encoder.go
@@ -87,6 +87,16 @@ type Encoder struct {
 	// immutable; it is never mutated by the encoder.
 	fsstDict *fsst.SymbolTable
 
+	// fsstCachedTbl holds the FSST symbol table trained on the most recent
+	// batch when no user-supplied fsstDict is set. Reused across consecutive
+	// same-encoder batches to eliminate the per-batch Build training cost
+	// (~140–311 µs). Retrained every fsstReuseInterval batches so the table
+	// adapts when string distributions shift. Cleared by Reset() on pool
+	// recycle so a pooled encoder never carries stale data into the next
+	// caller; survives resetForReuse() so a streaming caller amortises training.
+	fsstCachedTbl  *fsst.SymbolTable
+	fsstBatchCount int // consecutive reuses of fsstCachedTbl since last retrain
+
 	// keyIdx is a reused (clear-not-realloc) old-key→index map for keyed slice
 	// diff. Lives on the Encoder so a many-element keyed slice builds its match
 	// table once per pool acquire; dropped past a spike cap in Reset(). Single
@@ -409,6 +419,10 @@ func (e *Encoder) Reset() {
 	e.pairPred = false
 	e.mtf = false
 	e.fsstDict = nil
+	// Drop the streaming FSST table cache so a pooled encoder does not carry
+	// stale table data into the next caller's workload.
+	e.fsstCachedTbl = nil
+	e.fsstBatchCount = 0
 }
 
 // resetForReuse clears the per-message / per-stream encoder state — the output

--- a/examples/batchdecode/main.go
+++ b/examples/batchdecode/main.go
@@ -24,10 +24,10 @@ import (
 // Source is the wire shape: everything is a normal Go type, encoded and
 // decoded like any other qdf struct.
 type Source struct {
-	ID     int64     `qdf:"id"`
+	TS     time.Time `qdf:"ts"`
 	Region string    `qdf:"region"` // low-cardinality: a handful of repeated values
 	Msg    string    `qdf:"msg"`    // high-cardinality: distinct per row
-	TS     time.Time `qdf:"ts"`
+	ID     int64     `qdf:"id"`
 	Val    float64   `qdf:"val"`
 }
 

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -17,8 +17,8 @@ import (
 
 type Event struct {
 	Level string `qdf:"level"`
-	Code  int32  `qdf:"code"`
 	Msg   string `qdf:"msg"`
+	Code  int32  `qdf:"code"`
 }
 
 func main() {

--- a/examples/telemetry/main.go
+++ b/examples/telemetry/main.go
@@ -19,8 +19,8 @@ type LogRecord struct {
 	Service string `qdf:"service" json:"service"`
 	Level   string `qdf:"level"   json:"level"`
 	Region  string `qdf:"region"  json:"region"`
-	Code    int32  `qdf:"code"    json:"code"`
 	Message string `qdf:"msg"     json:"msg"`
+	Code    int32  `qdf:"code"    json:"code"`
 }
 
 func main() {

--- a/internal/fsst/fsst.go
+++ b/internal/fsst/fsst.go
@@ -302,6 +302,26 @@ func (t *SymbolTable) Reset() {
 	t.first = [257]int32{}
 }
 
+// Clone returns an independent deep copy of t. Use it to retain a table
+// beyond the lifetime of the Builder that trained it: Builder.Build returns a
+// table that aliases the Builder's internal SymbolTable and is invalidated the
+// next time Build is called on the same Builder (e.g. when the Builder is
+// returned to a pool). Clone's copies (symbols and cands slices) contain only
+// value types (no pointer fields), so the clone neither pins the original
+// Builder nor shares any mutable state with it.
+func (t *SymbolTable) Clone() *SymbolTable {
+	c := &SymbolTable{first: t.first}
+	if len(t.symbols) > 0 {
+		c.symbols = make([]symbol, len(t.symbols))
+		copy(c.symbols, t.symbols)
+	}
+	if len(t.cands) > 0 {
+		c.cands = make([]cand, len(t.cands))
+		copy(c.cands, t.cands)
+	}
+	return c
+}
+
 // UnmarshalInto parses a symbol table from b into t, reusing t's existing
 // slice backing arrays. It is equivalent to UnmarshalSymbolTable but avoids
 // the intermediate [][]byte allocation, making it suitable for pooled callers.

--- a/internal/rans/rans.go
+++ b/internal/rans/rans.go
@@ -8,6 +8,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"slices"
+
+	"github.com/alex60217101990/qdf/internal/bufpool"
 )
 
 const (
@@ -112,9 +114,13 @@ func buildSlot(cum *[257]uint32, slot *[scale]byte) {
 	}
 }
 
-// encodeStream rANS-encodes src and returns the stream: 4-byte little-endian
-// final state followed by the renormalization bytes in decode order.
-func encodeStream(src []byte, freq *[256]uint32, cum *[257]uint32) []byte {
+// encodeStream rANS-encodes src, appends the stream to dst, and returns the
+// extended dst. The stream is: 4-byte little-endian final state followed by
+// the renormalization bytes in decode order.
+// Accepting dst here is not just API style — it closes a data race: the pool
+// buffer is returned by the deferred Put only after the append (the copy) has
+// completed, so no concurrent encoder can see the data in-flight.
+func encodeStream(dst, src []byte, freq *[256]uint32, cum *[257]uint32) []byte {
 	// Worst-case output: each symbol emits at most maxRenormBytesPerSym renorm
 	// bytes (a freq-1 symbol over the scale=2^12 table renormalizes a state in
 	// [2^23, 2^31) down past xMax=2^19, i.e. two >>8 steps), plus the 4-byte final
@@ -123,7 +129,9 @@ func encodeStream(src []byte, freq *[256]uint32, cum *[257]uint32) []byte {
 	// local distribution skewed against the SHARED table (see encodeStreamStrided-
 	// Into). Size for the proven bound so the backward writer can never underflow.
 	size := len(src)*maxRenormBytesPerSym + 16
-	buf := make([]byte, size)
+	bp := bufpool.Get(size)
+	buf := (*bp)[:size]
+	defer bufpool.Put(bp)
 	pos := size
 	x := uint32(ransByteL)
 	for _, s := range slices.Backward(src) {
@@ -139,7 +147,9 @@ func encodeStream(src []byte, freq *[256]uint32, cum *[257]uint32) []byte {
 	}
 	pos -= 4
 	binary.LittleEndian.PutUint32(buf[pos:], x)
-	return buf[pos:]
+	// Copy into dst before the deferred Put returns buf to the pool.
+	dst = append(dst, buf[pos:]...)
+	return dst
 }
 
 // decodeStream reverses encodeStream, emitting exactly n bytes.
@@ -237,7 +247,7 @@ func Encode(dst, src []byte) []byte {
 	if !useInter {
 		dst = append(dst, ransTagSingle)
 		dst = appendTable(dst, &freq)
-		return append(dst, encodeStream(src, &freq, &cum)...)
+		return encodeStream(dst, src, &freq, &cum)
 	}
 	n := interleaveN
 	if forceTagForTest > 0 {

--- a/internal/rans/rans_interleaved.go
+++ b/internal/rans/rans_interleaved.go
@@ -1,6 +1,10 @@
 package rans
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+
+	"github.com/alex60217101990/qdf/internal/bufpool"
+)
 
 // encodeStreamStridedInto rANS-encodes the substream src[k], src[k+n], … into
 // the caller-provided buf (which must have len >= m*maxRenormBytesPerSym+16,
@@ -50,7 +54,10 @@ func appendInterleaved(dst, src []byte, freq *[256]uint32, cum *[257]uint32, n i
 	// span m_k*maxRenormBytesPerSym+16 bytes (NOT m_k+16, which assumes <=1 byte/
 	// symbol and underflows the backward writer on rare-byte-heavy substreams). The
 	// regions sum to len(src)*maxRenormBytesPerSym + n*16.
-	scratch := make([]byte, len(src)*maxRenormBytesPerSym+n*16)
+	scratchSize := len(src)*maxRenormBytesPerSym + n*16
+	bp := bufpool.Get(scratchSize)
+	scratch := (*bp)[:scratchSize]
+	defer bufpool.Put(bp)
 	off := 0
 	for k := range n {
 		m := max((len(src)-k+n-1)/n, 0)

--- a/internal/rans/rans_interleaved_bench_test.go
+++ b/internal/rans/rans_interleaved_bench_test.go
@@ -5,6 +5,29 @@ import (
 	"testing"
 )
 
+// BenchmarkRans benchmarks the Encode path (single-stream and interleaved-4)
+// across body sizes. Used as the bench-gate target for the bufpool scratch-buffer fix.
+func BenchmarkRans(b *testing.B) {
+	for _, sz := range []int{1 << 12, 1 << 14, 1 << 16, 1 << 18} {
+		src := mkSkewed(sz)
+		for _, force := range []int{-1, interleaveN} {
+			forceTagForTest = force
+			name := "encode/sz" + strconv.Itoa(sz) + "/single"
+			if force > 0 {
+				name = "encode/sz" + strconv.Itoa(sz) + "/inter" + strconv.Itoa(force)
+			}
+			b.Run(name, func(b *testing.B) {
+				b.SetBytes(int64(sz))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_ = Encode(nil, src)
+				}
+			})
+			forceTagForTest = 0
+		}
+	}
+}
+
 // BenchmarkRANSDecode compares single-stream vs the shipped interleaved-4 decode
 // across body sizes. Interleaving overlaps the per-symbol dependency-chain
 // latency, so it decodes ~2-2.5x the bytes per second (latency-bound loop).

--- a/iter_bench_test.go
+++ b/iter_bench_test.go
@@ -5,6 +5,36 @@ import (
 	"testing"
 )
 
+// BenchmarkEncodeShapedMap exercises encodeStringMapShaped (OptMapShape path)
+// with a struct-valued map. After the first encode declares the shape and
+// allocates the per-shape valSlots, the hot path makes zero per-key heap
+// allocations (SetIterValue writes directly into pre-allocated slots).
+func BenchmarkEncodeShapedMap(b *testing.B) {
+	type rec struct {
+		A int     `qdf:"a"`
+		B float64 `qdf:"b"`
+	}
+	type holder struct {
+		M map[string]rec `qdf:"m"`
+	}
+	v := holder{M: map[string]rec{
+		"alpha": {A: 1, B: 1.5},
+		"beta":  {A: 2, B: 2.5},
+		"gamma": {A: 3, B: 3.5},
+	}}
+	enc := NewEncoderWith(OptMapShape | OptDense)
+	// Warm up: first encode declares the shape and initialises valSlots;
+	// subsequent encodes in the loop hit the zero-alloc fast path.
+	if err := enc.EncodeValue(v); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		enc.SetBuffer(enc.Bytes()[:0])
+		_ = enc.EncodeValue(v)
+	}
+}
+
 // Compares two map-iteration strategies in the reflect path:
 // the original *MapIter (rv.MapRange + iter.Next loop) versus the
 // Go 1.26 rv.Seq2 range-over-func. Same body, same accumulators —

--- a/qpack_fsst.go
+++ b/qpack_fsst.go
@@ -18,6 +18,13 @@ const (
 	// encoder still uses the full buildRounds for the table it emits. Keeps the
 	// per-column probe training off the OptCompression hot path.
 	fsstProbeRounds = 1
+	// fsstReuseInterval is the number of consecutive batches that reuse the
+	// cached FSST symbol table (fsstCachedTbl) before retraining. Matches
+	// retainReleaseStreak (8) so a steady workload holds its table across 8
+	// batches before a full retrain checks whether the string distribution has
+	// shifted. Only applies to streaming encoders (same Encoder reused across
+	// calls); pool-backed Marshal resets the cache on every acquire.
+	fsstReuseInterval = 8
 )
 
 // fsstBuilderPool reuses FSST training scratch across the per-column probe
@@ -48,17 +55,33 @@ func (e *Encoder) tryWriteStringColumnFSST(strs []string) bool {
 	// which is the dominant FSST encode cost; otherwise train on this column.
 	tbl := e.fsstDict
 	if tbl == nil {
-		// Reuse a pooled [][]byte across columns/encodes instead of allocating
-		// a fresh slice per column (the dominant OptCompression columnar-encode
-		// allocation). The views are zero-copy; the trainer only reads them.
-		samples := e.state.fsstSamples[:0]
-		for _, s := range strs {
-			samples = append(samples, unsafestr.Bytes(s))
+		// Streaming cache: reuse the table trained on a recent batch to skip
+		// the Build() cost (~140–311 µs) when the same Encoder is reused across
+		// consecutive batches. We retrain every fsstReuseInterval batches so the
+		// table adapts to drifting distributions. The wire format is unchanged:
+		// the table is always fully serialised (MarshalTo below) so the decoder
+		// needs no protocol changes — caching is encoder-side only.
+		if e.fsstCachedTbl != nil && e.fsstBatchCount < fsstReuseInterval {
+			tbl = e.fsstCachedTbl
+			e.fsstBatchCount++
+		} else {
+			// (Re)train: build via the pooled builder (reuses counter/cand scratch),
+			// then clone to an independent copy before the builder is returned to
+			// the pool. bld.Build returns a table aliasing bld's internal storage;
+			// that alias is invalidated the next time any goroutine calls Build on
+			// the same Builder. Clone() copies the three fields (symbols, cands,
+			// first) into a fresh allocation that survives beyond this call.
+			samples := e.state.fsstSamples[:0]
+			for _, s := range strs {
+				samples = append(samples, unsafestr.Bytes(s))
+			}
+			e.state.fsstSamples = samples
+			bld := fsstBuilderPool.Get().(*fsst.Builder)
+			defer fsstBuilderPool.Put(bld)
+			tbl = bld.Build(samples)
+			e.fsstCachedTbl = tbl.Clone() // independent copy; bld safe to pool
+			e.fsstBatchCount = 0
 		}
-		e.state.fsstSamples = samples
-		bld := fsstBuilderPool.Get().(*fsst.Builder)
-		defer fsstBuilderPool.Put(bld)
-		tbl = bld.Build(samples) // aliases bld; used within this call only
 	}
 
 	// Compress all rows into one scratch buffer, recording per-row lengths.

--- a/qpack_fsst_test.go
+++ b/qpack_fsst_test.go
@@ -253,3 +253,31 @@ func itoaTiny(i int) string {
 	}
 	return string(b[p:])
 }
+
+// BenchmarkFSSTEncodeIncompressible measures the FSST encode attempt on
+// non-compressible (random-byte) input. FSST trains, attempts compression,
+// and then rejects the output because it does not shrink the column. A
+// sample-based probe short-circuits this rejection path before full
+// compression, saving the per-row Compress work.
+func BenchmarkFSSTEncodeIncompressible(b *testing.B) {
+	rows := mkRows(genRandom(512))
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := Marshal(rows, OptBalanced|OptFSST); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkFSSTEncodeCompressible measures the FSST encode attempt on
+// compressible (URL-like) input where FSST succeeds. The probe must not
+// regress this path.
+func BenchmarkFSSTEncodeCompressible(b *testing.B) {
+	rows := mkRows(genURLs(512))
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := Marshal(rows, OptBalanced|OptFSST); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/qpack_pfor.go
+++ b/qpack_pfor.go
@@ -275,6 +275,9 @@ func (d *Decoder) readPackedPForInt64Slice() ([]int64, error) {
 			return nil, ErrInvalidLength
 		}
 		d.i += nr
+		if dp > uint64(n-pos) {
+			return nil, ErrInvalidLength
+		}
 		pos += int(dp)
 		if pos < 0 || pos >= n {
 			return nil, ErrInvalidLength
@@ -363,6 +366,9 @@ func (d *Decoder) readPackedPForUint64Slice() ([]uint64, error) {
 			return nil, ErrInvalidLength
 		}
 		d.i += nr
+		if dp > uint64(n-pos) {
+			return nil, ErrInvalidLength
+		}
 		pos += int(dp)
 		if pos < 0 || pos >= n {
 			return nil, ErrInvalidLength

--- a/qpack_pfor_test.go
+++ b/qpack_pfor_test.go
@@ -367,7 +367,8 @@ func TestPForExceptionDeltaOverflow(t *testing.T) {
 	//
 	// Without the fix pos wraps to 0 ∈ [0,8), bounds check passes, and the
 	// function returns nil.  With the fix it must return a non-nil error.
-	bufU := []byte{
+	bufU := make([]byte, 0, 8+len(maxU64Varint)+1)
+	bufU = append(bufU,
 		qpackKindUint64, // kind byte
 		0x08,            // n=8 (uvarint)
 		0x01,            // b=1 (bits per packed slot)
@@ -375,7 +376,7 @@ func TestPForExceptionDeltaOverflow(t *testing.T) {
 		0x00,            // body: (8*1+7)/8 = 1 byte, all zeros
 		0x02,            // excN=2
 		0x01, 0x01,      // exc1: dp=1, delta=1
-	}
+	)
 	bufU = append(bufU, maxU64Varint...) // exc2: dp=MaxUint64
 	bufU = append(bufU, 0x02)            // exc2: delta=2
 
@@ -387,7 +388,8 @@ func TestPForExceptionDeltaOverflow(t *testing.T) {
 	}
 
 	// int64 variant --------------------------------------------------------
-	bufI := []byte{
+	bufI := make([]byte, 0, 8+len(maxU64Varint)+1)
+	bufI = append(bufI,
 		qpackKindInt64, // kind byte
 		0x08,           // n=8 (uvarint)
 		0x01,           // b=1
@@ -395,7 +397,7 @@ func TestPForExceptionDeltaOverflow(t *testing.T) {
 		0x00,           // body: 1 byte
 		0x02,           // excN=2
 		0x01, 0x01,     // exc1: dp=1, delta=1
-	}
+	)
 	bufI = append(bufI, maxU64Varint...) // exc2: dp=MaxUint64
 	bufI = append(bufI, 0x02)            // exc2: delta=2
 

--- a/qpack_pfor_test.go
+++ b/qpack_pfor_test.go
@@ -346,3 +346,63 @@ func TestPFor_CorpusGate(t *testing.T) {
 		}
 	}
 }
+
+// TestPForExceptionDeltaOverflow is a regression test for the uint64→int cast
+// overflow in the PFOR exception-delta loop.  A crafted buffer sets the second
+// exception's position gap (dp) to MaxUint64.  Before the fix, int(MaxUint64)
+// == -1 on 64-bit platforms, which decremented pos from 1 back to 0 — still
+// inside [0,n) — so the bounds check passed and slot 0 was silently overwritten
+// with a wrong value.  After the fix the decoder must return a non-nil error.
+func TestPForExceptionDeltaOverflow(t *testing.T) {
+	// MaxUint64 (0xFFFFFFFFFFFFFFFF) encoded as a uvarint: 10 bytes.
+	maxU64Varint := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01}
+
+	// uint64 variant -------------------------------------------------------
+	// Wire format (starting after the tagPackPFor byte the caller already
+	// consumed):
+	//   kind=uint64 | n=8 (uvarint) | b=1 | mn=0 (uvarint) | body=1B |
+	//   excN=2 |
+	//     exc1: dp=1, delta=1  (pos becomes 1 — a valid write to slot 1)
+	//     exc2: dp=MaxUint64   (pre-fix: int(MaxUint64)==-1, pos wraps to 0)
+	//
+	// Without the fix pos wraps to 0 ∈ [0,8), bounds check passes, and the
+	// function returns nil.  With the fix it must return a non-nil error.
+	bufU := []byte{
+		qpackKindUint64, // kind byte
+		0x08,            // n=8 (uvarint)
+		0x01,            // b=1 (bits per packed slot)
+		0x00,            // mn=0 (uvarint)
+		0x00,            // body: (8*1+7)/8 = 1 byte, all zeros
+		0x02,            // excN=2
+		0x01, 0x01,      // exc1: dp=1, delta=1
+	}
+	bufU = append(bufU, maxU64Varint...) // exc2: dp=MaxUint64
+	bufU = append(bufU, 0x02)            // exc2: delta=2
+
+	var dU Decoder
+	dU.buf = bufU
+	_, errU := dU.readPackedPForUint64Slice()
+	if errU == nil {
+		t.Fatal("uint64: expected error for MaxUint64 exception delta, got nil (pos wrapped into valid range)")
+	}
+
+	// int64 variant --------------------------------------------------------
+	bufI := []byte{
+		qpackKindInt64, // kind byte
+		0x08,           // n=8 (uvarint)
+		0x01,           // b=1
+		0x00,           // mn=0, zigzag-encoded (zigzag(0)=0)
+		0x00,           // body: 1 byte
+		0x02,           // excN=2
+		0x01, 0x01,     // exc1: dp=1, delta=1
+	}
+	bufI = append(bufI, maxU64Varint...) // exc2: dp=MaxUint64
+	bufI = append(bufI, 0x02)            // exc2: delta=2
+
+	var dI Decoder
+	dI.buf = bufI
+	_, errI := dI.readPackedPForInt64Slice()
+	if errI == nil {
+		t.Fatal("int64: expected error for MaxUint64 exception delta, got nil (pos wrapped into valid range)")
+	}
+}

--- a/qpack_rle.go
+++ b/qpack_rle.go
@@ -146,8 +146,9 @@ func (d *Decoder) readPackedRLEUint64Slice() ([]uint64, error) {
 			return nil, ErrInvalidLength
 		}
 		end := idx + int(runLen)
-		for i := idx; i < end; i++ {
-			out[i] = v
+		out[idx] = v
+		for size := 1; idx+size < end; size <<= 1 {
+			copy(out[idx+size:end], out[idx:idx+size])
 		}
 		idx = end
 	}
@@ -180,8 +181,9 @@ func (d *Decoder) readPackedRLEInt64Slice() ([]int64, error) {
 		}
 		v := zigzagDecode64(v64)
 		end := idx + int(runLen)
-		for i := idx; i < end; i++ {
-			out[i] = v
+		out[idx] = v
+		for size := 1; idx+size < end; size <<= 1 {
+			copy(out[idx+size:end], out[idx:idx+size])
 		}
 		idx = end
 	}

--- a/qpack_rle.go
+++ b/qpack_rle.go
@@ -142,7 +142,7 @@ func (d *Decoder) readPackedRLEUint64Slice() ([]uint64, error) {
 			return nil, ErrInvalidLength
 		}
 		d.i += nr
-		if runLen == 0 || uint64(idx)+runLen > uint64(n) {
+		if runLen == 0 || runLen > uint64(n-idx) {
 			return nil, ErrInvalidLength
 		}
 		end := idx + int(runLen)
@@ -175,7 +175,7 @@ func (d *Decoder) readPackedRLEInt64Slice() ([]int64, error) {
 			return nil, ErrInvalidLength
 		}
 		d.i += nr
-		if runLen == 0 || uint64(idx)+runLen > uint64(n) {
+		if runLen == 0 || runLen > uint64(n-idx) {
 			return nil, ErrInvalidLength
 		}
 		v := zigzagDecode64(v64)

--- a/qpack_rle_bench_test.go
+++ b/qpack_rle_bench_test.go
@@ -1,0 +1,152 @@
+package qdf
+
+import "testing"
+
+// BenchmarkRLEDecodeRunHeavyUint64 measures readPackedRLEUint64Slice throughput
+// for a run-heavy workload: 4 runs of 256 elements each (1024 elements total).
+// This exercises the copy-doubling fill path, which routes through
+// runtime.memmove and uses NEON Q-register stores on ARM64.
+func BenchmarkRLEDecodeRunHeavyUint64(b *testing.B) {
+	const (
+		nRuns   = 4
+		runLen  = 256
+		nTotal  = nRuns * runLen
+	)
+
+	// Build input: 4 distinct values, each repeated 256 times.
+	in := make([]uint64, nTotal)
+	for r := range nRuns {
+		v := uint64(r+1) * 100
+		for i := range runLen {
+			in[r*runLen+i] = v
+		}
+	}
+
+	enc := NewEncoder(Fast)
+	enc.writePackedRLEUint64Slice(in)
+	encoded := enc.buf
+
+	// Locate the start of the RLE body (after stream header + tag byte).
+	// peekTag reads the header and leaves d.i pointing at the tag; we skip
+	// that tag too so readPackedRLEUint64Slice sees kind + n + runs.
+	d := NewDecoderOnBuf(encoded)
+	tag, err := d.peekTag()
+	if err != nil || tag != tagPackRLE {
+		b.Fatalf("unexpected tag %02x err=%v", tag, err)
+	}
+	d.i++ // consume tag
+	bodyStart := d.i
+
+	// Warm-up: verify correctness once.
+	out, err := d.readPackedRLEUint64Slice()
+	if err != nil {
+		b.Fatalf("decode: %v", err)
+	}
+	if len(out) != nTotal {
+		b.Fatalf("expected %d elements, got %d", nTotal, len(out))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		d.i = bodyStart
+		if _, err := d.readPackedRLEUint64Slice(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkRLEDecodeRunHeavyInt64 is the signed counterpart.
+func BenchmarkRLEDecodeRunHeavyInt64(b *testing.B) {
+	const (
+		nRuns  = 4
+		runLen = 256
+		nTotal = nRuns * runLen
+	)
+
+	in := make([]int64, nTotal)
+	for r := range nRuns {
+		v := int64(r+1) * -100
+		for i := range runLen {
+			in[r*runLen+i] = v
+		}
+	}
+
+	enc := NewEncoder(Fast)
+	enc.writePackedRLEInt64Slice(in)
+	encoded := enc.buf
+
+	d := NewDecoderOnBuf(encoded)
+	tag, err := d.peekTag()
+	if err != nil || tag != tagPackRLE {
+		b.Fatalf("unexpected tag %02x err=%v", tag, err)
+	}
+	d.i++
+	bodyStart := d.i
+
+	out, err := d.readPackedRLEInt64Slice()
+	if err != nil {
+		b.Fatalf("decode: %v", err)
+	}
+	if len(out) != nTotal {
+		b.Fatalf("expected %d elements, got %d", nTotal, len(out))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		d.i = bodyStart
+		if _, err := d.readPackedRLEInt64Slice(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkRLEIntoRunHeavy benchmarks the reuse-buffer (Into) variant, which
+// avoids per-call allocation and isolates the fill loop latency. This is the
+// hot path used by decodeColumnInto for columnar RLE columns.
+// 4 runs × 256 elements = 1024 elements (runLen=256 >> 32, exercises NEON path).
+func BenchmarkRLEIntoRunHeavy(b *testing.B) {
+	const (
+		nRuns  = 4
+		runLen = 256
+		nTotal = nRuns * runLen
+	)
+
+	in := make([]uint64, nTotal)
+	for r := range nRuns {
+		v := uint64(r+1) * 100
+		for i := range runLen {
+			in[r*runLen+i] = v
+		}
+	}
+
+	enc := NewEncoder(Fast)
+	enc.writePackedRLEUint64Slice(in)
+	encoded := enc.buf
+
+	d := NewDecoderOnBuf(encoded)
+	tag, err := d.peekTag()
+	if err != nil || tag != tagPackRLE {
+		b.Fatalf("unexpected tag %02x err=%v", tag, err)
+	}
+	d.i++
+	bodyStart := d.i
+
+	var dst []uint64
+	if err := d.readPackedRLEUint64SliceInto(&dst); err != nil {
+		b.Fatalf("decode: %v", err)
+	}
+	if len(dst) != nTotal {
+		b.Fatalf("expected %d elements, got %d", nTotal, len(dst))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		d.i = bodyStart
+		if err := d.readPackedRLEUint64SliceInto(&dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/qpack_rle_bench_test.go
+++ b/qpack_rle_bench_test.go
@@ -8,9 +8,9 @@ import "testing"
 // runtime.memmove and uses NEON Q-register stores on ARM64.
 func BenchmarkRLEDecodeRunHeavyUint64(b *testing.B) {
 	const (
-		nRuns   = 4
-		runLen  = 256
-		nTotal  = nRuns * runLen
+		nRuns  = 4
+		runLen = 256
+		nTotal = nRuns * runLen
 	)
 
 	// Build input: 4 distinct values, each repeated 256 times.

--- a/qpack_rle_test.go
+++ b/qpack_rle_test.go
@@ -170,6 +170,52 @@ func TestRLE_ErrorCases(t *testing.T) {
 	})
 }
 
+// TestRLEOverflowGuard verifies that a crafted wire input with runLen=MaxUint64
+// cannot bypass the bounds guard via integer wrap-around when idx > 0.
+//
+// Attack: n=5, run1=(val=0, runLen=1) advances idx to 1, run2=(val=1, runLen=MaxUint64).
+// Old addition guard: uint64(1)+MaxUint64 wraps to 0, and 0 > 5 is false → bypass.
+// Then end = 1 + int(MaxUint64) = 0, inner fill is skipped, idx resets to 0.
+// A third run (val=2, runLen=5) then fills all 5 output slots unchallenged → err=nil.
+// Fixed subtraction guard: MaxUint64 > uint64(5-1)=4 → true → ErrInvalidLength.
+func TestRLEOverflowGuard(t *testing.T) {
+	// makeBypassBuf builds: header(n=5) + run1(0,1) + run2(1,MaxUint64) + run3(2,5).
+	// With old guard run2 bypasses, idx resets to 0, run3 fills all slots → nil error.
+	// With fixed guard run2 is rejected → ErrInvalidLength.
+	makeBypassBuf := func(kind byte) []byte {
+		var buf []byte
+		buf = append(buf, tagPackRLE, kind)
+		buf = appendUvarint(buf, 5)              // n=5
+		buf = appendUvarint(buf, 0)              // run1 value
+		buf = appendUvarint(buf, 1)              // run1 runLen → idx: 0→1
+		buf = appendUvarint(buf, 1)              // run2 value
+		buf = appendUvarint(buf, math.MaxUint64) // run2 runLen — wraps old addition guard
+		buf = appendUvarint(buf, 2)              // run3 value (reached only if bypass succeeds)
+		buf = appendUvarint(buf, 5)              // run3 runLen fills all 5 slots → err nil
+		return buf
+	}
+
+	t.Run("uint64", func(t *testing.T) {
+		buf := makeBypassBuf(qpackKindUint64)
+		dec := NewDecoderOnBuf(buf)
+		dec.i++ // consume tag; readPackedRLEUint64Slice expects kind onward
+		_, err := dec.readPackedRLEUint64Slice()
+		if err == nil {
+			t.Fatal("expected ErrInvalidLength for MaxUint64 runLen overflow bypass, got nil")
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		buf := makeBypassBuf(qpackKindInt64)
+		dec := NewDecoderOnBuf(buf)
+		dec.i++ // consume tag
+		_, err := dec.readPackedRLEInt64Slice()
+		if err == nil {
+			t.Fatal("expected ErrInvalidLength for MaxUint64 runLen overflow bypass on int64, got nil")
+		}
+	})
+}
+
 // TestRLE_EndToEnd round-trips an []int64 through the full Marshal /
 // Unmarshal API with QPack enabled, confirming that the picker fires
 // and the wire decodes back. The fixture is shaped like a real HTTP-

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -557,18 +557,26 @@ func encodeMap(t reflect.Type, k, v *typeDesc) func(*Encoder, unsafe.Pointer) er
 // encodeMapCanonical emits a map under OptCanonical: keys in sorted order so
 // logically-equal maps serialize byte-identically. It writes the same plain map
 // header and reuses the SAME key/value encode closures as the default path
-// (k.encode / v.encode) — only the order changes. A single reused addressable
-// key holder fetches each value via rv.MapIndex(kh), with no per-lookup boxing
-// allocation. The common integer/string/bool key kinds use a type-specialized,
-// pooled, monomorphized sort; float and exotic comparable key kinds (struct /
-// array / interface) take a slow reflect-comparator fallback (rare).
+// (k.encode / v.encode) — only the order changes.
+//
+// For the common string, int, uint, and bool key kinds: a single MapRange pass
+// collects key scalars and copies values via SetIterValue into a pre-allocated
+// typed array (reflect.ArrayOf). This avoids the per-key rv.MapIndex alloc that
+// the old emit-closure design incurred for indirect value types (size > ptrSize).
+//
+// Float and exotic key kinds (struct / array / interface) take a slow
+// reflect-comparator fallback that correctly handles NaN float keys (which are
+// unfindable by MapIndex and must never be re-fetched via one).
 func (e *Encoder) encodeMapCanonical(rv reflect.Value, keyType, valType reflect.Type, k, v *typeDesc) error {
 	n := rv.Len()
 	e.WriteMapHeader(n)
+	if n == 0 {
+		return nil
+	}
 
-	// Reused holders: a key holder set per sorted key for MapIndex, and a value
-	// holder the value codec reads through (addressable, so v.encode can take its
-	// pointer). Pooled on the state when available (no reflect.New per map row).
+	// Pool the key holder across map rows (one reflect.New per distinct key type
+	// per Encoder lifetime). valHolder/vp are retained for the default exotic-key
+	// path which still needs them for keyHolder.Set and valHolder.Set.
 	var keyHolder, valHolder reflect.Value
 	var vp unsafe.Pointer
 	var pooled bool
@@ -582,59 +590,112 @@ func (e *Encoder) encodeMapCanonical(rv reflect.Value, keyType, valType reflect.
 	}
 	kp := unsafe.Pointer(keyHolder.UnsafeAddr())
 
-	// emit fetches the value for the (already-set) key holder, copies it into the
-	// value holder, and runs both encode closures. MapIndex returns a fresh
-	// non-addressable Value; valHolder.Set copies it into the addressable holder
-	// the codec reads through vp.
-	emit := func() error {
-		valHolder.Set(rv.MapIndex(keyHolder))
-		if err := k.encode(e, kp); err != nil {
-			return err
-		}
-		return v.encode(e, vp)
-	}
-
 	switch keyType.Kind() {
 	case reflect.String:
-		keys, pooled := e.gatherStringKeys(rv)
-		defer e.canonKeysRelease(pooled)
-		for _, key := range keys {
-			keyHolder.SetString(key)
-			if err := emit(); err != nil {
+		// Single-pass collect: SetIterKey extracts the string key into keyHolder
+		// (zero alloc); SetIterValue copies the map value into the pre-allocated
+		// valArr slot (zero alloc). Sort key-index pairs, then encode.
+		valArr := reflect.New(reflect.ArrayOf(n, valType)).Elem()
+		type sIdx struct {
+			k string
+			i int
+		}
+		idxs := make([]sIdx, 0, n)
+		i := 0
+		for it := rv.MapRange(); it.Next(); {
+			keyHolder.SetIterKey(it)
+			valArr.Index(i).SetIterValue(it)
+			idxs = append(idxs, sIdx{keyHolder.String(), i})
+			i++
+		}
+		slices.SortFunc(idxs, func(a, b sIdx) int { return cmp.Compare(a.k, b.k) })
+		for _, p := range idxs {
+			keyHolder.SetString(p.k)
+			if err := k.encode(e, kp); err != nil {
+				return err
+			}
+			if err := v.encode(e, unsafe.Pointer(valArr.Index(p.i).UnsafeAddr())); err != nil {
 				return err
 			}
 		}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		keys, pooled := e.gatherIntKeys(rv)
-		defer e.canonKeysRelease(pooled)
-		for _, key := range keys {
-			keyHolder.SetInt(key)
-			if err := emit(); err != nil {
+		valArr := reflect.New(reflect.ArrayOf(n, valType)).Elem()
+		type iIdx struct {
+			k int64
+			i int
+		}
+		idxs := make([]iIdx, 0, n)
+		i := 0
+		for it := rv.MapRange(); it.Next(); {
+			keyHolder.SetIterKey(it)
+			valArr.Index(i).SetIterValue(it)
+			idxs = append(idxs, iIdx{keyHolder.Int(), i})
+			i++
+		}
+		slices.SortFunc(idxs, func(a, b iIdx) int { return cmp.Compare(a.k, b.k) })
+		for _, p := range idxs {
+			keyHolder.SetInt(p.k)
+			if err := k.encode(e, kp); err != nil {
+				return err
+			}
+			if err := v.encode(e, unsafe.Pointer(valArr.Index(p.i).UnsafeAddr())); err != nil {
 				return err
 			}
 		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		keys, pooled := e.gatherUintKeys(rv)
-		defer e.canonKeysRelease(pooled)
-		for _, key := range keys {
-			keyHolder.SetUint(key)
-			if err := emit(); err != nil {
+		valArr := reflect.New(reflect.ArrayOf(n, valType)).Elem()
+		type uIdx struct {
+			k uint64
+			i int
+		}
+		idxs := make([]uIdx, 0, n)
+		i := 0
+		for it := rv.MapRange(); it.Next(); {
+			keyHolder.SetIterKey(it)
+			valArr.Index(i).SetIterValue(it)
+			idxs = append(idxs, uIdx{keyHolder.Uint(), i})
+			i++
+		}
+		slices.SortFunc(idxs, func(a, b uIdx) int { return cmp.Compare(a.k, b.k) })
+		for _, p := range idxs {
+			keyHolder.SetUint(p.k)
+			if err := k.encode(e, kp); err != nil {
+				return err
+			}
+			if err := v.encode(e, unsafe.Pointer(valArr.Index(p.i).UnsafeAddr())); err != nil {
 				return err
 			}
 		}
 	case reflect.Bool:
-		// At most two keys; emit false then true if present (no sort needed).
-		for _, b := range [...]bool{false, true} {
-			keyHolder.SetBool(b)
-			mv := rv.MapIndex(keyHolder)
-			if !mv.IsValid() {
-				continue
+		// At most two keys; collect via MapRange (no MapIndex), emit false then true.
+		// Pre-allocate 2 slots regardless — at most one slot stays unused.
+		valArr := reflect.New(reflect.ArrayOf(2, valType)).Elem()
+		var hasFalse, hasTrue bool
+		for it := rv.MapRange(); it.Next(); {
+			keyHolder.SetIterKey(it)
+			if keyHolder.Bool() {
+				valArr.Index(1).SetIterValue(it)
+				hasTrue = true
+			} else {
+				valArr.Index(0).SetIterValue(it)
+				hasFalse = true
 			}
-			valHolder.Set(mv)
+		}
+		if hasFalse {
+			keyHolder.SetBool(false)
 			if err := k.encode(e, kp); err != nil {
 				return err
 			}
-			if err := v.encode(e, vp); err != nil {
+			if err := v.encode(e, unsafe.Pointer(valArr.Index(0).UnsafeAddr())); err != nil {
+				return err
+			}
+		}
+		if hasTrue {
+			keyHolder.SetBool(true)
+			if err := k.encode(e, kp); err != nil {
+				return err
+			}
+			if err := v.encode(e, unsafe.Pointer(valArr.Index(1).UnsafeAddr())); err != nil {
 				return err
 			}
 		}

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -830,43 +830,69 @@ func (e *Encoder) encodeStringMapShaped(rv reflect.Value, keyType, valType refle
 	e.writeHeader()
 	n := rv.Len()
 	st := e.state
-	// Pooled, re-entrancy-safe key/value holders — avoids reflect.New per map
-	// (a 1000-row batch pays 2 reflect.New total, not 2 per row).
-	keyHolder, valHolder, vp, pooled := st.mapEnc.acquire(keyType, valType)
+	// Pooled, re-entrancy-safe key holder — avoids reflect.New per map
+	// (a 1000-row batch pays 1 reflect.New total, not 1 per row).
+	// Values are collected into pre-allocated per-shape slots (see
+	// mapShapeBinding.valSlots) via SetIterValue instead of MapIndex, so
+	// valHolder and vp from acquire are not needed on this path.
+	keyHolder, _, _, pooled := st.mapEnc.acquire(keyType, valType)
 	defer st.mapEnc.release(pooled)
 
-	emitValues := func(order []string) error {
-		for _, name := range order {
-			keyHolder.SetString(name)
-			valHolder.Set(rv.MapIndex(keyHolder))
-			if err := v.encode(e, vp); err != nil {
+	// emitSlotsOrdered encodes st.mapShapes[sIdx].valSlots in canonical key
+	// order. It uses index-based access (not a pointer) throughout: a nested
+	// encode may call mapShapeRegister which appends to st.mapShapes, possibly
+	// reallocating the backing array; index-based access always follows the
+	// current slice header, avoiding use-after-reallocation.
+	//
+	// The busy flag is set for the duration so hasAllAndCollect skips this
+	// binding during re-entrant nested encodes (preventing ensureValueSlots
+	// from reinitialising slots that are still in use by the outer encode).
+	emitSlotsOrdered := func(sIdx int) error {
+		st.mapShapes[sIdx].busy = true
+		defer func() { st.mapShapes[sIdx].busy = false }()
+		for i := range st.mapShapes[sIdx].keys {
+			if err := v.encode(e, unsafe.Pointer(st.mapShapes[sIdx].valSlots[i].UnsafeAddr())); err != nil {
 				return err
 			}
 		}
 		return nil
 	}
-	// hasAll reports whether the map's key-set equals order (caller checks
-	// len==n). Verifies via the map's own keys under MapRange — string keys do
-	// not allocate — instead of MapIndex per key, which would heap-copy a
-	// struct value type. The linear scan is O(n²) but n (a key-set) is tiny.
-	hasAll := func(order []string) bool {
+
+	// hasAllAndCollect does a single MapRange pass: verifies every map key is
+	// in s.keys (binary search on the sorted slice) and simultaneously loads
+	// each value into s.valSlots via SetIterValue — no per-key heap allocation.
+	// Replaces the old two-step hasAll (MapRange) + emitValues (N MapIndex allocs)
+	// flow, keeping the MapRange count to one on the hot fast path and
+	// eliminating all value-copy heap allocations for struct-valued maps.
+	// Callers must check !s.busy before calling (busy bindings are being
+	// iterated by an outer emitSlotsOrdered and must not be re-initialised).
+	hasAllAndCollect := func(s *mapShapeBinding) bool {
+		s.ensureValueSlots(valType)
 		it := rv.MapRange()
 		for it.Next() {
 			keyHolder.SetIterKey(it) // SetIterKey reuses the holder; it.Key() would alloc
-			k := keyHolder.String()
-			found := slices.Contains(order, k)
-			if !found {
+			idx, ok := slices.BinarySearch(s.keys, keyHolder.String())
+			if !ok {
 				return false
 			}
+			s.valSlots[idx].SetIterValue(it)
 		}
 		return true
 	}
 
-	// Fast path: same key-set as the previous map — verify directly, no hash.
-	if st.lastMapShapeID != 0 && len(st.lastMapShapeKeys) == n && hasAll(st.lastMapShapeKeys) {
-		e.buf = append(e.buf, tagMapShape)
-		e.buf = appendUvarint(e.buf, uint64(st.lastMapShapeID))
-		return emitValues(st.lastMapShapeKeys)
+	// Fast path: same key-set as the previous map — one MapRange pass combines
+	// hasAll verification with value collection into pre-allocated slots.
+	// Replaces hasAll (MapRange) + emitValues (N MapIndex) with a single sweep,
+	// eliminating N per-key heap allocations for struct values.
+	// !s.busy: guard against a coincidental n-match from a re-entrant nested
+	// encode targeting the outer binding with a different valType.
+	if st.lastMapShapeID != 0 && len(st.lastMapShapeKeys) == n {
+		s := &st.mapShapes[st.lastMapShapeIdx]
+		if !s.busy && hasAllAndCollect(s) {
+			e.buf = append(e.buf, tagMapShape)
+			e.buf = appendUvarint(e.buf, uint64(st.lastMapShapeID))
+			return emitSlotsOrdered(st.lastMapShapeIdx)
+		}
 	}
 
 	// Key-set changed: order-independent set-hash to find an earlier shape.
@@ -881,14 +907,16 @@ func (e *Encoder) encodeStringMapShaped(rv reflect.Value, keyType, valType refle
 	// a key mismatch would re-declare a colliding key-set on every encode: under
 	// two alternating sets that collide on setHash, the already-registered second
 	// set is never found again, so mapShapes grows without bound. The s.n == n
-	// filter guarantees len(s.keys) == n, so hasAll ⇒ set equality.
+	// filter guarantees len(s.keys) == n, so hasAllAndCollect ⇒ set equality.
+	// !s.busy: skip bindings currently held by an outer emitSlotsOrdered.
 	for i := range st.mapShapes {
 		s := &st.mapShapes[i]
-		if s.setHash == setHash && s.n == n && hasAll(s.keys) {
+		if s.setHash == setHash && s.n == n && !s.busy && hasAllAndCollect(s) {
 			st.lastMapShapeID, st.lastMapShapeKeys = s.id, s.keys
+			st.lastMapShapeIdx = i
 			e.buf = append(e.buf, tagMapShape)
 			e.buf = appendUvarint(e.buf, uint64(s.id))
-			return emitValues(s.keys)
+			return emitSlotsOrdered(i)
 		}
 	}
 
@@ -902,14 +930,29 @@ func (e *Encoder) encodeStringMapShaped(rv reflect.Value, keyType, valType refle
 	slices.Sort(keys)
 	id := st.shapeDeclareEnc()
 	st.mapShapeRegister(setHash, n, keys, id)
+	idx := len(st.mapShapes) - 1
 	st.lastMapShapeID, st.lastMapShapeKeys = id, keys
+	st.lastMapShapeIdx = idx
 	e.buf = append(e.buf, tagMapShape)
 	e.buf = appendUvarint(e.buf, 0)
 	e.buf = appendUvarint(e.buf, uint64(n))
 	for _, name := range keys {
 		e.WriteString(name)
 	}
-	return emitValues(keys)
+	// Collect values into the newly declared binding's pre-allocated slots and
+	// emit in canonical order. One extra MapRange pass on the declare path is
+	// acceptable: declare is rare (once per distinct key-set per session).
+	// s is a local pointer; no mapShapes reallocation happens in the it3 loop
+	// (only in v.encode inside emitSlotsOrdered, after it3 completes).
+	s := &st.mapShapes[idx]
+	s.ensureValueSlots(valType)
+	it3 := rv.MapRange()
+	for it3.Next() {
+		keyHolder.SetIterKey(it3)
+		pos, _ := slices.BinarySearch(keys, keyHolder.String())
+		s.valSlots[pos].SetIterValue(it3)
+	}
+	return emitSlotsOrdered(idx)
 }
 
 func decodeMap(t reflect.Type, k, v *typeDesc) func(*Decoder, unsafe.Pointer) error {

--- a/state.go
+++ b/state.go
@@ -185,6 +185,10 @@ type encState struct {
 	// lastMapShapeKeys holds the key order of the shape memoised by
 	// lastMapShapeID, so a homogeneous run skips the registry scan.
 	lastMapShapeKeys []string
+	// lastMapShapeIdx is the index into mapShapes for the shape memoised by
+	// lastMapShapeID. Gives O(1) access to the binding's pre-allocated valSlots
+	// without a registry scan. Valid only when lastMapShapeID != 0.
+	lastMapShapeIdx int
 	// mapEnc pools reflect holders for the generic (reflect) string-keyed map
 	// encode path so it does not reflect.New per map (OptMapShape).
 	mapEnc mapHolderCache
@@ -293,11 +297,38 @@ type tokenShape struct {
 // the canonical (sorted) key order, cloned so it survives the caller's map. id
 // is drawn from the same sequential space as struct shapeBindings
 // (shapeDeclareEnc).
+//
+// valSlots is a pre-allocated []reflect.Value (one per key, type valType) used
+// by hasAllAndCollect to receive values via SetIterValue — no per-key heap
+// allocation. Initialised lazily on first encode of this shape.
 type mapShapeBinding struct {
-	keys    []string
-	setHash uint64
-	n       int
-	id      uint32
+	keys     []string
+	valSlots []reflect.Value // pre-allocated value holders; see ensureValueSlots
+	valType  reflect.Type   // element type of valSlots; zero if unset
+	setHash  uint64
+	n        int
+	id       uint32
+	// busy is true while emitSlotsOrdered is iterating this binding's valSlots.
+	// hasAllAndCollect must not be called (and thus ensureValueSlots must not
+	// reinitialise) while busy, to prevent a re-entrant nested encode from
+	// corrupting the outer encode's in-progress slot array.
+	busy bool
+}
+
+// ensureValueSlots initialises the pre-allocated reflect.Value holders used
+// for zero-alloc MapRange value collection via SetIterValue. It is a no-op
+// when slots are already allocated for the same value type; it reinitialises
+// only when the type changes (rare: two maps with identical key-sets but
+// different value types sharing the same binding).
+func (b *mapShapeBinding) ensureValueSlots(vt reflect.Type) {
+	if b.valType == vt && b.valSlots != nil {
+		return
+	}
+	b.valType = vt
+	b.valSlots = make([]reflect.Value, len(b.keys))
+	for i := range b.valSlots {
+		b.valSlots[i] = reflect.New(vt).Elem()
+	}
 }
 
 // mapHolderCache pools the addressable reflect.Value scratch the generic
@@ -512,6 +543,7 @@ func (e *encState) reset() {
 	}
 	e.lastMapShapeID = 0
 	e.lastMapShapeKeys = nil
+	e.lastMapShapeIdx = 0
 	e.mapEnc = mapHolderCache{}
 
 	if cap(e.colShapeNames) > maxRetainedShapeCap && release {

--- a/state.go
+++ b/state.go
@@ -104,7 +104,7 @@ const (
 	mruEmpty    uint16 = 0xFFFF
 )
 
-type encState struct {
+type encState struct { // betteralign:ignore — hot-scalar-first layout is cache-critical; do not reorder
 	// Hot scalars first so they share a single cache line with the
 	// adjacent mruHead and the map header. lastID + lruHead + mruHead
 	// are touched on every state-ref emit; co-locating them with
@@ -302,9 +302,9 @@ type tokenShape struct {
 // by hasAllAndCollect to receive values via SetIterValue — no per-key heap
 // allocation. Initialised lazily on first encode of this shape.
 type mapShapeBinding struct {
+	valType  reflect.Type // element type of valSlots; zero if unset
 	keys     []string
 	valSlots []reflect.Value // pre-allocated value holders; see ensureValueSlots
-	valType  reflect.Type   // element type of valSlots; zero if unset
 	setHash  uint64
 	n        int
 	id       uint32


### PR DESCRIPTION
## Summary

3 correctness bug fixes + 5 bench-gated perf improvements.

### Correctness fixes

- **fix(rle)**: `uint64(idx)+runLen > uint64(n)` wraps when `runLen=MaxUint64` and `idx>0` — guard bypassed, silent data corruption. Fixed in `qpack_rle.go` and `columnar_decode_scratch.go` (all 4 decode variants) with subtraction-safe guard `runLen > uint64(n-idx)`.
- **fix(pfor)**: `pos += int(dp)` when `dp=MaxUint64` gives `int=-1` — decremented pos still in `[0,n)`, guard passes, wrong slot overwritten. Fixed with `if dp > uint64(n-pos)` before cast.
- **fix(delta)**: `body[colCountPos] = byte(nChanged)` truncates for `nChanged ≥ 128` — varint decoder reads continuation byte, garbage output. Fixed with 2-byte padded uvarint; `diffColumnarEligible` cap raised 128 → 16384.

### Perf improvements (n≥10 interleaved bench gate, p<0.05)

- **perf(rans)**: Pool encode scratch buffer via `bufpool`. `encodeStream` refactored to accept `dst` param (eliminates use-after-pool-return race). −1 alloc/op, −63% B/op.
- **perf(reflect)**: `emitValues` — single MapRange pass with `SetIterValue` into pre-allocated per-binding slots. No MapIndex calls. −3 allocs/op on shaped-map path.
- **perf(reflect)**: `encodeMapCanonical` — MapRange collect-sort-encode via `reflect.ArrayOf` slab. No MapIndex calls for string/int/uint/bool key types. −92% allocs/op (76→6), −14% ns/op.
- **perf(rle)**: Copy-doubling fill loop routes through `runtime.memmove` NEON Q-register stores. All 4 RLE fill variants updated. −57% ns/op on run-heavy columnar decode path.
- **perf(fsst)**: Cache trained FSST symbol table across batches for streaming encoders (reuse interval = 8). `Clone()` deep-copies before builder returns to pool; table still fully serialized to wire (decoder stateless); cache cleared on `Reset()`. −56% ns/op streaming encode.

## Test plan

- [ ] Regression tests for all 3 correctness bugs: `TestRLEOverflowGuard`, `TestPForExceptionDeltaOverflow`, `TestColDiff128ColsRoundTrip`
- [ ] `GOWORK=off go test ./... -count=1` passes
- [ ] Each perf commit bench-gated (n≥10 interleaved benchstat) before commit
