### PR TITLE
perf(qdf): rANS-frame a top-level generated struct

### DIFF
--- a/cmd/qdf-bench/types_qdf_gen.go
+++ b/cmd/qdf-bench/types_qdf_gen.go
@@ -55,6 +55,9 @@ var qdfColKinds_GenMetric = []byte{0x00, 0x02, 0x01, 0x01, 0x03}
 // the extended slice.
 func (v *GenHost) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -606,6 +609,9 @@ func (v *GenHost) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int,
 // the extended slice.
 func (v *GenMetric) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -766,6 +772,9 @@ func (v *GenMetric) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (in
 // the extended slice.
 func (v *GenMetricHost) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -1033,6 +1042,9 @@ func (v *GenMetricHost) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena)
 // the extended slice.
 func (v *GenService) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -1292,6 +1304,9 @@ func (v *GenService) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (i
 // the extended slice.
 func (v *GenTask) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()

--- a/cmd/qdfgen/gen/gen.go
+++ b/cmd/qdfgen/gen/gen.go
@@ -602,6 +602,15 @@ func (g *gen) emitMarshal(typeName string, fields []fieldInfo) error {
 	// Decide whether dst already contains a QDF stream (nested call) or is
 	// a fresh buffer (top-level call). We use the magic bytes to detect.
 	fmt.Fprintf(w, "\thadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2\n")
+	// A framed body is one sealed unit. Appending plain tags after it does not
+	// extend the message — it corrupts the frame, and the value that WAS
+	// readable stops being so. Before entropy framing could reach these bodies
+	// the same append merely produced trailing bytes every decoder ignored, so
+	// nothing usable is being taken away; the difference is that the failure is
+	// now reported instead of silently destroying data.
+	fmt.Fprintf(w, "\tif hadHeader && dst[4]&qdf.FlagRANS != 0 {\n")
+	fmt.Fprintf(w, "\t\treturn nil, qdf.ErrAppendAfterFrame\n")
+	fmt.Fprintf(w, "\t}\n")
 	fmt.Fprintf(w, "\te := qdf.NewEncoderOnBuf(dst, qdf.Fast)\n")
 	fmt.Fprintf(w, "\tif hadHeader {\n\t\te.MarkHeaderWritten()\n\t} else {\n\t\te.EnsureHeader()\n\t}\n")
 	fmt.Fprintf(w, "\tif err := v.EncodeQDF(e); err != nil {\n\t\treturn nil, err\n\t}\n")

--- a/errors.go
+++ b/errors.go
@@ -6,16 +6,24 @@ import (
 )
 
 var (
-	ErrShortBuffer    = errors.New("qdf: short buffer")
-	ErrBadMagic       = errors.New("qdf: bad magic / not a qdf stream")
-	ErrBadVersion     = errors.New("qdf: unsupported wire version")
-	ErrBadTag         = errors.New("qdf: unknown tag")
-	ErrTypeMismatch   = errors.New("qdf: type mismatch on decode")
-	ErrInvalidLength  = errors.New("qdf: invalid length prefix")
-	ErrUnknownStateID = errors.New("qdf: unknown state-table id")
-	ErrUnsupported    = errors.New("qdf: unsupported type")
-	ErrCycleDetected  = errors.New("qdf: pointer cycle detected (max depth exceeded)")
-	ErrFieldNotFound  = errors.New("qdf: query predicate field not found")
+	ErrShortBuffer   = errors.New("qdf: short buffer")
+	ErrBadMagic      = errors.New("qdf: bad magic / not a qdf stream")
+	ErrBadVersion    = errors.New("qdf: unsupported wire version")
+	ErrBadTag        = errors.New("qdf: unknown tag")
+	ErrTypeMismatch  = errors.New("qdf: type mismatch on decode")
+	ErrInvalidLength = errors.New("qdf: invalid length prefix")
+	// ErrAppendAfterFrame is returned when a Marshaler is asked to append into a
+	// buffer whose body has already been framed — compressed, in practice. Its
+	// bytes are one sealed unit, so appending plain tags after them does not
+	// extend the message; it corrupts the frame and destroys the value that was
+	// there. Appending after a completed message never produced a readable
+	// two-value wire, so this reports what was always true rather than removing
+	// a capability.
+	ErrAppendAfterFrame = errors.New("qdf: cannot append to an already-framed (compressed) buffer")
+	ErrUnknownStateID   = errors.New("qdf: unknown state-table id")
+	ErrUnsupported      = errors.New("qdf: unsupported type")
+	ErrCycleDetected    = errors.New("qdf: pointer cycle detected (max depth exceeded)")
+	ErrFieldNotFound    = errors.New("qdf: query predicate field not found")
 	// ErrStreamBadFlags is returned by StreamDecoder.Decode when the stream
 	// header carries whole-payload flags that do not apply to a frame stream
 	// (FlagRANS / FlagColIndex). A conforming StreamEncoder never sets them; a

--- a/internal/codegen_test/named_codec_field_test.go
+++ b/internal/codegen_test/named_codec_field_test.go
@@ -14,9 +14,16 @@ import (
 func TestNamedCodecFieldRoutesThroughCodec(t *testing.T) {
 	v := GenNamedCodec{Label: "hello", N: 42}
 
-	// Interop invariant: generated MarshalQDF must produce byte-identical wire to
-	// the reflect encoder (which routes GenTag through MarshalQDF). A bypass emits
-	// the bare string instead of the codec frame → the wires differ.
+	// Interop invariant: generated MarshalQDF must produce the same BODY as the
+	// reflect encoder (which routes GenTag through MarshalQDF). A bypass emits
+	// the bare string instead of the codec frame → the bodies differ.
+	//
+	// Bodies, not whole wires. The two entry points frame differently by design:
+	// MarshalQDF builds its own encoder at qdf.Fast and ignores Options, while
+	// qdf.Marshal states the mode it was asked for. They agreed only while the
+	// reflect path forced a Fast header onto every top-level Marshaler, which
+	// also cost generated structs their rANS framing. The header is five bytes
+	// and is not what this test is about.
 	gb, err := any(&v).(interface{ MarshalQDF([]byte) ([]byte, error) }).MarshalQDF(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -25,8 +32,13 @@ func TestNamedCodecFieldRoutesThroughCodec(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(gb, rb) {
-		t.Fatalf("generated wire diverges from reflect (codec bypassed):\n gen=%q\nrefl=%q", gb, rb)
+	const hdr = 5
+	if len(gb) < hdr || len(rb) < hdr {
+		t.Fatalf("wire shorter than a header: gen=%d refl=%d", len(gb), len(rb))
+	}
+	if !bytes.Equal(gb[hdr:], rb[hdr:]) {
+		t.Fatalf("generated body diverges from reflect (codec bypassed):\n gen=%q\nrefl=%q",
+			gb[hdr:], rb[hdr:])
 	}
 
 	// Round-trip via the generated codec preserves the value.

--- a/internal/codegen_test/named_codec_field_test.go
+++ b/internal/codegen_test/named_codec_field_test.go
@@ -14,16 +14,26 @@ import (
 func TestNamedCodecFieldRoutesThroughCodec(t *testing.T) {
 	v := GenNamedCodec{Label: "hello", N: 42}
 
-	// Interop invariant: generated MarshalQDF must produce the same BODY as the
-	// reflect encoder (which routes GenTag through MarshalQDF). A bypass emits
-	// the bare string instead of the codec frame → the bodies differ.
+	// A bypass emits the bare string where the codec's frame belongs, and the
+	// way to see that is to encode the same value under TWO DIFFERENT MODES and
+	// compare the bodies.
 	//
-	// Bodies, not whole wires. The two entry points frame differently by design:
-	// MarshalQDF builds its own encoder at qdf.Fast and ignores Options, while
-	// qdf.Marshal states the mode it was asked for. They agreed only while the
-	// reflect path forced a Fast header onto every top-level Marshaler, which
-	// also cost generated structs their rANS framing. The header is five bytes
-	// and is not what this test is about.
+	// That is the whole mechanism, and it is easy to break by "improving" it.
+	// MarshalQDF builds its own encoder at qdf.Fast; qdf.Marshal here runs
+	// OptBalanced — and note it also reaches generated code, since Marshal
+	// dispatches to EncodeQDF for an EncoderMarshaler, so this is not a reflect
+	// encode despite appearances. A value that went through the codec is
+	// mode-invariant — the codec writes its own bytes and never consults
+	// Options — so the two agree. A bypassed bare string is mode-SENSITIVE:
+	// Balanced interns it, Fast does not, and the bodies diverge.
+	//
+	// Levelling both sides to OptSpeed makes the comparison look tidier and
+	// blinds it completely: a bypassed string then matches too. Measured — with
+	// the bypass reintroduced and both sides at OptSpeed, this assertion passes
+	// and only the round-trip below notices.
+	//
+	// Bodies, not whole wires: the two entry points frame differently by design,
+	// and the five-byte header is not what this test is about.
 	gb, err := any(&v).(interface{ MarshalQDF([]byte) ([]byte, error) }).MarshalQDF(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -37,7 +47,7 @@ func TestNamedCodecFieldRoutesThroughCodec(t *testing.T) {
 		t.Fatalf("wire shorter than a header: gen=%d refl=%d", len(gb), len(rb))
 	}
 	if !bytes.Equal(gb[hdr:], rb[hdr:]) {
-		t.Fatalf("generated body diverges from reflect (codec bypassed):\n gen=%q\nrefl=%q",
+		t.Fatalf("generated body diverges from the Balanced encode (codec bypassed):\n gen=%q\nbal=%q",
 			gb[hdr:], rb[hdr:])
 	}
 

--- a/internal/codegen_test/rans_frame_bench_test.go
+++ b/internal/codegen_test/rans_frame_bench_test.go
@@ -1,0 +1,44 @@
+package cgsample
+
+import (
+	"fmt"
+	"testing"
+
+	qdf "github.com/alex60217101990/qdf"
+)
+
+func benchRF(b *testing.B, n int, opts qdf.Options) {
+	rows := make([]GenRow, n)
+	for i := range rows {
+		id := fmt.Sprintf("%06d", i)
+		rows[i] = GenRow{ID: int64(i), Name: "com.acme.platform.worker.service." + id,
+			Inner: GenRowInner{X: i, Y: "/opt/acme/platform/bin/worker --shard=" + id}}
+	}
+	set := GenRowSet{Rows: rows}
+	wire, err := qdf.Marshal(set, opts)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Run("encode", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := qdf.Marshal(set, opts); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("decode", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			var out GenRowSet
+			if err := qdf.Unmarshal(wire, &out); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkRF64Rans(b *testing.B)   { benchRF(b, 64, qdf.OptBalanced|qdf.OptRANS) }
+func BenchmarkRF512Rans(b *testing.B)  { benchRF(b, 512, qdf.OptBalanced|qdf.OptRANS) }
+func BenchmarkRF512Compr(b *testing.B) { benchRF(b, 512, qdf.OptCompression) }
+func BenchmarkRF512Bal(b *testing.B)   { benchRF(b, 512, qdf.OptBalanced) }

--- a/internal/codegen_test/rans_frame_test.go
+++ b/internal/codegen_test/rans_frame_test.go
@@ -67,10 +67,17 @@ func TestTopLevelGeneratedStructIsRANSFramed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The framing bit is the property this test is named for, and unlike a size
+	// comparison it cannot be satisfied by degrading the other side: a
+	// regression that INFLATED the OptBalanced wire would make a
+	// smaller-than-balanced assertion easier to pass, not harder.
+	if structRANS[4]&qdf.FlagRANS == 0 {
+		t.Errorf("a top-level generated struct came back with header flag %08b, "+
+			"FlagRANS clear — the body was not framed", structRANS[4])
+	}
 	if len(structRANS) >= len(structBal) {
 		t.Errorf("a top-level generated struct went %d -> %d with rANS (no change), "+
-			"while the same rows as a slice went %d -> %d (%.1f%% off) — the struct "+
-			"is not being framed",
+			"while the same rows as a slice went %d -> %d (%.1f%% off)",
 			len(structBal), len(structRANS), len(sliceBal), len(sliceRANS),
 			float64(len(sliceBal)-len(sliceRANS))/float64(len(sliceBal))*100)
 	}
@@ -103,61 +110,12 @@ func TestTopLevelGeneratedStructIsRANSFramed(t *testing.T) {
 	}
 }
 
-// handBlob is a HAND-WRITTEN Marshaler in the shape this repository already
-// uses for one (see GenTag): a self-delimiting body it writes and reads itself,
-// with no reference to the encoder's Options at all.
+// The hand-written side of this distinction is NOT tested here on purpose.
+// marshaler_framing_test.go in the root package already covers it and covers it
+// more strictly — it asserts the flag byte is zero, where a version of this test
+// only compared two wires for equality and would have missed a Balanced header
+// stamped onto a hand-written body while rANS declined.
 //
-// That is precisely the contract customFramed protects. Reframing such a body
-// would stamp FlagRANS onto bytes that were never produced under those options,
-// and the fix below must not touch it.
-type handBlob struct {
-	Payload string
-}
-
-func (h handBlob) MarshalQDF(dst []byte) ([]byte, error) {
-	dst = append(dst, 'B', byte(len(h.Payload)>>8), byte(len(h.Payload)))
-	return append(dst, h.Payload...), nil
-}
-
-func (h *handBlob) UnmarshalQDF(src []byte) (int, error) {
-	if len(src) < 3 || src[0] != 'B' {
-		return 0, qdfErrShort
-	}
-	n := int(src[1])<<8 | int(src[2])
-	if len(src) < 3+n {
-		return 0, qdfErrShort
-	}
-	h.Payload = string(src[3 : 3+n])
-	return 3 + n, nil
-}
-
-// The protection must survive the fix: a hand-written Marshaler stays unframed.
-//
-// Its body is opts-invariant by contract, so the bytes come out identical with
-// rANS on and off — and they must, or the decoder is handed a FlagRANS frame
-// around a payload that was never compressed.
-func TestHandWrittenMarshalerIsNotReframed(t *testing.T) {
-	// Long and entirely uniform, so rANS would certainly take it if allowed to.
-	v := handBlob{Payload: string(make([]byte, 4096))}
-
-	plain, err := qdf.Marshal(v, qdf.OptBalanced)
-	if err != nil {
-		t.Fatal(err)
-	}
-	framed, err := qdf.Marshal(v, qdf.OptBalanced|qdf.OptRANS)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(plain) != string(framed) {
-		t.Fatalf("a hand-written Marshaler's bytes changed with rANS: %d vs %d — its body "+
-			"is opts-invariant by contract and must not be reframed",
-			len(plain), len(framed))
-	}
-	var got handBlob
-	if err := qdf.Unmarshal(framed, &got); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if got.Payload != v.Payload {
-		t.Fatal("hand-written Marshaler did not round-trip")
-	}
-}
+// That test was also verified to fail if this change is made too broadly (the
+// kind distinction dropped, customFramed never set), so the guard is real and
+// duplicating it here would only be a second thing to maintain.

--- a/internal/codegen_test/rans_frame_test.go
+++ b/internal/codegen_test/rans_frame_test.go
@@ -1,0 +1,163 @@
+package cgsample
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	qdf "github.com/alex60217101990/qdf"
+)
+
+// ransRows is prefix-rich so rANS has real redundancy to remove — otherwise the
+// assertions below would be measuring an entropy coder that had nothing to do
+// and would pass whether or not it ran.
+func ransRows(n int) []GenRow {
+	out := make([]GenRow, n)
+	for i := range out {
+		id := fmt.Sprintf("%06d", i)
+		out[i] = GenRow{
+			ID:   int64(i),
+			Name: "com.acme.platform.worker.service." + id,
+			Inner: GenRowInner{
+				X: i,
+				Y: "/opt/acme/platform/bin/worker --shard=" + id,
+			},
+		}
+	}
+	return out
+}
+
+// A top-level value that is a GENERATED STRUCT must be rANS-framed like any
+// other, and today it is not.
+//
+// reflect_encode.go marks any top-level Marshaler `customFramed`, and
+// maybeApplyRANS then declines: "a top-level Marshaler forced Fast framing and
+// its bytes are opts-invariant by contract". True of a hand-written Marshaler,
+// which emits its own Fast body and ignores Options. NOT true of a generated
+// EncoderMarshaler, which writes into the shared encoder and honours its mode —
+// it calls StructShape and WriteStringField, both of which respect Dense.
+//
+// The slice arm is the anchor rather than decoration. The same rows as a
+// []GenRow ARE framed, so it proves this data compresses; without it, a test
+// that only checks the struct would pass the day rANS stops helping for an
+// unrelated reason.
+func TestTopLevelGeneratedStructIsRANSFramed(t *testing.T) {
+	rows := ransRows(64)
+	set := GenRowSet{Rows: rows}
+
+	sliceBal, err := qdf.Marshal(rows, qdf.OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sliceRANS, err := qdf.Marshal(rows, qdf.OptBalanced|qdf.OptRANS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sliceRANS) >= len(sliceBal) {
+		t.Fatalf("anchor: a slice of the same rows went %d -> %d with rANS — this data "+
+			"does not compress, so the struct assertion below would prove nothing",
+			len(sliceBal), len(sliceRANS))
+	}
+
+	structBal, err := qdf.Marshal(set, qdf.OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	structRANS, err := qdf.Marshal(set, qdf.OptBalanced|qdf.OptRANS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(structRANS) >= len(structBal) {
+		t.Errorf("a top-level generated struct went %d -> %d with rANS (no change), "+
+			"while the same rows as a slice went %d -> %d (%.1f%% off) — the struct "+
+			"is not being framed",
+			len(structBal), len(structRANS), len(sliceBal), len(sliceRANS),
+			float64(len(sliceBal)-len(sliceRANS))/float64(len(sliceBal))*100)
+	}
+
+	// Whatever framing it gets, the value must come back.
+	for _, o := range []struct {
+		name string
+		opts qdf.Options
+	}{
+		{"balanced", qdf.OptBalanced},
+		{"balanced+rans", qdf.OptBalanced | qdf.OptRANS},
+		{"compression", qdf.OptCompression},
+	} {
+		b, err := qdf.Marshal(set, o.opts)
+		if err != nil {
+			t.Fatalf("%s: %v", o.name, err)
+		}
+		var got GenRowSet
+		if err := qdf.Unmarshal(b, &got); err != nil {
+			t.Fatalf("%s: decode: %v", o.name, err)
+		}
+		if len(got.Rows) != len(rows) {
+			t.Fatalf("%s: %d rows, want %d", o.name, len(got.Rows), len(rows))
+		}
+		for i := range rows {
+			if !reflect.DeepEqual(got.Rows[i], rows[i]) {
+				t.Fatalf("%s row %d:\n got %+v\nwant %+v", o.name, i, got.Rows[i], rows[i])
+			}
+		}
+	}
+}
+
+// handBlob is a HAND-WRITTEN Marshaler in the shape this repository already
+// uses for one (see GenTag): a self-delimiting body it writes and reads itself,
+// with no reference to the encoder's Options at all.
+//
+// That is precisely the contract customFramed protects. Reframing such a body
+// would stamp FlagRANS onto bytes that were never produced under those options,
+// and the fix below must not touch it.
+type handBlob struct {
+	Payload string
+}
+
+func (h handBlob) MarshalQDF(dst []byte) ([]byte, error) {
+	dst = append(dst, 'B', byte(len(h.Payload)>>8), byte(len(h.Payload)))
+	return append(dst, h.Payload...), nil
+}
+
+func (h *handBlob) UnmarshalQDF(src []byte) (int, error) {
+	if len(src) < 3 || src[0] != 'B' {
+		return 0, qdfErrShort
+	}
+	n := int(src[1])<<8 | int(src[2])
+	if len(src) < 3+n {
+		return 0, qdfErrShort
+	}
+	h.Payload = string(src[3 : 3+n])
+	return 3 + n, nil
+}
+
+// The protection must survive the fix: a hand-written Marshaler stays unframed.
+//
+// Its body is opts-invariant by contract, so the bytes come out identical with
+// rANS on and off — and they must, or the decoder is handed a FlagRANS frame
+// around a payload that was never compressed.
+func TestHandWrittenMarshalerIsNotReframed(t *testing.T) {
+	// Long and entirely uniform, so rANS would certainly take it if allowed to.
+	v := handBlob{Payload: string(make([]byte, 4096))}
+
+	plain, err := qdf.Marshal(v, qdf.OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	framed, err := qdf.Marshal(v, qdf.OptBalanced|qdf.OptRANS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(plain) != string(framed) {
+		t.Fatalf("a hand-written Marshaler's bytes changed with rANS: %d vs %d — its body "+
+			"is opts-invariant by contract and must not be reframed",
+			len(plain), len(framed))
+	}
+	var got handBlob
+	if err := qdf.Unmarshal(framed, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Payload != v.Payload {
+		t.Fatal("hand-written Marshaler did not round-trip")
+	}
+}

--- a/internal/codegen_test/rans_frame_test.go
+++ b/internal/codegen_test/rans_frame_test.go
@@ -1,6 +1,7 @@
 package cgsample
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -119,3 +120,47 @@ func TestTopLevelGeneratedStructIsRANSFramed(t *testing.T) {
 // That test was also verified to fail if this change is made too broadly (the
 // kind distinction dropped, customFramed never set), so the guard is real and
 // duplicating it here would only be a second thing to maintain.
+
+// Appending into a buffer whose body is already framed must FAIL, not corrupt.
+//
+// A framed body is one sealed unit; plain tags written after it do not extend
+// the message, they invalidate the frame. Before entropy framing could reach a
+// generated body the same append merely left trailing bytes every decoder
+// ignored — so nothing that worked is being taken away. What changed is that
+// the failure is reported instead of destroying the value that was readable:
+// without the guard, decoding the extended buffer returns "tans: corrupt
+// stream" and zero rows where it previously returned all of them.
+func TestAppendIntoFramedBufferIsRefused(t *testing.T) {
+	rows := ransRows(64)
+	base, err := qdf.Marshal(GenRowSet{Rows: rows}, qdf.OptBalanced|qdf.OptRANS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base[4]&qdf.FlagRANS == 0 {
+		t.Fatalf("fixture is not framed (flag %08b) — this test would prove nothing", base[4])
+	}
+
+	extra := GenRowInner{X: 7, Y: "y"}
+	if _, err := extra.MarshalQDF(base); !errors.Is(err, qdf.ErrAppendAfterFrame) {
+		t.Fatalf("appending into a framed buffer returned %v, want ErrAppendAfterFrame", err)
+	}
+
+	// The refusal must leave the original readable — reporting a failure is only
+	// an improvement if nothing was damaged reaching it.
+	var got GenRowSet
+	if err := qdf.Unmarshal(base, &got); err != nil {
+		t.Fatalf("the original buffer no longer decodes: %v", err)
+	}
+	if len(got.Rows) != len(rows) {
+		t.Fatalf("original decoded to %d rows, want %d", len(got.Rows), len(rows))
+	}
+
+	// An UNframed buffer still accepts the append, as it always did.
+	plain, err := qdf.Marshal(GenRowSet{Rows: rows}, qdf.OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := extra.MarshalQDF(plain); err != nil {
+		t.Fatalf("appending into an unframed buffer failed: %v", err)
+	}
+}

--- a/internal/codegen_test/sample_qdf.go
+++ b/internal/codegen_test/sample_qdf.go
@@ -80,6 +80,9 @@ var qdfHybKinds_GenRow = []byte{0x00, 0x04, 0xff, 0xff}
 // the extended slice.
 func (v *Edge) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -304,6 +307,9 @@ func (v *Edge) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, er
 // the extended slice.
 func (v *GenAnyBox) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -435,6 +441,9 @@ func (v *GenAnyBox) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (in
 // the extended slice.
 func (v *GenBlobRow) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -580,6 +589,9 @@ func (v *GenBlobRow) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (i
 // the extended slice.
 func (v *GenBlobSet) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -799,6 +811,9 @@ func (v *GenBlobSet) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (i
 // the extended slice.
 func (v *GenEmbedTime) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -935,6 +950,9 @@ func (v *GenEmbedTime) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) 
 // the extended slice.
 func (v *GenEvent) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -1089,6 +1107,9 @@ func (v *GenEvent) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int
 // the extended slice.
 func (v *GenEventLog) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -1337,6 +1358,9 @@ func (v *GenEventLog) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (
 // the extended slice.
 func (v *GenFloatMap) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -1522,6 +1546,9 @@ func (v *GenFloatMap) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (
 // the extended slice.
 func (v *GenMetric) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -1682,6 +1709,9 @@ func (v *GenMetric) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (in
 // the extended slice.
 func (v *GenMetricBatch) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -1949,6 +1979,9 @@ func (v *GenMetricBatch) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena
 // the extended slice.
 func (v *GenName) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -2082,6 +2115,9 @@ func (v *GenName) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int,
 // the extended slice.
 func (v *GenNameList) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -2300,6 +2336,9 @@ func (v *GenNameList) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (
 // the extended slice.
 func (v *GenNamedCodec) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -2431,6 +2470,9 @@ func (v *GenNamedCodec) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena)
 // the extended slice.
 func (v *GenOpt) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -2642,6 +2684,9 @@ func (v *GenOpt) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, 
 // the extended slice.
 func (v *GenOptSet) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -2952,6 +2997,9 @@ func (v *GenOptSet) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (in
 // the extended slice.
 func (v *GenRow) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -3150,6 +3198,9 @@ func (v *GenRow) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, 
 // the extended slice.
 func (v *GenRowInner) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -3283,6 +3334,9 @@ func (v *GenRowInner) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (
 // the extended slice.
 func (v *GenRowSet) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -3541,6 +3595,9 @@ func (v *GenRowSet) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (in
 // the extended slice.
 func (v *GenTrailed) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -3844,6 +3901,9 @@ func (v *GenTrailed) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (i
 // the extended slice.
 func (v *Inner) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()
@@ -3977,6 +4037,9 @@ func (v *Inner) UnmarshalQDFArena(src []byte, noCopy bool, a *qdf.Arena) (int, e
 // the extended slice.
 func (v *Sample) MarshalQDF(dst []byte) ([]byte, error) {
 	hadHeader := len(dst) >= 5 && dst[0] == qdf.Magic0 && dst[1] == qdf.Magic1 && dst[2] == qdf.Magic2
+	if hadHeader && dst[4]&qdf.FlagRANS != 0 {
+		return nil, qdf.ErrAppendAfterFrame
+	}
 	e := qdf.NewEncoderOnBuf(dst, qdf.Fast)
 	if hadHeader {
 		e.MarkHeaderWritten()

--- a/marshaler.go
+++ b/marshaler.go
@@ -94,10 +94,23 @@ func DecodeNested(d *Decoder, u Unmarshaler) error {
 // from a QDF wire-format slice. Implementations should consume exactly one
 // value from src and return the number of bytes consumed.
 //
-// A custom UnmarshalQDF reads the Fast wire format. Marshal honours this: a
-// type implementing Marshaler always emits its Fast-format body and is framed
-// as Fast regardless of the Options passed, so Marshaler+Unmarshaler types
-// round-trip under any Options. A type that implements Unmarshaler WITHOUT
+// A custom UnmarshalQDF reads the Fast wire format, and Marshal honours that
+// for a HAND-WRITTEN Marshaler: such a type emits its own Fast body and is
+// framed as Fast regardless of the Options passed, so it round-trips under any
+// Options and its wire may be read by stripping the five-byte header and
+// calling UnmarshalQDF directly.
+//
+// An EncoderMarshaler — generated code — is different, and the difference
+// matters to anyone reading its bytes by hand. It writes its body into the
+// caller's encoder and honours that encoder's Options, so its framing follows
+// them too: under OptRANS or OptCompression the body is entropy-coded and
+// everything after the header is a compressed blob, not a tag stream. Read it
+// through Unmarshal or UnmarshalDirect, which unframe first. Stripping five
+// bytes and calling UnmarshalQDF on the remainder was never guaranteed and now
+// fails outright on a framed body — usually with an error, but a compressed
+// blob is arbitrary bytes and a parser can be unlucky.
+//
+// A type that implements Unmarshaler WITHOUT
 // also implementing Marshaler is encoded structurally; under a Dense/QPack
 // tier that produces a Dense body its Fast-only UnmarshalQDF cannot read.
 // Implement both interfaces (or neither) to avoid this — generated code from

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -2075,21 +2075,36 @@ func encodeMarshaler(t reflect.Type) func(*Encoder, unsafe.Pointer) error {
 		// and the decoder allocates dense state it never uses. Nested
 		// Marshaler fields (header already emitted) are unaffected: their
 		// custom body is written inline as before.
-		if !e.headerOut {
-			savedMode, savedQPack := e.mode, e.qpack
-			e.mode, e.qpack = Fast, false
-			e.writeHeader()
-			e.mode, e.qpack = savedMode, savedQPack
-			// The top-level Marshaler owns the framing (Fast). Mark it so the
-			// post-encode rANS pass leaves the body opts-invariant.
-			e.customFramed = true
-		}
 		m := reflect.NewAt(t, p).Interface().(Marshaler)
-		// Thread the shared encoder when the type supports it (generated code):
-		// no fresh encoder (and its state) per element, and shape/intern state is
-		// shared across a slice so it can be interned. The top-level framing above
-		// has already run; EncodeQDF writes the body into e directly.
-		if em, ok := m.(EncoderMarshaler); ok {
+		// Which KIND of Marshaler decides the framing, so it has to be known
+		// before the header is written.
+		//
+		// An EncoderMarshaler — generated code — writes its body into THIS
+		// encoder and honours its mode: StructShape and WriteStringField both
+		// respect Dense. Its bytes are not opts-invariant, so the header must
+		// state the real mode and the post-encode rANS pass may reframe them.
+		// Forcing Fast and marking customFramed for it cost a top-level
+		// generated struct every byte rANS would have saved — measured at 2205
+		// against 1084->925 for the same rows as a slice.
+		//
+		// A plain Marshaler emits its own Fast body and never looks at Options,
+		// which is the contract the Fast header and customFramed exist for.
+		em, threaded := m.(EncoderMarshaler)
+		if !e.headerOut {
+			if threaded {
+				e.writeHeader()
+			} else {
+				savedMode, savedQPack := e.mode, e.qpack
+				e.mode, e.qpack = Fast, false
+				e.writeHeader()
+				e.mode, e.qpack = savedMode, savedQPack
+				e.customFramed = true
+			}
+		}
+		// Thread the shared encoder when the type supports it: no fresh encoder
+		// (and its state) per element, and shape/intern state is shared across a
+		// slice so it can be interned.
+		if threaded {
 			return em.EncodeQDF(e)
 		}
 		out, err := m.MarshalQDF(e.buf)

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -2067,14 +2067,8 @@ func decodeTime(d *Decoder, p unsafe.Pointer) error {
 
 func encodeMarshaler(t reflect.Type) func(*Encoder, unsafe.Pointer) error {
 	return func(e *Encoder, p unsafe.Pointer) error {
-		// A Marshaler emits its own Fast-format body and ignores the
-		// encoder's Options. When it is the top-level value, frame the
-		// stream honestly as Fast (flag 0) instead of stamping the
-		// encoder's Dense/QPack mode onto a Fast body — otherwise the
-		// header lies, UnmarshalDirect takes a needless reflect fallback,
-		// and the decoder allocates dense state it never uses. Nested
-		// Marshaler fields (header already emitted) are unaffected: their
-		// custom body is written inline as before.
+		// Nested Marshaler fields (header already emitted) are unaffected by
+		// any of the framing below: their custom body is written inline.
 		m := reflect.NewAt(t, p).Interface().(Marshaler)
 		// Which KIND of Marshaler decides the framing, so it has to be known
 		// before the header is written.


### PR DESCRIPTION
A top-level value that is a **generated struct** was never rANS-framed. Under
`OptCompression` at 512 elements that cost 31.7% of the wire — the caller asked
for compression and silently did not get it.

## Cause

`reflect_encode.go` forced a Fast header onto every top-level `Marshaler` and set
`customFramed`, and `maybeApplyRANS` declines on that flag: *"a top-level
Marshaler forced Fast framing and its bytes are opts-invariant by contract"*.

The contract is real, but it belongs to one of the two kinds:

- A **hand-written `Marshaler`** emits its own body and never reads Options. The
  Fast header is the truth, and reframing it would be wrong. Unchanged.
- An **`EncoderMarshaler`** (generated) writes its body into *this* encoder and
  honours its mode — `StructShape` and `WriteStringField` both respect Dense. For
  it the Fast header was the lie, and the flag cost it every byte rANS would have
  saved.

The kind is now decided *before* the header is written.

## Wire

| shape | main | this |
|---|---:|---:|
| 512 elements, `OptCompression` | 11342 | **7749** (−31.7%) |
| 512 elements, `+OptRANS` | 17402 | 14648 (−15.8%) |
| 64 elements, `OptCompression` | 1889 | 1433 (−24.1%) |
| 64 elements, `+OptRANS` | 2205 | 2090 (−5.2%) |
| `OptBalanced` | unchanged | unchanged |

## CPU — read this one carefully

Against the old baseline, encode is +78% and decode +33..140%. That baseline was
**not compressing at all**, so the comparison prices work that was being skipped.

Priced against the path that always did that work — reflect, same data, same
options — the generated path is **81.7µs to reflect's 116.1µs**, still 30% ahead.
It did not get slower; it started doing what it was asked to do, and does it
better than the encoder that always did.

## Compatibility

Verified in both directions: 40 wire fixtures × both trees, all decode. Golden
digests unaffected (none cover a top-level Marshaler). Patches (`Diff`/`Apply`)
and streams are byte-identical — both already have `headerOut` set, so the
changed branch cannot fire. `OptSpeed` wire is byte-identical.

**Release note:** for this one shape the bytes change — header flag `0x00` →
`0x03`/`0x07` and a compressed body. Anyone content-addressing stored blobs of a
top-level generated struct will see cache misses on upgrade. Nothing fails to
decode.

## Found by audit, fixed here

- **Appending into a framed buffer destroyed the value that was readable.**
  Previously it left trailing bytes every decoder ignored; with a compressed body
  the same append corrupts the frame — "tans: corrupt stream", zero rows. It
  returns `ErrAppendAfterFrame` now, and the test checks the original stays
  decodable.
- **`marshaler.go` documented a contract the code no longer honours** — it invited
  "strip five bytes, call `UnmarshalQDF`", which fails on a framed body. Usually
  with an error, but a compressed blob is arbitrary bytes; that is the one
  silent-wrong risk here and why the paragraph was rewritten.
- **A stale comment argued for the replaced behaviour**, including a claim the
  audit refuted by measurement: a non-Fast header does not make `UnmarshalDirect`
  take "a needless reflect fallback" — the fallback is *faster* (11.2µs/143
  allocs against 15.2µs/228), because it lands on the pooled decoder.
- **The tests were strengthened where they were one-sided.** The rANS test is
  named for framing and only compared sizes; it asserts `FlagRANS` now, which
  cannot be satisfied by degrading the baseline. A duplicate hand-written-Marshaler
  test was dropped — `marshaler_framing_test.go` covers it more strictly — and its
  stated hazard turned out not to exist.
- One audit recommendation was applied, tested, and **reverted**: levelling
  `TestNamedCodecFieldRoutesThroughCodec` to `OptSpeed` blinds it. Both sides of
  that comparison are generated code, and it works precisely because the modes
  differ — a codec frame is mode-invariant, a bypassed bare string is not. The
  mechanism is now written down.

## Not in this PR

The largest remaining codegen gap — a top-level slice of a generated type is
never columnar, +62.6% wire at 512 — was investigated and deliberately left
alone. Relaxing the guard that causes it produces wire generated decoders cannot
read (verified). It is blocked on the decoder-fallback defect and wants a
different design: give the generated type its own columnar entry rather than
letting reflect transpose it.

## Verification

All four modules green; `-race` clean; fuzzers clean; `qdf_reflect2` / `qdf_simd`
pass; golangci clean on the changed files; the two-phase codegen job passes.
