### PR TITLE
fix+perf: round-6 full codebase audit (18 subsystems, 17 bugs fixed)

### DIFF
--- a/batch_matrix_test.go
+++ b/batch_matrix_test.go
@@ -83,7 +83,7 @@ func TestBatchColumnarBytesAndEmpty(t *testing.T) {
 	for i := range src {
 		var blob []byte
 		if i%4 != 0 { // every 4th row: empty blob AND empty name
-			blob = []byte(fmt.Sprintf("blob-%d-%x", i, i*7))
+			blob = fmt.Appendf(blob, "blob-%d-%x", i, i*7)
 		}
 		name := ""
 		if i%4 != 0 {

--- a/columnar_decode_scratch.go
+++ b/columnar_decode_scratch.go
@@ -326,10 +326,10 @@ func (d *Decoder) readPackedPForInt64SliceInto(dst *[]int64) error {
 			return ErrInvalidLength
 		}
 		d.i += nr
-		pos += int(dp)
-		if pos < 0 || pos >= n {
+		if dp >= uint64(n-pos) {
 			return ErrInvalidLength
 		}
+		pos += int(dp)
 		out[pos] = int64(mnU + delta)
 	}
 	return nil

--- a/delta_columnar_test.go
+++ b/delta_columnar_test.go
@@ -223,8 +223,8 @@ func benchColRows(n int) ([]ccRow, []ccRow) {
 func BenchmarkColDiffDiff(b *testing.B) {
 	old, neu := benchColRows(1000)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		if _, err := Diff(old, neu, OptBalanced); err != nil {
 			b.Fatal(err)
 		}
@@ -238,8 +238,8 @@ func BenchmarkColDiffApply(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		got := append([]ccRow(nil), old...)
 		if err := Apply(&got, patch); err != nil {
 			b.Fatal(err)

--- a/internal/bitpack/bitpack_scalar.go
+++ b/internal/bitpack/bitpack_scalar.go
@@ -65,6 +65,9 @@ func bitUnpackU64LEFast(out []uint64, in []byte, bitsPer int) {
 				// already captured by the `have > 56` split above.
 			}
 		}
+		if have < b {
+			break // input exhausted; remaining elements stay zero
+		}
 		out[i] = lo & mask
 		lo = (lo >> b) | (hi << (64 - b))
 		hi >>= b

--- a/internal/vecquant/codec.go
+++ b/internal/vecquant/codec.go
@@ -93,12 +93,14 @@ func encodeScalar(orig [][]float64, flat []float64, pdim, dim int, sigma float64
 	// overflow tracks the int32 saturation of the LAST quantization (the q that
 	// is returned), so the caller can abort to lossless.
 	var overflow bool
-	for range 4 {
+	for i := range 4 {
 		q, overflow = lattice.QuantizeScalar(flat, delta, q)
 		if budgetMetScalar(orig, q, pdim, dim, delta, b, row) {
 			break
 		}
-		delta *= 0.6
+		if i < 3 {
+			delta *= 0.6
+		}
 	}
 	return delta, q, overflow
 }
@@ -113,13 +115,15 @@ func encodeE8(orig [][]float64, flat []float64, pdim, dim int, sigma float64, b 
 		delta = sigma
 	}
 	coords = qDst
-	for range 4 {
+	for i := range 4 {
 		coords, cosets, overflow = lattice.QuantizeE8(flat, delta, coords)
 		if budgetMetE8(orig, coords, cosets, pdim, dim, delta, b, row) {
 			ok = true
 			break
 		}
-		delta *= 0.6
+		if i < 3 {
+			delta *= 0.6
+		}
 	}
 	return delta, coords, cosets, ok, overflow
 }

--- a/lossyvec_batch.go
+++ b/lossyvec_batch.go
@@ -357,6 +357,18 @@ func (d *Decoder) decodeVectorBatchStruct(t reflect.Type, td *typeDesc, p unsafe
 			d.i += used
 			norms = ns
 		}
+		// Pre-check OOM before committing the allocation inside readLossyVec.
+		// Header layout: tag(1) + flags(1) + dim(uvarint). elemF32 bit is flags&1.
+		if len(d.buf[d.i:]) >= 3 {
+			dim, _ := binary.Uvarint(d.buf[d.i+2:])
+			elemBytes := uint64(8)
+			if d.buf[d.i+1]&1 != 0 {
+				elemBytes = 4
+			}
+			if newBytes := uint64(n) * dim * elemBytes; totalVecBytes+newBytes > maxColumnarBytes {
+				return ErrInvalidLength
+			}
+		}
 		vecs, elemF32, used, err := readLossyVec(d.buf[d.i:])
 		if err != nil {
 			return err

--- a/lossyvec_bench_test.go
+++ b/lossyvec_bench_test.go
@@ -25,8 +25,8 @@ func benchEmbF32(n, dim int) []embedRow {
 func BenchmarkLossyEncodeWarm(b *testing.B) {
 	rows := benchEmbF32(256, 768)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		if _, err := Marshal(rows, OptBalanced|OptLossyVec); err != nil {
 			b.Fatal(err)
 		}
@@ -39,8 +39,8 @@ func BenchmarkLossyEncodeWarm(b *testing.B) {
 func BenchmarkLossyEncodeCold(b *testing.B) {
 	rows := benchEmbF32(256, 768)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		enc := NewEncoderWith(OptBalanced | OptLossyVec)
 		enc.SetVectorBudget(MaxRelError(0.02))
 		if err := enc.EncodeValue(rows); err != nil {
@@ -57,8 +57,8 @@ func BenchmarkLossyDecode(b *testing.B) {
 	_ = enc.EncodeValue(rows)
 	data := append([]byte(nil), enc.Bytes()...)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		var out []embedRow
 		if err := Unmarshal(data, &out); err != nil {
 			b.Fatal(err)

--- a/maps_reuse_test.go
+++ b/maps_reuse_test.go
@@ -82,8 +82,8 @@ func BenchmarkMapRecycle(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		if err := Unmarshal(data, &out); err != nil {
 			b.Fatal(err)
 		}
@@ -112,8 +112,8 @@ func BenchmarkMapRecycleBaseline(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		var out []rec // fresh target → no reuse, no harvest, no recycle
 		if err := Unmarshal(data, &out); err != nil {
 			b.Fatal(err)

--- a/qpack_alp.go
+++ b/qpack_alp.go
@@ -434,7 +434,11 @@ func (d *Decoder) readPackedALPFloat32Slice() ([]float32, error) {
 		bitpack.Unpack(packed, d.buf[d.i:d.i+bodyBytes], width)
 		d.i += bodyBytes
 		for i := range out {
-			out[i] = float32(float64(int64(packed[i])+forMin) * ie)
+			v := int64(packed[i])
+			if (forMin > 0 && v > math.MaxInt64-forMin) || (forMin < 0 && v < math.MinInt64-forMin) {
+				return nil, ErrInvalidLength
+			}
+			out[i] = float32(float64(v+forMin) * ie)
 		}
 	} else {
 		fv := float32(float64(forMin) * ie)
@@ -545,7 +549,11 @@ func (d *Decoder) readPackedALPFloat64Slice() ([]float64, error) {
 		bitpack.Unpack(packed, d.buf[d.i:d.i+bodyBytes], width)
 		d.i += bodyBytes
 		for i := range out {
-			out[i] = float64(int64(packed[i])+forMin) * ie
+			v := int64(packed[i])
+			if (forMin > 0 && v > math.MaxInt64-forMin) || (forMin < 0 && v < math.MinInt64-forMin) {
+				return nil, ErrInvalidLength
+			}
+			out[i] = float64(v+forMin) * ie
 		}
 	} else {
 		fv := float64(forMin) * ie

--- a/qpack_dict.go
+++ b/qpack_dict.go
@@ -203,11 +203,12 @@ func (d *Decoder) readPackedDictUint64Slice() ([]uint64, error) {
 	}
 	idx := d.deltaScratch[:n]
 	bitpack.Unpack(idx, body, bitsPer)
+	tab := table[:count]
 	for i, k := range idx {
 		if k >= uint64(count) {
 			return nil, ErrBadTag
 		}
-		out[i] = table[k]
+		out[i] = tab[k]
 	}
 	return out, nil
 }
@@ -271,11 +272,12 @@ func (d *Decoder) readPackedDictInt64Slice() ([]int64, error) {
 	}
 	idx := d.deltaScratch[:n]
 	bitpack.Unpack(idx, body, bitsPer)
+	tab64 := table[:count]
 	for i, k := range idx {
 		if k >= uint64(count) {
 			return nil, ErrBadTag
 		}
-		out[i] = table[k]
+		out[i] = tab64[k]
 	}
 	return out, nil
 }

--- a/qpack_gorilla.go
+++ b/qpack_gorilla.go
@@ -193,7 +193,7 @@ func (e *Encoder) writePackedGorillaFloat64Slice(s []float64) {
 	// Reserve generously: 4 byte body per sample is a comfortable upper
 	// bound for any non-pathological input; the slow path appends if it
 	// exceeds.
-	out := slices.Grow(e.buf, 2+10+8+10+4*n)
+	out := slices.Grow(e.buf, 2+10+8+10+10*n)
 	out = append(out, tagPackGorilla, qpackKindFloat64)
 	out = appendUvarint(out, uint64(n))
 	if n == 0 {
@@ -250,7 +250,7 @@ func (e *Encoder) writePackedGorillaFloat64Slice(s []float64) {
 func (e *Encoder) writePackedGorillaFloat32Slice(s []float32) {
 	e.writeHeader()
 	n := len(s)
-	out := slices.Grow(e.buf, 2+10+4+10+2*n)
+	out := slices.Grow(e.buf, 2+10+4+10+6*n)
 	out = append(out, tagPackGorilla, qpackKindFloat32)
 	out = appendUvarint(out, uint64(n))
 	if n == 0 {

--- a/qpack_pfor.go
+++ b/qpack_pfor.go
@@ -264,7 +264,7 @@ func (d *Decoder) readPackedPForInt64Slice() ([]int64, error) {
 		return nil, ErrInvalidLength
 	}
 	pos := 0
-	for range excN64 {
+	for i := range excN64 {
 		dp, nr := readUvarint(d.buf[d.i:])
 		if nr <= 0 {
 			return nil, ErrInvalidLength
@@ -275,6 +275,9 @@ func (d *Decoder) readPackedPForInt64Slice() ([]int64, error) {
 			return nil, ErrInvalidLength
 		}
 		d.i += nr
+		if i > 0 && dp == 0 {
+			return nil, ErrInvalidLength
+		}
 		if dp > uint64(n-pos) {
 			return nil, ErrInvalidLength
 		}
@@ -355,7 +358,7 @@ func (d *Decoder) readPackedPForUint64Slice() ([]uint64, error) {
 		return nil, ErrInvalidLength
 	}
 	pos := 0
-	for range excN64 {
+	for i := range excN64 {
 		dp, nr := readUvarint(d.buf[d.i:])
 		if nr <= 0 {
 			return nil, ErrInvalidLength
@@ -366,6 +369,9 @@ func (d *Decoder) readPackedPForUint64Slice() ([]uint64, error) {
 			return nil, ErrInvalidLength
 		}
 		d.i += nr
+		if i > 0 && dp == 0 {
+			return nil, ErrInvalidLength
+		}
 		if dp > uint64(n-pos) {
 			return nil, ErrInvalidLength
 		}

--- a/qpack_rle.go
+++ b/qpack_rle.go
@@ -34,6 +34,12 @@ func (e *Encoder) writePackedRLEUint64Slice(s []uint64) {
 		e.buf = out
 		return
 	}
+	if runs == 1 {
+		out = appendUvarint(out, s[0])
+		out = appendUvarint(out, uint64(n))
+		e.buf = out
+		return
+	}
 	runLen := uint64(1)
 	prev := s[0]
 	for i := 1; i < n; i++ {
@@ -67,6 +73,12 @@ func (e *Encoder) writePackedRLEInt64Slice(s []int64) {
 	out = append(out, tagPackRLE, qpackKindInt64)
 	out = appendUvarint(out, uint64(n))
 	if n == 0 {
+		e.buf = out
+		return
+	}
+	if runs == 1 {
+		out = appendUvarint(out, zigzagEncode64(s[0]))
+		out = appendUvarint(out, uint64(n))
 		e.buf = out
 		return
 	}

--- a/query_bounds.go
+++ b/query_bounds.go
@@ -153,6 +153,10 @@ func WhereCmp[T Ordered](field string, op CmpOp, val T) QueryOption {
 			t.hiU64 = vU
 		}
 	case colKindFloat, colKindFloat32:
+		if vF != vF { // NaN query value matches nothing; no zone bounds
+			t.pF64 = func(float64) bool { return false }
+			break
+		}
 		t.pF64 = func(v float64) bool {
 			if v != v { // NaN matches nothing
 				return false

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -51,6 +51,9 @@ func decodeIntN(sz int) func(*Decoder, unsafe.Pointer) error {
 			if err != nil {
 				return err
 			}
+			if v < math.MinInt8 || v > math.MaxInt8 {
+				return ErrTypeMismatch
+			}
 			*(*int8)(p) = int8(v)
 			return nil
 		}
@@ -60,6 +63,9 @@ func decodeIntN(sz int) func(*Decoder, unsafe.Pointer) error {
 			if err != nil {
 				return err
 			}
+			if v < math.MinInt16 || v > math.MaxInt16 {
+				return ErrTypeMismatch
+			}
 			*(*int16)(p) = int16(v)
 			return nil
 		}
@@ -68,6 +74,9 @@ func decodeIntN(sz int) func(*Decoder, unsafe.Pointer) error {
 			v, err := d.ReadInt()
 			if err != nil {
 				return err
+			}
+			if v < math.MinInt32 || v > math.MaxInt32 {
+				return ErrTypeMismatch
 			}
 			*(*int32)(p) = int32(v)
 			return nil
@@ -104,6 +113,9 @@ func decodeUintN(sz int) func(*Decoder, unsafe.Pointer) error {
 			if err != nil {
 				return err
 			}
+			if v > math.MaxUint8 {
+				return ErrTypeMismatch
+			}
 			*(*uint8)(p) = uint8(v)
 			return nil
 		}
@@ -113,6 +125,9 @@ func decodeUintN(sz int) func(*Decoder, unsafe.Pointer) error {
 			if err != nil {
 				return err
 			}
+			if v > math.MaxUint16 {
+				return ErrTypeMismatch
+			}
 			*(*uint16)(p) = uint16(v)
 			return nil
 		}
@@ -121,6 +136,9 @@ func decodeUintN(sz int) func(*Decoder, unsafe.Pointer) error {
 			v, err := d.ReadUint()
 			if err != nil {
 				return err
+			}
+			if v > math.MaxUint32 {
+				return ErrTypeMismatch
 			}
 			*(*uint32)(p) = uint32(v)
 			return nil
@@ -482,6 +500,11 @@ func encodeMap(t reflect.Type, k, v *typeDesc) func(*Encoder, unsafe.Pointer) er
 	valType := t.Elem()
 	stringKey := keyType.Kind() == reflect.String
 	return func(e *Encoder, p unsafe.Pointer) error {
+		rv := reflect.NewAt(t, p).Elem()
+		if rv.IsNil() {
+			e.WriteNil()
+			return nil
+		}
 		// Depth guard mirroring Decoder.descend in decodeMap (see encodeSlice).
 		if e.maxDepth != 0 {
 			e.depth++
@@ -490,11 +513,6 @@ func encodeMap(t reflect.Type, k, v *typeDesc) func(*Encoder, unsafe.Pointer) er
 				return ErrCycleDetected
 			}
 			defer func() { e.depth-- }()
-		}
-		rv := reflect.NewAt(t, p).Elem()
-		if rv.IsNil() {
-			e.WriteNil()
-			return nil
 		}
 		n := rv.Len()
 		// Canonical emit takes precedence over the OptMapShape/OptDense shape
@@ -849,8 +867,11 @@ func canonReflectKeyCompare(a, b reflect.Value) int {
 			}
 		}
 		return 0
-	case reflect.Interface, reflect.Pointer:
+	case reflect.Interface:
 		return canonReflectKeyCompare(a.Elem(), b.Elem())
+	case reflect.Pointer:
+		// Pointer map keys are compared by address, not by pointed-to value.
+		return cmp.Compare(a.Pointer(), b.Pointer())
 	default:
 		// Stable rendering for any residual comparable kind (complex, chan, etc.).
 		return cmp.Compare(reflectRender(a), reflectRender(b))

--- a/state.go
+++ b/state.go
@@ -104,6 +104,16 @@ const (
 	mruEmpty    uint16 = 0xFFFF
 )
 
+// mruRingSentinel is a pre-filled [mruRingSize]uint16 with every slot set to
+// mruEmpty. A single array copy replaces the scalar fill loop in reset paths.
+var mruRingSentinel = func() [mruRingSize]uint16 {
+	var a [mruRingSize]uint16
+	for i := range a {
+		a[i] = mruEmpty
+	}
+	return a
+}()
+
 type encState struct { // betteralign:ignore — hot-scalar-first layout is cache-critical; do not reorder
 	// Hot scalars first so they share a single cache line with the
 	// adjacent mruHead and the map header. lastID + lruHead + mruHead
@@ -388,9 +398,7 @@ func newEncState() *encState {
 	}
 	// Prime ring with sentinels so a scan never matches id 0 by
 	// accident before the ring has been written.
-	for i := range e.mruRing {
-		e.mruRing[i] = mruEmpty
-	}
+	e.mruRing = mruRingSentinel
 	return e
 }
 
@@ -682,9 +690,7 @@ func (e *encState) reset() {
 
 	// Ring side-cache: re-prime with sentinels so post-reset emits
 	// can't false-match a stale id 0.
-	for i := range e.mruRing {
-		e.mruRing[i] = mruEmpty
-	}
+	e.mruRing = mruRingSentinel
 	e.mruHead = 0
 }
 
@@ -1161,9 +1167,7 @@ func newDecState() *decState {
 		lruHead:      lruInvalidID,
 		lastID:       lruInvalidID,
 	}
-	for i := range d.mruRing {
-		d.mruRing[i] = mruEmpty
-	}
+	d.mruRing = mruRingSentinel
 	return d
 }
 
@@ -1284,9 +1288,7 @@ func (d *decState) reset() {
 	if cap(d.deltaColRows) > maxRetainedColScratch {
 		d.deltaColRows = nil
 	}
-	for i := range d.mruRing {
-		d.mruRing[i] = mruEmpty
-	}
+	d.mruRing = mruRingSentinel
 	d.mruHead = 0
 	d.mapDec = mapHolderCache{}
 }

--- a/stream_arena_retain_bench_test.go
+++ b/stream_arena_retain_bench_test.go
@@ -50,8 +50,8 @@ func BenchmarkStreamEncodeADRetain(b *testing.B) {
 	enc := NewStreamEncoder(io.Discard, Dense)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for i := 0; b.Loop(); i++ {
 		batch := batches[i%len(batches)]
 		enc.Reset(io.Discard)
 		for j := range batch {


### PR DESCRIPTION
## Summary

Full Round-6 audit of all 18 qdf subsystems — bugs-first methodology with adversarial verification (44 skeptic agents).

### Bug fixes (17 confirmed)

**HIGH**
- `internal/vecquant/codec.go`: prevent delta/q inconsistency when all budget iterations fail
- `query_bounds.go`: NaN query value now matches nothing (was matching every zone)
- `columnar_decode_scratch.go`: uint64→int overflow enabling slot overwrite

**MEDIUM**
- `qpack_alp.go`: int64 overflow guard in ALP float packing
- `qpack_pfor.go`: dp=0 exception slot overwrite for non-first exceptions
- `lossyvec_batch.go`: OOM pre-check before allocation
- `reflect_encode.go`: nil check before depth guard + truncation range checks for int8/16/32 and uint8/16/32

**LOW**
- `reflect_encode.go`: pointer key sort
- `internal/bitpack/bitpack_scalar.go`: uint underflow guard

### Perf (4 confirmed no-risk findings)
- RLE all-same fast-path, Gorilla grow fix, Dict bounds-check elimination, mruRing sentinel copy