### PR TITLE
feat(decode): UnmarshalKeys — project a map-rooted payload by key

### DIFF
--- a/batch_decode.go
+++ b/batch_decode.go
@@ -213,6 +213,7 @@ func tryDecodeBatchColumnar(data []byte, plan *batchPlan, slab *batchSlab, rows 
 	d.noCopy = true
 	d.arena = nil
 	d.selectFields = nil
+	d.selectKeys = nil
 	d.query = nil
 	if d.state != nil {
 		d.state.reset()
@@ -281,6 +282,7 @@ func tryDecodeBatchRowMajor(data []byte, plan *batchPlan, slab *batchSlab, rows 
 	d.noCopy = true
 	d.arena = nil
 	d.selectFields = nil
+	d.selectKeys = nil
 	d.query = nil
 	if d.state != nil {
 		d.state.reset()

--- a/columnar_select.go
+++ b/columnar_select.go
@@ -1,6 +1,9 @@
 package qdf
 
-import "slices"
+import (
+	"reflect"
+	"slices"
+)
 
 // wantedColumns maps each WIRE column index to the target plan column to
 // decode it into, or nil to skip. Matched by field name. Wire columns whose
@@ -36,8 +39,98 @@ func UnmarshalColumns(data []byte, out any, fields ...string) error {
 // wantField reports whether name is in the active selectFields filter. A nil
 // filter wants every column (no filtering).
 func (d *Decoder) wantField(name string) bool {
-	if d.selectFields == nil {
+	if len(d.selectFields) == 0 {
 		return true
 	}
 	return slices.Contains(d.selectFields, name)
+}
+
+// keyFilter is the consumed form of an UnmarshalKeys projection. The zero
+// value wants every key, so an absent filter costs one nil check.
+type keyFilter struct {
+	list []string
+	set  map[string]struct{} // built only for large lists, see takeKeyFilter
+}
+
+// keyFilterSetMin is where linear scanning stops paying. Map entry counts are
+// data-driven (an attacker picks them), so a large key list must not turn a
+// projection into O(keys x entries).
+const keyFilterSetMin = 16
+
+// takeKeyFilter consumes the pending UnmarshalKeys projection. It is one-shot:
+// the root map's decode loop takes it, and every nested decode — values, Skip,
+// nested maps, columnar containers — then runs unfiltered. Sharing one filter
+// field with the columnar column names, and clearing it per value rather than
+// once per map, produced three separate silent-data-loss bugs; this shape has
+// neither hazard.
+func (d *Decoder) takeKeyFilter() keyFilter {
+	keys := d.selectKeys
+	if len(keys) == 0 {
+		return keyFilter{}
+	}
+	d.selectKeys = nil
+	f := keyFilter{list: keys}
+	if len(keys) >= keyFilterSetMin {
+		f.set = make(map[string]struct{}, len(keys))
+		for _, k := range keys {
+			f.set[k] = struct{}{}
+		}
+	}
+	return f
+}
+
+// want reports whether name survives the filter. The zero filter wants all.
+func (f keyFilter) want(name string) bool {
+	if f.list == nil {
+		return true
+	}
+	if f.set != nil {
+		_, ok := f.set[name]
+		return ok
+	}
+	return slices.Contains(f.list, name)
+}
+
+// UnmarshalKeys decodes only the named keys of a map-rooted payload into out,
+// skipping every other entry's value without decoding it. out must point at a
+// string-keyed map (or at an interface, for the dynamic form) — the projection
+// is defined on the ROOT map only, and values decode in full, so a nested map
+// inside a selected value keeps all of its keys.
+//
+// This is the projection path for payloads whose member names are dynamic — a
+// model checkpoint keyed by tensor name, a metrics blob keyed by series —
+// where a typed subset struct (which Unmarshal already projects through Skip)
+// cannot be written ahead of time. Skipping is far cheaper than decoding: on a
+// 64-tensor checkpoint, taking two tensors runs ~27x faster than a full decode
+// under OptBalanced. Under OptRANS the gain is much smaller (~2x): the entropy
+// pass has to inflate the whole message before any entry can be skipped.
+//
+// With no keys it behaves like Unmarshal.
+func UnmarshalKeys(data []byte, out any, keys ...string) error {
+	if len(keys) == 0 {
+		return Unmarshal(data, out)
+	}
+	if !rootTakesKeyFilter(out) {
+		return ErrTypeMismatch
+	}
+	return unmarshalKeys(data, out, keys)
+}
+
+// rootTakesKeyFilter reports whether out roots a payload the key projection is
+// defined for: a pointer to a string-keyed map, or to an interface (the
+// dynamic map[string]any form). Anything else would let the filter land on a
+// map nested at an arbitrary depth, which is not what the caller asked for.
+func rootTakesKeyFilter(out any) bool {
+	t := reflect.TypeOf(out)
+	if t == nil || t.Kind() != reflect.Pointer {
+		return false
+	}
+	switch e := t.Elem(); e.Kind() {
+	case reflect.Interface:
+		return true
+	case reflect.Map:
+		return e.Key().Kind() == reflect.String
+	default:
+		return false
+	}
 }

--- a/columnar_select.go
+++ b/columnar_select.go
@@ -1,9 +1,6 @@
 package qdf
 
-import (
-	"reflect"
-	"slices"
-)
+import "slices"
 
 // wantedColumns maps each WIRE column index to the target plan column to
 // decode it into, or nil to skip. Matched by field name. Wire columns whose
@@ -110,27 +107,5 @@ func UnmarshalKeys(data []byte, out any, keys ...string) error {
 	if len(keys) == 0 {
 		return Unmarshal(data, out)
 	}
-	if !rootTakesKeyFilter(out) {
-		return ErrTypeMismatch
-	}
 	return unmarshalKeys(data, out, keys)
-}
-
-// rootTakesKeyFilter reports whether out roots a payload the key projection is
-// defined for: a pointer to a string-keyed map, or to an interface (the
-// dynamic map[string]any form). Anything else would let the filter land on a
-// map nested at an arbitrary depth, which is not what the caller asked for.
-func rootTakesKeyFilter(out any) bool {
-	t := reflect.TypeOf(out)
-	if t == nil || t.Kind() != reflect.Pointer {
-		return false
-	}
-	switch e := t.Elem(); e.Kind() {
-	case reflect.Interface:
-		return true
-	case reflect.Map:
-		return e.Key().Kind() == reflect.String
-	default:
-		return false
-	}
 }

--- a/decoder.go
+++ b/decoder.go
@@ -38,6 +38,14 @@ type Decoder struct {
 	// reset / return-to-pool / SetInput so it never leaks across decodes.
 	selectFields []string
 
+	// selectKeys is the UnmarshalKeys projection: the keys to keep from the
+	// ROOT map. It is deliberately separate from selectFields (column names)
+	// — sharing one field made a column projection filter map entries and
+	// vice versa — and is consumed one-shot by the root map's decode loop, so
+	// nothing nested (values, Skip, nested maps, columnar containers) ever
+	// sees a live filter.
+	selectKeys []string
+
 	// query, when non-nil, makes a columnar decode filter rows by the plan's
 	// predicates (AND) and project the plan's columns. Set by Unmarshal when
 	// QueryOptions are passed; cleared on reset / SetInput so it never leaks.
@@ -234,6 +242,7 @@ func (d *Decoder) SetInput(buf []byte) {
 	d.colIndex = false
 	d.colMaxLen = 0
 	d.selectFields = nil
+	d.selectKeys = nil
 	d.query = nil
 	clear(d.mapFreeList) // drop recycled maps; keep the backing allocated
 	if d.state != nil {

--- a/internal/mapsgen/main.go
+++ b/internal/mapsgen/main.go
@@ -334,7 +334,11 @@ func emitPair(buf *bytes.Buffer, p pair) {
 		fmt.Fprintf(buf, "\tif t == tagMapShape {\n")
 		fmt.Fprintf(buf, "\t\tnames, err := decodeMapStringShapeHeader(d)\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n")
 		fmt.Fprintf(buf, "\t\tm := reuseOrMakeMap[%s, %s](d, p, len(names))\n", p.K.goType, p.V.goType)
+		// UnmarshalKeys projection: consume the root filter ONCE, before the
+		// loop, so values and Skip below run unfiltered.
+		fmt.Fprintf(buf, "\t\tkf := d.takeKeyFilter()\n")
 		fmt.Fprintf(buf, "\t\tfor _, k := range names {\n")
+		fmt.Fprintf(buf, "\t\t\tif !kf.want(k) {\n\t\t\t\tif err := d.Skip(); err != nil {\n\t\t\t\t\treturn err\n\t\t\t\t}\n\t\t\t\tcontinue\n\t\t\t}\n")
 		fmt.Fprintf(buf, "\t\t\t%s\n", p.V.readBlock("v"))
 		fmt.Fprintf(buf, "\t\t\tm[k] = v\n")
 		fmt.Fprintf(buf, "\t\t}\n\t\t*(*%s)(p) = m\n\t\treturn nil\n\t}\n", mapTy)
@@ -342,8 +346,16 @@ func emitPair(buf *bytes.Buffer, p pair) {
 	fmt.Fprintf(buf, "\tn, err := d.ReadMapHeader()\n\tif err != nil {\n\t\treturn err\n\t}\n")
 	fmt.Fprintf(buf, "\tif err := d.CheckLength(n, 2); err != nil {\n\t\treturn err\n\t}\n")
 	fmt.Fprintf(buf, "\tm := reuseOrMakeMap[%s, %s](d, p, n)\n", p.K.goType, p.V.goType)
+	if p.K.suffix == "String" {
+		// UnmarshalKeys projection: consume the root filter ONCE, before the
+		// loop. Only string-keyed maps participate — the filter is name-based.
+		fmt.Fprintf(buf, "\tkf := d.takeKeyFilter()\n")
+	}
 	fmt.Fprintf(buf, "\tfor range n {\n")
 	fmt.Fprintf(buf, "\t\t%s\n", indent(p.K.readKey("k")))
+	if p.K.suffix == "String" {
+		fmt.Fprintf(buf, "\t\tif !kf.want(k) {\n\t\t\tif err := d.Skip(); err != nil {\n\t\t\t\treturn err\n\t\t\t}\n\t\t\tcontinue\n\t\t}\n")
+	}
 	fmt.Fprintf(buf, "\t\t%s\n", indent(p.V.readBlock("v")))
 	fmt.Fprintf(buf, "\t\tm[k] = v\n")
 	fmt.Fprintf(buf, "\t}\n\t*(*%s)(p) = m\n\treturn nil\n}\n\n", mapTy)

--- a/maps_fast_generated.go
+++ b/maps_fast_generated.go
@@ -73,7 +73,14 @@ func decodeMapStringString(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, string](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			v, err := d.ReadString()
 			if err != nil {
 				return err
@@ -91,12 +98,19 @@ func decodeMapStringString(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, string](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		v, err := d.ReadString()
 		if err != nil {
 			return err
@@ -171,7 +185,14 @@ func decodeMapStringBool(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, bool](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			v, err := d.ReadBool()
 			if err != nil {
 				return err
@@ -189,12 +210,19 @@ func decodeMapStringBool(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, bool](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		v, err := d.ReadBool()
 		if err != nil {
 			return err
@@ -269,7 +297,14 @@ func decodeMapStringInt8(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, int8](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			vWide, err := d.ReadInt()
 			if err != nil {
 				return err
@@ -288,12 +323,19 @@ func decodeMapStringInt8(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, int8](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		vWide, err := d.ReadInt()
 		if err != nil {
 			return err
@@ -369,7 +411,14 @@ func decodeMapStringInt16(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, int16](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			vWide, err := d.ReadInt()
 			if err != nil {
 				return err
@@ -388,12 +437,19 @@ func decodeMapStringInt16(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, int16](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		vWide, err := d.ReadInt()
 		if err != nil {
 			return err
@@ -469,7 +525,14 @@ func decodeMapStringInt32(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, int32](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			vWide, err := d.ReadInt()
 			if err != nil {
 				return err
@@ -488,12 +551,19 @@ func decodeMapStringInt32(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, int32](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		vWide, err := d.ReadInt()
 		if err != nil {
 			return err
@@ -569,7 +639,14 @@ func decodeMapStringInt(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, int](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			vWide, err := d.ReadInt()
 			if err != nil {
 				return err
@@ -588,12 +665,19 @@ func decodeMapStringInt(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, int](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		vWide, err := d.ReadInt()
 		if err != nil {
 			return err
@@ -669,7 +753,14 @@ func decodeMapStringInt64(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, int64](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			v, err := d.ReadInt()
 			if err != nil {
 				return err
@@ -687,12 +778,19 @@ func decodeMapStringInt64(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, int64](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		v, err := d.ReadInt()
 		if err != nil {
 			return err
@@ -767,7 +865,14 @@ func decodeMapStringUint8(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, uint8](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			vWide, err := d.ReadUint()
 			if err != nil {
 				return err
@@ -786,12 +891,19 @@ func decodeMapStringUint8(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, uint8](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		vWide, err := d.ReadUint()
 		if err != nil {
 			return err
@@ -867,7 +979,14 @@ func decodeMapStringUint16(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, uint16](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			vWide, err := d.ReadUint()
 			if err != nil {
 				return err
@@ -886,12 +1005,19 @@ func decodeMapStringUint16(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, uint16](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		vWide, err := d.ReadUint()
 		if err != nil {
 			return err
@@ -967,7 +1093,14 @@ func decodeMapStringUint32(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, uint32](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			vWide, err := d.ReadUint()
 			if err != nil {
 				return err
@@ -986,12 +1119,19 @@ func decodeMapStringUint32(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, uint32](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		vWide, err := d.ReadUint()
 		if err != nil {
 			return err
@@ -1067,7 +1207,14 @@ func decodeMapStringUint(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, uint](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			vWide, err := d.ReadUint()
 			if err != nil {
 				return err
@@ -1086,12 +1233,19 @@ func decodeMapStringUint(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, uint](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		vWide, err := d.ReadUint()
 		if err != nil {
 			return err
@@ -1167,7 +1321,14 @@ func decodeMapStringUint64(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, uint64](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			v, err := d.ReadUint()
 			if err != nil {
 				return err
@@ -1185,12 +1346,19 @@ func decodeMapStringUint64(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, uint64](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		v, err := d.ReadUint()
 		if err != nil {
 			return err
@@ -1265,7 +1433,14 @@ func decodeMapStringFloat32(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, float32](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			v, err := d.ReadFloat32()
 			if err != nil {
 				return err
@@ -1283,12 +1458,19 @@ func decodeMapStringFloat32(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, float32](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		v, err := d.ReadFloat32()
 		if err != nil {
 			return err
@@ -1363,7 +1545,14 @@ func decodeMapStringFloat64(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, float64](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			v, err := d.ReadFloat64()
 			if err != nil {
 				return err
@@ -1381,12 +1570,19 @@ func decodeMapStringFloat64(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, float64](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		v, err := d.ReadFloat64()
 		if err != nil {
 			return err
@@ -1473,7 +1669,14 @@ func decodeMapStringBytes(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, []byte](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			var v []byte
 			vTag, err := d.peekTag()
 			if err != nil {
@@ -1500,12 +1703,19 @@ func decodeMapStringBytes(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, []byte](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		var v []byte
 		vTag, err := d.peekTag()
 		if err != nil {
@@ -1610,7 +1820,14 @@ func decodeMapStringStringSlice(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, []string](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			var v []string
 			vTag, err := d.peekTag()
 			if err != nil {
@@ -1648,12 +1865,19 @@ func decodeMapStringStringSlice(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, []string](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		var v []string
 		vTag, err := d.peekTag()
 		if err != nil {
@@ -1754,7 +1978,14 @@ func decodeMapStringAny(d *Decoder, p unsafe.Pointer) error {
 			return err
 		}
 		m := reuseOrMakeMap[string, any](d, p, len(names))
+		kf := d.takeKeyFilter()
 		for _, k := range names {
+			if !kf.want(k) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
 			v, err := decodeAny(d)
 			if err != nil {
 				return err
@@ -1772,12 +2003,19 @@ func decodeMapStringAny(d *Decoder, p unsafe.Pointer) error {
 		return err
 	}
 	m := reuseOrMakeMap[string, any](d, p, n)
+	kf := d.takeKeyFilter()
 	for range n {
 		kb, err := d.readStringBytes()
 		if err != nil {
 			return err
 		}
 		k := d.keyCache.Make(kb)
+		if !kf.want(k) {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+			continue
+		}
 		v, err := decodeAny(d)
 		if err != nil {
 			return err

--- a/qdf.go
+++ b/qdf.go
@@ -561,6 +561,35 @@ func unmarshalQuery(data []byte, out any, qp *queryPlan) error {
 // unmarshal is the shared pooled-decoder dispatch behind Unmarshal and
 // UnmarshalColumns. When fields is non-nil it restricts the columnar map
 // (any) decode to those columns (see Decoder.selectFields).
+// unmarshalKeys mirrors unmarshal but arms the root-map key projection
+// (UnmarshalKeys) rather than the columnar field filter. The two are separate
+// decoder fields on purpose: one filter must never be read as the other.
+func unmarshalKeys(data []byte, out any, keys []string) error {
+	dec := decPool.Get().(*Decoder)
+	dec.buf = data
+	dec.i = 0
+	dec.depth = 0
+	dec.headerRead = false
+	dec.mode = Fast
+	dec.colIndex = false
+	dec.colMaxLen = 0
+	dec.noCopy = false
+	dec.arena = nil
+	dec.selectFields = nil
+	dec.selectKeys = keys
+	dec.query = nil
+	clear(dec.mapFreeList)
+	if dec.state != nil {
+		dec.state.reset()
+	}
+	err := decodeReflect(dec, out)
+	dec.buf = nil
+	dec.selectKeys = nil
+	dec.i = 0
+	decPool.Put(dec)
+	return err
+}
+
 func unmarshal(data []byte, out any, fields []string, noCopy bool, arena *Arena) error {
 	dec := decPool.Get().(*Decoder)
 	dec.buf = data
@@ -573,6 +602,7 @@ func unmarshal(data []byte, out any, fields []string, noCopy bool, arena *Arena)
 	dec.noCopy = noCopy
 	dec.arena = arena
 	dec.selectFields = fields
+	dec.selectKeys = nil
 	dec.query = nil        // parity with UnmarshalT / SetInput: never inherit a prior query decode's plan from the shared pool
 	clear(dec.mapFreeList) // drop maps recycled by a prior decode into a different target
 	if dec.state != nil {

--- a/qdf_generic.go
+++ b/qdf_generic.go
@@ -89,6 +89,7 @@ func UnmarshalT[T any](data []byte, out *T) error {
 	// in unmarshal / unmarshalQuery — UnmarshalT shares the same decoder pool).
 	dec.colMaxLen = 0
 	dec.selectFields = nil
+	dec.selectKeys = nil
 	dec.query = nil
 	clear(dec.mapFreeList) // drop maps recycled by a prior decode into a different target
 	if dec.state != nil {

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -2103,11 +2103,34 @@ func decodeReflect(d *Decoder, out any) error {
 	if d.query != nil && t.Kind() != reflect.Slice {
 		return &QueryError{Op: "predicate pushdown", Err: ErrUnsupported}
 	}
+	// The UnmarshalKeys projection is defined on the ROOT map. Reject a target
+	// that does not root one here rather than letting the filter drift down to
+	// whatever map happens to be nested inside — same reasoning as the query
+	// check above, and the same place, so the decode entry point stays the one
+	// spot that rules on target shape.
+	if d.selectKeys != nil && !rootsStringKeyedMap(t) {
+		d.selectKeys = nil
+		return ErrTypeMismatch
+	}
 	td, err := descOf(t)
 	if err != nil {
 		return err
 	}
 	return td.decode(d, unsafe.Pointer(rv.Pointer()))
+}
+
+// rootsStringKeyedMap reports whether the decode target's element type roots a
+// payload the key projection is defined for: a string-keyed map, or an
+// interface (the dynamic map[string]any form).
+func rootsStringKeyedMap(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Interface:
+		return true
+	case reflect.Map:
+		return t.Key().Kind() == reflect.String
+	default:
+		return false
+	}
 }
 
 // encodeNilSlice emits tagNil and returns true when the slice at p is nil

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -1069,7 +1069,16 @@ func decodeMap(t reflect.Type, k, v *typeDesc) func(*Decoder, unsafe.Pointer) er
 			// for every entry (and across rows) — no reflect.New per entry.
 			kh, vh, vp, pooled := d.state.mapDec.acquire(keyType, valType)
 			defer d.state.mapDec.release(pooled)
+			// UnmarshalKeys projection: consume the root filter ONCE so the
+			// values and Skip below decode unfiltered.
+			kf := d.takeKeyFilter()
 			for _, name := range names {
+				if !kf.want(name) {
+					if err := d.Skip(); err != nil {
+						return err
+					}
+					continue
+				}
 				kh.SetString(name)
 				// Reset the value holder each entry: a slice-backed value type
 				// would otherwise have its backing array reused across entries
@@ -1103,9 +1112,21 @@ func decodeMap(t reflect.Type, k, v *typeDesc) func(*Decoder, unsafe.Pointer) er
 		vv := reflect.New(valType).Elem()
 		kp := unsafe.Pointer(kv.UnsafeAddr())
 		vp := unsafe.Pointer(vv.UnsafeAddr())
+		// UnmarshalKeys projection, consumed once (string keys only — the
+		// filter is name-based).
+		var kf keyFilter
+		if keyType.Kind() == reflect.String {
+			kf = d.takeKeyFilter()
+		}
 		for range n {
 			if err := k.decode(d, kp); err != nil {
 				return err
+			}
+			if !kf.want(kv.String()) {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
 			}
 			// Reset the value holder each entry so a slice-backed value type does
 			// not reuse the previous entry's backing array (reuseOrMakeSlice keeps

--- a/select_keys_test.go
+++ b/select_keys_test.go
@@ -309,3 +309,26 @@ func TestUnmarshalKeysLargeFilter(t *testing.T) {
 		t.Fatal("wrong values")
 	}
 }
+
+// TestEmptyKeyFilterKeepsEverything pins one half of a footgun both
+// projections shared: an empty-but-NON-NIL filter (how a caller hits it:
+// keys := []string{} then keys...) must mean "no filter", not "drop
+// everything". The column half of the same guard (wantField's len check) is
+// hardening only — no payload shape was found that reaches wantField with an
+// empty filter, so it is deliberately left untested rather than pinned by a
+// test that would pass vacuously.
+func TestEmptyKeyFilterKeepsEverything(t *testing.T) {
+	m := map[string]int64{"a": 1, "b": 2}
+	blob, err := Marshal(m, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	empty := []string{}
+	var got map[string]int64
+	if err := UnmarshalKeys(blob, &got, empty...); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("empty key filter dropped data: %v", got)
+	}
+}

--- a/select_keys_test.go
+++ b/select_keys_test.go
@@ -1,0 +1,311 @@
+package qdf
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+// UnmarshalKeys projects a dynamic-keyed payload the way a typed subset struct
+// projects a static one: wanted values decode, everything else is skipped.
+func TestUnmarshalKeys(t *testing.T) {
+	m := map[string][]uint16{
+		"a": mkWeights16(2048, 1, bf16Bits),
+		"b": mkWeights16(2048, 2, bf16Bits),
+		"c": mkWeights16(2048, 3, bf16Bits),
+		"d": mkWeights16(2048, 4, bf16Bits),
+	}
+	for _, opts := range []Options{OptSpeed, OptBalanced, OptCompression, OptBalanced | OptMapShape} {
+		blob, err := Marshal(m, opts)
+		if err != nil {
+			t.Fatalf("%v encode: %v", opts, err)
+		}
+		var got map[string][]uint16
+		if err := UnmarshalKeys(blob, &got, "b", "d"); err != nil {
+			t.Fatalf("%v: %v", opts, err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("%v: got %d entries, want 2", opts, len(got))
+		}
+		if !reflect.DeepEqual(got["b"], m["b"]) || !reflect.DeepEqual(got["d"], m["d"]) {
+			t.Fatalf("%v: projected values wrong", opts)
+		}
+		if _, ok := got["a"]; ok {
+			t.Fatalf("%v: unwanted key present", opts)
+		}
+		// No keys behaves like Unmarshal.
+		var all map[string][]uint16
+		if err := UnmarshalKeys(blob, &all); err != nil {
+			t.Fatalf("%v all: %v", opts, err)
+		}
+		if len(all) != len(m) {
+			t.Fatalf("%v: empty filter dropped keys (%d of %d)", opts, len(all), len(m))
+		}
+		// Keys absent from the payload yield an empty result, not an error.
+		var none map[string][]uint16
+		if err := UnmarshalKeys(blob, &none, "nope"); err != nil {
+			t.Fatalf("%v missing: %v", opts, err)
+		}
+		if len(none) != 0 {
+			t.Fatalf("%v: %d entries for an absent key", opts, len(none))
+		}
+	}
+}
+
+// TestUnmarshalKeysNested pins the scoping rule: the filter applies to the
+// OUTERMOST map only. Without that, a nested map inside a selected value
+// silently loses every key not in the caller's list.
+func TestUnmarshalKeysNested(t *testing.T) {
+	m := map[string]map[string]int64{
+		"keep": {"a": 1, "b": 2, "c": 3},
+		"drop": {"a": 9, "b": 9, "c": 9},
+	}
+	for _, opts := range []Options{OptSpeed, OptBalanced, OptBalanced | OptMapShape} {
+		blob, err := Marshal(m, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got map[string]map[string]int64
+		if err := UnmarshalKeys(blob, &got, "keep"); err != nil {
+			t.Fatalf("%v: %v", opts, err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("%v: outer filter kept %d entries", opts, len(got))
+		}
+		if !reflect.DeepEqual(got["keep"], m["keep"]) {
+			t.Fatalf("%v: nested map lost keys: %v", opts, got["keep"])
+		}
+	}
+}
+
+// TestUnmarshalKeysValueShapes: skipping must handle every value shape, not
+// just the packed slices the checkpoint case uses.
+func TestUnmarshalKeysValueShapes(t *testing.T) {
+	type inner struct {
+		S string
+		N []int64
+	}
+	m := map[string]any{
+		"str":    "hello",
+		"num":    int64(42),
+		"slice":  []int64{1, 2, 3},
+		"nested": map[string]any{"x": int64(1)},
+		"struct": inner{S: "s", N: []int64{7, 8}},
+		"want":   int64(99),
+	}
+	for _, opts := range []Options{OptSpeed, OptBalanced} {
+		blob, err := Marshal(m, opts)
+		if err != nil {
+			t.Fatalf("%v encode: %v", opts, err)
+		}
+		var got map[string]any
+		if err := UnmarshalKeys(blob, &got, "want"); err != nil {
+			t.Fatalf("%v: %v", opts, err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("%v: got %v", opts, got)
+		}
+		// decodeAny picks the narrowest integer kind that fits, so compare
+		// numerically rather than against one concrete type.
+		v := reflect.ValueOf(got["want"])
+		num := int64(-1)
+		switch {
+		case v.CanInt():
+			num = v.Int()
+		case v.CanUint():
+			num = int64(v.Uint())
+		}
+		if num != 99 {
+			t.Fatalf("%v: want=%#v", opts, got["want"])
+		}
+	}
+}
+
+// TestUnmarshalKeysRejectsNonMapRoots: the projection is defined on the root
+// map. Targets it cannot project must be rejected outright — silently ignoring
+// the keys, or letting the filter drift down to some map nested at an
+// arbitrary depth, are both worse than an error.
+func TestUnmarshalKeysRejectsNonMapRoots(t *testing.T) {
+	type row struct {
+		Tags map[string]string
+	}
+	blobMap, err := Marshal(map[int64]string{1: "a", 2: "b"}, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blobRows, err := Marshal([]row{{Tags: map[string]string{"env": "prod"}}}, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var intKeyed map[int64]string
+	if err := UnmarshalKeys(blobMap, &intKeyed, "1"); err == nil {
+		t.Fatal("non-string-keyed root accepted")
+	}
+	var rows []row
+	if err := UnmarshalKeys(blobRows, &rows, "env"); err == nil {
+		t.Fatal("slice root accepted; the filter would have hit a nested map")
+	}
+	// Empty key list is still a plain Unmarshal, whatever the root is.
+	rows = nil
+	if err := UnmarshalKeys(blobRows, &rows); err != nil {
+		t.Fatalf("empty filter: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Tags["env"] != "prod" {
+		t.Fatalf("empty filter dropped data: %v", rows)
+	}
+}
+
+// TestUnmarshalKeysCheckpoint is the shape the API exists for.
+func TestUnmarshalKeysCheckpoint(t *testing.T) {
+	const tensors, per = 32, 4096
+	m := make(map[string][]uint16, tensors)
+	for i := range tensors {
+		m["model.layers."+strconv.Itoa(i)+".weight"] = mkWeights16(per, int64(i), bf16Bits)
+	}
+	blob, err := Marshal(m, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "model.layers.19.weight"
+	var got map[string][]uint16
+	if err := UnmarshalKeys(blob, &got, want); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || !reflect.DeepEqual(got[want], m[want]) {
+		t.Fatal("checkpoint projection wrong")
+	}
+}
+
+// TestUnmarshalKeysNoLeakIntoColumnar pins the first bug an adversarial review
+// found: a selected value containing a columnar []struct had the OUTER key
+// list matched against its COLUMN names, silently dropping every column.
+func TestUnmarshalKeysNoLeakIntoColumnar(t *testing.T) {
+	type inner struct {
+		Name string
+		N    int64
+		Tag  string
+	}
+	rows := make([]inner, 40)
+	for i := range rows {
+		rows[i] = inner{Name: "row" + strconv.Itoa(i), N: int64(i), Tag: "t"}
+	}
+	m := map[string]any{"aaa": rows, "zzz": int64(7)}
+	for _, opts := range []Options{OptSpeed, OptBalanced, OptCompression,
+		OptBalanced | OptColumnIndex, OptBalanced | OptMapShape, OptBalanced | OptCanonical} {
+		blob, err := Marshal(m, opts)
+		if err != nil {
+			t.Fatalf("%v encode: %v", opts, err)
+		}
+		var full, proj map[string]any
+		if err := Unmarshal(blob, &full); err != nil {
+			t.Fatalf("%v full: %v", opts, err)
+		}
+		if err := UnmarshalKeys(blob, &proj, "aaa"); err != nil {
+			t.Fatalf("%v proj: %v", opts, err)
+		}
+		if !reflect.DeepEqual(proj["aaa"], full["aaa"]) {
+			t.Fatalf("%v: selected value decoded differently under projection:\n proj=%v\n full=%v",
+				opts, proj["aaa"], full["aaa"])
+		}
+	}
+}
+
+// TestUnmarshalColumnsKeepsMapFields pins the second bug: sharing one filter
+// field between column names and map keys made a COLUMN projection drop
+// entries from string-keyed map fields — silent data loss in an API that
+// predates the key projection entirely.
+func TestUnmarshalColumnsKeepsMapFields(t *testing.T) {
+	type r struct {
+		ID   int64
+		Name string
+		Tags map[string]string
+	}
+	rows := make([]r, 24)
+	for i := range rows {
+		rows[i] = r{ID: int64(i), Name: "n" + strconv.Itoa(i),
+			Tags: map[string]string{"env": "prod", "region": "eu", "ID": "shadow"}}
+	}
+	for _, opts := range []Options{OptSpeed, OptBalanced, OptCompression, OptBalanced | OptColumnIndex} {
+		blob, err := Marshal(rows, opts)
+		if err != nil {
+			t.Fatalf("%v: %v", opts, err)
+		}
+		var proj []r
+		if err := UnmarshalColumns(blob, &proj, "ID", "Tags"); err != nil {
+			t.Fatalf("%v: %v", opts, err)
+		}
+		if len(proj) != len(rows) {
+			t.Fatalf("%v: %d rows", opts, len(proj))
+		}
+		if !reflect.DeepEqual(proj[0].Tags, rows[0].Tags) {
+			t.Fatalf("%v: column projection ate map entries: %v", opts, proj[0].Tags)
+		}
+	}
+}
+
+// TestUnmarshalKeysSkipKeepsInternState pins the third bug: Skip ran with the
+// filter still live, so a skipped columnar value byte-skipped its columns
+// instead of replaying them, and the intern/shape registrations inside were
+// lost — later WANTED values then failed with an unknown state id, or decoded
+// as garbage.
+func TestUnmarshalKeysSkipKeepsInternState(t *testing.T) {
+	type inner struct {
+		Name string
+		Tag  string
+	}
+	const shared = "interned-payload-string"
+	rows := make([]inner, 40)
+	for i := range rows {
+		rows[i] = inner{Name: "row" + strconv.Itoa(i), Tag: shared}
+	}
+	tail := make([]string, 40)
+	for i := range tail {
+		tail[i] = shared
+	}
+	m := map[string]any{"aaa": rows, "bbb": tail, "ccc": rows, "zzz": tail}
+	for _, opts := range []Options{OptBalanced, OptBalanced | OptColumnIndex, OptCompression} {
+		blob, err := Marshal(m, opts)
+		if err != nil {
+			t.Fatalf("%v: %v", opts, err)
+		}
+		var full, proj map[string]any
+		if err := Unmarshal(blob, &full); err != nil {
+			t.Fatal(err)
+		}
+		if err := UnmarshalKeys(blob, &proj, "zzz"); err != nil {
+			t.Fatalf("%v: skipping earlier values broke decoder state: %v", opts, err)
+		}
+		if !reflect.DeepEqual(proj["zzz"], full["zzz"]) {
+			t.Fatalf("%v: projected value corrupted by skipped state: %v", opts, proj["zzz"])
+		}
+	}
+}
+
+// TestUnmarshalKeysLargeFilter pins the complexity fix: a big key list must not
+// turn the projection into O(keys x entries) — entry counts are data-driven.
+func TestUnmarshalKeysLargeFilter(t *testing.T) {
+	const n = 4000
+	m := make(map[string]int64, n)
+	keys := make([]string, 0, n/2)
+	for i := range n {
+		k := "k" + strconv.Itoa(i)
+		m[k] = int64(i)
+		if i%2 == 0 {
+			keys = append(keys, k)
+		}
+	}
+	blob, err := Marshal(m, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]int64
+	if err := UnmarshalKeys(blob, &got, keys...); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != n/2 {
+		t.Fatalf("got %d entries, want %d", len(got), n/2)
+	}
+	if got["k100"] != 100 || got["k3998"] != 3998 {
+		t.Fatal("wrong values")
+	}
+}


### PR DESCRIPTION
## Summary

`UnmarshalKeys(data, out, keys...)` decodes only the named keys of a string-keyed map payload, calling `Skip` on every other entry's value.

This is the projection path for payloads whose member names are **dynamic** — a model checkpoint keyed by tensor name, a metrics blob keyed by series — where the typed-subset-struct trick (which `Unmarshal` already projects through `Skip`) cannot be written ahead of time.

| Load 2 tensors of 64 | Time | Speedup |
|---|---|---|
| full `Unmarshal` | 1.37 ms | 1× |
| `UnmarshalKeys` | 49.9 µs | **27×** |

Under `OptRANS` the gain drops to ~2×: the entropy pass must inflate the whole message before any entry can be skipped. That is inherent and documented on the API.

**Measured but deliberately not built:** a plain struct with one field per tensor *already* projects through `Skip` — 20× for one-of-24, 133–588× for metadata-only. That pattern needs no code and stays the recommendation when names are static. The `[]struct{Name; W}` shape does not project (row-major); left alone.

## Bugs found by adversarial review of the first cut, fixed here

The first cut shared one filter field between column names and map keys, and cleared it per selected value instead of once per map. That produced three silent-data-loss bugs:

1. A selected value containing a columnar `[]struct` had the outer **key** list matched against its **column** names — every column dropped, no error.
2. **Regression against a shipped API:** `UnmarshalColumns` started dropping entries from string-keyed map fields of the projected rows. Reproduced against `HEAD` to confirm it was new.
3. `Skip` ran with the filter live, so skipping a columnar value byte-skipped its columns instead of replaying them, losing the intern/shape registrations inside — later *wanted* values then failed with an unknown state id, or decoded as another entry's data.

The projection now has its own decoder field, is consumed **once** by the root map's loop, and is only armed when the target actually roots a map (a non-map root is rejected rather than letting the filter drift to a map nested at arbitrary depth).

Two secondary findings fixed: an empty-but-non-nil filter silently dropped everything (`len` check, in `wantField` too), and the linear key scan made a large filter O(keys × entries) — 20k keys over 20k entries measured **126× slower** than a full decode, now **1.6×**, via a set above a threshold.

## Verification

Regression test for each of the three bugs; the nested-map scoping test is verified non-vacuous by mutation. Review's clean vectors: 12 payload shapes × 10 option sets round-trip equivalence, 4000 mutations × 10 option sets + 24.7M-exec fuzz with zero panics, pooled-decoder hygiene under `-race`, and `go generate` reproducing the committed generated file byte-for-byte (17 string-keyed pairs project, 10 non-string-keyed untouched).

