### PR TITLE
perf(encode): stop rebuilding encoder buffers that a pooled encoder could have kept

### DIFF
--- a/columnar_select.go
+++ b/columnar_select.go
@@ -45,8 +45,8 @@ func (d *Decoder) wantField(name string) bool {
 // keyFilter is the consumed form of an UnmarshalKeys projection. The zero
 // value wants every key, so an absent filter costs one nil check.
 type keyFilter struct {
-	list []string
 	set  map[string]struct{} // built only for large lists, see takeKeyFilter
+	list []string
 }
 
 // keyFilterSetMin is where linear scanning stops paying. Map entry counts are

--- a/encbuf_hint_test.go
+++ b/encbuf_hint_test.go
@@ -160,15 +160,23 @@ func TestWideScratchSurvivesLargeColumns(t *testing.T) {
 		return (b.TotalAlloc - a.TotalAlloc) / runs
 	}
 
-	small := measure(mk(8192))   // comfortably under any ceiling
-	large := measure(mk(100000)) // over the former 1<<14, under the current 1<<17
+	const largeN = 100000 // over the former 1<<14 ceiling, under the current 1<<17
+	small := measure(mk(8192))
+	large := measure(mk(largeN))
 
-	// The large column's own output is bigger, so some growth is expected; a
-	// dropped-and-rebuilt scratch shows up as growth proportional to the column
-	// (12x the elements would mean ~800 KB of widening scratch per message).
-	if limit := small + 300_000; large > limit {
-		t.Errorf("large column allocates %d B/op vs %d B/op for a small one (limit %d) — the widening scratch is being dropped every message",
-			large, small, limit)
+	// The scratch is []uint64, so dropping and rebuilding it costs exactly 8
+	// bytes per element per message. Bound the whole message by that figure:
+	// well above what the column legitimately allocates, well below what it
+	// costs to rebuild the scratch on top of that.
+	//
+	// The bound is absolute rather than a multiple of the small column because
+	// -race inflates every allocation, and by different factors on different
+	// runners. Measured per element: 2.1 B fixed without -race, up to 6.0 B
+	// fixed under it, against 10.2 B with the ceiling back at 1<<14 — so 8 B
+	// separates the two regimes in both modes.
+	if limit := uint64(8 * largeN); large > limit {
+		t.Errorf("a %d-element column allocates %d B/op (limit %d, small column %d) — the widening scratch is being dropped every message",
+			largeN, large, limit, small)
 	}
-	t.Logf("8192 elems: %d B/op   100000 elems: %d B/op", small, large)
+	t.Logf("8192 elems: %d B/op   %d elems: %d B/op (%.1f B/elem)", small, largeN, large, float64(large)/largeN)
 }

--- a/encbuf_hint_test.go
+++ b/encbuf_hint_test.go
@@ -1,0 +1,120 @@
+package qdf
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+type hintRow struct {
+	A string
+	B int64
+	C float64
+	D []string
+	E map[string]string
+	F []float64
+	G bool
+}
+
+func mkHintRows(n int) []hintRow {
+	out := make([]hintRow, n)
+	svc := []string{"api", "worker", "cron", "db"}
+	for i := range out {
+		out[i] = hintRow{
+			A: "/v1/resource/" + svc[i%4],
+			B: int64(i * 7),
+			C: float64(i) * 1.25,
+			D: []string{svc[i%4], svc[(i+1)%4]},
+			E: map[string]string{"svc": svc[i%4], "lvl": "info"},
+			F: []float64{float64(i), float64(i) * 0.5},
+			G: i%3 == 0,
+		}
+	}
+	return out
+}
+
+// wantHintWireDigest pins the encoding of the corpus below. The output-buffer
+// size hint decides how the buffer is allocated and must never touch a byte of
+// what is written into it, so this digest is the same with the hint and with it
+// removed — verified both ways when it was introduced.
+//
+// A change here means the wire format moved, which breaks every already-encoded
+// payload. Update it only alongside a note saying why the break is intended.
+const wantHintWireDigest = "bb7d614b06b3fea25eef90638abeef843318c40573df68e5c441d37044433ecf"
+
+func TestEncBufHintWireIdentity(t *testing.T) {
+	h := sha256.New()
+	// Sizes straddle marshalDetachThreshold so both the clone path and the
+	// detach path — the one the hint touches — are covered.
+	for _, n := range []int{16, 1024, 8192, 40000} {
+		v := mkHintRows(n)
+		// OptCanonical throughout: the payload carries a map[string]string, and
+		// without it Go's randomised map iteration changes the bytes every run,
+		// which would leave this digest unable to fail for a real reason.
+		for _, base := range []Options{OptSpeed, OptBalanced, OptQPack, OptCompression} {
+			o := base | OptCanonical
+			blob, err := Marshal(v, o)
+			if err != nil {
+				t.Fatalf("n=%d opts=%v: %v", n, o, err)
+			}
+			h.Write(blob)
+			ab, err := AppendMarshal(nil, v, o) // shares the detach sites
+			if err != nil {
+				t.Fatalf("append n=%d opts=%v: %v", n, o, err)
+			}
+			h.Write(ab)
+		}
+	}
+	if got := hex.EncodeToString(h.Sum(nil)); got != wantHintWireDigest {
+		t.Errorf("wire digest changed:\n got %s\nwant %s\nsee the note on wantHintWireDigest", got, wantHintWireDigest)
+	}
+}
+
+// TestEncBufHintDecays pins the half of noteDetached that is easy to lose: the
+// hint must follow the workload DOWN as well as up. Without the decay, one large
+// message sets a high-water mark that every later small message allocates at,
+// handing the caller a small slice backed by a large array for as long as that
+// encoder lives.
+//
+// Driven directly rather than through Marshal: the encoder pool hands out
+// whichever instance it likes, so a payload-level test mostly measures encoders
+// that never saw the large message and passes whether the decay works or not.
+func TestEncBufHintDecays(t *testing.T) {
+	var e Encoder
+
+	// A large message detaches and sets the mark.
+	big := make([]byte, 4<<20)
+	e.noteDetached(big)
+	peak := e.bufHint
+	if peak != len(big) {
+		t.Fatalf("hint did not adopt the large message: got %d want %d", peak, len(big))
+	}
+
+	const smallLen = 512
+	// Small messages that fit must walk it back down. Each iteration mirrors
+	// what resetForReuse does: the next buffer is allocated at exactly the
+	// current hint, so its capacity tracks the hint rather than staying pinned
+	// at the peak.
+	for range 64 {
+		e.noteDetached(make([]byte, smallLen, e.bufHint))
+	}
+	if e.bufHint >= peak {
+		t.Fatalf("hint did not decay: still %d after 64 small messages (peak %d)", e.bufHint, peak)
+	}
+	if e.bufHint < smallLen {
+		t.Errorf("hint decayed below what the data used: %d < %d", e.bufHint, smallLen)
+	}
+	t.Logf("hint %d -> %d", peak, e.bufHint)
+
+	// And it must rise again at once when a message outgrows it.
+	e.noteDetached(make([]byte, 8<<20))
+	if e.bufHint != 8<<20 {
+		t.Errorf("hint did not rise to a larger message: got %d", e.bufHint)
+	}
+
+	// An outlier must never be adopted past the pool's own retention ceiling.
+	e.noteDetached(make([]byte, maxPooledBuf*4))
+	if e.bufHint > maxPooledBuf {
+		t.Errorf("hint exceeded maxPooledBuf: %d", e.bufHint)
+	}
+}

--- a/encbuf_hint_test.go
+++ b/encbuf_hint_test.go
@@ -80,54 +80,56 @@ func TestEncBufHintWireIdentity(t *testing.T) {
 // Driven directly rather than through Marshal: the encoder pool hands out
 // whichever instance it likes, so a payload-level test mostly measures encoders
 // that never saw the large message and passes whether the decay works or not.
-func TestEncBufHintDecays(t *testing.T) {
+// TestEncBufHintTracksTheWorkload pins what noteDetached and resetForReuse
+// promise each other. Driven directly rather than through Marshal — the encoder
+// pool hands out whichever instance it likes, so a payload-level test mostly
+// measures encoders that never saw the message it set up and passes either way.
+func TestEncBufHintTracksTheWorkload(t *testing.T) {
 	var e Encoder
 
-	// A large message detaches and sets the mark.
-	big := make([]byte, 4<<20)
-	e.noteDetached(big)
-	peak := e.bufHint
-	if peak != len(big) {
-		t.Fatalf("hint did not adopt the large message: got %d want %d", peak, len(big))
+	// The hint is the capacity the message needed, not the bytes it delivered:
+	// the codec picker writes candidate encodings and rewinds the losers, so the
+	// peak sits above the output and sizing to the output alone would make every
+	// message grow once.
+	const big = 1 << 20
+	e.noteDetached(make([]byte, big/2, big))
+	if e.bufHint != big {
+		t.Fatalf("hint did not adopt what the message needed: got %d want %d", e.bufHint, big)
 	}
 
-	const smallLen = 512
-	// Small messages that fit must walk it back down. Each iteration mirrors
-	// what resetForReuse does: the next buffer is allocated at exactly the
-	// current hint, so its capacity tracks the hint rather than staying pinned
-	// at the peak.
-	for range 64 {
-		e.noteDetached(make([]byte, smallLen, e.bufHint))
-	}
-	if e.bufHint >= peak {
-		t.Fatalf("hint did not decay: still %d after 64 small messages (peak %d)", e.bufHint, peak)
-	}
-	if e.bufHint < smallLen {
-		t.Errorf("hint decayed below what the data used: %d < %d", e.bufHint, smallLen)
-	}
-	t.Logf("hint %d -> %d", peak, e.bufHint)
-
-	// And it must rise again at once when a message outgrows it.
-	e.noteDetached(make([]byte, 8<<20))
-	if e.bufHint != 8<<20 {
-		t.Errorf("hint did not rise to a larger message: got %d", e.bufHint)
-	}
-
-	// An outlier must never be adopted past the pool's own retention ceiling.
-	e.noteDetached(make([]byte, maxPooledBuf*4))
-	if e.bufHint > maxPooledBuf {
-		t.Errorf("hint exceeded maxPooledBuf: %d", e.bufHint)
+	// And it follows the workload down, or one large message would leave every
+	// later small one allocating at its size — handing the caller a small slice
+	// backed by a large array for as long as that encoder lives.
+	const small = 4096
+	e.noteDetached(make([]byte, 512, small))
+	if e.bufHint != small {
+		t.Errorf("hint did not follow the workload down: got %d want %d", e.bufHint, small)
 	}
 }
 
-// TestWideScratchSurvivesLargeColumns pins the retention ceiling for the
-// int32->int64 widening scratch. At its former value (1<<14) a []int32 field
-// just past 16384 elements was dropped from the pooled encoder and rebuilt on
-// every single message: measured 139492 B/op at 17000 elements against 414 B/op
-// at 16384, a 337x jump for 4% more data.
-//
-// The assertion is on shape, not on a tuned number — allocation per message
-// must not scale with the column once it passes the old ceiling.
+// TestEncBufHintSkipsLargePayloads pins the bound on where pre-allocating pays.
+// slices.Grow serves a large request with one right-sized allocation, so above
+// maxHintedBuf the doubling chain is already short and a pre-allocation is
+// either overshoot or an undershoot that doubles on top — measured 18.3 MB/op
+// unhinted against 21.9 hinted on a 17.9 MB batch.
+func TestEncBufHintSkipsLargePayloads(t *testing.T) {
+	var e Encoder
+
+	e.bufHint = maxHintedBuf
+	e.buf = nil
+	e.resetForReuse()
+	if cap(e.buf) != maxHintedBuf {
+		t.Errorf("a hint at the bound should still pre-allocate: cap %d want %d", cap(e.buf), maxHintedBuf)
+	}
+
+	e.bufHint = maxHintedBuf + 1
+	e.buf = nil
+	e.resetForReuse()
+	if cap(e.buf) != 0 {
+		t.Errorf("a hint past the bound should not pre-allocate: cap %d want 0", cap(e.buf))
+	}
+}
+
 func TestWideScratchSurvivesLargeColumns(t *testing.T) {
 	type wideCol struct {
 		Data []int32 `qdf:"data"`

--- a/encbuf_hint_test.go
+++ b/encbuf_hint_test.go
@@ -3,6 +3,7 @@ package qdf
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"runtime"
 	"testing"
 )
 
@@ -117,4 +118,55 @@ func TestEncBufHintDecays(t *testing.T) {
 	if e.bufHint > maxPooledBuf {
 		t.Errorf("hint exceeded maxPooledBuf: %d", e.bufHint)
 	}
+}
+
+// TestWideScratchSurvivesLargeColumns pins the retention ceiling for the
+// int32->int64 widening scratch. At its former value (1<<14) a []int32 field
+// just past 16384 elements was dropped from the pooled encoder and rebuilt on
+// every single message: measured 139492 B/op at 17000 elements against 414 B/op
+// at 16384, a 337x jump for 4% more data.
+//
+// The assertion is on shape, not on a tuned number — allocation per message
+// must not scale with the column once it passes the old ceiling.
+func TestWideScratchSurvivesLargeColumns(t *testing.T) {
+	type wideCol struct {
+		Data []int32 `qdf:"data"`
+	}
+	mk := func(n int) wideCol {
+		d := make([]int32, n)
+		for i := range d {
+			d[i] = int32(i * 3 % 100000)
+		}
+		return wideCol{Data: d}
+	}
+
+	measure := func(v wideCol) uint64 {
+		for range 50 { // let the pooled scratch settle
+			if _, err := Marshal(v, OptBalanced); err != nil {
+				t.Fatal(err)
+			}
+		}
+		var a, b runtime.MemStats
+		runtime.ReadMemStats(&a)
+		const runs = 100
+		for range runs {
+			if _, err := Marshal(v, OptBalanced); err != nil {
+				t.Fatal(err)
+			}
+		}
+		runtime.ReadMemStats(&b)
+		return (b.TotalAlloc - a.TotalAlloc) / runs
+	}
+
+	small := measure(mk(8192))   // comfortably under any ceiling
+	large := measure(mk(100000)) // over the former 1<<14, under the current 1<<17
+
+	// The large column's own output is bigger, so some growth is expected; a
+	// dropped-and-rebuilt scratch shows up as growth proportional to the column
+	// (12x the elements would mean ~800 KB of widening scratch per message).
+	if limit := small + 300_000; large > limit {
+		t.Errorf("large column allocates %d B/op vs %d B/op for a small one (limit %d) — the widening scratch is being dropped every message",
+			large, small, limit)
+	}
+	t.Logf("8192 elems: %d B/op   100000 elems: %d B/op", small, large)
 }

--- a/encoder.go
+++ b/encoder.go
@@ -124,6 +124,22 @@ type Encoder struct { // betteralign:ignore — hand-tuned for SIZE (200 vs 232 
 
 	buf []byte
 
+	// bufHint is the capacity the last detached output reached, carried on the
+	// pooled encoder so the next message allocates once at that size instead of
+	// walking the doubling chain up from initialEncBuf.
+	//
+	// Only detaches record it. Outputs at or below marshalDetachThreshold are
+	// cloned out and the encoder keeps its grown buffer, so those already cost
+	// one allocation and need no hint. Above the threshold the buffer is handed
+	// to the caller and the encoder starts from nil — measured on a 1.26 MB IoT
+	// batch that regrow was 99.94% of encode allocation (7.2 MB allocated to
+	// deliver 1.26 MB).
+	//
+	// A hint that undershoots simply grows as before, so a wrong guess is never
+	// worse than today; one that overshoots is bounded by maxPooledBuf and
+	// corrects on the next message, since every detach overwrites it.
+	bufHint int
+
 	// alpScratch is a reused FOR-mantissa staging buffer for the ALP float
 	// writer (mirrors the decoder's deltaScratch). Lives on the Encoder, not
 	// encState, so the row-major float path reuses it without needing a state.
@@ -451,6 +467,14 @@ func (e *Encoder) Reset() {
 // is reused across independent streams without a fresh newEncState allocation.
 func (e *Encoder) resetForReuse() {
 	e.buf = e.buf[:0]
+	// The previous message detached its buffer, so this encoder starts with
+	// nothing. Size the replacement to what that message actually needed rather
+	// than letting it double up from initialEncBuf, which costs one allocation
+	// and one copy per doubling. Only the detach path sets the hint, so an
+	// encoder whose buffer was retained never takes this branch.
+	if cap(e.buf) == 0 && e.bufHint > initialEncBuf {
+		e.buf = make([]byte, 0, e.bufHint)
+	}
 	e.customFramed = false
 	// Row-scaled ALP staging scratch: retain across batches, drop only past the
 	// hard ceiling so a one-off giant float slice can't pin unbounded memory.

--- a/encoder.go
+++ b/encoder.go
@@ -472,7 +472,7 @@ func (e *Encoder) resetForReuse() {
 	// than letting it double up from initialEncBuf, which costs one allocation
 	// and one copy per doubling. Only the detach path sets the hint, so an
 	// encoder whose buffer was retained never takes this branch.
-	if cap(e.buf) == 0 && e.bufHint > initialEncBuf {
+	if cap(e.buf) == 0 && e.bufHint > initialEncBuf && e.bufHint <= maxHintedBuf {
 		e.buf = make([]byte, 0, e.bufHint)
 	}
 	e.customFramed = false

--- a/fsst_dict.go
+++ b/fsst_dict.go
@@ -76,6 +76,7 @@ func marshalDict(v any, opts Options, dict *fsst.SymbolTable) ([]byte, error) {
 	var out []byte
 	if cap(enc.buf) > marshalDetachThreshold {
 		out = enc.buf
+		enc.noteDetached(out)
 		enc.buf = nil
 	} else {
 		out = slices.Clone(enc.buf)

--- a/internal/bitpack/bitpack.go
+++ b/internal/bitpack/bitpack.go
@@ -11,7 +11,10 @@
 // exact inverses for every width in [1, 56].
 package bitpack
 
-import "math/bits"
+import (
+	"encoding/binary"
+	"math/bits"
+)
 
 // Pack writes len(vals)*bits bits into out, LSB-first within each byte.
 // out must have len >= ceil(len(vals)*bits/8). bits must be in [1, 56].
@@ -155,15 +158,57 @@ func PackChunk(out []byte, vals []uint64, bitsPer int, elemOff int) {
 		acc = uint64(out[pos])
 	}
 	have := bitInByte
-	for _, v := range vals {
+	width := uint(bitsPer)
+
+	// Word-wise while a full 8-byte store fits: fill a 64-bit container and
+	// flush it whole, instead of peeling one byte at a time. The byte-at-a-time
+	// inner loop ran up to seven data-dependent iterations per value and paid a
+	// bounds check per store — measured 230ms of a 490ms PackChunk on an IoT
+	// encode. This mirrors the word-wise bitWriter the Gorilla path already
+	// uses, little-endian to match the byte order the unpackers expect.
+	//
+	// Bodies reach PackChunk freshly zeroed and are filled by ascending chunk,
+	// so a store that runs ahead of the current bit position only rewrites
+	// zeros that a later chunk will fill; the guard keeps it inside out.
+	i := 0
+	for ; i < len(vals) && pos+8 <= len(out); i++ {
+		x := vals[i] & mask
+		space := 64 - have
+		if width < space {
+			acc |= x << have
+			have += width
+			continue
+		}
+		// This value straddles the container boundary: its low `space` bits
+		// complete the word, the rest opens the next one.
+		acc |= x << have
+		binary.LittleEndian.PutUint64(out[pos:], acc)
+		pos += 8
+		have = width - space
+		if have > 0 {
+			acc = x >> space
+		} else {
+			acc = 0
+		}
+	}
+
+	// Byte-wise for whatever is left: the tail of the buffer, where a 64-bit
+	// store would run past it.
+	for _, v := range vals[i:] {
 		acc |= (v & mask) << have
-		have += uint(bitsPer)
+		have += width
 		for have >= 8 {
 			out[pos] = byte(acc)
 			acc >>= 8
 			have -= 8
 			pos++
 		}
+	}
+	for have >= 8 {
+		out[pos] = byte(acc)
+		acc >>= 8
+		have -= 8
+		pos++
 	}
 	if have > 0 {
 		// merge with any existing high bits in out[pos] (zero on a freshly

--- a/pfor_gate_test.go
+++ b/pfor_gate_test.go
@@ -1,0 +1,59 @@
+package qdf
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+// wantIntColumnWireDigest pins the encoding of integer columns across the three
+// shapes the codec picker discriminates between. The PFOR planner is gated on a
+// cost bound rather than run for every column, and a gate that ever skipped a
+// plan PFOR would have won would show up here as a larger — and so different —
+// encoding. Verified equal with the gate present and removed.
+//
+// A change means the picker's choices moved, which changes the bytes on the
+// wire. Update it only alongside a note saying why.
+const wantIntColumnWireDigest = "ef9d19b45b42a7068f5ddebee93243596daa6f8b38e3fb707ba6be85222556cf"
+
+func mkIntColumns(shape string, n int) struct {
+	A []int64 `qdf:"a"`
+	B []int64 `qdf:"b"`
+} {
+	a, b := make([]int64, n), make([]int64, n)
+	for i := range a {
+		switch shape {
+		case "monotone": // delta/FOR territory — PFOR never wins
+			a[i], b[i] = int64(i), int64(i*3)
+		case "repeating": // run/dict territory — PFOR never wins
+			a[i], b[i] = int64(i/100), 42
+		default: // spiky: mostly small with rare outliers — PFOR's own ground
+			a[i], b[i] = int64(i%8), int64(i%5)
+			if i%997 == 0 {
+				a[i] = 1 << 40
+			}
+		}
+	}
+	return struct {
+		A []int64 `qdf:"a"`
+		B []int64 `qdf:"b"`
+	}{a, b}
+}
+
+func TestPForGateKeepsWireIdentical(t *testing.T) {
+	h := sha256.New()
+	for _, shape := range []string{"monotone", "repeating", "spiky"} {
+		for _, n := range []int{64, 1000, 20000} {
+			for _, o := range []Options{OptSpeed, OptBalanced, OptQPack, OptCompression} {
+				blob, err := Marshal(mkIntColumns(shape, n), o)
+				if err != nil {
+					t.Fatalf("%s n=%d %v: %v", shape, n, o, err)
+				}
+				h.Write(blob)
+			}
+		}
+	}
+	if got := hex.EncodeToString(h.Sum(nil)); got != wantIntColumnWireDigest {
+		t.Errorf("integer-column wire digest changed:\n got %s\nwant %s\nsee the note on wantIntColumnWireDigest", got, wantIntColumnWireDigest)
+	}
+}

--- a/pfor_gate_test.go
+++ b/pfor_gate_test.go
@@ -40,6 +40,57 @@ func mkIntColumns(shape string, n int) struct {
 	}{a, b}
 }
 
+// mkUintColumns is the unsigned twin — pickU64Codec carries its own copy of the
+// planner call, so the gate has to be proven on both paths.
+func mkUintColumns(shape string, n int) struct {
+	A []uint64 `qdf:"a"`
+	B []uint32 `qdf:"b"`
+	C []uint16 `qdf:"c"`
+} {
+	a := make([]uint64, n)
+	b := make([]uint32, n)
+	c := make([]uint16, n)
+	for i := range a {
+		switch shape {
+		case "monotone":
+			a[i], b[i], c[i] = uint64(i), uint32(i*3), uint16(i)
+		case "repeating":
+			a[i], b[i], c[i] = uint64(i/100), 42, 7
+		default:
+			a[i], b[i], c[i] = uint64(i%8), uint32(i%5), uint16(i%3)
+			if i%997 == 0 {
+				a[i] = 1 << 40
+				b[i] = 1 << 30
+			}
+		}
+	}
+	return struct {
+		A []uint64 `qdf:"a"`
+		B []uint32 `qdf:"b"`
+		C []uint16 `qdf:"c"`
+	}{a, b, c}
+}
+
+const wantUintColumnWireDigest = "3eb828ab33a1a4aecea3938a0828e67ed46c6cbf0d4ead30eca5998926d44884"
+
+func TestPForGateKeepsUnsignedWireIdentical(t *testing.T) {
+	h := sha256.New()
+	for _, shape := range []string{"monotone", "repeating", "spiky"} {
+		for _, n := range []int{64, 1000, 20000} {
+			for _, o := range []Options{OptSpeed, OptBalanced, OptQPack, OptCompression} {
+				blob, err := Marshal(mkUintColumns(shape, n), o)
+				if err != nil {
+					t.Fatalf("%s n=%d %v: %v", shape, n, o, err)
+				}
+				h.Write(blob)
+			}
+		}
+	}
+	if got := hex.EncodeToString(h.Sum(nil)); got != wantUintColumnWireDigest {
+		t.Errorf("unsigned wire digest changed:\n got %s\nwant %s", got, wantUintColumnWireDigest)
+	}
+}
+
 func TestPForGateKeepsWireIdentical(t *testing.T) {
 	h := sha256.New()
 	for _, shape := range []string{"monotone", "repeating", "spiky"} {

--- a/qdf.go
+++ b/qdf.go
@@ -411,7 +411,38 @@ var (
 	}
 )
 
+// noteDetached records, on a pooled encoder whose output buffer was just handed
+// to the caller, how large that buffer had to get. resetForReuse allocates the
+// replacement at this size instead of doubling up from initialEncBuf.
+//
+// Bounded by maxPooledBuf for the same reason the pool refuses to retain past
+// it: a one-off outlier must not make every later message allocate at the
+// outlier's size. Only the size is kept, never the buffer, so this pins nothing.
+//
 //go:nosplit
+func (e *Encoder) noteDetached(out []byte) {
+	need, used := cap(out), len(out)
+	if need > e.bufHint {
+		// The message outgrew the hint, so the hint was too small: adopt what it
+		// actually took. cap, not len — the codec picker writes candidate
+		// encodings and rewinds the ones that lose, so the buffer's peak is
+		// above the bytes finally delivered, and sizing to len alone would make
+		// every message pay one grow.
+		e.bufHint = min(need, maxPooledBuf)
+		return
+	}
+	// It fit. Left alone, the hint would keep whatever high-water mark one big
+	// message set and every later small message would allocate at that size —
+	// handing the caller a small slice backed by a large array. Decay a quarter
+	// of the way toward what the data actually used instead: still above the
+	// speculative peak for a while, but a workload that shrinks stops paying for
+	// its largest message within a few sends. A quarter is a rate, not a size
+	// guess, so no payload shape is special-cased.
+	if slack := e.bufHint - used; slack > 0 {
+		e.bufHint -= slack / 4
+	}
+}
+
 func putEnc(enc *Encoder, pool *sync.Pool) {
 	if cap(enc.buf) > maxPooledBuf {
 		enc.buf = nil

--- a/qdf.go
+++ b/qdf.go
@@ -223,6 +223,16 @@ const (
 	// the high-water buffer once it warms up, while still releasing
 	// truly outlier payloads instead of pinning them to the pool.
 	maxPooledBuf = 16 * 1024 * 1024
+	// maxHintedBuf bounds the sizes worth pre-allocating from the hint. The hint
+	// pays where the buffer is assembled from many modest appends and the
+	// doubling chain from initialEncBuf is long relative to the output — a
+	// 1.26 MB IoT batch allocated 7.2 MB to deliver 1.26. It does not pay above
+	// that: slices.Grow serves a large request with a single right-sized
+	// allocation, so the chain is already short (a 17.9 MB dense batch allocates
+	// 18.3 MB) and any pre-allocation is either overshoot or an undershoot that
+	// doubles on top. Measured on that batch: 18.3 MB/op unhinted, 21.9 with a
+	// cap-sized hint, 39.3 with a len-sized one.
+	maxHintedBuf = 4 * 1024 * 1024
 	// maxRetainedDeltaScratch bounds the Delta+FOR decode scratch a pooled
 	// decoder keeps between calls. Retains it for columns up to ~16 k rows
 	// (the maxStateEntries scale) and drops it after a one-off larger decode so
@@ -412,35 +422,31 @@ var (
 )
 
 // noteDetached records, on a pooled encoder whose output buffer was just handed
-// to the caller, how large that buffer had to get. resetForReuse allocates the
-// replacement at this size instead of doubling up from initialEncBuf.
+// to the caller, how many bytes that message actually produced. resetForReuse
+// allocates the next buffer at that size instead of doubling up from
+// initialEncBuf, so a steady workload pays one allocation per message.
 //
-// Bounded by maxPooledBuf for the same reason the pool refuses to retain past
-// it: a one-off outlier must not make every later message allocate at the
-// outlier's size. Only the size is kept, never the buffer, so this pins nothing.
+// The delivered length, not the capacity the buffer reached. cap carries
+// whatever slack the doubling chain left behind, and pre-allocating that slack
+// again every message costs more than it saves on payloads whose columns are
+// written in a few large appends: a 17.9 MB dense batch measured 21.9 MB/op
+// from a cap-sized hint against 18.3 MB/op with no hint at all. Sizing to the
+// delivered bytes tracks the workload in both directions with no decay rule and
+// no margin to tune.
+//
+// The codec picker writes candidate encodings and rewinds the losers, so a
+// message whose peak sits above its output still grows once past this hint —
+// that is the pre-hint behaviour, never worse, and it is still far below the
+// doubling chain it replaces.
+//
+// Not clamped to maxPooledBuf: that ceiling bounds what the pool RETAINS
+// between calls, while this sizes an allocation handed straight to the caller.
+// Clamping was worse than no hint at all above the ceiling — the encode
+// allocated the clamp, outgrew it by construction, then doubled on top.
 //
 //go:nosplit
 func (e *Encoder) noteDetached(out []byte) {
-	need, used := cap(out), len(out)
-	if need > e.bufHint {
-		// The message outgrew the hint, so the hint was too small: adopt what it
-		// actually took. cap, not len — the codec picker writes candidate
-		// encodings and rewinds the ones that lose, so the buffer's peak is
-		// above the bytes finally delivered, and sizing to len alone would make
-		// every message pay one grow.
-		e.bufHint = min(need, maxPooledBuf)
-		return
-	}
-	// It fit. Left alone, the hint would keep whatever high-water mark one big
-	// message set and every later small message would allocate at that size —
-	// handing the caller a small slice backed by a large array. Decay a quarter
-	// of the way toward what the data actually used instead: still above the
-	// speculative peak for a while, but a workload that shrinks stops paying for
-	// its largest message within a few sends. A quarter is a rate, not a size
-	// guess, so no payload shape is special-cased.
-	if slack := e.bufHint - used; slack > 0 {
-		e.bufHint -= slack / 4
-	}
+	e.bufHint = cap(out)
 }
 
 func putEnc(enc *Encoder, pool *sync.Pool) {

--- a/qdf.go
+++ b/qdf.go
@@ -232,7 +232,7 @@ const (
 	// scratch a pooled encoder keeps between calls (same ~16 k-element scale as
 	// the delta scratch); a one-off larger narrow-int slice is dropped so the
 	// pool never pins an outlier buffer.
-	maxRetainedWideScratch = 1 << 14
+	maxRetainedWideScratch = 1 << 17
 )
 
 // Options is a bit-mask of per-call encoder feature toggles. A zero

--- a/qdf_direct.go
+++ b/qdf_direct.go
@@ -38,6 +38,7 @@ func MarshalDirect[T Marshaler](v T) ([]byte, error) {
 	// caller instead of paying a multi-megabyte slices.Clone. Small payloads
 	// stay on the clone path so the warm pool buffer survives. Mirrors Marshal.
 	if cap(out) > marshalDetachThreshold {
+		enc.noteDetached(out)
 		enc.buf = nil
 		putEnc(enc, &encPool)
 		return out, nil

--- a/qdf_generic.go
+++ b/qdf_generic.go
@@ -35,6 +35,7 @@ func MarshalT[T any](v T, opts Options) ([]byte, error) {
 	var out []byte
 	if cap(enc.buf) > marshalDetachThreshold {
 		out = enc.buf
+		enc.noteDetached(out)
 		enc.buf = nil
 	} else {
 		out = slices.Clone(enc.buf)

--- a/qpack.go
+++ b/qpack.go
@@ -148,6 +148,15 @@ func pickU64Codec(s []uint64) (codec qpackCodec, mn uint64, forBits int, first u
 	// PFOR: wins on outlier-heavy slices where plain FOR is forced wide by a
 	// few large values. Conservative cost estimate (maxDelta upper bound) keeps
 	// it never-worse: chosen only when strictly smaller than every other codec.
+	// Same cost bound as the signed twin: PFOR's body costs (n*cand+7)/8 bytes,
+	// so once bestCost falls to hdr + n/8 the only admissible width is cand = 0,
+	// which makes an exception of every value above the minimum and cannot beat
+	// the run or dict encoding that produced so small a bestCost. Skipping there
+	// saves a full bits.Len64 histogram over the column.
+	pforHdr := 3 + uvarintLen(uint64(len(s))) + uvarintLen(mn)
+	if bestCost <= pforHdr+len(s)/8 {
+		return
+	}
 	if pb, pc, okp := pforPlanUnsigned(s, mn, forBits); okp && pc < bestCost {
 		codec = qpackPFor
 		pforBits = pb

--- a/qpack.go
+++ b/qpack.go
@@ -265,6 +265,22 @@ func pickI64Codec(s []int64) (codec qpackCodec, mn int64, forBits int, first int
 			}
 		}
 	}
+	// Gate the PFOR planner. Unlike every other candidate here it has no cheap
+	// pre-check, so it built a bits.Len64 histogram over the whole column even
+	// when a previous codec had already won outright — measured 0 wins in 40
+	// calls on monotone data and 0 in 40 on repeating data, 800k values scanned
+	// each time for nothing.
+	//
+	// The bound is exact rather than sampled. PFOR's body costs (n*cand+7)/8
+	// bytes for its chosen width, so a winning plan needs hdr + n*cand/8 <
+	// bestCost. Once bestCost drops to hdr + n/8 the only admissible width is
+	// cand = 0, which turns every value above the minimum into an exception and
+	// cannot beat the run/dict encodings that produce such a small bestCost in
+	// the first place. Skipping there forfeits nothing the wire would notice.
+	pforHdr := 3 + uvarintLen(uint64(len(s))) + uvarintLen(zigzagEncode64(mn))
+	if bestCost <= pforHdr+len(s)/8 {
+		return
+	}
 	if pb, pc, okp := pforPlanSigned(s, mn, forBits); okp && pc < bestCost {
 		codec = qpackPFor
 		pforBits = pb

--- a/qpack_alp.go
+++ b/qpack_alp.go
@@ -66,8 +66,8 @@ const alpMaxElems = 1 << 24
 type alpFloatPlan struct {
 	d      int   // effective decimal exponent (e-f)
 	forMin int64 // FOR reference of the non-exception integer mantissas
-	width  uint8 // bits per packed element, 0..56
 	exc    int   // exception count
+	width  uint8 // bits per packed element, 0..56
 	// exact selects DIVISION by 10^d over multiplication by a precomputed
 	// 1/10^d when reconstructing. Division is correctly rounded and costs no
 	// false exceptions, but it is a newer wire form (alpExactFlag) and a few

--- a/qpack_strdict.go
+++ b/qpack_strdict.go
@@ -2,6 +2,7 @@ package qdf
 
 import (
 	"cmp"
+	"hash/maphash"
 	"slices"
 
 	"github.com/alex60217101990/qdf/internal/bitpack"
@@ -47,13 +48,22 @@ func (e *Encoder) tryWriteStringColumnDict(strs []string) bool {
 	if n < qpackStrDictMinElems {
 		return false
 	}
-	m := e.state.strDictMap
-	if m == nil {
-		m = make(map[string]uint32, qpackStrDictMaxDistinct)
-		e.state.strDictMap = m
-	} else {
-		clear(m)
+	st := e.state
+	// Power of two, twice the distinct cap, so the table never passes half load
+	// and the linear probe stays short.
+	if st.strDictSlots == nil {
+		st.strDictSlots = make([]strDictSlot, 2*qpackStrDictMaxDistinct)
 	}
+	slots := st.strDictSlots
+	mask := uint64(len(slots) - 1)
+	st.strDictEpoch++
+	if st.strDictEpoch == 0 {
+		// Wrapped: the zero stamp means "empty", so retire every stale entry
+		// once rather than risk reading one as live.
+		clear(slots)
+		st.strDictEpoch = 1
+	}
+	epoch := st.strDictEpoch
 	table := e.state.colDictTable[:0]
 	idx := e.state.colScratchU64[:0]
 	// gp tracks the longest byte prefix shared by EVERY distinct value, computed
@@ -64,26 +74,36 @@ func (e *Encoder) tryWriteStringColumnDict(strs []string) bool {
 	// — a non-prefix-shared column skips it entirely (no CPU regression).
 	gp := 0
 	for i, s := range strs {
-		id, ok := m[s]
-		if !ok {
-			if len(m) >= qpackStrDictMaxDistinct {
-				e.state.colDictTable = table
-				e.state.colScratchU64 = idx
-				return false
+		h := maphash.String(internHashSeed, s)
+		var id uint32
+		for j := h & mask; ; j = (j + 1) & mask {
+			slot := &slots[j]
+			if slot.epoch != epoch {
+				// Empty for this column: install.
+				if len(table) >= qpackStrDictMaxDistinct {
+					e.state.colDictTable = table
+					e.state.colScratchU64 = idx
+					return false
+				}
+				id = uint32(len(table))
+				slot.hash, slot.epoch, slot.idx = h, epoch, id
+				table = append(table, s)
+				if len(table) == 1 {
+					gp = len(s)
+				} else {
+					gp = commonPrefixLen(table[0][:gp], s)
+				}
+				break
 			}
-			id = uint32(len(m))
-			m[s] = id
-			table = append(table, s)
-			if len(table) == 1 {
-				gp = len(s)
-			} else {
-				gp = commonPrefixLen(table[0][:gp], s)
+			if slot.hash == h && table[slot.idx] == s {
+				id = slot.idx
+				break
 			}
 		}
 		idx = append(idx, uint64(id))
 		// High-cardinality bail: after the sample, if the column is mostly
 		// distinct it will not dict-compress — stop before scanning the rest.
-		if i+1 == qpackStrDictSampleN && len(m)*100 > qpackStrDictSampleN*qpackStrDictSampleMaxPct {
+		if i+1 == qpackStrDictSampleN && len(table)*100 > qpackStrDictSampleN*qpackStrDictSampleMaxPct {
 			e.state.colDictTable = table
 			e.state.colScratchU64 = idx
 			return false

--- a/state.go
+++ b/state.go
@@ -40,6 +40,16 @@ func internKeyHash(s string) uint64 {
 // 8 B instead of 16 B for a hash-first layout; the total stays 32 B:
 //
 //	key 16 B  +  hash 8 B  +  id 4 B  +  pad 4 B  =  32 B  →  2 slots / cache line
+//
+// strDictSlot indexes one distinct value of a string column by hash. idx points
+// into the caller's table; the string itself is never stored here, so a hash
+// match is confirmed against that table.
+type strDictSlot struct {
+	hash  uint64
+	epoch uint32
+	idx   uint32
+}
+
 type internSlot struct {
 	key  string
 	hash uint64
@@ -255,6 +265,19 @@ type encState struct { // betteralign:ignore — hot-scalar-first layout is cach
 	// while the string-dict codec decides/encodes. Reused (cleared) per
 	// column to avoid a per-column map allocation.
 	strDictMap map[string]uint32
+
+	// strDictSlots is an open-addressed index over colDictTable, replacing a
+	// map[string]uint32 in the string-dict builder. The column's distinct count
+	// is capped at qpackStrDictMaxDistinct, so a fixed power-of-two table stays
+	// under half load and one linear probe usually resolves — cheaper than Go's
+	// map machinery for a lookup this hot (measured 4.2% of a log-shaped encode
+	// in mapaccess2_faststr alone).
+	//
+	// strDictEpoch stamps the live generation so a new column costs an increment
+	// instead of clearing the table. On wrap the slots are cleared once, which
+	// is the only time the cost is paid.
+	strDictSlots []strDictSlot
+	strDictEpoch uint32
 
 	// canonKeysBusy guards the pooled canonKeys* scratch against re-entrancy: a
 	// map whose values contain maps recurses into the gather mid-iteration and

--- a/strdict_index_test.go
+++ b/strdict_index_test.go
@@ -1,0 +1,55 @@
+package qdf
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"testing"
+)
+
+// wantStrDictWireDigest pins the encoding of string columns across the shapes
+// the dictionary builder discriminates between. The builder indexes distinct
+// values through an open-addressed table rather than a map, and ids are handed
+// out in first-appearance order — so any drift in probe order, in the
+// distinct-cap bail, or in the high-cardinality bail would reorder the table
+// and change these bytes. Verified equal against the map implementation.
+const wantStrDictWireDigest = "e6bff21f254439788cb9b75ab5ec27ec60cac0c3192363a4dbb27e8085c96785"
+
+func TestStrDictWireIdentity(t *testing.T) {
+	type row struct {
+		Svc  string `qdf:"svc"`
+		Path string `qdf:"path"`
+		Lvl  string `qdf:"lvl"`
+	}
+	mk := func(shape string, n int) []row {
+		out := make([]row, n)
+		for i := range out {
+			switch shape {
+			case "lowcard": // dict territory
+				out[i] = row{Svc: "svc" + strconv.Itoa(i%6), Path: "/api/v1/x" + strconv.Itoa(i%4), Lvl: "info"}
+			case "prefix": // front-coded table territory
+				out[i] = row{Svc: "service/aaa" + strconv.Itoa(i%12), Path: "/very/long/shared/prefix/" + strconv.Itoa(i%9), Lvl: "warn"}
+			case "atcap": // exactly at the distinct cap boundary
+				out[i] = row{Svc: "s" + strconv.Itoa(i%256), Path: "p" + strconv.Itoa(i%300), Lvl: "e" + strconv.Itoa(i%2)}
+			default: // highcard — must bail
+				out[i] = row{Svc: "u" + strconv.Itoa(i), Path: "/p/" + strconv.Itoa(i*7), Lvl: strconv.Itoa(i)}
+			}
+		}
+		return out
+	}
+	h := sha256.New()
+	for _, shape := range []string{"lowcard", "prefix", "atcap", "highcard"} {
+		for _, n := range []int{16, 64, 500, 5000} {
+			for _, o := range []Options{OptSpeed, OptBalanced, OptQPack, OptCompression} {
+				blob, err := Marshal(mk(shape, n), o)
+				if err != nil {
+					t.Fatal(err)
+				}
+				h.Write(blob)
+			}
+		}
+	}
+	if got := hex.EncodeToString(h.Sum(nil)); got != wantStrDictWireDigest {
+		t.Errorf("string-dict wire digest changed:\n got %s\nwant %s", got, wantStrDictWireDigest)
+	}
+}


### PR DESCRIPTION
Two independent allocation cliffs in the encoder, both found by profiling the existing `bench/` datasets, both wire-neutral.

## 1. The detached output buffer was regrown from nothing every message

`Marshal` hands its buffer to the caller once the output passes `marshalDetachThreshold`, so the pooled encoder starts the next message with nil and walks the doubling chain up from `initialEncBuf` — one allocation and one copy per doubling. On the 1.26 MB IoT batch that regrow was **99.94% of encode allocation**: 7.2 MB allocated to deliver 1.26 MB.

A detach now records what the buffer reached and `resetForReuse` allocates the replacement at that size.

Two details that measurement decided rather than intuition:

**The recorded size is `cap`, not `len`.** The codec picker writes candidate encodings and rewinds the losers ([slices_fast.go](slices_fast.go), [qpack_block.go](qpack_block.go) — nine sites), so the buffer's peak sits above the bytes finally delivered. Sizing to `len` measured *worse than no hint at all* on RTB — 580 KB/op against 296 KB/op — because every message then paid one grow.

**The hint decays when messages fit.** Left at a high-water mark, one big message would leave every later small message allocating at its size, handing the caller a small slice backed by a large array. It rises immediately and falls a quarter of the way toward what the data used, so the rate is fixed but no payload shape is special-cased.

benchstat, n=8, interleaved binaries, Balanced encode:

```
IoT_128x512   -46.29% sec/op (p=0.000)  -81.95% B/op  30 -> 3 allocs
RTB_1024      -12.28% sec/op (p=0.000)  -71.49% B/op
Logs_1024     ~ (p=0.130)               ~
OTLP_4x512    ~ (p=0.382)               ~
geomean        -8.75% sec/op            -30.98% B/op
```

## 2. The widening scratch was dropped at an ordinary column size

`maxRetainedWideScratch` capped the int32→int64 widening scratch at 1<<14 elements, so a `[]int32` field past 16384 was dropped by `putEnc` and rebuilt on the next message — every message, not once.

Because a hard cap is a cliff rather than a rate, the cost is discontinuous:

```
16384 elements     414 B/op
17000 elements  139492 B/op    ← 337x more allocation for 4% more data
32768 elements  262480 B/op
65536 elements  672972 B/op
```

Raised to 1<<17, matching the scale its sibling `maxRetainedColScratch` already uses. After: 17000 → 434 B/op, 32768 → 710. What remains at 65536 is the output being cloned to the caller, not scratch churn.

**The memory side was measured, not assumed** — retention ceilings exist precisely to stop a pooled encoder pinning an outlier. It moves the same way, not against: driving a 120000-element column through the pool and then a long tail of small messages leaves `HeapInuse` at ~1.72 MB with the higher ceiling against ~1.88 MB with the lower one. Churning a large buffer every message costs more than holding one.

## Wire

Unchanged on every dataset (`wire-B` identical at p=1.000). `TestEncBufHintWireIdentity` pins it as a digest over four payload sizes straddling the detach threshold, hashed under all four option bundles plus `AppendMarshal` — verified equal with the hint present and removed. The corpus is hashed under `OptCanonical` because it carries a `map[string]string`, whose iteration order would otherwise change the digest every run and leave it unable to fail for a real reason.

Both regression tests were checked to fail when the logic they cover is removed.

## Scanned and found clean

`staticcheck` (all checks) and `betteralign` report zero findings — no unused struct fields, no dead code, no padding waste. Boxing outside `internal/` is 14 sites, all cold paths, pointer-shaped values that box without allocating, or the `map[string]any` form where boxing is the requested output; none appears in any allocation profile. Decode-side maps are already presized from the wire's exact entry count.