### PR TITLE
feat(qpack): 16-bit slice fast paths + byte-plane codec for bf16/fp16 tensors

### DIFF
--- a/decoder_skip.go
+++ b/decoder_skip.go
@@ -293,6 +293,9 @@ func (d *Decoder) Skip() error {
 			return ErrShortBuffer
 		}
 		k := d.buf[d.i]
+		if k == qpackKindPlane16 {
+			return d.skipPlane16() // variable-length body, not n*width
+		}
 		d.i++
 		w := qpackRawWidthBytes(k)
 		if w == 0 {

--- a/encoder.go
+++ b/encoder.go
@@ -109,6 +109,12 @@ type Encoder struct { // betteralign:ignore — hand-tuned for SIZE (200 vs 232 
 	// resets), so it survives Reset() safely.
 	alprdScr *alprdScratch
 
+	// plane16Scr / plane16Enc are the byte-plane codec's de-interleave buffer
+	// and its compressed high plane, retained across encodes (the plan step
+	// compresses for real, and the emit step reuses that exact blob).
+	plane16Scr []byte
+	plane16Enc []byte
+
 	// keyIdx is a reused (clear-not-realloc) old-key→index map for keyed slice
 	// diff. Lives on the Encoder so a many-element keyed slice builds its match
 	// table once per pool acquire; dropped past a spike cap in Reset(). Single
@@ -461,6 +467,12 @@ func (e *Encoder) resetForReuse() {
 	// ALP exception-index scratch: pointer-free, drop when oversized.
 	if cap(e.alpExcScratch) > maxRetainedColScratch {
 		e.alpExcScratch = nil
+	}
+	// Byte-plane codec scratch: the de-interleave buffer is 2 B/elem and the
+	// compressed high plane tracks it, so one ceiling check drops both.
+	if cap(e.plane16Scr) > maxRetainedColScratch {
+		e.plane16Scr = nil
+		e.plane16Enc = nil
 	}
 	e.vecScratch.Reset()
 	if cap(e.wideF64) > maxRetainedColScratch {

--- a/qpack.go
+++ b/qpack.go
@@ -39,6 +39,11 @@ const (
 	qpackKindFloat32 = qpackRawFamFloat | qpackRawW4
 	qpackKindFloat64 = qpackRawFamFloat | qpackRawW8
 
+	// qpackKindPlane16 marks a byte-plane-split []uint16 column under
+	// tagPackRaw (family 3 is otherwise unused; the width bits keep saying 2
+	// so kind-agnostic width math stays right). See qpack_plane16.go.
+	qpackKindPlane16 = 3<<2 | qpackRawW2
+
 	// qpackKindChimp64 marks a Chimp128-coded []float64 under tagPackGorilla
 	// (family 3 is otherwise unused). Width bits still say 8, so kind-agnostic
 	// paths (Skip, header first-value read) treat it exactly like Float64.

--- a/qpack.go
+++ b/qpack.go
@@ -909,3 +909,81 @@ func (d *Decoder) readPackedBool() ([]bool, error) {
 	d.i += nBytes
 	return out, nil
 }
+
+// writePackedUint16Slice emits a native 2 B/elem raw uint16 column. This is
+// the never-larger floor for []uint16: the QPack pipeline scores codecs
+// against a uint64-raw baseline, so incompressible 16-bit data must land here
+// rather than in a widened column.
+func (e *Encoder) writePackedUint16Slice(s []uint16) {
+	n := len(s)
+	if endian.NativeIsLittle && n > 0 {
+		body := unsafe.Slice((*byte)(unsafe.Pointer(&s[0])), n*2)
+		e.writePackedRawBytes(qpackKindUint16, n, body)
+		return
+	}
+	e.writeHeader()
+	out := slices.Grow(e.buf, 2+10+n*2)
+	out = append(out, tagPackRaw, qpackKindUint16)
+	out = appendUvarint(out, uint64(n))
+	for _, v := range s {
+		out = append(out, byte(v), byte(v>>8))
+	}
+	e.buf = out
+}
+
+func (e *Encoder) writePackedInt16Slice(s []int16) {
+	n := len(s)
+	if endian.NativeIsLittle && n > 0 {
+		body := unsafe.Slice((*byte)(unsafe.Pointer(&s[0])), n*2)
+		e.writePackedRawBytes(qpackKindInt16, n, body)
+		return
+	}
+	e.writeHeader()
+	out := slices.Grow(e.buf, 2+10+n*2)
+	out = append(out, tagPackRaw, qpackKindInt16)
+	out = appendUvarint(out, uint64(n))
+	for _, v := range s {
+		out = append(out, byte(uint16(v)), byte(uint16(v)>>8))
+	}
+	e.buf = out
+}
+
+func (d *Decoder) readPackedUint16Slice() ([]uint16, error) {
+	n, body, err := d.readPackedRawHeader(qpackKindUint16)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]uint16, n)
+	if n == 0 {
+		return out, nil
+	}
+	if endian.NativeIsLittle {
+		dst := unsafe.Slice((*byte)(unsafe.Pointer(&out[0])), n*2)
+		copy(dst, body)
+		return out, nil
+	}
+	for i := range n {
+		out[i] = uint16(body[i*2]) | uint16(body[i*2+1])<<8
+	}
+	return out, nil
+}
+
+func (d *Decoder) readPackedInt16Slice() ([]int16, error) {
+	n, body, err := d.readPackedRawHeader(qpackKindInt16)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]int16, n)
+	if n == 0 {
+		return out, nil
+	}
+	if endian.NativeIsLittle {
+		dst := unsafe.Slice((*byte)(unsafe.Pointer(&out[0])), n*2)
+		copy(dst, body)
+		return out, nil
+	}
+	for i := range n {
+		out[i] = int16(uint16(body[i*2]) | uint16(body[i*2+1])<<8)
+	}
+	return out, nil
+}

--- a/qpack_plane16.go
+++ b/qpack_plane16.go
@@ -1,0 +1,221 @@
+package qdf
+
+import (
+	"math"
+	"slices"
+
+	"github.com/alex60217101990/qdf/internal/tans"
+)
+
+// Byte-plane codec for []uint16 columns whose high byte carries far less
+// entropy than the low one — the shape of bf16/fp16 weight tensors, quantized
+// activations, and any 16-bit column clustered around a few magnitudes.
+//
+// The values are de-interleaved into a high-byte plane and a low-byte plane,
+// and ONLY the high plane is entropy-coded (its own tANS frequency table).
+// The split matters because order-0 entropy is order-independent: running one
+// shared table over the interleaved stream, or over the concatenated planes,
+// scores the same (measured 1.271x on bf16 weights either way). A table fitted
+// to the high plane alone is what pays — measured 1.49x on bf16, 1.18x on
+// fp16, against an order-0 floor of 1.53x / 1.21x.
+//
+// The low plane is stored raw on purpose: at ~8 bits of entropy it is
+// incompressible, and a tANS pass over it costs a 256-entry table for nothing.
+//
+// Wire (kind qpackKindPlane16 under tagPackRaw):
+//
+//	tag, kind, varuint(n), varuint(len(hiBody)), hiBody, n raw low bytes
+//
+// hiBody is always a tANS blob strictly shorter than the n-byte high plane:
+// when entropy coding does not shrink it, plane16Estimate declines and the
+// caller emits the native 2 B/elem column instead. The decoder therefore
+// rejects hiLen >= n rather than treating it as a raw plane — no flag byte is
+// spent, and a hostile stream cannot smuggle in arbitrary high bytes that
+// would decode silently. The caller only emits this codec when the total
+// beats the native column, so it is never larger.
+
+// plane16MinElems is the smallest column worth the codec: below it the tANS
+// frequency table (up to 512 B) dwarfs any saving.
+const plane16MinElems = 1024
+
+// plane16Sample bounds the projection's histogram pass.
+const plane16Sample = 2048
+
+// plane16Split de-interleaves s into the high and low byte planes of dst,
+// which must have room for 2*len(s) bytes. Returns the two plane slices.
+func plane16Split(dst []byte, s []uint16) (hi, lo []byte) {
+	n := len(s)
+	hi, lo = dst[:n], dst[n:2*n]
+	for i, v := range s {
+		hi[i] = byte(v >> 8)
+		lo[i] = byte(v)
+	}
+	return hi, lo
+}
+
+// plane16Project estimates the byte-plane size from a sampled high-plane
+// histogram: order-0 entropy of the high byte plus one raw byte per value.
+// This is the cheap gate — a full trial compression only runs when this
+// projection beats the alternatives, so columns the codec cannot help never
+// pay for a wasted tANS pass.
+func plane16Project(s []uint16) int {
+	n := len(s)
+	stride := 1
+	if n > plane16Sample {
+		stride = n / plane16Sample
+	}
+	var hist [256]int32
+	sampled := 0
+	for i := 0; i < n && sampled < 2*plane16Sample; i += stride {
+		hist[s[i]>>8]++
+		sampled++
+	}
+	// Sum -p*log2(p) over the sampled high bytes.
+	var bits float64
+	inv := 1 / float64(sampled)
+	for _, c := range hist {
+		if c == 0 {
+			continue
+		}
+		p := float64(c) * inv
+		bits -= float64(p * math.Log2(p)) // explicit conversion forbids FMA fusion: the gate must not be arch-dependent
+	}
+	// Per value: entropy-coded high byte + raw low byte. The +512 covers the
+	// tANS frequency table; the projection is deliberately optimistic, the
+	// real trial below is what decides.
+	return int(bits*float64(n)/8) + n + 512
+}
+
+// plane16Estimate returns the encoded size of the byte-plane form and the
+// entropy-coded high plane, or ok=false when the codec does not apply. The
+// high plane is compressed for real (there is no cheaper reliable proxy for
+// what tANS will do), so callers should gate this behind a size threshold.
+func (e *Encoder) plane16Estimate(s []uint16) (hiBody []byte, total int, ok bool) {
+	n := len(s)
+	if n < plane16MinElems {
+		return nil, 0, false
+	}
+	if cap(e.plane16Scr) < 2*n {
+		e.plane16Scr = make([]byte, 2*n)
+	}
+	hi, _ := plane16Split(e.plane16Scr[:2*n], s)
+
+	hiBody = tans.Encode(e.plane16Enc[:0], hi)
+	if len(hiBody) >= n {
+		// Entropy coding did not pay on the high plane either — the whole
+		// codec collapses to the native raw column, which the caller emits.
+		e.plane16Enc = hiBody[:0]
+		return nil, 0, false
+	}
+	e.plane16Enc = hiBody
+	total = 2 + uvarintLen(uint64(n)) + uvarintLen(uint64(len(hiBody))) + len(hiBody) + n
+	return hiBody, total, true
+}
+
+// writePackedPlane16Slice emits the byte-plane form using a high plane already
+// compressed by plane16Estimate (the low plane is re-derived from s).
+func (e *Encoder) writePackedPlane16Slice(s []uint16, hiBody []byte) {
+	e.writeHeader()
+	n := len(s)
+	out := slices.Grow(e.buf, 2+10+10+len(hiBody)+n)
+	out = append(out, tagPackRaw, qpackKindPlane16)
+	out = appendUvarint(out, uint64(n))
+	out = appendUvarint(out, uint64(len(hiBody)))
+	out = append(out, hiBody...)
+	base := len(out)
+	out = out[:base+n]
+	for i, v := range s {
+		out[base+i] = byte(v)
+	}
+	e.buf = out
+}
+
+// readPackedPlane16Slice decodes a byte-plane u16 column. d.i points at the
+// kind byte.
+func (d *Decoder) readPackedPlane16Slice() ([]uint16, error) {
+	if d.i >= len(d.buf) || d.buf[d.i] != qpackKindPlane16 {
+		return nil, ErrTypeMismatch
+	}
+	d.i++
+	n64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, ErrInvalidLength
+	}
+	d.i += nr
+	if !d.colLenOK(n64) {
+		return nil, ErrInvalidLength
+	}
+	// Every value costs at least its raw low byte, so n is bounded by the
+	// remaining input before anything is allocated.
+	if rem := uint64(len(d.buf) - d.i); n64 > rem {
+		return nil, ErrShortBuffer
+	}
+	n := int(n64)
+	if n == 0 {
+		return []uint16{}, nil
+	}
+	hiLen64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return nil, ErrInvalidLength
+	}
+	d.i += nr
+	if hiLen64 > uint64(len(d.buf)-d.i) {
+		return nil, ErrShortBuffer
+	}
+	// A valid encoder always compresses the high plane strictly below n bytes
+	// (plane16Estimate declines otherwise), so hiLen >= n is malformed.
+	if hiLen64 >= n64 {
+		return nil, ErrBadTag
+	}
+	hiLen := int(hiLen64)
+	hiBody := d.buf[d.i : d.i+hiLen]
+	d.i += hiLen
+	if d.i+n > len(d.buf) {
+		return nil, ErrShortBuffer
+	}
+	lo := d.buf[d.i : d.i+n]
+	d.i += n
+
+	hi, err := tans.Decode(hiBody, n)
+	if err != nil {
+		return nil, ErrBadTag
+	}
+	out := make([]uint16, n)
+	for i := range out {
+		out[i] = uint16(hi[i])<<8 | uint16(lo[i])
+	}
+	return out, nil
+}
+
+// skipPlane16 walks a byte-plane body without decoding it. d.i points at the
+// kind byte.
+func (d *Decoder) skipPlane16() error {
+	d.i++ // kind
+	n64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return ErrInvalidLength
+	}
+	d.i += nr
+	if n64 == 0 {
+		return nil
+	}
+	// Bound n by the remaining bytes before adding it to an offset: the low
+	// plane alone is one byte per value.
+	if n64 > uint64(len(d.buf)-d.i) {
+		return ErrShortBuffer
+	}
+	hiLen64, nr := readUvarint(d.buf[d.i:])
+	if nr <= 0 {
+		return ErrInvalidLength
+	}
+	d.i += nr
+	if hiLen64 > uint64(len(d.buf)-d.i) {
+		return ErrShortBuffer
+	}
+	d.i += int(hiLen64)
+	if uint64(len(d.buf)-d.i) < n64 {
+		return ErrShortBuffer
+	}
+	d.i += int(n64)
+	return nil
+}

--- a/qpack_plane16_test.go
+++ b/qpack_plane16_test.go
@@ -1,0 +1,263 @@
+package qdf
+
+import (
+	"math"
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+// bf16Bits / fp16Bits mirror the standard fp32 truncations. Weight tensors in
+// these formats are the byte-plane codec's target class.
+func bf16Bits(f float32) uint16 {
+	u := math.Float32bits(f)
+	if u&0x7fffffff > 0x7f800000 { // NaN: keep it quiet
+		return uint16(u>>16) | 0x0040
+	}
+	return uint16((u + 0x7fff + ((u >> 16) & 1)) >> 16)
+}
+
+func fp16Bits(f float32) uint16 {
+	u := math.Float32bits(f)
+	sign := uint16((u >> 16) & 0x8000)
+	exp := int32((u>>23)&0xff) - 127 + 15
+	man := u & 0x7fffff
+	if exp <= 0 {
+		if exp < -10 {
+			return sign
+		}
+		man |= 0x800000
+		return sign | uint16(man>>uint32(14-exp))
+	}
+	if exp >= 0x1f {
+		return sign | 0x7c00
+	}
+	return sign | uint16(exp)<<10 | uint16(man>>13)
+}
+
+func mkWeights16(n int, seed int64, conv func(float32) uint16) []uint16 {
+	rng := rand.New(rand.NewSource(seed))
+	s := make([]uint16, n)
+	for i := range s {
+		s[i] = conv(float32(rng.NormFloat64() * 0.02))
+	}
+	return s
+}
+
+func TestPlane16RoundTrip(t *testing.T) {
+	type row struct{ V []uint16 }
+	rng := rand.New(rand.NewSource(4))
+	randU := make([]uint16, 4096)
+	for i := range randU {
+		randU[i] = uint16(rng.Uint32())
+	}
+	hiConst := make([]uint16, 4096) // high byte constant, low random: best case
+	for i := range hiConst {
+		hiConst[i] = 0x3F00 | uint16(rng.Intn(256))
+	}
+	loConst := make([]uint16, 4096) // low byte constant, high random: worst case
+	for i := range loConst {
+		loConst[i] = uint16(rng.Intn(256))<<8 | 0x7B
+	}
+	cases := map[string][]uint16{
+		"bf16":      mkWeights16(8192, 11, bf16Bits),
+		"fp16":      mkWeights16(8192, 11, fp16Bits),
+		"random":    randU,
+		"hi_const":  hiConst,
+		"lo_const":  loConst,
+		"threshold": mkWeights16(plane16MinElems, 3, bf16Bits),
+		"below_thr": mkWeights16(plane16MinElems-1, 3, bf16Bits),
+		"allzero":   make([]uint16, 4096),
+	}
+	for name, in := range cases {
+		for _, opts := range []Options{OptBalanced, OptCompression, OptQPack} {
+			blob, err := Marshal(row{in}, opts)
+			if err != nil {
+				t.Fatalf("%s/%v encode: %v", name, opts, err)
+			}
+			var out row
+			if err := Unmarshal(blob, &out); err != nil {
+				t.Fatalf("%s/%v decode: %v", name, opts, err)
+			}
+			if !reflect.DeepEqual(in, out.V) {
+				t.Fatalf("%s/%v round-trip mismatch", name, opts)
+			}
+			if len(blob) > 2*len(in)+64 {
+				t.Fatalf("%s/%v grew: %d for raw %d", name, opts, len(blob), 2*len(in))
+			}
+		}
+	}
+}
+
+// TestPlane16Wins pins the reason the codec exists: bf16/fp16 weight tensors
+// must land on the plane codec and beat the native raw column.
+func TestPlane16Wins(t *testing.T) {
+	type row struct{ V []uint16 }
+	for _, tc := range []struct {
+		name    string
+		data    []uint16
+		minGain float64
+	}{
+		{"bf16", mkWeights16(65536, 7, bf16Bits), 1.40},
+		{"fp16", mkWeights16(65536, 7, fp16Bits), 1.12},
+	} {
+		blob, err := Marshal(row{tc.data}, OptBalanced)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gain := float64(2*len(tc.data)) / float64(len(blob))
+		if gain < tc.minGain {
+			t.Fatalf("%s: gain %.3fx below the %.2fx this codec exists for", tc.name, gain, tc.minGain)
+		}
+		t.Logf("%s: %d bytes for %d raw (%.3fx)", tc.name, len(blob), 2*len(tc.data), gain)
+	}
+}
+
+// TestPlane16Hostile: corrupted plane bodies must error, never panic.
+func TestPlane16Hostile(t *testing.T) {
+	type row struct{ V []uint16 }
+	blob, err := Marshal(row{mkWeights16(4096, 5, bf16Bits)}, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var probe row
+	if err := Unmarshal(blob, &probe); err != nil {
+		t.Fatal(err)
+	}
+	rng := rand.New(rand.NewSource(17))
+	for range 30000 {
+		b := append([]byte(nil), blob...)
+		b[rng.Intn(len(b))] ^= byte(1 + rng.Intn(255))
+		var out row
+		_ = Unmarshal(b, &out) // must not panic
+	}
+	for cut := 0; cut < len(blob); cut += 7 {
+		var out row
+		_ = Unmarshal(blob[:cut], &out)
+	}
+}
+
+// TestPlane16Skip: an unknown plane-coded field must Skip to the right offset.
+func TestPlane16Skip(t *testing.T) {
+	type full struct {
+		V    []uint16
+		Tail int64
+	}
+	type slim struct{ Tail int64 }
+	for _, opts := range []Options{OptBalanced, OptCompression} {
+		blob, err := Marshal(full{mkWeights16(8192, 9, bf16Bits), 1234}, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out slim
+		if err := Unmarshal(blob, &out); err != nil {
+			t.Fatalf("skip %v: %v", opts, err)
+		}
+		if out.Tail != 1234 {
+			t.Fatalf("tail=%d", out.Tail)
+		}
+	}
+}
+
+// TestPlane16BeatsNarrowRange pins the projection gate: all-positive weight
+// tensors fit a narrow value range, so FOR posts a modest win and the old
+// "only try when the integer codecs decline" gate skipped the plane form
+// entirely — leaving ~11% on the table.
+func TestPlane16BeatsNarrowRange(t *testing.T) {
+	const n = 65536
+	rng := rand.New(rand.NewSource(7))
+	pos := make([]uint16, n)
+	for i := range pos {
+		v := float32(rng.NormFloat64() * 0.02)
+		if v < 0 {
+			v = -v
+		}
+		pos[i] = bf16Bits(v)
+	}
+	type row struct{ V []uint16 }
+	blob, err := Marshal(row{pos}, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out row
+	if err := Unmarshal(blob, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(pos, out.V) {
+		t.Fatal("round-trip mismatch")
+	}
+	gain := float64(2*n) / float64(len(blob))
+	if gain < 1.55 { // FOR alone gives 1.454x here
+		t.Fatalf("gain %.3fx: the plane codec was not reached", gain)
+	}
+	t.Logf("all-positive bf16: %d bytes (%.3fx)", len(blob), gain)
+}
+
+// TestPlane16AnyTyped pins the any-typed path: the 16-bit fast paths made
+// []uint16/[]int16 reach pack tags for the first time, which decodeAnyPackedSlice
+// did not know about — an any-typed field silently started failing with
+// ErrBadTag until the kinds were added.
+func TestPlane16AnyTyped(t *testing.T) {
+	for _, opts := range []Options{OptSpeed, OptBalanced, OptCompression} {
+		in := map[string]any{
+			"small":  []uint16{1, 2, 3, 40000},
+			"signed": []int16{-1, 0, 32767, -32768},
+			"plane":  mkWeights16(4096, 2, bf16Bits),
+		}
+		blob, err := Marshal(in, opts)
+		if err != nil {
+			t.Fatalf("%v encode: %v", opts, err)
+		}
+		var out map[string]any
+		if err := Unmarshal(blob, &out); err != nil {
+			t.Fatalf("%v any decode: %v", opts, err)
+		}
+		if got, ok := out["plane"].([]uint16); ok {
+			if !reflect.DeepEqual(got, in["plane"]) {
+				t.Fatalf("%v plane column mismatch", opts)
+			}
+		} else if opts != OptSpeed { // OptSpeed keeps the plain-array form
+			t.Fatalf("%v plane column decoded as %T", opts, out["plane"])
+		}
+	}
+}
+
+// TestPlane16RejectsRawHiPlane pins the wire invariant: the encoder always
+// compresses the high plane strictly below n bytes, so a body claiming
+// hiLen >= n is malformed and must error rather than decode as a raw plane
+// (which would let a hostile stream supply arbitrary high bytes silently).
+func TestPlane16RejectsRawHiPlane(t *testing.T) {
+	type row struct{ V []uint16 }
+	blob, err := Marshal(row{mkWeights16(4096, 5, bf16Bits)}, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Locate the plane field and rewrite hiLen to exactly n.
+	for i := 0; i+1 < len(blob); i++ {
+		if blob[i] != tagPackRaw || blob[i+1] != qpackKindPlane16 {
+			continue
+		}
+		d := NewDecoderOnBuf(blob[i:])
+		d.MarkHeaderRead()
+		d.i++
+		if _, err := d.readPackedPlane16Slice(); err != nil {
+			continue // false positive inside a tANS blob
+		}
+		n64, nr := readUvarint(blob[i+2:])
+		hiOff := i + 2 + nr
+		_, hnr := readUvarint(blob[hiOff:])
+		if hnr != uvarintLen(n64) {
+			t.Skip("hiLen varint width differs from n's; splice not applicable")
+		}
+		bad := append([]byte(nil), blob...)
+		_ = appendUvarint(bad[hiOff:hiOff], n64)
+		bd := NewDecoderOnBuf(bad[i:])
+		bd.MarkHeaderRead()
+		bd.i++
+		if _, err := bd.readPackedPlane16Slice(); err == nil {
+			t.Fatal("hiLen == n accepted; a hostile raw high plane decodes silently")
+		}
+		return
+	}
+	t.Skip("no plane field located")
+}

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -1868,6 +1868,16 @@ func decodeAnyPackedSlice(d *Decoder) (any, error) {
 		var s []uint32
 		err := decodeSliceUint32(d, unsafe.Pointer(&s))
 		return s, err
+	case qpackKindUint16, qpackKindPlane16:
+		// The 16-bit slice fast paths emit native raw and byte-plane columns,
+		// so an any-typed field can carry either.
+		var s []uint16
+		err := decodeSliceUint16(d, unsafe.Pointer(&s))
+		return s, err
+	case qpackKindInt16:
+		var s []int16
+		err := decodeSliceInt16(d, unsafe.Pointer(&s))
+		return s, err
 	case qpackKindFloat64:
 		var s []float64
 		err := decodeSliceFloat64(d, unsafe.Pointer(&s))
@@ -1877,7 +1887,7 @@ func decodeAnyPackedSlice(d *Decoder) (any, error) {
 		err := decodeSliceFloat32(d, unsafe.Pointer(&s))
 		return s, err
 	default:
-		// Narrower kinds (Int8/Int16/Uint8/Uint16) never reach a pack tag — they
+		// The remaining narrow kinds (Int8/Uint8) never reach a pack tag — they
 		// encode as a plain array (or []byte for uint8), handled by decodeAny's
 		// array/bin cases — so any other kind is malformed input.
 		return nil, ErrBadTag

--- a/slices16_test.go
+++ b/slices16_test.go
@@ -1,0 +1,177 @@
+package qdf
+
+import (
+	"math"
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+// Before the 16-bit fast paths, []uint16/[]int16 fell through to the generic
+// reflect encoder (one uvarint per element), which EXPANDS high-entropy data
+// by 1.5x. These tests pin both the round-trip and the never-larger floor.
+func TestSlice16RoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(5))
+	randU := make([]uint16, 4096)
+	randI := make([]int16, 4096)
+	for i := range randU {
+		randU[i] = uint16(rng.Uint32())
+		randI[i] = int16(rng.Uint32())
+	}
+	seqU := make([]uint16, 1000)
+	seqI := make([]int16, 1000)
+	for i := range seqU {
+		seqU[i] = uint16(i)
+		seqI[i] = int16(i - 500)
+	}
+	constU := make([]uint16, 500)
+	constI := make([]int16, 500)
+	for i := range constU {
+		constU[i] = 4242
+		constI[i] = -4242
+	}
+
+	type rowU struct{ V []uint16 }
+	type rowI struct{ V []int16 }
+
+	uCases := [][]uint16{
+		nil, {}, {0}, {math.MaxUint16}, {0, math.MaxUint16, 1, 32768},
+		seqU, constU, randU,
+	}
+	iCases := [][]int16{
+		nil, {}, {0}, {math.MinInt16}, {math.MaxInt16},
+		{math.MinInt16, -1, 0, 1, math.MaxInt16},
+		seqI, constI, randI,
+	}
+	for _, opts := range []Options{OptSpeed, OptBalanced, OptCompression, OptQPack} {
+		for _, c := range uCases {
+			blob, err := Marshal(rowU{c}, opts)
+			if err != nil {
+				t.Fatalf("uint16 encode opts=%v: %v", opts, err)
+			}
+			var out rowU
+			if err := Unmarshal(blob, &out); err != nil {
+				t.Fatalf("uint16 decode opts=%v n=%d: %v", opts, len(c), err)
+			}
+			if !reflect.DeepEqual(c, out.V) {
+				t.Fatalf("uint16 mismatch opts=%v n=%d: %v vs %v", opts, len(c), c, out.V)
+			}
+		}
+		for _, c := range iCases {
+			blob, err := Marshal(rowI{c}, opts)
+			if err != nil {
+				t.Fatalf("int16 encode opts=%v: %v", opts, err)
+			}
+			var out rowI
+			if err := Unmarshal(blob, &out); err != nil {
+				t.Fatalf("int16 decode opts=%v n=%d: %v", opts, len(c), err)
+			}
+			if !reflect.DeepEqual(c, out.V) {
+				t.Fatalf("int16 mismatch opts=%v n=%d", opts, len(c))
+			}
+		}
+	}
+}
+
+// TestSlice16NeverLarger pins the floor the fast paths exist for: incompressible
+// 16-bit data must cost ~2 B/elem, not the 3 B/elem the varint path charged.
+func TestSlice16NeverLarger(t *testing.T) {
+	const n = 8192
+	rng := rand.New(rand.NewSource(9))
+	u := make([]uint16, n)
+	s := make([]int16, n)
+	for i := range u {
+		u[i] = uint16(rng.Uint32())
+		s[i] = int16(rng.Uint32())
+	}
+	type rowU struct{ V []uint16 }
+	type rowI struct{ V []int16 }
+	const slack = 64 // header + tag + length
+	for _, opts := range []Options{OptBalanced, OptQPack} {
+		bu, err := Marshal(rowU{u}, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bi, err := Marshal(rowI{s}, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(bu) > 2*n+slack {
+			t.Fatalf("uint16 opts=%v: %d bytes for %d values (raw=%d)", opts, len(bu), n, 2*n)
+		}
+		if len(bi) > 2*n+slack {
+			t.Fatalf("int16 opts=%v: %d bytes for %d values (raw=%d)", opts, len(bi), n, 2*n)
+		}
+	}
+}
+
+// TestSlice16NilVsEmpty: the field-level nil/empty distinction must survive.
+func TestSlice16NilVsEmpty(t *testing.T) {
+	type rowU struct{ V []uint16 }
+	type rowI struct{ V []int16 }
+	for _, opts := range []Options{OptSpeed, OptBalanced, OptCompression} {
+		b, err := Marshal(rowU{nil}, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var ou rowU
+		if err := Unmarshal(b, &ou); err != nil {
+			t.Fatal(err)
+		}
+		if ou.V != nil {
+			t.Fatalf("uint16 nil became %v under %v", ou.V, opts)
+		}
+		b, err = Marshal(rowU{[]uint16{}}, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ou = rowU{}
+		if err := Unmarshal(b, &ou); err != nil {
+			t.Fatal(err)
+		}
+		if ou.V == nil || len(ou.V) != 0 {
+			t.Fatalf("uint16 empty became %v under %v", ou.V, opts)
+		}
+		bi, err := Marshal(rowI{nil}, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var oi rowI
+		if err := Unmarshal(bi, &oi); err != nil {
+			t.Fatal(err)
+		}
+		if oi.V != nil {
+			t.Fatalf("int16 nil became %v under %v", oi.V, opts)
+		}
+	}
+}
+
+// TestSlice16Skip: an unknown 16-bit field must Skip cleanly.
+func TestSlice16Skip(t *testing.T) {
+	type full struct {
+		V    []uint16
+		S    []int16
+		Tail int64
+	}
+	type slim struct{ Tail int64 }
+	rng := rand.New(rand.NewSource(3))
+	u := make([]uint16, 2000)
+	s := make([]int16, 2000)
+	for i := range u {
+		u[i] = uint16(rng.Uint32())
+		s[i] = int16(rng.Uint32())
+	}
+	for _, opts := range []Options{OptBalanced, OptCompression} {
+		b, err := Marshal(full{u, s, 99}, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out slim
+		if err := Unmarshal(b, &out); err != nil {
+			t.Fatalf("skip opts=%v: %v", opts, err)
+		}
+		if out.Tail != 99 {
+			t.Fatalf("tail=%d", out.Tail)
+		}
+	}
+}

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -13,8 +13,10 @@ import (
 var (
 	sliceStringType  = reflect.TypeFor[[]string]()
 	sliceIntType     = reflect.TypeFor[[]int]()
+	sliceInt16Type   = reflect.TypeFor[[]int16]()
 	sliceInt32Type   = reflect.TypeFor[[]int32]()
 	sliceInt64Type   = reflect.TypeFor[[]int64]()
+	sliceUint16Type  = reflect.TypeFor[[]uint16]()
 	sliceUint32Type  = reflect.TypeFor[[]uint32]()
 	sliceUint64Type  = reflect.TypeFor[[]uint64]()
 	sliceFloat32Type = reflect.TypeFor[[]float32]()
@@ -39,10 +41,14 @@ func installSliceFastPath(t reflect.Type) (
 		return encodeSliceStringNil, decodeSliceStringNil, true
 	case sliceIntType:
 		return encodeSliceIntNil, decodeSliceIntNil, true
+	case sliceInt16Type:
+		return encodeSliceInt16Nil, decodeSliceInt16Nil, true
 	case sliceInt32Type:
 		return encodeSliceInt32Nil, decodeSliceInt32Nil, true
 	case sliceInt64Type:
 		return encodeSliceInt64Nil, decodeSliceInt64Nil, true
+	case sliceUint16Type:
+		return encodeSliceUint16Nil, decodeSliceUint16Nil, true
 	case sliceUint32Type:
 		return encodeSliceUint32Nil, decodeSliceUint32Nil, true
 	case sliceUint64Type:
@@ -1330,4 +1336,219 @@ func decodeSliceBool(d *Decoder, p unsafe.Pointer) error {
 	}
 	*(*[]bool)(p) = out
 	return nil
+}
+
+// widenU64From16 / widenI64From16 stage a 16-bit slice into the shared 64-bit
+// scratch so the uint64/int64 QPack pickers can score it.
+func (e *Encoder) widenU64From16(s []uint16) []uint64 {
+	if cap(e.wideU64) < len(s) {
+		e.wideU64 = make([]uint64, len(s))
+	}
+	w := e.wideU64[:len(s)]
+	for i, v := range s {
+		w[i] = uint64(v)
+	}
+	return w
+}
+
+func (e *Encoder) widenI64From16(s []int16) []int64 {
+	if cap(e.wideI64) < len(s) {
+		e.wideI64 = make([]int64, len(s))
+	}
+	w := e.wideI64[:len(s)]
+	for i, v := range s {
+		w[i] = int64(v)
+	}
+	return w
+}
+
+// encodeSliceUint16 mirrors encodeSliceUint32 one width down. Without this
+// fast path a []uint16 fell through to the generic reflect encoder, which
+// writes one uvarint per element — 3 bytes for any value >= 16384, i.e. a 1.5x
+// EXPANSION over the 2 B/elem native form on high-entropy data (bf16 weights,
+// hashes, quantized tensors).
+func encodeSliceUint16(e *Encoder, p unsafe.Pointer) error {
+	s := *(*[]uint16)(p)
+	if e.qpack {
+		w := e.widenU64From16(s)
+		codec, mn, forBits, first, minDelta, deltaBits, pforBits, bestCost := pickU64Codec(w)
+		// Never-worse floor: the picker scores against a uint64-raw 8 B/elem
+		// baseline; the native form here is 2 B/elem.
+		if bestCost >= 2+uvarintLen(uint64(len(s)))+2*len(s) {
+			e.writePackedUint16Slice(s)
+			return nil
+		}
+		if qpackConstantOverCap(len(s), codec, forBits, deltaBits, pforBits) {
+			e.writePackedUint16Slice(s)
+			return nil
+		}
+		e.emitQPackUint64(w, codec, mn, forBits, first, minDelta, deltaBits, pforBits)
+		return nil
+	}
+	e.WriteArrayHeader(len(s))
+	for i := range s {
+		e.WriteUint(uint64(s[i]))
+	}
+	return nil
+}
+
+func decodeSliceUint16(d *Decoder, p unsafe.Pointer) error {
+	t, err := d.peekTag()
+	if err != nil {
+		return err
+	}
+	switch t {
+	case tagPackRaw:
+		// Either the native 16-bit column or a widened uint64 QPack column.
+		if d.i+1 < len(d.buf) && d.buf[d.i+1] == qpackKindUint64 {
+			v64, err := d.readQPackUint64(t)
+			if err != nil {
+				return err
+			}
+			out := make([]uint16, len(v64))
+			for i, x := range v64 {
+				out[i] = uint16(x)
+			}
+			*(*[]uint16)(p) = out
+			return nil
+		}
+		d.i++
+		v, err := d.readPackedUint16Slice()
+		if err != nil {
+			return err
+		}
+		*(*[]uint16)(p) = v
+		return nil
+	case tagPackFor, tagPackDeltaFor, tagPackRLE, tagPackDict, tagPackPFor, tagPackBlock, tagZoneChunk:
+		v64, err := d.readQPackUint64(t)
+		if err != nil {
+			return err
+		}
+		out := make([]uint16, len(v64))
+		for i, x := range v64 {
+			out[i] = uint16(x)
+		}
+		*(*[]uint16)(p) = out
+		return nil
+	}
+	n, err := d.ReadArrayHeader()
+	if err != nil {
+		return err
+	}
+	out := make([]uint16, n)
+	for i := range out {
+		v, err := d.ReadUint()
+		if err != nil {
+			return err
+		}
+		out[i] = uint16(v)
+	}
+	*(*[]uint16)(p) = out
+	return nil
+}
+
+// encodeSliceInt16 is the signed twin of encodeSliceUint16.
+func encodeSliceInt16(e *Encoder, p unsafe.Pointer) error {
+	s := *(*[]int16)(p)
+	if e.qpack {
+		w := e.widenI64From16(s)
+		codec, mn, forBits, first, minDelta, deltaBits, pforBits, bestCost := pickI64Codec(w)
+		if bestCost >= 2+uvarintLen(uint64(len(s)))+2*len(s) {
+			e.writePackedInt16Slice(s)
+			return nil
+		}
+		if qpackConstantOverCap(len(s), codec, forBits, deltaBits, pforBits) {
+			e.writePackedInt16Slice(s)
+			return nil
+		}
+		e.emitQPackInt64(w, codec, mn, forBits, first, minDelta, deltaBits, pforBits)
+		return nil
+	}
+	e.WriteArrayHeader(len(s))
+	for i := range s {
+		e.WriteInt(int64(s[i]))
+	}
+	return nil
+}
+
+func decodeSliceInt16(d *Decoder, p unsafe.Pointer) error {
+	t, err := d.peekTag()
+	if err != nil {
+		return err
+	}
+	switch t {
+	case tagPackRaw:
+		if d.i+1 < len(d.buf) && d.buf[d.i+1] == qpackKindInt64 {
+			v64, err := d.readQPackInt64(t)
+			if err != nil {
+				return err
+			}
+			out := make([]int16, len(v64))
+			for i, x := range v64 {
+				out[i] = int16(x)
+			}
+			*(*[]int16)(p) = out
+			return nil
+		}
+		d.i++
+		v, err := d.readPackedInt16Slice()
+		if err != nil {
+			return err
+		}
+		*(*[]int16)(p) = v
+		return nil
+	case tagPackFor, tagPackDeltaFor, tagPackRLE, tagPackDict, tagPackPFor, tagPackBlock, tagZoneChunk:
+		v64, err := d.readQPackInt64(t)
+		if err != nil {
+			return err
+		}
+		out := make([]int16, len(v64))
+		for i, x := range v64 {
+			out[i] = int16(x)
+		}
+		*(*[]int16)(p) = out
+		return nil
+	}
+	n, err := d.ReadArrayHeader()
+	if err != nil {
+		return err
+	}
+	out := make([]int16, n)
+	for i := range out {
+		v, err := d.ReadInt()
+		if err != nil {
+			return err
+		}
+		out[i] = int16(v)
+	}
+	*(*[]int16)(p) = out
+	return nil
+}
+
+func encodeSliceUint16Nil(e *Encoder, p unsafe.Pointer) error {
+	if e.encodeNilSlice(p) {
+		return nil
+	}
+	return encodeSliceUint16(e, p)
+}
+
+func decodeSliceUint16Nil(d *Decoder, p unsafe.Pointer) error {
+	if d.decodeNilSlice(p) {
+		return nil
+	}
+	return decodeSliceUint16(d, p)
+}
+
+func encodeSliceInt16Nil(e *Encoder, p unsafe.Pointer) error {
+	if e.encodeNilSlice(p) {
+		return nil
+	}
+	return encodeSliceInt16(e, p)
+}
+
+func decodeSliceInt16Nil(d *Decoder, p unsafe.Pointer) error {
+	if d.decodeNilSlice(p) {
+		return nil
+	}
+	return decodeSliceInt16(d, p)
 }

--- a/slices_fast.go
+++ b/slices_fast.go
@@ -1374,7 +1374,26 @@ func encodeSliceUint16(e *Encoder, p unsafe.Pointer) error {
 		codec, mn, forBits, first, minDelta, deltaBits, pforBits, bestCost := pickU64Codec(w)
 		// Never-worse floor: the picker scores against a uint64-raw 8 B/elem
 		// baseline; the native form here is 2 B/elem.
-		if bestCost >= 2+uvarintLen(uint64(len(s)))+2*len(s) {
+		nativeCost := 2 + uvarintLen(uint64(len(s))) + 2*len(s)
+		// The byte-plane split reaches columns whose high byte is low-entropy
+		// (bf16/fp16 tensors, quantized data) — a class the integer codecs
+		// only ever score by value range, so FOR can post a small win while
+		// the plane form is far smaller. Gate the trial compression on a
+		// sampled-entropy projection rather than on the integer picker
+		// declining outright, which left ~11% on the table for all-positive
+		// weight tensors.
+		// Require a real margin, not just any win: the codec costs the decoder
+		// a 16 KiB tANS table build, which a fraction-of-a-percent saving does
+		// not pay for.
+		floor := min(bestCost, nativeCost)
+		floor -= floor / 64
+		if len(s) >= plane16MinElems && plane16Project(s) < floor {
+			if hiBody, total, ok := e.plane16Estimate(s); ok && total < floor {
+				e.writePackedPlane16Slice(s, hiBody)
+				return nil
+			}
+		}
+		if bestCost >= nativeCost {
 			e.writePackedUint16Slice(s)
 			return nil
 		}
@@ -1399,7 +1418,16 @@ func decodeSliceUint16(d *Decoder, p unsafe.Pointer) error {
 	}
 	switch t {
 	case tagPackRaw:
-		// Either the native 16-bit column or a widened uint64 QPack column.
+		// Native 16-bit column, byte-plane column, or a widened uint64 one.
+		if d.i+1 < len(d.buf) && d.buf[d.i+1] == qpackKindPlane16 {
+			d.i++
+			v, err := d.readPackedPlane16Slice()
+			if err != nil {
+				return err
+			}
+			*(*[]uint16)(p) = v
+			return nil
+		}
 		if d.i+1 < len(d.buf) && d.buf[d.i+1] == qpackKindUint64 {
 			v64, err := d.readQPackUint64(t)
 			if err != nil {


### PR DESCRIPTION
## Summary

Makes qdf usable for 16-bit numeric columns — the format LLM weights and quantized activations actually ship in. Two commits:

**1. `[]uint16` / `[]int16` slice fast paths.** 16-bit slices had none: they fell through to the generic reflect encoder (one uvarint per element, 3 bytes for any value ≥ 16384), which **expanded** the wire 1.5× over the native 2 B/elem form, in every mode. They now mirror the 32-bit paths — widen into the shared 64-bit scratch, score with the existing uint64/int64 pickers (FOR / delta+FOR / RLE / dict / PFOR), fall back to a native 2 B/elem raw column. The raw kinds were already reserved and honored by the decoder and Skip, so no wire surface is added. Structured 16-bit columns also reach FOR/RLE/dict for the first time.

**2. Byte-plane codec.** A `[]uint16` column is de-interleaved into a high- and low-byte plane; only the high plane is entropy-coded, with its own tANS table. The split is the whole point: order-0 entropy is order-independent, so one shared table over the interleaved stream and over the concatenated planes score identically (both 1.271× on bf16) — a table fitted to the high plane alone reaches **1.488×**, against a 1.53× order-0 floor. The low plane stays raw: ~8 bits of entropy, incompressible.

## Numbers (bf16 weight tensor, n=65536, raw 131072 B, OptBalanced)

| Stage | Bytes | Ratio |
|---|---|---|
| before | 196 623 | 0.667× (+50% expansion) |
| + fast paths | 131 087 | 1.000× |
| + plane codec | **88 111** | **1.488×** |

fp16: 1.181×. Because the codec carries its own entropy stage the win lands in `OptBalanced`, not only under `OptRANS`. Throughput: encode ~420 MB/s, decode ~1.76 GB/s.

The trial compression is gated on a sampled-entropy projection, not on the integer picker declining outright — the conservative gate missed all-positive tensors entirely (narrow range → FOR posts 1.454×, plane form 1.641×). The projection costs nothing measurable where the codec cannot help (benchstat p=0.28/0.57).

## Verification

Adversarial review: no correctness bugs; 270-case never-larger property (9 shapes × 10 sizes × 3 option sets, 48 landing on the codec), 80k hostile bit flips + truncation sweeps through both `Unmarshal` and `Skip` with zero panics, alloc-free giant-length rejection, determinism under pooled reuse and `-race`, 3.6M-exec fuzz.

Four findings from that review are fixed in the second commit: a **regression the first commit introduced** (`decodeAnyPackedSlice` had no 16-bit cases, so any-typed fields started failing with `ErrBadTag`), a silent-corruption channel (`hiLen == n` was decoded as a raw high plane but is unreachable from the encoder — now rejected), scratch escaping the pooled-encoder spike ceiling (~3.6 MB pinned), and an FMA-fusable entropy sum that made the gate arch-dependent (`docs/CANONICAL.md` promises byte-identical output across amd64/arm64).

