### PR TITLE
fix(alp): reconstruct decimal blocks exactly instead of by inverse multiply

### DIFF
--- a/qpack_alp.go
+++ b/qpack_alp.go
@@ -32,6 +32,26 @@ func init() {
 	}
 }
 
+// alpExactFlag marks, in the wire's exponent byte, that the block reconstructs
+// values by DIVIDING the integer mantissa by 10^d rather than multiplying it
+// by a precomputed 1/10^d.
+//
+// Multiplying by the inverse is an approximation: 1/10^d is not representable,
+// so the map I -> I*(1/10^d) misses many doubles that are exactly round(x,d).
+// Measured over decimal columns, 13-35% of perfectly representable values
+// failed the encoder's round-trip check and were stored as raw exceptions,
+// which is what actually dominated the block size (a 2-decimal price column
+// spent 11 KB on the packed body and 14 KB on 1087 spurious exceptions).
+// Dividing by the exactly-representable 10^d is correctly rounded and has zero
+// false exceptions; it measured ~3% slower on the decode loop, which is
+// memory-bound rather than divider-bound.
+//
+// The flag lives in the high bit of the exponent byte because a decoder that
+// predates it validates that byte against alpMaxExp (18) and returns ErrBadTag
+// — a loud failure rather than silently different values. New decoders read
+// both forms, so every blob ever written stays readable.
+const alpExactFlag = 0x80
+
 // alpMaxExpSearch caps the effective-exponent search. 0..15 covers every
 // practical decimal resolution; 16..18 only ever add exceptions.
 const alpMaxExpSearch = 15
@@ -48,36 +68,87 @@ type alpFloatPlan struct {
 	forMin int64 // FOR reference of the non-exception integer mantissas
 	width  uint8 // bits per packed element, 0..56
 	exc    int   // exception count
+	// exact selects DIVISION by 10^d over multiplication by a precomputed
+	// 1/10^d when reconstructing. Division is correctly rounded and costs no
+	// false exceptions, but it is a newer wire form (alpExactFlag) and a few
+	// percent slower to decode — so it is only chosen when it actually
+	// removes exceptions. Columns that score identically keep the original
+	// multiply form: same bytes, same speed, readable by older decoders.
+	exact bool
+}
+
+// alpRoundTrips reports whether the integer mantissa iv reconstructs v exactly
+// under the block's chosen operation. Encoder and decoder MUST agree on it —
+// that is what the exponent byte's alpExactFlag carries.
+func alpRoundTrips(iv int64, v, pe float64, exact bool) bool {
+	if exact {
+		return math.Float64bits(float64(iv)/pe) == math.Float64bits(v)
+	}
+	return math.Float64bits(float64(iv)*(1/pe)) == math.Float64bits(v)
 }
 
 // alpScoreExp evaluates one effective exponent d over s: returns the FOR min,
 // bit width, exception count. Round-trip uses exact float64 equality.
-func alpScoreExp(s []float64, d int) (forMin int64, width uint8, exc int) {
+func alpScoreExp(s []float64, d int) (forMin int64, width uint8, exc int, exact bool) {
 	pe := alpPow10[d]
 	ie := alpInv10[d]
-	mn := int64(math.MaxInt64)
-	mx := int64(math.MinInt64)
+	// Score both reconstructions in one pass. They accept DIFFERENT sets of
+	// values, so each needs its own FOR range: pairing one op's range with the
+	// other op's accepted set yields a width wider than necessary (measured
+	// +167 B on the IoT benchmark when the ranges were shared).
+	mnDiv, mxDiv := int64(math.MaxInt64), int64(math.MinInt64)
+	mnMul, mxMul := int64(math.MaxInt64), int64(math.MinInt64)
+	excDiv, excMul := 0, 0
 	for _, v := range s {
-		I := int64(math.RoundToEven(v * pe))
-		// Bit-exact round-trip check. Arithmetic == would treat -0.0 as equal
+		iv := int64(math.RoundToEven(v * pe))
+		bv := math.Float64bits(v)
+		// Bit-exact round-trip checks. Arithmetic == would treat -0.0 as equal
 		// to +0.0 and silently drop the sign bit, and NaN != NaN; comparing
 		// bits makes -0.0/NaN/±Inf land in the exception list as the spec
 		// requires (exact float64 bit equality).
-		if math.Float64bits(float64(I)*ie) != math.Float64bits(v) {
-			exc++
-			continue
+		if math.Float64bits(float64(iv)/pe) == bv {
+			mnDiv = min(mnDiv, iv)
+			mxDiv = max(mxDiv, iv)
+		} else {
+			excDiv++
 		}
-		if I < mn {
-			mn = I
+		if math.Float64bits(float64(iv)*ie) == bv {
+			mnMul = min(mnMul, iv)
+			mxMul = max(mxMul, iv)
+		} else {
+			excMul++
 		}
-		if I > mx {
-			mx = I
+	}
+	// Choose the reconstruction by BYTES, not by exception ratio. The two ops
+	// accept different value sets, so each implies its own FOR width as well
+	// as its own exception count — scoring only the counts let a single
+	// exception flip a 40% size difference, took the exact form for zero gain
+	// on short blocks, and once picked a form 2.17x LARGER because the values
+	// only division accepts forced the FOR width from 12 to 50 bits.
+	//
+	// An exception costs a varuint position plus the raw 8-byte value; 13 is
+	// the same conservative charge alpPlanFloat64's estimate uses. Ties go to
+	// multiplication: same bytes, slightly faster decode, and readable by
+	// decoders that predate alpExactFlag.
+	const excBytes = 13
+	widthOf := func(lo, hi int64) int {
+		if lo > hi {
+			return 0
 		}
+		return bits.Len64(uint64(hi - lo))
+	}
+	wDiv, wMul := widthOf(mnDiv, mxDiv), widthOf(mnMul, mxMul)
+	costDiv := (wDiv*len(s)+7)/8 + excDiv*excBytes
+	costMul := (wMul*len(s)+7)/8 + excMul*excBytes
+	exact = costDiv < costMul
+	mn, mx, exc := mnMul, mxMul, excMul
+	if exact {
+		mn, mx, exc = mnDiv, mxDiv, excDiv
 	}
 	if mn > mx { // all exceptions
-		return 0, 0, exc
+		return 0, 0, exc, exact
 	}
-	return mn, uint8(bits.Len64(uint64(mx - mn))), exc
+	return mn, uint8(bits.Len64(uint64(mx - mn))), exc, exact
 }
 
 // alpChooseExp samples ~32 evenly-spaced values to pick the cheapest effective
@@ -95,7 +166,11 @@ func alpChooseExp(s []float64) int {
 	}
 	bestD, bestCost := 0, math.MaxInt // platform max sentinel (int, 32-bit safe)
 	for d := 0; d <= alpMaxExpSearch; d++ {
-		_, w, exc := alpScoreExp(sample, d)
+		// alpScoreExp returns the cheaper of the two reconstructions for this
+		// exponent, so costing its (w, exc) compares each exponent at its own
+		// optimum — mixing ops across exponents made the curve incomparable
+		// and once picked d=4 where d=2 was 52% smaller.
+		_, w, exc, _ := alpScoreExp(sample, d)
 		cost := (int(w)*len(sample)+7)/8 + exc*10
 		if cost < bestCost {
 			bestCost, bestD = cost, d
@@ -119,14 +194,14 @@ func alpPlanFloat64(s []float64) (plan alpFloatPlan, estBytes int, ok bool) {
 		return alpFloatPlan{}, 0, false // too large; raw/Gorilla (buffer-bounded) handle it
 	}
 	d := alpChooseExp(s)
-	forMin, width, exc := alpScoreExp(s, d)
+	forMin, width, exc, exact := alpScoreExp(s, d)
 	if width > qpackForMaxBits {
 		return alpFloatPlan{}, 0, false
 	}
 	if exc >= n { // nothing packs; raw/Gorilla strictly better
 		return alpFloatPlan{}, 0, false
 	}
-	plan = alpFloatPlan{d: d, forMin: forMin, width: width, exc: exc}
+	plan = alpFloatPlan{d: d, forMin: forMin, width: width, exc: exc, exact: exact}
 	body := (int(width)*n + 7) / 8
 	estBytes = 2 + uvarintLen(uint64(n)) + 1 + uvarintLen(zigzagEncode64(forMin)) +
 		1 + body + uvarintLen(uint64(exc)) + exc*(5+8)
@@ -145,12 +220,15 @@ func (e *Encoder) writePackedALPFloat64Slice(s []float64, plan alpFloatPlan) {
 		e.buf = out
 		return
 	}
-	out = append(out, byte(plan.d))
+	expByte := byte(plan.d)
+	if plan.exact {
+		expByte |= alpExactFlag
+	}
+	out = append(out, expByte)
 	out = appendUvarint(out, zigzagEncode64(plan.forMin))
 	out = append(out, plan.width)
 
 	pe := alpPow10[plan.d]
-	ie := alpInv10[plan.d]
 
 	// Acquire exception-index scratch. Populated during the pack pass so the
 	// exception-emit phase below never needs a second O(n) re-scan of s.
@@ -168,7 +246,7 @@ func (e *Encoder) writePackedALPFloat64Slice(s []float64, plan alpFloatPlan) {
 		clear(packed)
 		for i, v := range s {
 			I := int64(math.RoundToEven(v * pe))
-			if math.Float64bits(float64(I)*ie) == math.Float64bits(v) {
+			if alpRoundTrips(I, v, pe, plan.exact) {
 				packed[i] = uint64(I - plan.forMin)
 			} else {
 				excIdx = append(excIdx, i) // collect exception index for emit below
@@ -187,7 +265,7 @@ func (e *Encoder) writePackedALPFloat64Slice(s []float64, plan alpFloatPlan) {
 		// for the emit pass below.
 		for i, v := range s {
 			I := int64(math.RoundToEven(v * pe))
-			if math.Float64bits(float64(I)*ie) != math.Float64bits(v) {
+			if !alpRoundTrips(I, v, pe, plan.exact) {
 				excIdx = append(excIdx, i)
 			}
 		}
@@ -298,6 +376,9 @@ func alpPlanFloat32(s []float32) (plan alpFloatPlan, estBytes int, ok bool) {
 	if exc >= n {
 		return alpFloatPlan{}, 0, false
 	}
+	// float32 keeps the original multiply reconstruction: its 24-bit
+	// mantissa loses far less to the inverse approximation than float64's 53,
+	// and leaving it alone keeps every f32 blob byte-identical.
 	plan = alpFloatPlan{d: d, forMin: forMin, width: width, exc: exc}
 	body := (int(width)*n + 7) / 8
 	estBytes = 2 + uvarintLen(uint64(n)) + 1 + uvarintLen(zigzagEncode64(forMin)) +
@@ -316,6 +397,10 @@ func (e *Encoder) writePackedALPFloat32Slice(s []float32, plan alpFloatPlan) {
 		e.buf = out
 		return
 	}
+	// float32 always reconstructs by multiplication (alpMantissaF32 is the
+	// only predicate its pack loop uses), so the exponent byte never carries
+	// alpExactFlag — stamping it here would let the reader divide while the
+	// writer multiplied.
 	out = append(out, byte(plan.d))
 	out = appendUvarint(out, zigzagEncode64(plan.forMin))
 	out = append(out, plan.width)
@@ -399,7 +484,9 @@ func (d *Decoder) readPackedALPFloat32Slice() ([]float32, error) {
 	if d.i >= len(d.buf) {
 		return nil, ErrShortBuffer
 	}
-	expD := int(d.buf[d.i])
+	rawExp := d.buf[d.i]
+	exact := rawExp&alpExactFlag != 0
+	expD := int(rawExp &^ alpExactFlag)
 	d.i++
 	if expD > alpMaxExp {
 		return nil, ErrBadTag
@@ -424,6 +511,7 @@ func (d *Decoder) readPackedALPFloat32Slice() ([]float32, error) {
 	}
 	n := int(n64)
 	ie := alpInv10[expD]
+	pe := alpPow10[expD]
 	out := make([]float32, n)
 	if width > 0 {
 		bodyBytes := int((n64*uint64(width) + 7) / 8)
@@ -433,15 +521,28 @@ func (d *Decoder) readPackedALPFloat32Slice() ([]float32, error) {
 		packed := d.deltaScratch[:n]
 		bitpack.Unpack(packed, d.buf[d.i:d.i+bodyBytes], width)
 		d.i += bodyBytes
-		for i := range out {
-			v := int64(packed[i])
-			if (forMin > 0 && v > math.MaxInt64-forMin) || (forMin < 0 && v < math.MinInt64-forMin) {
-				return nil, ErrInvalidLength
+		if exact { // see the float64 twin: branch hoisted out of the loop
+			for i := range out {
+				v := int64(packed[i])
+				if (forMin > 0 && v > math.MaxInt64-forMin) || (forMin < 0 && v < math.MinInt64-forMin) {
+					return nil, ErrInvalidLength
+				}
+				out[i] = float32(float64(v+forMin) / pe)
 			}
-			out[i] = float32(float64(v+forMin) * ie)
+		} else {
+			for i := range out {
+				v := int64(packed[i])
+				if (forMin > 0 && v > math.MaxInt64-forMin) || (forMin < 0 && v < math.MinInt64-forMin) {
+					return nil, ErrInvalidLength
+				}
+				out[i] = float32(float64(v+forMin) * ie)
+			}
 		}
 	} else {
 		fv := float32(float64(forMin) * ie)
+		if exact {
+			fv = float32(float64(forMin) / pe)
+		}
 		for i := range out {
 			out[i] = fv
 		}
@@ -508,7 +609,9 @@ func (d *Decoder) readPackedALPFloat64Slice() ([]float64, error) {
 	if d.i >= len(d.buf) {
 		return nil, ErrShortBuffer
 	}
-	expD := int(d.buf[d.i])
+	rawExp := d.buf[d.i]
+	exact := rawExp&alpExactFlag != 0
+	expD := int(rawExp &^ alpExactFlag)
 	d.i++
 	if expD > alpMaxExp {
 		return nil, ErrBadTag
@@ -534,6 +637,7 @@ func (d *Decoder) readPackedALPFloat64Slice() ([]float64, error) {
 	}
 	n := int(n64)
 	ie := alpInv10[expD]
+	pe := alpPow10[expD]
 	out := make([]float64, n)
 	if width > 0 {
 		bodyBytes := int((n64*uint64(width) + 7) / 8)
@@ -548,15 +652,31 @@ func (d *Decoder) readPackedALPFloat64Slice() ([]float64, error) {
 		packed := d.deltaScratch[:n]
 		bitpack.Unpack(packed, d.buf[d.i:d.i+bodyBytes], width)
 		d.i += bodyBytes
-		for i := range out {
-			v := int64(packed[i])
-			if (forMin > 0 && v > math.MaxInt64-forMin) || (forMin < 0 && v < math.MinInt64-forMin) {
-				return nil, ErrInvalidLength
+		// Two loops rather than a branch per element: the reconstruction op is
+		// fixed for the whole block, and testing it inside the loop measured
+		// +13% on decode.
+		if exact {
+			for i := range out {
+				v := int64(packed[i])
+				if (forMin > 0 && v > math.MaxInt64-forMin) || (forMin < 0 && v < math.MinInt64-forMin) {
+					return nil, ErrInvalidLength
+				}
+				out[i] = float64(v+forMin) / pe
 			}
-			out[i] = float64(v+forMin) * ie
+		} else {
+			for i := range out {
+				v := int64(packed[i])
+				if (forMin > 0 && v > math.MaxInt64-forMin) || (forMin < 0 && v < math.MinInt64-forMin) {
+					return nil, ErrInvalidLength
+				}
+				out[i] = float64(v+forMin) * ie
+			}
 		}
 	} else {
 		fv := float64(forMin) * ie
+		if exact {
+			fv = float64(forMin) / pe
+		}
 		for i := range out {
 			out[i] = fv
 		}

--- a/qpack_alp_test.go
+++ b/qpack_alp_test.go
@@ -2,6 +2,7 @@ package qdf
 
 import (
 	"math"
+	"math/bits"
 	"math/rand"
 	"testing"
 )
@@ -225,5 +226,243 @@ func TestALPSkip(t *testing.T) {
 	}
 	if d.i != len(payload) {
 		t.Fatalf("Skip left cursor at %d, want %d (full payload consumed)", d.i, len(payload))
+	}
+}
+
+// TestALPExactReconstruction pins the reason the exact (division) form exists:
+// multiplying the integer mantissa by a precomputed 1/10^d is an
+// approximation, so perfectly representable decimals failed the round-trip
+// check and were stored raw. A 2-decimal column measured 1087 spurious
+// exceptions out of 8192; the exact form must have none.
+func TestALPExactReconstruction(t *testing.T) {
+	const n = 8192
+	rng := rand.New(rand.NewSource(9))
+	for _, beta := range []int{1, 2, 3, 4} {
+		data := make([]float64, n)
+		p := math.Pow(10, float64(beta))
+		v := 42.5
+		for i := range data {
+			v += float64(rng.Intn(21)-10) / p
+			data[i] = math.Round(v*p) / p
+		}
+		plan, _, ok := alpPlanFloat64(data)
+		if !ok {
+			t.Fatalf("beta=%d: ALP declined a pure decimal column", beta)
+		}
+		// -0.0 and non-finites are exceptions BY DESIGN (the integer mantissa
+		// cannot carry the sign of zero), so the exact form's promise is that
+		// nothing else is.
+		special := 0
+		for _, x := range data {
+			if math.Signbit(x) && x == 0 || math.IsNaN(x) || math.IsInf(x, 0) {
+				special++
+			}
+		}
+		if plan.exc != special {
+			t.Fatalf("beta=%d: %d exceptions, only %d are -0.0/non-finite — the rest are spurious",
+				beta, plan.exc, special)
+		}
+		enc := NewEncoder(Fast)
+		enc.writePackedALPFloat64Slice(data, plan)
+		dec := NewDecoderOnBuf(enc.buf)
+		if _, err := dec.peekTag(); err != nil {
+			t.Fatal(err)
+		}
+		dec.i++
+		got, err := dec.readPackedALPFloat64Slice()
+		if err != nil {
+			t.Fatalf("beta=%d: %v", beta, err)
+		}
+		for i := range data {
+			if math.Float64bits(got[i]) != math.Float64bits(data[i]) {
+				t.Fatalf("beta=%d: value %d not bit-exact", beta, i)
+			}
+		}
+	}
+}
+
+// TestALPExactFlagIsLoadBearing: decoding an exact-form body through the
+// legacy multiply path must produce DIFFERENT values — which is why a decoder
+// that predates the flag has to reject the blob (it validates the exponent
+// byte against alpMaxExp and returns ErrBadTag) rather than guess.
+func TestALPExactFlagIsLoadBearing(t *testing.T) {
+	const n = 4096
+	rng := rand.New(rand.NewSource(3))
+	data := make([]float64, n)
+	v := 42.5
+	for i := range data {
+		v += float64(rng.Intn(21)-10) / 100
+		data[i] = math.Round(v*100) / 100
+	}
+	plan, _, ok := alpPlanFloat64(data)
+	if !ok {
+		t.Skip("ALP declined")
+	}
+	enc := NewEncoder(Fast)
+	enc.writePackedALPFloat64Slice(data, plan)
+	blob := append([]byte(nil), enc.buf...)
+	stripped := append([]byte(nil), blob...)
+	found := false
+	for i := 0; i+1 < len(stripped); i++ {
+		if stripped[i] == tagPackALP && stripped[i+1] == qpackKindFloat64 {
+			_, nr := readUvarint(stripped[i+2:])
+			if stripped[i+2+nr]&alpExactFlag == 0 {
+				continue
+			}
+			stripped[i+2+nr] &^= alpExactFlag
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Skip("no flagged ALP block on the wire")
+	}
+	d := NewDecoderOnBuf(stripped)
+	if _, err := d.peekTag(); err != nil {
+		t.Fatal(err)
+	}
+	d.i++
+	old, err := d.readPackedALPFloat64Slice()
+	if err != nil {
+		t.Fatalf("legacy path errored: %v", err)
+	}
+	diff := 0
+	for i := range data {
+		if math.Float64bits(old[i]) != math.Float64bits(data[i]) {
+			diff++
+		}
+	}
+	if diff == 0 {
+		t.Fatal("legacy and exact paths agree; the flag would be pointless")
+	}
+}
+
+// TestALPChoosesCheaperReconstruction pins the invariant that the whole
+// exact/multiply choice rests on: the block must take whichever reconstruction
+// costs FEWER BYTES, counting both the FOR width its accepted set implies and
+// its exceptions. Scoring only the exception counts produced three separate
+// regressions — a one-exception ratio cliff flipping a 40% size difference,
+// short blocks taking the newer wire form for zero gain, and a case where the
+// values only division accepts widened FOR from 12 to 50 bits and the "better"
+// form came out 2.17x larger.
+func TestALPChoosesCheaperReconstruction(t *testing.T) {
+	rng := rand.New(rand.NewSource(4))
+	mkNoisy := func(n, pct int) []float64 {
+		s := make([]float64, n)
+		v := 100.0
+		for i := range s {
+			v += (rng.Float64() - 0.5) * 2
+			if rng.Intn(100) < pct {
+				s[i] = v + rng.NormFloat64()*1e-7
+			} else {
+				s[i] = math.Round(v*100) / 100
+			}
+		}
+		return s
+	}
+	// Values only division accepts, planted so they widen the FOR range hard.
+	planted := make([]float64, 5000)
+	for i := range planted {
+		planted[i] = math.Round(rng.Float64()*4095) / 100
+	}
+	for i := range 12 {
+		planted[i*400] = float64(int64(1)<<49) / 100
+	}
+	corpus := map[string][]float64{
+		"noisy_5":  mkNoisy(3000, 5),
+		"noisy_10": mkNoisy(3000, 10),
+		"noisy_25": mkNoisy(3000, 25),
+		"planted":  planted,
+		"pure_2dp": mkNoisy(3000, 0),
+		"short_32": mkNoisy(32, 0),
+		"sensor":   mkSensor(2048, 7),
+		"allsame":  make([]float64, 512),
+	}
+	const excBytes = 13
+	for name, data := range corpus {
+		plan, _, ok := alpPlanFloat64(data)
+		if !ok {
+			continue
+		}
+		// Re-derive both candidates at the chosen exponent and confirm the plan
+		// took the cheaper one, with ties going to multiply (older wire, faster
+		// decode).
+		pe, ie := alpPow10[plan.d], alpInv10[plan.d]
+		var mnD, mxD, mnM, mxM int64 = math.MaxInt64, math.MinInt64, math.MaxInt64, math.MinInt64
+		excD, excM := 0, 0
+		for _, v := range data {
+			iv := int64(math.RoundToEven(v * pe))
+			bv := math.Float64bits(v)
+			if math.Float64bits(float64(iv)/pe) == bv {
+				mnD, mxD = min(mnD, iv), max(mxD, iv)
+			} else {
+				excD++
+			}
+			if math.Float64bits(float64(iv)*ie) == bv {
+				mnM, mxM = min(mnM, iv), max(mxM, iv)
+			} else {
+				excM++
+			}
+		}
+		width := func(lo, hi int64) int {
+			if lo > hi {
+				return 0
+			}
+			return bits.Len64(uint64(hi - lo))
+		}
+		costD := (width(mnD, mxD)*len(data)+7)/8 + excD*excBytes
+		costM := (width(mnM, mxM)*len(data)+7)/8 + excM*excBytes
+		wantExact := costD < costM
+		if plan.exact != wantExact {
+			t.Fatalf("%s: chose exact=%v but costs are div=%d mul=%d", name, plan.exact, costD, costM)
+		}
+		if !plan.exact && excM == excD && excM == 0 {
+			// Nothing to gain: must stay on the original wire form.
+			if plan.exact {
+				t.Fatalf("%s: took the newer wire form for zero gain", name)
+			}
+		}
+	}
+}
+
+// TestALPFloat32NeverFlagged: the float32 pack loop only ever uses the
+// multiply predicate, so its wire must never claim the exact form — a
+// mismatch there would have the reader divide what the writer multiplied.
+func TestALPFloat32NeverFlagged(t *testing.T) {
+	rng := rand.New(rand.NewSource(8))
+	for _, n := range []int{64, 1000, 4096} {
+		s := make([]float32, n)
+		v := float32(12.0)
+		for i := range s {
+			v += float32(rng.Intn(21)-10) / 100
+			s[i] = float32(math.Round(float64(v)*100) / 100)
+		}
+		plan, _, ok := alpPlanFloat32(s)
+		if !ok {
+			continue
+		}
+		if plan.exact {
+			t.Fatalf("n=%d: float32 plan claims the exact form", n)
+		}
+		e := NewEncoder(Fast)
+		e.MarkHeaderWritten()
+		e.writePackedALPFloat32Slice(s, plan)
+		// exponent byte sits after tag, kind, uvarint(n), first value
+		_, nr := readUvarint(e.buf[2:])
+		if e.buf[2+nr]&alpExactFlag != 0 {
+			t.Fatalf("n=%d: float32 wire carries alpExactFlag", n)
+		}
+		dec := NewDecoderOnBuf(e.buf)
+		dec.MarkHeaderRead()
+		dec.i++
+		got, err := dec.readPackedALPFloat32Slice()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range s {
+			if math.Float32bits(got[i]) != math.Float32bits(s[i]) {
+				t.Fatalf("n=%d: lossy at %d", n, i)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

ALP checked its round-trip with `I * (1/10^d)` and reconstructed the same way. `1/10^d` is not representable, so that map misses many doubles that **are** exactly `round(x, d)` — **13–35% of perfectly representable decimals** failed the check and were stored as raw exceptions. A 2-decimal price column spent 11 KB on the packed body and **14 KB on 1087 exceptions that should never have existed**. Dividing by the exactly-representable `10^d` is correctly rounded and produces none.

A block now takes whichever reconstruction costs **fewer bytes** — counting the FOR width its accepted set implies as well as its exceptions — with ties going to multiplication (original wire, slightly faster decode). The choice rides in the high bit of the exponent byte; a decoder that predates it validates that byte against `alpMaxExp` and returns `ErrBadTag`, so old readers fail loudly rather than producing different values.

## Numbers

| | before | after |
|---|---|---|
| pure decimal column (5000 vals) | 29,062 B | **12,513 B (−57%)** |
| traced 256-value decimal column | 716 B (Chimp) | **297 B** |
| corpus-wide `Marshal` total | 2,400,294 B | **2,156,796 B (−10.1%)** |
| decode | — | +3% in isolation (memory-bound loop) |

**Every existing golden fixture is byte-identical** — with the byte-cost gate none of them flips form. float32 is untouched.

## Found by measuring, not by planning

This came out of probing whether the **Elf** codec has a niche. Elf's erase-then-XOR does win 13–48% on decimal columns (and pairs with Gorilla, not Chimp — erasure makes trailing zeros, which Gorilla's window exploits), but fixing ALP beats Elf on the same corpora, so Elf is rejected with evidence.

## Review findings, all fixed here

Adversarial review found four bugs in the first cut, all from scoring exception **counts** instead of bytes — pinned now by `TestALPChoosesCheaperReconstruction`:

- the exponent chooser compared exponents scored under *different* reconstructions, once picking `d=4` where `d=2` was 52% smaller;
- a ratio cliff let **two** exceptions flip a 44% size difference;
- blocks shorter than 64 took the newer wire form for zero gain;
- a case where the values only division accepts widened FOR from 12 to 50 bits and the "better" form came out **2.17× larger**.

Plus a trap the review spotted: the float32 writer stamped the flag from a plan field its pack loop ignores, so a reader would have divided what the writer multiplied (`TestALPFloat32NeverFlagged`).

Verified clean: bit-exact losslessness across decimals/denormals/NaN payloads/±0/±Inf/near-2^53 under four option sets, `estBytes` still a true upper bound, ~100k hostile mutations with zero panics, both build lanes (`qdf_reflect2` included), fuzz.

## Known and accepted

The IoT benchmark grows **222 B (+0.17%)**: ALP now wins the float picker on columns where it previously lost, and for a few of them the alternative would have been marginally smaller — the picker weighs candidates in an order that predates this change. Documented rather than papered over; against −10% corpus-wide it is worth taking.

