### PR TITLE
perf(qdf): delete a dead LRU chain and stop re-hashing proven repeats

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -989,6 +989,7 @@ func (e *Encoder) emitStateRef(id uint32) {
 	// ≥1 byte) nor Pair (rank varuint =1 byte) can be strictly shorter,
 	// so we write the raw form directly and skip the LRU walk entirely.
 	if id < 0x80 {
+		st.mruPush(id)
 		e.buf = append(e.buf, tagStateRef, byte(id))
 		if prevValid && pairOn {
 			st.pairRecord(prev, id)
@@ -1003,7 +1004,8 @@ func (e *Encoder) emitStateRef(id uint32) {
 	// excluded.
 	if prevValid && pairOn {
 		if st.pairLookup(prev, id) {
-				// Top-1 predictor: rank is always 0 (see encState.pairLookup
+			st.mruPush(id)
+			// Top-1 predictor: rank is always 0 (see encState.pairLookup
 			// comment), so the rank byte is a hard-coded literal here.
 			e.buf = append(e.buf, tagStatePair, 0)
 			st.pairRecord(prev, id)
@@ -1029,7 +1031,8 @@ func (e *Encoder) emitStateRef(id uint32) {
 	idLen := uvarintLen(uint64(id))
 	if e.mtf {
 		if rank, ok := st.mruRank(id); ok {
-				if rankLen := uvarintLen(uint64(rank)); rankLen < idLen {
+			st.mruPush(id)
+			if rankLen := uvarintLen(uint64(rank)); rankLen < idLen {
 				e.buf = append(e.buf, tagStateMTF)
 				e.buf = appendUvarint(e.buf, uint64(rank))
 			} else {
@@ -1037,10 +1040,12 @@ func (e *Encoder) emitStateRef(id uint32) {
 				e.buf = appendUvarint(e.buf, uint64(id))
 			}
 		} else {
-				e.buf = append(e.buf, tagStateRef)
+			st.mruPush(id)
+			e.buf = append(e.buf, tagStateRef)
 			e.buf = appendUvarint(e.buf, uint64(id))
 		}
 	} else {
+		st.mruPush(id)
 		e.buf = append(e.buf, tagStateRef)
 		e.buf = appendUvarint(e.buf, uint64(id))
 	}

--- a/encoder.go
+++ b/encoder.go
@@ -989,7 +989,6 @@ func (e *Encoder) emitStateRef(id uint32) {
 	// ≥1 byte) nor Pair (rank varuint =1 byte) can be strictly shorter,
 	// so we write the raw form directly and skip the LRU walk entirely.
 	if id < 0x80 {
-		st.lruMoveFront(id)
 		e.buf = append(e.buf, tagStateRef, byte(id))
 		if prevValid && pairOn {
 			st.pairRecord(prev, id)
@@ -1004,8 +1003,7 @@ func (e *Encoder) emitStateRef(id uint32) {
 	// excluded.
 	if prevValid && pairOn {
 		if st.pairLookup(prev, id) {
-			st.lruMoveFront(id)
-			// Top-1 predictor: rank is always 0 (see encState.pairLookup
+				// Top-1 predictor: rank is always 0 (see encState.pairLookup
 			// comment), so the rank byte is a hard-coded literal here.
 			e.buf = append(e.buf, tagStatePair, 0)
 			st.pairRecord(prev, id)
@@ -1031,8 +1029,7 @@ func (e *Encoder) emitStateRef(id uint32) {
 	idLen := uvarintLen(uint64(id))
 	if e.mtf {
 		if rank, ok := st.mruRank(id); ok {
-			st.lruMoveFront(id)
-			if rankLen := uvarintLen(uint64(rank)); rankLen < idLen {
+				if rankLen := uvarintLen(uint64(rank)); rankLen < idLen {
 				e.buf = append(e.buf, tagStateMTF)
 				e.buf = appendUvarint(e.buf, uint64(rank))
 			} else {
@@ -1040,12 +1037,10 @@ func (e *Encoder) emitStateRef(id uint32) {
 				e.buf = appendUvarint(e.buf, uint64(id))
 			}
 		} else {
-			st.lruMoveFront(id)
-			e.buf = append(e.buf, tagStateRef)
+				e.buf = append(e.buf, tagStateRef)
 			e.buf = appendUvarint(e.buf, uint64(id))
 		}
 	} else {
-		st.lruMoveFront(id)
 		e.buf = append(e.buf, tagStateRef)
 		e.buf = appendUvarint(e.buf, uint64(id))
 	}

--- a/internal/mapsgen/main.go
+++ b/internal/mapsgen/main.go
@@ -305,7 +305,15 @@ func emitPair(buf *bytes.Buffer, p pair) {
 	if p.K.suffix == "String" {
 		// OptMapShape fast path: recurring key-sets emit a shape header +
 		// values in canonical order via the shared generic helper.
-		fmt.Fprintf(buf, "\tif len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {\n")
+		//
+		// !OptCanonical, matching the reflect encoder, which documents that the
+		// canonical emit takes precedence over this branch "regardless of the
+		// other shape bits". Both forms are deterministic on their own, but they
+		// are DIFFERENT BYTES, and OptCanonical promises that one logical value
+		// has one encoding — bytes callers are invited to hash, sign and
+		// content-address. Letting the branch depend on whether a (K,V) pair
+		// happens to have a generated fast path breaks exactly that.
+		fmt.Fprintf(buf, "\tif len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {\n")
 		fmt.Fprintf(buf, "\t\tfor _, k := range mapStringShapeOrder(e, m) {\n")
 		fmt.Fprintf(buf, "\t\t\tv := m[k]\n")
 		fmt.Fprintf(buf, "\t\t\t%s\n", p.V.writeBlock("v"))
@@ -316,8 +324,8 @@ func emitPair(buf *bytes.Buffer, p pair) {
 	// serialize byte-identically. The key type is concrete, so slices.Sort is
 	// directly monomorphized (no reflect). Reuse the pooled canonKeys* scratch
 	// when state is available; fall back to a local slice otherwise. Canonical
-	// is independent of the OptMapShape/OptDense shape branch above (which is
-	// String-keyed only and already deterministic via mapStringShapeOrder).
+	// now takes precedence over the OptMapShape/OptDense shape branch above,
+	// which is gated on !OptCanonical for the reason stated there.
 	emitCanonicalEncode(buf, p)
 	fmt.Fprintf(buf, "\tfor k, v := range m {\n")
 	fmt.Fprintf(buf, "\t\t%s\n", indent(p.K.writeBlock("k")))

--- a/map_canonical_precedence_test.go
+++ b/map_canonical_precedence_test.go
@@ -1,0 +1,44 @@
+package qdf
+
+import (
+	"bytes"
+	"testing"
+)
+
+// OptCanonical outranks the map-shape branch, on the generated fast paths as
+// well as in the reflect encoder.
+//
+// The reflect encoder documents the rule — "canonical emit takes precedence over
+// the OptMapShape/OptDense shape branch … regardless of the other shape bits" —
+// and the generated map paths used to test the shape branch FIRST. Both forms
+// are deterministic on their own, so the symptom was never randomness: it was
+// that one logical value got two encodings depending on whether its (K,V) pair
+// happened to have a generated fast path. OptCanonical promises bytes a caller
+// can hash, sign and content-address, which that breaks.
+//
+// Asserted by comparing against canonical WITHOUT the shape bit rather than by
+// scanning for tagMapShape: that tag also carries struct shapes under
+// OptShapeIntern, so a byte scan catches shapes this test is not about.
+func TestCanonicalOutranksTheShapeBranch(t *testing.T) {
+	for _, c := range []struct {
+		what string
+		v    any
+	}{
+		{"generated pair map[string]string", any(map[string]string{"bb": "2", "aa": "1", "cc": "3"})},
+		{"generated pair map[string]int64", any(map[string]int64{"bb": 2, "aa": 1, "cc": 3})},
+	} {
+		plain, err := Marshal(c.v, OptCanonical|OptDense)
+		if err != nil {
+			t.Fatalf("%s: %v", c.what, err)
+		}
+		withShape, err := Marshal(c.v, OptCanonical|OptDense|OptMapShape)
+		if err != nil {
+			t.Fatalf("%s: %v", c.what, err)
+		}
+		if !bytes.Equal(plain, withShape) {
+			t.Errorf("%s: adding OptMapShape changed a CANONICAL encoding (%d -> %d bytes) — "+
+				"the shape branch outranked canonical, so the same value encodes two ways",
+				c.what, len(plain), len(withShape))
+		}
+	}
+}

--- a/map_shape.go
+++ b/map_shape.go
@@ -77,7 +77,11 @@ func mapStringShapeOrder[V any](e *Encoder, m map[string]V) []string {
 	for i := range st.mapShapes {
 		s := &st.mapShapes[i]
 		if s.setHash == setHash && s.n == n && mapHasAll(m, s.keys) {
-			st.lastMapShapeID, st.lastMapShapeKeys = s.id, s.keys
+			// lastMapShapeIdx travels with the id and the keys. The reflect
+			// memo (reflect_encode.go) indexes mapShapes with it while emitting
+			// lastMapShapeID, so leaving it behind here would let one shape's id
+			// go on the wire with another shape's slot ordering.
+			st.lastMapShapeID, st.lastMapShapeKeys, st.lastMapShapeIdx = s.id, s.keys, i
 			e.buf = append(e.buf, tagMapShape)
 			e.buf = appendUvarint(e.buf, uint64(s.id))
 			return s.keys
@@ -90,7 +94,7 @@ func mapStringShapeOrder[V any](e *Encoder, m map[string]V) []string {
 	slices.Sort(keys)
 	id := st.shapeDeclareEnc()
 	st.mapShapeRegister(setHash, n, keys, id)
-	st.lastMapShapeID, st.lastMapShapeKeys = id, keys
+	st.lastMapShapeID, st.lastMapShapeKeys, st.lastMapShapeIdx = id, keys, len(st.mapShapes)-1
 	e.buf = append(e.buf, tagMapShape)
 	e.buf = appendUvarint(e.buf, 0)
 	e.buf = appendUvarint(e.buf, uint64(n))

--- a/map_shape_memo_test.go
+++ b/map_shape_memo_test.go
@@ -1,0 +1,44 @@
+package qdf
+
+import "testing"
+
+// The map-shape memo has three parts — lastMapShapeID, lastMapShapeKeys and
+// lastMapShapeIdx — written by TWO paths: mapStringShapeOrder (the generated
+// map fast path) and encodeMapStringShape (reflect). The reflect memo indexes
+// mapShapes with the Idx while putting the ID on the wire, so if one writer
+// updates two parts and not the third, a stale index can pair one shape's id
+// with another shape's slot ordering.
+//
+// mapStringShapeOrder used to leave Idx behind. The invariant is asserted here
+// directly rather than through a payload: the desync depends on which paths a
+// message happens to interleave, and a payload test would only cover the pairs
+// that payload produces.
+func TestMapShapeMemoPartsStayInStep(t *testing.T) {
+	e := NewEncoderWith(OptBalanced)
+	e.EnsureHeader()
+	if e.state == nil {
+		e.state = newEncState()
+	}
+	st := e.state
+
+	// Two distinct key sets, driven through the generated path.
+	for _, m := range []map[string]string{
+		{"aa": "1", "bb": "2"},
+		{"xx": "1", "yy": "2"},
+		{"aa": "1", "bb": "2"},
+	} {
+		mapStringShapeOrder(e, m)
+		if st.lastMapShapeID == 0 {
+			t.Fatal("no shape memoised")
+		}
+		if st.lastMapShapeIdx >= len(st.mapShapes) {
+			t.Fatalf("lastMapShapeIdx %d out of range (%d shapes)",
+				st.lastMapShapeIdx, len(st.mapShapes))
+		}
+		if got := st.mapShapes[st.lastMapShapeIdx].id; got != st.lastMapShapeID {
+			t.Fatalf("memo desync: index %d holds shape id %d, but lastMapShapeID is %d — "+
+				"the reflect memo would emit the latter while ordering values by the former",
+				st.lastMapShapeIdx, got, st.lastMapShapeID)
+		}
+	}
+}

--- a/maps_fast_generated.go
+++ b/maps_fast_generated.go
@@ -17,7 +17,7 @@ func encodeMapStringString(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			e.WriteString(v)
@@ -129,7 +129,7 @@ func encodeMapStringBool(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			e.WriteBool(v)
@@ -241,7 +241,7 @@ func encodeMapStringInt8(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			e.WriteInt(int64(v))
@@ -355,7 +355,7 @@ func encodeMapStringInt16(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			e.WriteInt(int64(v))
@@ -469,7 +469,7 @@ func encodeMapStringInt32(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			e.WriteInt(int64(v))
@@ -583,7 +583,7 @@ func encodeMapStringInt(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			e.WriteInt(int64(v))
@@ -697,7 +697,7 @@ func encodeMapStringInt64(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			e.WriteInt(int64(v))
@@ -809,7 +809,7 @@ func encodeMapStringUint8(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			e.WriteUint(uint64(v))
@@ -923,7 +923,7 @@ func encodeMapStringUint16(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			e.WriteUint(uint64(v))
@@ -1037,7 +1037,7 @@ func encodeMapStringUint32(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			e.WriteUint(uint64(v))
@@ -1151,7 +1151,7 @@ func encodeMapStringUint(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			e.WriteUint(uint64(v))
@@ -1265,7 +1265,7 @@ func encodeMapStringUint64(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			e.WriteUint(uint64(v))
@@ -1377,7 +1377,7 @@ func encodeMapStringFloat32(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			e.WriteFloat32(v)
@@ -1489,7 +1489,7 @@ func encodeMapStringFloat64(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			e.WriteFloat64(v)
@@ -1601,7 +1601,7 @@ func encodeMapStringBytes(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			if v == nil {
@@ -1743,7 +1743,7 @@ func encodeMapStringStringSlice(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			if v == nil {
@@ -1916,7 +1916,7 @@ func encodeMapStringAny(e *Encoder, p unsafe.Pointer) error {
 		e.WriteNil()
 		return nil
 	}
-	if len(m) > 0 && e.state != nil && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
+	if len(m) > 0 && e.state != nil && !e.opts.Has(OptCanonical) && e.opts.Has(OptMapShape) && e.opts.Has(OptDense) {
 		for _, k := range mapStringShapeOrder(e, m) {
 			v := m[k]
 			if err := encodeIface(e, unsafe.Pointer(&v)); err != nil {

--- a/mtf_gate_test.go
+++ b/mtf_gate_test.go
@@ -1,0 +1,89 @@
+package qdf
+
+import (
+	"bytes"
+	"fmt"
+	"maps"
+	"testing"
+)
+
+// TestMTFRanksStillReachTheWire pins that the encoder actually emits move-to-front
+// ranks, which nothing else in the suite checks.
+//
+// This exists because a refactor deleted the MRU ring's only writer and silently
+// disabled MTF on the encode side, and NOTHING caught it: not the round-trip
+// tests (raw state-refs decode fine), not the 112-encoding wire digest, and not
+// the benchmarks — which got FASTER, because not emitting ranks is cheaper than
+// emitting them.
+//
+// The digest missed it for a specific reason worth writing down: emitStateRef
+// takes a small-id fast path below 128 and never consults the ring there, and no
+// digest fixture interns enough distinct strings to leave that range. So the
+// fixture here is built to clear it: >128 distinct interned values, then repeats
+// of the high ids, which is the only shape where a rank can be shorter than the
+// id it replaces.
+func TestMTFRanksStillReachTheWire(t *testing.T) {
+	// A slice of structs would route these strings through the columnar
+	// dictionary and never reach the intern path at all; reflect-driven maps
+	// are what actually emit state refs.
+	const distinct = 200 // comfortably past the 128-id fast path
+	names := make([]string, distinct)
+	kinds := make([]string, distinct)
+	for i := range distinct {
+		names[i] = fmt.Sprintf("com.acme.platform.service.instance.%06d", i)
+		kinds[i] = fmt.Sprintf("workload-class-%06d", i)
+	}
+
+	rows := make([]map[string]string, 0, distinct*3)
+	for i := range distinct {
+		rows = append(rows, map[string]string{"name": names[i], "kind": kinds[i]})
+	}
+	// Revisit the high ids: a repeat of a recently-emitted high id is what MTF
+	// encodes as a short rank.
+	for pass := range 2 {
+		for i := distinct - 1; i >= distinct/2; i-- {
+			rows = append(rows, map[string]string{
+				"name": names[i],
+				"kind": kinds[(i+pass)%distinct],
+			})
+		}
+	}
+
+	wire, err := Marshal(rows, OptBalanced)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Contains(wire, []byte{tagStateMTF}) {
+		t.Fatalf("no tagStateMTF (0x%02X) anywhere in %d bytes of wire: the encoder "+
+			"is not emitting move-to-front ranks. Check that encState.mruPush still "+
+			"has callers — mruRank answers from that ring, and an unfilled ring makes "+
+			"every rank lookup miss and fall back to a raw state-ref.",
+			tagStateMTF, len(wire))
+	}
+
+	// The ranks must also survive a round trip, so the gate cannot be satisfied
+	// by emitting the tag incorrectly.
+	var back []map[string]string
+	if err := Unmarshal(wire, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(back) != len(rows) {
+		t.Fatalf("round trip changed length: got %d want %d", len(back), len(rows))
+	}
+	for i := range rows {
+		if !maps.Equal(back[i], rows[i]) {
+			t.Fatalf("row %d differs: got %+v want %+v", i, back[i], rows[i])
+		}
+	}
+
+	// And MTF must genuinely be shortening the wire, not merely appearing in it.
+	raw, err := Marshal(rows, OptBalanced&^OptMTF)
+	if err != nil {
+		t.Fatalf("marshal without MTF: %v", err)
+	}
+	if len(wire) >= len(raw) {
+		t.Fatalf("MTF did not shrink the wire: %d bytes with it, %d without", len(wire), len(raw))
+	}
+	t.Logf("MTF present; wire %d bytes vs %d without it (-%.1f%%)",
+		len(wire), len(raw), 100*float64(len(raw)-len(wire))/float64(len(raw)))
+}

--- a/reflect_encode.go
+++ b/reflect_encode.go
@@ -1085,7 +1085,11 @@ func (e *Encoder) encodeStringMapShaped(rv reflect.Value, keyType, valType refle
 	// encode targeting the outer binding with a different valType.
 	if st.lastMapShapeID != 0 && len(st.lastMapShapeKeys) == n {
 		s := &st.mapShapes[st.lastMapShapeIdx]
-		if !s.busy && hasAllAndCollect(s) {
+		// s.id, not just the length of lastMapShapeKeys: the memo's three parts
+		// are written by two different paths (here and mapStringShapeOrder), and
+		// a length match alone would let a stale index emit one shape's id with
+		// another's slot ordering.
+		if s.id == st.lastMapShapeID && !s.busy && hasAllAndCollect(s) {
 			e.buf = append(e.buf, tagMapShape)
 			e.buf = appendUvarint(e.buf, uint64(st.lastMapShapeID))
 			return emitSlotsOrdered(st.lastMapShapeIdx)

--- a/shrink_test.go
+++ b/shrink_test.go
@@ -62,33 +62,12 @@ func TestShrink_SteadyLargeRetainsInternTable(t *testing.T) {
 	}
 }
 
-// LRU slice: retained on the first post-burst reset, released after the
-// workload stays small for retainReleaseStreak consecutive messages.
-func TestShrink_EncStateReleasesLRUAfterStreak(t *testing.T) {
-	st := newEncState()
-	for i := range maxRetainedLRUCap + 64 {
-		st.lookupOrAssign(fmt.Sprintf("lru-%05d", i))
-	}
-	if cap(st.lruLink) <= maxRetainedLRUCap {
-		t.Fatalf("test premise: lruLink should exceed cap (%d), got %d",
-			maxRetainedLRUCap, cap(st.lruLink))
-	}
-	burstCap := cap(st.lruLink)
+// The encoder's LRU chain used to be retained and released here. It is gone:
+// nothing on the encode side ever read it. State-ref ranks come from the MRU
+// ring (encState.mruRank), and a ring miss emits the raw id rather than walking
+// a chain — so the chain was maintained on every emission and consumed by no
+// one. The decoder keeps its own, which decState still exercises.
 
-	// First reset right after the burst RETAINS (internLoad was large).
-	st.reset()
-	if cap(st.lruLink) != burstCap {
-		t.Fatalf("lruLink dropped on first post-burst reset (should retain): burst=%d post=%d",
-			burstCap, cap(st.lruLink))
-	}
-	// After retainReleaseStreak small (internLoad==0) resets, release.
-	for range retainReleaseStreak {
-		st.reset()
-	}
-	if st.lruLink != nil {
-		t.Fatalf("lruLink not released after %d small resets: cap=%d", retainReleaseStreak, cap(st.lruLink))
-	}
-}
 
 // pairPred slice — same retain-then-release contract as LRU.
 func TestShrink_EncStateReleasesPairPredAfterStreak(t *testing.T) {
@@ -124,7 +103,7 @@ func TestShrink_EncStateKeepsCapsUnderThreshold(t *testing.T) {
 		st.lookupOrAssign(fmt.Sprintf("steady-%05d", i))
 	}
 	preIDs := int(st.internLoad)
-	preLRU := cap(st.lruLink)
+	preTable := cap(st.internTable)
 	st.reset()
 	if preIDs > maxRetainedIDs {
 		t.Skipf("steady-state breached maxRetainedIDs (%d > %d)", preIDs, maxRetainedIDs)
@@ -133,8 +112,10 @@ func TestShrink_EncStateKeepsCapsUnderThreshold(t *testing.T) {
 	for i := range 100 {
 		st.lookupOrAssign(fmt.Sprintf("steady-after-%05d", i))
 	}
-	if cap(st.lruLink) > preLRU*2 {
-		t.Fatalf("lruLink cap grew unexpectedly: pre=%d post=%d", preLRU, cap(st.lruLink))
+	// The intern table is what this test now watches: the encoder's LRU chain
+	// it used to check is gone, since nothing on the encode side read it.
+	if cap(st.internTable) > preTable*2 {
+		t.Fatalf("internTable cap grew unexpectedly: pre=%d post=%d", preTable, cap(st.internTable))
 	}
 }
 
@@ -176,16 +157,15 @@ func TestShrink_BurstThenSteadyState(t *testing.T) {
 	}
 	st.pairRecord(uint32(int(st.internLoad)-1), 0)
 
-	burstLRUCap := cap(st.lruLink)
 	burstPairCap := cap(st.pairPred)
 	burstArena := st.arena.BytesUsed()
-	t.Logf("burst peak: ids=%d lruCap=%d pairCap=%d arenaUsed=%d KiB",
-		int(st.internLoad), burstLRUCap, burstPairCap, burstArena/1024)
+	t.Logf("burst peak: ids=%d pairCap=%d arenaUsed=%d KiB",
+		int(st.internLoad), burstPairCap, burstArena/1024)
 
-	// First post-burst reset retains the grown LRU/pair backings.
+	// First post-burst reset retains the grown pair backing.
 	st.reset()
-	if burstLRUCap > maxRetainedLRUCap && cap(st.lruLink) != burstLRUCap {
-		t.Fatalf("lruLink dropped on first post-burst reset: burst=%d post=%d", burstLRUCap, cap(st.lruLink))
+	if burstPairCap > maxRetainedPairCap && cap(st.pairPred) != burstPairCap {
+		t.Fatalf("pairPred dropped on first post-burst reset: burst=%d post=%d", burstPairCap, cap(st.pairPred))
 	}
 
 	// Quiet phase: small messages for the full streak → release.
@@ -196,10 +176,6 @@ func TestShrink_BurstThenSteadyState(t *testing.T) {
 		st.reset()
 	}
 
-	if cap(st.lruLink) >= burstLRUCap && burstLRUCap > maxRetainedLRUCap {
-		t.Fatalf("lruLink cap did not shrink after burst→quiet: burst=%d post=%d",
-			burstLRUCap, cap(st.lruLink))
-	}
 	if cap(st.pairPred) >= burstPairCap && burstPairCap > maxRetainedPairCap {
 		t.Fatalf("pairPred cap did not shrink: burst=%d post=%d",
 			burstPairCap, cap(st.pairPred))
@@ -227,7 +203,6 @@ func TestShrink_SmallSteadyIsInert(t *testing.T) {
 	st.reset()
 	fill(1)
 	warmCap := cap(st.internTable)
-	warmLRU := cap(st.lruLink)
 	if warmCap > maxRetainedIDs*2 {
 		t.Fatalf("test premise: small workload should stay under cap, got internTable cap=%d", warmCap)
 	}
@@ -240,11 +215,8 @@ func TestShrink_SmallSteadyIsInert(t *testing.T) {
 		if got := cap(st.internTable); got != warmCap {
 			t.Fatalf("cycle %d: internTable cap changed (realloc/drop churn): warm=%d got=%d", c, warmCap, got)
 		}
-		if got := cap(st.lruLink); got != warmLRU {
-			t.Fatalf("cycle %d: lruLink cap changed: warm=%d got=%d", c, warmLRU, got)
-		}
 	}
-	if st.internTable == nil || st.lruLink == nil {
+	if st.internTable == nil {
 		t.Fatal("small steady workload wrongly released under-cap backings")
 	}
 }

--- a/shrink_test.go
+++ b/shrink_test.go
@@ -68,7 +68,6 @@ func TestShrink_SteadyLargeRetainsInternTable(t *testing.T) {
 // a chain — so the chain was maintained on every emission and consumed by no
 // one. The decoder keeps its own, which decState still exercises.
 
-
 // pairPred slice — same retain-then-release contract as LRU.
 func TestShrink_EncStateReleasesPairPredAfterStreak(t *testing.T) {
 	st := newEncState()

--- a/state.go
+++ b/state.go
@@ -911,7 +911,6 @@ func setLinkPrev(link, prev uint32) uint32 { return (link &^ 0xFFFF) | (prev & 0
 //go:nosplit
 func setLinkNext(link, next uint32) uint32 { return (link & 0xFFFF) | ((next & 0xFFFF) << 16) }
 
-
 // lookupOrAssign returns (id, hit). On a miss a fresh entry is
 // installed and (id, false) is returned; the caller is expected to
 // emit an intern record. The key bytes are copied into the encState
@@ -1044,6 +1043,10 @@ func (e *encState) installInternSlot(slot *internSlot, h uint64, key string) uin
 	slot.key = stored
 	slot.id = id
 	e.internLoad++
+	// A fresh id counts as an emission for the MRU ring, which is what
+	// mruRank answers from. This used to ride along inside lruAddFresh; the
+	// LRU chain is gone and the ring is not.
+	e.mruPush(id)
 	// Grow at 3/4 load, not 1/2. A denser table is smaller (better cache)
 	// and rehashes less often; with the well-distributed maphash the longer
 	// linear-probe chains cost less than the cache + rehash savings.

--- a/state.go
+++ b/state.go
@@ -127,11 +127,10 @@ var mruRingSentinel = func() [mruRingSize]uint16 {
 
 type encState struct { // betteralign:ignore — hot-scalar-first layout is cache-critical; do not reorder
 	// Hot scalars first so they share a single cache line with the
-	// adjacent mruHead and the map header. lastID + lruHead + mruHead
+	// adjacent mruHead and the map header. lastID + mruHead
 	// are touched on every state-ref emit; co-locating them with
 	// mruRing keeps the per-emit footprint at 1-2 cache lines.
 	lastID     uint32
-	lruHead    uint32
 	mruHead    uint32
 	internLoad uint32 // number of occupied slots in internTable
 
@@ -150,16 +149,6 @@ type encState struct { // betteralign:ignore — hot-scalar-first layout is cach
 	// pattern sequential and predictable; load is kept below 0.5 by
 	// doubling on growth so probe chains stay short (typically 1).
 	internTable []internSlot
-
-	// Move-to-front LRU over intern IDs. lruHead is the ID at rank 0
-	// (most recently emitted state-ref or freshly interned). lruLink
-	// packs the previous + next ids for each chain slot into a single
-	// uint32 (low 16 bits = prev, high 16 bits = next). IDs are
-	// bounded by maxStateEntries (1 << 14) so they fit in 16 bits
-	// with 0xFFFF reserved as the "no neighbour" sentinel. Packing
-	// halves the cache lines a lruMoveFront has to touch (one array
-	// instead of two) while keeping the unlink/insert update O(1).
-	lruLink []uint32
 
 	// Pair predictor: top-1 successor per prev intern ID. Slot stores
 	// `succ+1` so zero = empty; this keeps Reset() on a memclr fast
@@ -434,7 +423,6 @@ func newEncState() *encState {
 	// allocated on first Put (see internarena.Arena.Put).
 	e := &encState{
 		internTable: make([]internSlot, internTableInitSize),
-		lruHead:     lruInvalidID,
 		lastID:      lruInvalidID,
 	}
 	// Prime ring with sentinels so a scan never matches id 0 by
@@ -552,12 +540,6 @@ func (e *encState) reset() {
 	}
 
 	e.lastID = lruInvalidID
-	e.lruHead = lruInvalidID
-	if cap(e.lruLink) > maxRetainedLRUCap && release {
-		e.lruLink = nil
-	} else {
-		e.lruLink = e.lruLink[:0]
-	}
 
 	// pairPred slice: clear in place (memclr-fast because the empty sentinel
 	// is zero); drop the backing array only when releasing.
@@ -929,56 +911,6 @@ func setLinkPrev(link, prev uint32) uint32 { return (link &^ 0xFFFF) | (prev & 0
 //go:nosplit
 func setLinkNext(link, next uint32) uint32 { return (link & 0xFFFF) | ((next & 0xFFFF) << 16) }
 
-// lruAddFresh inserts a brand-new ID (just assigned) at the head of
-// the LRU. Caller must have ensured id == len(ids)-1 (i.e. ids assigns
-// sequentially starting from 0). Also records the emit in the MRU
-// ring so the rank-discovery side-cache reflects the new chain head.
-func (e *encState) lruAddFresh(id uint32) {
-	for uint32(len(e.lruLink)) <= id {
-		e.lruLink = append(e.lruLink, lruLinkInvalid)
-	}
-	head := e.lruHead
-	// id.prev = invalid, id.next = head
-	if head == lruInvalidID {
-		e.lruLink[id] = lruLinkInvalid
-	} else {
-		e.lruLink[id] = lruLink16Invalid | (head << 16)
-		// head.prev = id
-		e.lruLink[head] = setLinkPrev(e.lruLink[head], id)
-	}
-	e.lruHead = id
-	e.mruPush(id)
-}
-
-// lruMoveFront performs the unlink+insert-at-head update of the LRU
-// but skips the rank walk. Use when the caller does not need the
-// rank (e.g. raw state-ref where MTF cannot win). Also records the
-// emit in the MRU ring so the rank side-cache mirrors the chain
-// head update.
-//
-//go:nosplit
-func (e *encState) lruMoveFront(id uint32) {
-	if e.lruHead == id {
-		e.mruPush(id)
-		return
-	}
-	link := e.lruLink[id]
-	p := linkPrev(link)
-	n := linkNext(link)
-	// p is always valid here (id was not head). Patch p.next = n.
-	e.lruLink[p] = setLinkNext(e.lruLink[p], n)
-	if n != lruLink16Invalid {
-		// Patch n.prev = p.
-		e.lruLink[n] = setLinkPrev(e.lruLink[n], p)
-	}
-	// Insert id at head: id.prev=invalid, id.next=head.
-	head := e.lruHead
-	e.lruLink[id] = lruLink16Invalid | (head << 16)
-	// head.prev = id (head is always valid here — id was in chain).
-	e.lruLink[head] = setLinkPrev(e.lruLink[head], id)
-	e.lruHead = id
-	e.mruPush(id)
-}
 
 // lookupOrAssign returns (id, hit). On a miss a fresh entry is
 // installed and (id, false) is returned; the caller is expected to
@@ -1112,7 +1044,6 @@ func (e *encState) installInternSlot(slot *internSlot, h uint64, key string) uin
 	slot.key = stored
 	slot.id = id
 	e.internLoad++
-	e.lruAddFresh(id)
 	// Grow at 3/4 load, not 1/2. A denser table is smaller (better cache)
 	// and rehashes less often; with the well-distributed maphash the longer
 	// linear-probe chains cost less than the cache + rehash savings.

--- a/strdelta.go
+++ b/strdelta.go
@@ -26,6 +26,16 @@ import (
 // vacuous: interning alone shrinks these payloads, so a smaller wire proves
 // nothing about whether this form ran. That is precisely how the columnar codec
 // on this branch looked healthy while never running once.
+// strDeltaCheckBaseID turns on an O(table) verification that a cached baseID
+// still names the value being written. Off in production — it exists so a test
+// can assert the invalidation discipline directly, which a round-trip cannot:
+// a stale id only produces wrong bytes when a later value happens to equal the
+// base the id no longer belongs to, and no fixture reliably lands there.
+//
+// Same shape as strDeltaCount below: a package-level bool, one predictable
+// branch, set only by tests.
+var strDeltaCheckBaseID bool
+
 var strDeltaEmitted atomic.Int64
 
 // strDeltaCount gates the two counters below. They exist so acceptance tests can
@@ -78,6 +88,11 @@ type strDeltaGate struct {
 // measured wins are (trace_id -45.4%, span_id -41.2%).
 type strFieldState struct {
 	learn *strAlphaLearn
+	// baseID is the intern id of the value currently in base, stored as id+1 so
+	// the zero value means "not interned" — clear() zeroes these records on
+	// reset, and 0 is a valid id. Set only where the id is already in hand;
+	// every other path that moves base clears it.
+	baseID uint32
 	base  string
 	gate  strDeltaGate
 	// alphaID is the well-known alphabet that has matched every value of this
@@ -175,7 +190,7 @@ func (e *Encoder) writeStringField(s string, fs *strFieldState) {
 	// encodes, which are exactly that shape.
 	if *base == "" {
 		e.WriteString(s)
-		*base = s
+		*base, fs.baseID = s, 0
 		return
 	}
 	if s == *base {
@@ -189,12 +204,43 @@ func (e *Encoder) writeStringField(s string, fs *strFieldState) {
 		//
 		// The compare is also cheaper than what it replaces: a full-length
 		// prefix scan of two identical strings.
+		//
+		// And when the base's intern id is already known, the emit does not need
+		// WriteString to re-derive it: this branch has just PROVEN the value
+		// equals the base, so hashing it and probing the table would answer a
+		// question already answered. The gates WriteString would apply still
+		// hold — dense does not change mid-encode, and referencing an existing
+		// id needs no room in the table — except suspension, which is checked.
+		if id := fs.baseID; id != 0 && st != nil && !e.stateSuspended {
+			id--
+			if strDeltaCheckBaseID {
+				ok := false
+				for i := range st.internTable {
+					if st.internTable[i].hash != 0 && st.internTable[i].id == id {
+						ok = st.internTable[i].key == s
+						break
+					}
+				}
+				if !ok {
+					panic("qdf: cached baseID does not name the value being written")
+				}
+			}
+			if st.lastID == id {
+				e.buf = append(e.buf, tagStateRepeat)
+				if e.pairPred {
+					st.pairRecord(id, id)
+				}
+				return
+			}
+			e.emitStateRef(id)
+			return
+		}
 		e.WriteString(s)
 		return
 	}
 	if !e.strDeltaEligible(s) {
 		e.WriteString(s)
-		*base = s
+		*base, fs.baseID = s, 0
 		return
 	}
 
@@ -221,7 +267,7 @@ func (e *Encoder) writeStringField(s string, fs *strFieldState) {
 	id, interned, keyHash := st.lookupOnly(s)
 	if interned {
 		e.emitStateRef(id)
-		*base = s
+		*base, fs.baseID = s, id+1
 		return
 	}
 
@@ -259,7 +305,7 @@ func (e *Encoder) writeStringField(s string, fs *strFieldState) {
 			// encoder drops it here, or the two disagree about what "previous"
 			// means — a desync, not a bigger wire.
 			st.lastID = lruInvalidID
-			*base = s
+			*base, fs.baseID = s, 0
 			return
 		}
 	} else {
@@ -296,7 +342,7 @@ func (e *Encoder) writeStringField(s string, fs *strFieldState) {
 		// entered the intern table, so a following tagStateRepeat must not
 		// resurrect whatever ID was last on the chain.
 		st.lastID = lruInvalidID
-		*base = s
+		*base, fs.baseID = s, 0
 		return
 	}
 
@@ -311,7 +357,7 @@ func (e *Encoder) writeStringField(s string, fs *strFieldState) {
 		st.pairRecord(st.lastID, id)
 	}
 	st.lastID = id
-	*base = s
+	*base, fs.baseID = s, id+1
 }
 
 // strDeltaEligible reports whether the delta form may be considered at all:

--- a/strdelta.go
+++ b/strdelta.go
@@ -93,8 +93,8 @@ type strFieldState struct {
 	// reset, and 0 is a valid id. Set only where the id is already in hand;
 	// every other path that moves base clears it.
 	baseID uint32
-	base  string
-	gate  strDeltaGate
+	base   string
+	gate   strDeltaGate
 	// alphaID is the well-known alphabet that has matched every value of this
 	// field so far, or 0 when none has been established.
 	alphaID uint8

--- a/strdelta_baseid_test.go
+++ b/strdelta_baseid_test.go
@@ -39,16 +39,17 @@ type baseIDRow struct {
 func TestBaseIDCacheSurvivesEveryBaseTransition(t *testing.T) {
 
 	const stem = "com.acme.platform.worker.service."
-	rows := []baseIDRow{
-		{S: stem + "000001", T: "x"},          // first value of each field
-		{S: stem + "000001", T: "x"},          // consecutive repeat
-		{S: stem + "000002", T: "y"},          // delta-eligible change
-		{S: stem + "000002", T: "y"},          // repeat after a delta
-		{S: "s", T: "z"},                      // short: below minIntern, inline
-		{S: "s", T: "z"},                      // repeat of an inline value
-		{S: stem + "000001", T: "x"},          // back to an id seen long ago
-		{S: stem + "000001", T: "x"},          // and repeat it
-	}
+	rows := make([]baseIDRow, 0, 48)
+	rows = append(rows, []baseIDRow{
+		{S: stem + "000001", T: "x"}, // first value of each field
+		{S: stem + "000001", T: "x"}, // consecutive repeat
+		{S: stem + "000002", T: "y"}, // delta-eligible change
+		{S: stem + "000002", T: "y"}, // repeat after a delta
+		{S: "s", T: "z"},             // short: below minIntern, inline
+		{S: "s", T: "z"},             // repeat of an inline value
+		{S: stem + "000001", T: "x"}, // back to an id seen long ago
+		{S: stem + "000001", T: "x"}, // and repeat it
+	}...)
 	for i := range 40 {
 		rows = append(rows, baseIDRow{
 			S: stem + fmt.Sprintf("%06d", i%3),

--- a/strdelta_baseid_test.go
+++ b/strdelta_baseid_test.go
@@ -1,0 +1,94 @@
+package qdf
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// strDeltaCheckBaseID is enabled for the WHOLE test binary, not inside one test.
+//
+// A stale cached id only reaches the wire when a later value happens to equal a
+// base the id no longer belongs to, and no single fixture lands there reliably —
+// this test's own does not. Running the invariant under every test in the
+// package does: with it on, removing either of the two load-bearing
+// invalidations in writeStringField trips the check, while the same removals go
+// unnoticed by any round-trip assertion including the one below.
+//
+// Same idiom as strDeltaCount: an init in a _test.go file is compiled only into
+// the test binary and reaches every test without a TestMain.
+func init() { strDeltaCheckBaseID = true }
+
+type baseIDRow struct {
+	S string `qdf:"s"`
+	T string `qdf:"t"`
+}
+
+// writeStringField caches the intern id of the value sitting in a field's base,
+// so a consecutive repeat emits a state-ref without re-hashing a string it has
+// just proven equal to that base.
+//
+// The risk is not the fast path; it is INVALIDATION. Four paths move the base
+// without interning the value — the first value of a field, an ineligible one,
+// and the two inline codec wins — and each must clear the cached id or a later
+// repeat would reference an id belonging to a different string.
+//
+// This walks a field through every transition that can move the base: first
+// value, repeat, delta-eligible change, repeat again, a short (sub-minIntern)
+// value, and a repeat after that.
+func TestBaseIDCacheSurvivesEveryBaseTransition(t *testing.T) {
+
+	const stem = "com.acme.platform.worker.service."
+	rows := []baseIDRow{
+		{S: stem + "000001", T: "x"},          // first value of each field
+		{S: stem + "000001", T: "x"},          // consecutive repeat
+		{S: stem + "000002", T: "y"},          // delta-eligible change
+		{S: stem + "000002", T: "y"},          // repeat after a delta
+		{S: "s", T: "z"},                      // short: below minIntern, inline
+		{S: "s", T: "z"},                      // repeat of an inline value
+		{S: stem + "000001", T: "x"},          // back to an id seen long ago
+		{S: stem + "000001", T: "x"},          // and repeat it
+	}
+	for i := range 40 {
+		rows = append(rows, baseIDRow{
+			S: stem + fmt.Sprintf("%06d", i%3),
+			T: fmt.Sprintf("t%02d", i%2),
+		})
+	}
+	for _, o := range []struct {
+		name string
+		opts Options
+	}{
+		{"balanced", OptBalanced},
+		{"balanced+alpha", OptBalanced | OptStringAlphabet},
+		{"compression", OptCompression},
+		{"dense only", OptDense},
+	} {
+		b, err := Marshal(rows, o.opts)
+		if err != nil {
+			t.Fatalf("%s: %v", o.name, err)
+		}
+		var got []baseIDRow
+		if err := Unmarshal(b, &got); err != nil {
+			t.Fatalf("%s: decode: %v", o.name, err)
+		}
+		if !reflect.DeepEqual(got, rows) {
+			for i := range rows {
+				if got[i] != rows[i] {
+					t.Fatalf("%s row %d: got %+v want %+v — a cached intern id outlived "+
+						"the value it belonged to", o.name, i, got[i], rows[i])
+				}
+			}
+		}
+		// Byte stability: two encodes of the same value must agree, or the cache
+		// has made the output depend on encoder history.
+		again, err := Marshal(rows, o.opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(b) != string(again) {
+			t.Errorf("%s: two encodes of the same value differ (%d vs %d bytes)",
+				o.name, len(b), len(again))
+		}
+	}
+}


### PR DESCRIPTION
An agent-assisted audit aimed at performance. Two real speedups, two correctness fixes, and one proposal measured and dropped.

## Speedups

**The encoder's LRU chain was dead.** `lruMoveFront` ran on every state-ref emission and `lruAddFresh` on every fresh intern, maintaining a head pointer and a packed prev/next array. Nothing on the encode side read either: the only rank consumer, `mruRank`, answers from the MRU ring, and on a ring miss it emits the raw id rather than walking a chain.

**I broke MTF removing it, and the correction matters more than the finding.** The three `mruPush` calls that fill that ring lived *inside* the two functions I deleted, so ranks stopped being emitted at all. `golangci-lint` caught it as an unused function; no test did. Restored in e90f9e7.

Two things that should have caught it did not:

- The 112-encoding wire digest is **identical** with the ring broken and with it restored. That digest is what I have leaned on throughout as proof the bytes did not move; it covers container and codec choice, not whether MTF fires.
- The first measurement of this change, `-9.51%` on telemetry encode, was mostly the bug — not emitting ranks is cheaper than emitting them.

**A repeat no longer re-hashes what the comparison just proved.** `writeStringField` opens with `s == *base`; when that hits it has established the value equals the field's base, then handed it to `WriteString`, which hashed the string and probed the intern table for an id it could have been told. The base now carries its id.

```
telemetry encode   162.3µs -> 155.8µs   -4.01%  (p=0.012, n=12)
```

Not the per-field cache measured at +1.77% earlier in this line of work and rejected: that one added a pointer comparison to every call, this adds no comparison at all.

### What the branch is actually worth

Re-measured against main with the ring intact:

```
telemetry encode   186.9µs -> 179.0µs   -4.23%  (p=0.000, n=15)
telemetry +rANS    317.1µs -> 306.2µs   -3.45%  (p=0.000, n=12)
AD batch                             unchanged
geomean                                -2.28%
```


### The gate that should have caught it

`mtf_gate_test.go` now pins that ranks reach the wire. Two fixture facts had to be worked out before it could fail for the right reason:

- `emitStateRef` takes a small-id fast path below 128 and never consults the ring there, so a fixture must intern **more than 128 distinct** values before a rank can appear at all. No digest fixture does — which is the whole reason the digest is blind here.
- The first attempt, a slice of structs, produced **no state refs whatsoever**: those strings route through the columnar dictionary and never reach the intern path. Reflect-driven maps are what exercise it.

The gate checks the tag is present, the payload round-trips, and the wire is strictly shorter than the same value with `OptMTF` off — so it cannot be satisfied by emitting the tag wrongly. Verified non-vacuous against both writers.

## Correctness

**The map-shape memo's three parts could drift.** It is ID + keys + index, written by two paths, and the reflect memo indexes `mapShapes` with the index while putting the ID on the wire. The generated path updated two parts and left the index. I could not build a payload that turns this into wrong bytes — a panic on "index and id disagree" at the point of use never fired across the root and codegen suites — but the drift itself is now demonstrable, and the reflect guard checks `s.id == lastMapShapeID` rather than a length match that cannot tell whether the index still belongs to the id.

**`OptCanonical` was outranked by the map-shape branch on the generated paths.** The reflect encoder documents the rule and follows it; the generated fast paths tested shape first. The generator even argued the case — canonical is "independent of the shape branch, which is already deterministic". True of each path alone, and beside the point: both forms are deterministic, they are different *bytes*, so one logical value had two encodings chosen by whether its (K,V) pair happened to have a generated fast path. The option exists to produce bytes callers can hash, sign and content-address. Fixed in `internal/mapsgen`; 17 string-keyed pairs regenerated.

## Measured and dropped

Threading the empty-slot index from `lookupOnly` into `assignHashed`, so a miss walk is not repeated: **−0.02% geomean, both benchmarks `~`**. The duplicated work is real; on these corpora a miss is one or two probes and there is nothing to save. Reverted.

## On verification

The 5.7% noise floor recorded earlier came from a noisier session, so rather than judge −4% against it I measured today's floor: the same binary against itself, all `~`, geomean −0.03%.

Every fix carries a test verified to fail when the fix is reverted. Two of those tests took several attempts to become non-vacuous, and the failures are worth stating: two canonical tests scanned bytes for `tagMapShape` and were false positives, because that tag also carries *struct* shapes — once from the enclosing struct, once from a struct-valued map. And the base-id transition test does not catch a single one of the four invalidations it was written for; a stale id only reaches the wire when a later value happens to equal a base the id no longer belongs to. So that invariant is checked at every use under a test-only flag enabled for the whole test binary, the way `strDeltaCount` already is — with it on, removing either load-bearing invalidation trips it; without it, nothing notices.

Wire digest unchanged at `4069ebfd...` after every commit. Four modules green, race clean, both phases of the codegen job, `FuzzDecoder_NeverPanics` 10,764,774 execs and `FuzzRoundTrip_StringSlice` 5,198,272, no crashers.


