### PR TITLE
fix(qdf): read a columnar frame into a slice whose element has its own codec

### DIFF
--- a/cmd/qdf-bench/codegen_convergence_test.go
+++ b/cmd/qdf-bench/codegen_convergence_test.go
@@ -383,12 +383,13 @@ func TestCodegenAndReflectWiresAreInterchangeable(t *testing.T) {
 			// corruption. Either the value comes back intact, or the decode
 			// fails with an error a caller can see and handle.
 			//
-			// Which lengths fail is deliberately NOT asserted from the root
-			// tag: under OptCompression the container is wrapped and the tag
-			// varies (0xBD, 0xEF, 0xD7 were all observed), so a byte test there
-			// would be guessing. TestReflectWireIntoGeneratedTypeBoundary pins
-			// the boundary separately, where it can be measured rather than
-			// inferred.
+			// This arm survives from when the decode could legitimately fail
+			// past fifteen elements. It no longer can — the columnar fallback
+			// reads that wire — and TestReflectWireDecodesIntoGeneratedType
+			// asserts the stronger property directly, across three option sets
+			// and with the values compared. The tolerant shape is kept because
+			// what it forbids is what actually costs a caller: a decode that
+			// returns no error and the wrong value.
 			var intoGen []GenService
 			if err := qdf.Unmarshal(rb, &intoGen); err == nil {
 				if !reflect.DeepEqual(intoGen, gen) {
@@ -397,40 +398,6 @@ func TestCodegenAndReflectWiresAreInterchangeable(t *testing.T) {
 						n, o.name)
 				}
 			}
-		}
-	}
-}
-
-// Where the reverse direction stops working, pinned so that fixing it or
-// breaking it further are both noticed.
-//
-// A wire written by reflect decodes into the generated type until reflect
-// switches to the columnar container; generated decoders do not read that form.
-// Measured here and identically on merged main (23a3b18), so it is neither the
-// string codecs nor this branch — it is the same split that leaves the
-// generator deciding its container with a static len >= 16 while reflect probes
-// the data.
-func TestReflectWireIntoGeneratedTypeBoundary(t *testing.T) {
-	type result struct {
-		n  int
-		ok bool
-	}
-	var got []result
-	for _, n := range []int{2, 15, 16, 17, 64} {
-		plain := mkServices(n)
-		rb, err := qdf.Marshal(plain, qdf.OptBalanced)
-		if err != nil {
-			t.Fatal(err)
-		}
-		var into []GenService
-		got = append(got, result{n, qdf.Unmarshal(rb, &into) == nil})
-	}
-	want := []result{{2, true}, {15, true}, {16, false}, {17, false}, {64, false}}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("n=%d: reflect wire into the generated type decodes=%v, was %v — "+
-				"the boundary moved; if this is a fix, update the expectation",
-				got[i].n, got[i].ok, want[i].ok)
 		}
 	}
 }

--- a/cmd/qdf-bench/columnar_decode_test.go
+++ b/cmd/qdf-bench/columnar_decode_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/alex60217101990/qdf"
+)
+
+// A wire written by the reflect encoder must decode into the generated twin.
+//
+// It does not, from sixteen elements up: reflect switches to the hybrid
+// columnar container there, and a generated decoder accepts only the ONE column
+// split baked into it at generation time —
+//
+//	if !slices.Equal(names, qdfHybNames_X) || !slices.Equal(kinds, qdfHybKinds_X) {
+//	    return qdf.ErrTypeMismatch
+//	}
+//
+// — while reflect chooses its split by probing the data. The refusal is correct
+// in itself: reading on would produce wrong values. What is missing is a way to
+// fall back.
+//
+// Service and GenService are defined types over one another with identical
+// layouts, so this is the same value by construction, not two similar ones. The
+// producer here is a plain library user with no generated code; the consumer
+// only has the generated type. Neither is doing anything unusual.
+func TestReflectWireDecodesIntoGeneratedType(t *testing.T) {
+	for _, n := range []int{2, 15, 16, 17, 64, 512} {
+		plain := mkServices(n)
+		for _, o := range []struct {
+			name string
+			opts qdf.Options
+		}{
+			{"speed", qdf.OptSpeed},
+			{"balanced", qdf.OptBalanced},
+			{"compression", qdf.OptCompression},
+		} {
+			wire, err := qdf.Marshal(plain, o.opts)
+			if err != nil {
+				t.Fatalf("n=%d %s: %v", n, o.name, err)
+			}
+			var got []GenService
+			if err := qdf.Unmarshal(wire, &got); err != nil {
+				t.Errorf("n=%-3d %-12s root=0x%02x: %v", n, o.name, wire[5], err)
+				continue
+			}
+			want := make([]GenService, n)
+			for k := range plain {
+				want[k] = GenService(plain[k])
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("n=%d %s: decoded value differs", n, o.name)
+			}
+		}
+	}
+}
+
+// The reverse direction already works and must keep working: a generated
+// producer's wire read by a consumer that only has the plain type.
+func TestGeneratedWireDecodesIntoPlainType(t *testing.T) {
+	for _, n := range []int{2, 16, 64} {
+		plain := mkServices(n)
+		gen := make([]GenService, n)
+		for k := range plain {
+			gen[k] = GenService(plain[k])
+		}
+		for _, o := range []struct {
+			name string
+			opts qdf.Options
+		}{
+			{"speed", qdf.OptSpeed},
+			{"balanced", qdf.OptBalanced},
+			{"compression", qdf.OptCompression},
+		} {
+			wire, err := qdf.Marshal(gen, o.opts)
+			if err != nil {
+				t.Fatalf("n=%d %s: %v", n, o.name, err)
+			}
+			var got []Service
+			if err := qdf.Unmarshal(wire, &got); err != nil {
+				t.Fatalf("n=%d %s: %v", n, o.name, err)
+			}
+			if !reflect.DeepEqual(got, plain) {
+				t.Fatalf("n=%d %s: decoded value differs", n, o.name)
+			}
+		}
+	}
+}

--- a/cmd/qdf-bench/columnar_decode_test.go
+++ b/cmd/qdf-bench/columnar_decode_test.go
@@ -87,3 +87,82 @@ func TestGeneratedWireDecodesIntoPlainType(t *testing.T) {
 		}
 	}
 }
+
+// Encoding must be untouched by the decode fallback.
+//
+// The bytes are compared against bytes produced in the same run rather than
+// against a stored digest: the property is that nothing here reaches the
+// encoder, and a stored digest would also fail for an unrelated deliberate wire
+// change and teach the next reader to update it without thinking.
+//
+// Re-encoding AFTER a fallback decode is the part that matters. The fallback
+// builds a columnar plan and caches it; if that plan ever leaked into the
+// encode path, the first encode of a process would differ from the second, and
+// only an ordering like this one would notice.
+func TestDecodeFallbackLeavesEncodingAlone(t *testing.T) {
+	// Counts the rows where the plain twin actually produced a columnar frame.
+	// The divergence check below compares the two root tags, and a comparison
+	// only means something while one side really is columnar — without this the
+	// whole assertion would go quiet the day reflect stopped transposing, and
+	// the test would keep passing.
+	columnarRows := 0
+	for _, n := range []int{2, 15, 16, 17, 64, 512} {
+		plain := mkServices(n)
+		gen := make([]GenService, n)
+		for k := range plain {
+			gen[k] = GenService(plain[k])
+		}
+		for _, o := range []struct {
+			name string
+			opts qdf.Options
+		}{
+			{"speed", qdf.OptSpeed},
+			{"balanced", qdf.OptBalanced},
+			{"compression", qdf.OptCompression},
+			{"balanced+rans", qdf.OptBalanced | qdf.OptRANS},
+			{"balanced+colindex", qdf.OptBalanced | qdf.OptColumnIndex},
+		} {
+			a, err := qdf.Marshal(plain, o.opts)
+			if err != nil {
+				t.Fatalf("n=%d %s: %v", n, o.name, err)
+			}
+			var round []GenService
+			if err := qdf.Unmarshal(a, &round); err != nil {
+				t.Fatalf("n=%d %s: decode: %v", n, o.name, err)
+			}
+			b, err := qdf.Marshal(plain, o.opts)
+			if err != nil {
+				t.Fatalf("n=%d %s: %v", n, o.name, err)
+			}
+			if string(a) != string(b) {
+				t.Errorf("n=%d %s: re-encoding after a fallback decode changed %d bytes to %d",
+					n, o.name, len(a), len(b))
+			}
+			g1, err := qdf.Marshal(gen, o.opts)
+			if err != nil {
+				t.Fatalf("n=%d %s gen: %v", n, o.name, err)
+			}
+			g2, err := qdf.Marshal(gen, o.opts)
+			if err != nil {
+				t.Fatalf("n=%d %s gen: %v", n, o.name, err)
+			}
+			if string(g1) != string(g2) {
+				t.Errorf("n=%d %s: the generated type's wire is not stable", n, o.name)
+			}
+			// The generated type must still take its own codec rather than the
+			// columnar container its plain twin takes. If the fallback had
+			// reached the encoder, this root tag would follow the reflect one.
+			if n >= 16 && a[5] == 0xF7 {
+				columnarRows++
+				if g1[5] == 0xF7 {
+					t.Errorf("n=%d %s: the generated type now encodes columnar (0xF7) like its "+
+						"plain twin — the fallback reached the encoder", n, o.name)
+				}
+			}
+		}
+	}
+	if columnarRows == 0 {
+		t.Fatal("no row produced a columnar frame from the plain type, so the divergence " +
+			"check above never ran and this test proved nothing about the encoder")
+	}
+}

--- a/cmd/qdf-bench/columnar_fallback_bench_test.go
+++ b/cmd/qdf-bench/columnar_fallback_bench_test.go
@@ -13,6 +13,19 @@ import (
 // decode at all, so there is no earlier number for it. OptSpeed writes the
 // row-major form of the identical slice, which is what a caller would have had
 // to fall back to.
+//
+// RUN IT BOTH WAYS — the answer changes sign with the build. Nearly all of the
+// columnar decode is bit-unpacking an alphabet-packed string column, and
+// internal/bitpack has hand-written assembly for it behind the qdf_simd tag,
+// which is off by default:
+//
+//	default (scalar)   columnar 194.6us   row-major 134.5us   columnar LOSES
+//	-tags qdf_simd     columnar 118.8us   row-major 133.5us   columnar WINS
+//
+// -38.96% on the columnar arm (p=0.000, n=10) and no movement on row-major,
+// which is the control: the vector path touches only the unpacking that the
+// columnar form uses. Quoting either row without naming the build is how a
+// wrong verdict gets recorded, and one already was.
 func benchDecodeInto(b *testing.B, opts qdf.Options, n int) {
 	wire, err := qdf.Marshal(mkServices(n), opts)
 	if err != nil {

--- a/cmd/qdf-bench/columnar_fallback_bench_test.go
+++ b/cmd/qdf-bench/columnar_fallback_bench_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/alex60217101990/qdf"
+)
+
+// What the fallback costs against what it replaces.
+//
+// The comparison is columnar-vs-row-major for the SAME values decoded into the
+// SAME type, not fallback-vs-error: before this branch the columnar arm did not
+// decode at all, so there is no earlier number for it. OptSpeed writes the
+// row-major form of the identical slice, which is what a caller would have had
+// to fall back to.
+func benchDecodeInto(b *testing.B, opts qdf.Options, n int) {
+	wire, err := qdf.Marshal(mkServices(n), opts)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(int64(len(wire)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		var into []GenService
+		if err := qdf.Unmarshal(wire, &into); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFallbackColumnar512(b *testing.B) { benchDecodeInto(b, qdf.OptBalanced, 512) }
+func BenchmarkFallbackRowMajor512(b *testing.B) { benchDecodeInto(b, qdf.OptSpeed, 512) }

--- a/columnar.go
+++ b/columnar.go
@@ -288,6 +288,41 @@ func buildColumnarPlan(td *typeDesc) *columnarPlan {
 	return plan
 }
 
+// structuralColumnarPlan builds a columnar plan for et from a SYNTHETIC
+// descriptor, for the one case the shared descriptor cannot serve: an element
+// type that carries a codec of its own.
+//
+// fillDesc returns early for such a type with no fields, so buildColumnarPlan
+// yields nil for its shared descriptor and the slice decoder has no plan to read
+// a columnar frame with. descBuild cannot help — it consults typeCache first and
+// would hand back that same fieldless descriptor.
+//
+// The result is used ONLY on decode, and only once a columnar frame has actually
+// been seen. That is what makes reading the type structurally faithful rather
+// than a guess: a hand-written codec writes its own format and never produces a
+// columnar frame, so meeting one is evidence the producer was the structural
+// encoder.
+//
+// The synthetic descriptor is deliberately not published to typeCache and never
+// replaces the shared one. Giving the shared descriptor fields would also give it
+// a columnar plan, and that plan feeds the slice ENCODER — which would start
+// transposing a type whose codec must be called.
+//
+// nil for anything that cannot be described structurally; the caller then behaves
+// exactly as it did before.
+func structuralColumnarPlan(et reflect.Type) *columnarPlan {
+	if et.Kind() != reflect.Struct {
+		return nil
+	}
+	ctx := &buildCtx{inProgress: make(map[reflect.Type]*typeDesc)}
+	fields, err := buildStructFields(et, ctx)
+	if err != nil {
+		return nil
+	}
+	// buildColumnarPlan reads exactly these three.
+	return buildColumnarPlan(&typeDesc{kind: reflect.Struct, rType: et, fields: fields})
+}
+
 // colShapeDeclare registers a new columnar shape (names + kinds) on the encoder
 // and returns its 1-based wire ID. Always appends; call colShapeFor first to
 // avoid duplicates.

--- a/columnar_fallback_refuse_test.go
+++ b/columnar_fallback_refuse_test.go
@@ -1,0 +1,64 @@
+package qdf
+
+import (
+	"testing"
+)
+
+// badRow has a codec of its own AND a field no structural walk can describe, so
+// the fallback must refuse it. The producer is a different type entirely — a
+// plain struct that encodes columnar — which is the only way this path is
+// reachable: nothing could ever WRITE a columnar frame from badRow itself.
+type badRow struct {
+	ID string   `qdf:"id"`
+	Ch chan int `qdf:"ch"`
+}
+
+func (v *badRow) MarshalQDF(dst []byte) ([]byte, error)      { return dst, nil }
+func (v *badRow) UnmarshalQDF(src []byte) (n int, err error) { return 0, nil }
+
+type goodRow struct {
+	ID   string `qdf:"id"`
+	Seq  int64  `qdf:"seq"`
+	Note string `qdf:"note"`
+}
+
+// An element the fallback cannot describe must be refused ONCE, not re-walked on
+// every decode.
+//
+// The refusal itself is the cheap half to get right. The expensive half is that
+// without remembering it, each decode rebuilds the element's whole field list —
+// allocating descriptors — and throws it away, forever, on the one path that
+// gains nothing. Asserted by allocation count rather than by timing: a walk that
+// no longer happens cannot allocate.
+func TestColumnarFallbackRefusesOnlyOnce(t *testing.T) {
+	rows := make([]goodRow, 64)
+	for i := range rows {
+		rows[i] = goodRow{
+			ID:   "svc-" + string(rune('a'+i%26)),
+			Seq:  int64(i),
+			Note: "a note that is long enough to be worth columnarising",
+		}
+	}
+	wire, err := Marshal(rows, OptBalanced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wire[5] != tagHybridColStruct && wire[5] != tagColStruct {
+		t.Fatalf("the fixture wire is 0x%02x, not columnar — this test would never reach "+
+			"the fallback and would pass without exercising anything", wire[5])
+	}
+
+	decode := func() {
+		var into []badRow
+		if err := Unmarshal(wire, &into); err == nil {
+			t.Fatal("an element with a channel field decoded a columnar frame")
+		}
+	}
+
+	decode() // first refusal: pays for the walk that fails
+	steady := testing.AllocsPerRun(50, decode)
+	if steady > 8 {
+		t.Errorf("a refused element still allocates %.0f objects per decode — the refusal "+
+			"is not being remembered and the field walk runs every time", steady)
+	}
+}

--- a/columnar_fallback_test.go
+++ b/columnar_fallback_test.go
@@ -1,0 +1,75 @@
+package qdf
+
+import (
+	"reflect"
+	"testing"
+)
+
+// fbRow is a struct with a codec of its own, standing in for a generated type.
+// It implements BOTH Marshaler and Unmarshaler, which is what sends fillDesc
+// down its early return with no fields — the single-direction case takes a
+// different path and would leave the fields populated.
+type fbRow struct {
+	ID   int64  `qdf:"id"`
+	Name string `qdf:"name"`
+}
+
+func (v *fbRow) MarshalQDF(dst []byte) ([]byte, error)      { return dst, nil }
+func (v *fbRow) UnmarshalQDF(src []byte) (n int, err error) { return 0, nil }
+
+// The shared descriptor of such a type has no fields, so buildColumnarPlan
+// yields nil for it — that is the defect's root, asserted here rather than
+// assumed. structuralColumnarPlan must produce a plan anyway, WITHOUT changing
+// the shared descriptor.
+func TestStructuralColumnarPlanSeesFieldsTheSharedDescriptorHides(t *testing.T) {
+	et := reflect.TypeFor[fbRow]()
+
+	shared, err := descOf(et)
+	if err != nil {
+		t.Fatalf("descOf: %v", err)
+	}
+	if len(shared.fields) != 0 {
+		t.Fatalf("the shared descriptor has %d fields — this type no longer takes the "+
+			"early return, and the premise of this test is gone", len(shared.fields))
+	}
+	if buildColumnarPlan(shared) != nil {
+		t.Fatal("the shared descriptor already yields a columnar plan — the defect this " +
+			"builds a fallback for does not exist as described")
+	}
+
+	plan := structuralColumnarPlan(et)
+	if plan == nil {
+		t.Fatal("structuralColumnarPlan returned nil for a plain two-field struct")
+	}
+
+	// The shared descriptor must be exactly as it was. This is the assertion
+	// that keeps the change decode-only: if fields appeared here, the slice
+	// ENCODER would start transposing this type and skipping its codec.
+	again, err := descOf(et)
+	if err != nil {
+		t.Fatalf("descOf: %v", err)
+	}
+	if again != shared {
+		t.Fatal("descOf returned a different descriptor — the synthetic build published to typeCache")
+	}
+	if len(again.fields) != 0 {
+		t.Fatalf("the shared descriptor gained %d fields", len(again.fields))
+	}
+	if buildColumnarPlan(again) != nil {
+		t.Fatal("the shared descriptor now yields a columnar plan — encoding would change")
+	}
+}
+
+// A type that cannot be described structurally must yield nil rather than an
+// error or a panic: the caller's contract is to fall back to today's behaviour.
+func TestStructuralColumnarPlanDeclinesWhatItCannotDescribe(t *testing.T) {
+	type undescribable struct {
+		Ch chan int `qdf:"ch"`
+	}
+	if plan := structuralColumnarPlan(reflect.TypeFor[undescribable]()); plan != nil {
+		t.Fatal("a struct with a channel field produced a columnar plan")
+	}
+	if plan := structuralColumnarPlan(reflect.TypeFor[int]()); plan != nil {
+		t.Fatal("a non-struct produced a columnar plan")
+	}
+}

--- a/encbuf_hint_test.go
+++ b/encbuf_hint_test.go
@@ -3,7 +3,6 @@ package qdf
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"runtime"
 	"testing"
 )
 
@@ -142,41 +141,45 @@ func TestWideScratchSurvivesLargeColumns(t *testing.T) {
 		return wideCol{Data: d}
 	}
 
-	measure := func(v wideCol) uint64 {
-		for range 50 { // let the pooled scratch settle
-			if _, err := Marshal(v, OptBalanced); err != nil {
-				t.Fatal(err)
-			}
-		}
-		var a, b runtime.MemStats
-		runtime.ReadMemStats(&a)
-		const runs = 100
-		for range runs {
-			if _, err := Marshal(v, OptBalanced); err != nil {
-				t.Fatal(err)
-			}
-		}
-		runtime.ReadMemStats(&b)
-		return (b.TotalAlloc - a.TotalAlloc) / runs
-	}
-
-	const largeN = 100000 // over the former 1<<14 ceiling, under the current 1<<17
-	small := measure(mk(8192))
-	large := measure(mk(largeN))
-
-	// The scratch is []uint64, so dropping and rebuilding it costs exactly 8
-	// bytes per element per message. Bound the whole message by that figure:
-	// well above what the column legitimately allocates, well below what it
-	// costs to rebuild the scratch on top of that.
+	// The property is what putEnc does with the widening scratch on release:
+	// keep it when it is within the retention ceiling, drop it when it is a
+	// one-off spike. Asserted on the scratch itself.
 	//
-	// The bound is absolute rather than a multiple of the small column because
-	// -race inflates every allocation, and by different factors on different
-	// runners. Measured per element: 2.1 B fixed without -race, up to 6.0 B
-	// fixed under it, against 10.2 B with the ceiling back at 1<<14 — so 8 B
-	// separates the two regimes in both modes.
-	if limit := uint64(8 * largeN); large > limit {
-		t.Errorf("a %d-element column allocates %d B/op (limit %d, small column %d) — the widening scratch is being dropped every message",
-			largeN, large, limit, small)
+	// It used to be inferred from a MemStats delta over 100 pooled Marshal
+	// calls, and that measurement could not see what it claimed to. In a full
+	// suite it failed about one run in three, blaming the scratch, while a
+	// memory profile of a failing run put widenI64 at 2.6% of allocation and
+	// resetForReuse at all the rest: the buffer HINT (encoder.go:524)
+	// pre-allocates cap(previous output) whenever a pooled encoder comes back
+	// with an empty buffer, so a hint left by a neighbouring test dominated the
+	// figure. Which encoder the pool returned depended on GC timing, so the
+	// verdict inverted with GOGC — off failed 5/5, GOGC=1 passed 3/3, the
+	// opposite of what a scratch-retention test should do.
+	release := func(n int) (retained int, ceiling int) {
+		enc := NewEncoderWith(OptBalanced)
+		if err := enc.EncodeValue(mk(n)); err != nil {
+			t.Fatalf("n=%d: %v", n, err)
+		}
+		if cap(enc.wideI64) == 0 {
+			t.Fatalf("n=%d: encoding an []int32 column did not widen anything — the test "+
+				"is no longer exercising the path it names", n)
+		}
+		putEnc(enc, &encPool)
+		return cap(enc.wideI64), maxRetainedWideScratch
 	}
-	t.Logf("8192 elems: %d B/op   %d elems: %d B/op (%.1f B/elem)", small, largeN, large, float64(large)/largeN)
+
+	// Under the ceiling: kept, so the next message of the same shape reuses it.
+	const largeN = 100000 // over the former 1<<14 ceiling, under the current 1<<17
+	if got, ceiling := release(largeN); got == 0 {
+		t.Errorf("a %d-element column released its widening scratch (ceiling %d) — every "+
+			"message of this shape now rebuilds it", largeN, ceiling)
+	}
+
+	// Over the ceiling: dropped, so one spike does not pin megabytes on a
+	// pooled encoder forever. Without this arm the test would pass with the
+	// retention check deleted and the scratch simply kept unconditionally.
+	if got, ceiling := release(maxRetainedWideScratch + 1); got != 0 {
+		t.Errorf("a spike-sized column kept a %d-element widening scratch (ceiling %d) — "+
+			"it is pinned on the pooled encoder", got, ceiling)
+	}
 }

--- a/reflect_desc.go
+++ b/reflect_desc.go
@@ -35,12 +35,6 @@ type typeDesc struct {
 	// without a key tag. See keyOff / keyed below. Set once at build.
 	keyDesc *typeDesc // descriptor of the key field's type
 
-	// scopeToken / scopeFields carry a generated type's field-state identity,
-	// resolved at descriptor build so the slice encoder binds the scope with a
-	// pointer load rather than an interface assertion per slice. nil for types
-	// that do not name one.
-	scopeToken *byte
-
 	fields []fieldDesc // structs only
 
 	// vecFields lists the []float32/[]float64 fields of a struct, in declaration
@@ -49,8 +43,6 @@ type typeDesc struct {
 	// (tagVecBatchStruct) to gather one column's vectors across all rows into a
 	// single count=N block. Pure type info (option-independent), set at build.
 	vecFields []vecBatchField
-
-	scopeFields int
 
 	// schemaFP is the structural fingerprint of this descriptor's full subtree
 	// (kind + field names + recursive field/element kinds). Computed once at build
@@ -223,15 +215,6 @@ func fillDesc(td *typeDesc, t reflect.Type, ctx *buildCtx) error {
 	if reflect.PointerTo(t).Implements(marshalerType) {
 		td.marshalerKind = 1
 		td.encode = encodeMarshaler(t)
-		// Generated types name their field-state identity. Resolve it ONCE
-		// here rather than asserting the interface per slice: a slice of such
-		// a type is usually driven by reflect's slice encoder — qdf.Marshal on
-		// a []GenService reaches EncodeQDF per element — and without the scope
-		// bound around that loop the string codecs are reachable only when
-		// generated code drives the loop itself.
-		if fs, ok := reflect.New(t).Interface().(FieldScoper); ok {
-			td.scopeToken, td.scopeFields = fs.QDFFieldScope()
-		}
 	}
 	if reflect.PointerTo(t).Implements(unmarshalerType) {
 		td.decode = decodeUnmarshaler(t)

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"reflect"
 	"slices"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -352,6 +353,18 @@ func decodeSlice(t reflect.Type, elem *typeDesc, stride uintptr, colPlan *column
 	elemDynamic := elemType == reflect.TypeFor[map[string]any]() || elemType.Kind() == reflect.Interface
 	elemPF := noPointers(elemType)     // gate for backing reuse (computed once per type)
 	elemHasMap := typeDescHasMap(elem) // gate the map-recycle harvest (once per type)
+	// elemCustomCodec marks the one class that can reach the columnar fallback
+	// below: a struct element whose descriptor carries no columnar plan because
+	// it has a codec of its own. Decided once per type so the decode path pays a
+	// branch on a constant rather than an interface check per slice.
+	elemCustomCodec := colPlan == nil && !elemDynamic && elemType.Kind() == reflect.Struct &&
+		(reflect.PointerTo(elemType).Implements(reflect.TypeFor[Marshaler]()) ||
+			reflect.PointerTo(elemType).Implements(reflect.TypeFor[Unmarshaler]()))
+	// Built at most once, on the first columnar frame this type actually meets.
+	// An atomic pointer rather than sync.Once: two racing builders produce
+	// equivalent plans, one wins, and the result is immutable — while sync.Once
+	// would put its cost on every read, which is the path that matters.
+	var fallbackPlan atomic.Pointer[columnarPlan]
 	return func(d *Decoder, p unsafe.Pointer) error {
 		if d.decodeNilSlice(p) { // tagNil → nil slice (distinct from empty)
 			return nil
@@ -385,6 +398,33 @@ func decodeSlice(t reflect.Type, elem *typeDesc, stride uintptr, colPlan *column
 					}
 					return decodeHybridColumnar(d, t, colPlan, p)
 				}
+			}
+		}
+		// A columnar frame written for an element type that has its own codec.
+		// The frame could only have come from the structural encoder — a
+		// hand-written codec writes its own format — so reading it structurally
+		// reproduces what the producer wrote. Refusing it loses a value that is
+		// fully described on the wire, which is what happened before this branch.
+		if elemCustomCodec {
+			if tag, err := d.peekTag(); err == nil &&
+				(tag == tagColStruct || tag == tagHybridColStruct) {
+				plan := fallbackPlan.Load()
+				if plan == nil {
+					if plan = structuralColumnarPlan(elemType); plan == nil {
+						return ErrTypeMismatch // not describable — as before
+					}
+					fallbackPlan.Store(plan)
+				}
+				if d.query != nil {
+					if tag == tagHybridColStruct {
+						return ErrUnsupported // v1: query/Select over a hybrid payload
+					}
+					return decodeColumnarQuery(d, t, plan, p)
+				}
+				if tag == tagHybridColStruct {
+					return decodeHybridColumnar(d, t, plan, p)
+				}
+				return decodeColumnar(d, t, plan, p)
 			}
 		}
 		if elemDynamic {

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -365,6 +365,11 @@ func decodeSlice(t reflect.Type, elem *typeDesc, stride uintptr, colPlan *column
 	// equivalent plans, one wins, and the result is immutable — while sync.Once
 	// would put its cost on every read, which is the path that matters.
 	var fallbackPlan atomic.Pointer[columnarPlan]
+	// And the refusal is remembered too. Without it an element that cannot be
+	// described structurally walks its fields, allocates them and throws the lot
+	// away on EVERY decode — unbounded repeated work on the one path that gets
+	// nothing for it.
+	var fallbackRefused atomic.Bool
 	return func(d *Decoder, p unsafe.Pointer) error {
 		if d.decodeNilSlice(p) { // tagNil → nil slice (distinct from empty)
 			return nil
@@ -410,7 +415,11 @@ func decodeSlice(t reflect.Type, elem *typeDesc, stride uintptr, colPlan *column
 				(tag == tagColStruct || tag == tagHybridColStruct) {
 				plan := fallbackPlan.Load()
 				if plan == nil {
+					if fallbackRefused.Load() {
+						return ErrTypeMismatch // decided once, on the first frame
+					}
 					if plan = structuralColumnarPlan(elemType); plan == nil {
+						fallbackRefused.Store(true)
 						return ErrTypeMismatch // not describable — as before
 					}
 					fallbackPlan.Store(plan)


### PR DESCRIPTION
A wire written by the reflect encoder could not be decoded into a generated type from sixteen elements up, where the encoder switches to the hybrid columnar container. Neither side was doing anything unusual: the producer is a library user with no generated code, the consumer has only the generated type.

```
n=16  balanced     root=0xf7 -> qdf: type mismatch on decode
n=16  compression  root=0xbd -> qdf: type mismatch on decode
n=512 balanced     root=0xf7 -> qdf: type mismatch on decode
```

## The cause was not what was recorded

The standing note blamed the generated decoder's baked column split. That is wrong for this case — the refusal happens before any generated code runs.

`decodeSlice` dispatches a columnar frame only when the slice descriptor carries a plan, and for an element with a codec of its own that plan is nil. Two separate mechanisms produce the nil: a type implementing **both** `Marshaler` and `Unmarshaler` (every generated type) returns early from `fillDesc` with no fields, and `buildColumnarPlan` yields nil for a fieldless descriptor; a type implementing only **one** is caught by an explicit guard. The failing test takes the first path.

## The fix

`structuralColumnarPlan` builds a plan from a **synthetic** descriptor. `descBuild` cannot supply one — it consults `typeCache` first and returns the same fieldless descriptor. The synthetic one is never published and the shared descriptor is never modified.

That restriction is load-bearing, not tidiness: giving the shared descriptor fields would also give it a columnar plan, and that plan feeds the slice **encoder**. Decode-only would not survive it.

Reading such a frame structurally is faithful rather than a guess. A hand-written codec writes its own format and never emits a columnar frame, so meeting one is evidence the structural encoder wrote it.

## Cost

Whether a type can reach the branch is decided once when the decoder closure is built, next to the existing `elemDynamic` / `elemPF` / `elemHasMap` hoists. The plan is built at most once per type, only after such a frame has actually been seen, and lives in the closure rather than in `typeDesc` — which grows by nothing.

## A measurement whose sign depends on the build

Wire is 54,141 B columnar against 246,278 B row-major — **4.5x smaller** — either way. Time is not so simple:

| build | columnar | row-major | |
|---|---:|---:|---|
| default (scalar) | 194.6 µs | 134.5 µs | columnar **loses** by 45% |
| `-tags qdf_simd` | 118.8 µs | 133.5 µs | columnar **wins** by 11% |

Nearly all of the columnar decode is bit-unpacking an alphabet-packed string column — `readStringColumnAlpha` is 13.4% of a profiled run, `bitUnpackU64LEFast` 9.6% of it — and `internal/bitpack` already carries hand-written amd64/arm64 assembly for that, behind a tag that is off by default. Enabling it is **-38.96%** on the columnar arm (p=0.000, n=10) with row-major unmoved, which is the control: the vector path touches only the unpacking the columnar form uses.

An earlier revision of this description said flatly that the fallback is "7.4% slower". That was the scalar build, quoted without saying so. Both numbers now travel with their build, in the spec and in the benchmark comment.

None of it changes whether to do the work: the alternative to a slower decode here is no decode at all.

Whether `qdf_simd` should be the default is a separate question and is **not** decided here — on amd64 it also needs `GOEXPERIMENT=simd`. Root, bitpack and qdf-bench all pass under the tag, and CI already benchmarks with it.

## Verification

Encoding is pinned byte-for-byte: re-encoding after a fallback decode must produce identical bytes, and a generated type must still refuse the columnar container its plain twin takes. That test counts the rows where the plain twin really did produce a columnar frame and fails if none did.

Both new behaviours were verified by breaking them — with the branch disabled all eight rows of the failure matrix return; with the refusal cache removed the allocation assertion fires.

Four modules green, race clean, both phases of the codegen CI job run locally. `FuzzDecoder_NeverPanics` 9,960,994 execs and `FuzzRoundTrip_StringSlice` 6,161,337 execs, no crashers. Columnar 38, ColumnIndex 1, Query 25, Select 12, Pushdown 1, Predicate 5, Batch 53, Skip 33, Hybrid 12 tests passing, none failing — counted, so an empty match cannot pass for coverage.

Two gaps were closed with evidence rather than reasoning: a self-referential element type does not exhaust the stack (the fresh `buildCtx` bypasses `descBuild`'s cycle registration, so this needed testing), and a slice of pointers is never written columnar by reflect, so the `Kind()==Struct` predicate leaves no gap.

**Bench.** Decode geomean -0.01%, memory unchanged, n=10 interleaved from a worktree at base. The noise floor was measured rather than assumed: the same binary against itself reports -5.66% (p=0.045) and -3.79% (p=0.005), geomean -3.28%, so this harness fabricates significant-looking differences of three to six percent and every movement on this branch is smaller than that.

## Included, found on the way

**A flaky test on main, root-caused.** `TestWideScratchSurvivesLargeColumns` failed about one full-suite run in three and blamed the widening scratch. A memory profile of a *failing* run puts `widenI64` at 2.6% of allocation and `resetForReuse` at all the rest: it was measuring the output-buffer hint, which a pooled encoder pre-allocates from the previous message, so a hint left by a neighbouring test dominated the figure. The tell is counter-intuitive — the verdict inverted with the collector, `GOGC=off` failing 5/5 and `GOGC=1` passing 3/3. It now asserts what `putEnc` promises directly on the scratch, both arms verified by breaking the matching half. Twelve full runs clean.

**Dead code.** `typeDesc.scopeToken` / `scopeFields` were written for every Marshaler type and read nowhere, left behind when the field-scope binding moved into `EncodeQDF`. `typeDesc` 160 -> 144 bytes.

**One inefficiency in this branch's own code.** A refused element was re-walked on every decode: 17 allocations per decode, now under 8.

## Unblocks

Columnar **encoding** for a slice of a generated type — the +62.6% wire gap at 512 elements — which needed this first and is a separate change with a much wider blast radius.

## Left alone, worth knowing

The buffer hint does not shrink for a smaller message while the encoder stays pooled, so one large message can size the next small one until GC drops the encoder. Deliberate, and untouched here.

