### PR TITLE
bench(qdf): measure qdf against the strongest JSON Go 1.27 has

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ A concrete head-to-head on a real **Active-Directory host dump** (adalanche
 department, and object-class strings; same data through each library, typed
 structs):
 
+> Re-measured 2026-08-22 on Darwin arm64 / Apple Silicon, Go 1.27.0, with
+> `encoding/json/v2` added: **json v1 502.7 KB / 0.40 ms enc / 0.97 ms dec /
+> 10 255 allocs**, **json/v2 502.7 KB / 0.40 ms / 0.77 ms / 10 255**,
+> **qdf `OptBalanced` 121.3 KB / 0.22 ms / 0.17 ms / 2 070**. Against json/v2
+> that is **4.1× smaller wire, 4.5× faster decode, a fifth of the allocations**.
+> json/v2 buys nothing at all on encode here — `adRow` has no maps to sort and no
+> HTML to escape, so v2's faster defaults have nothing to skip. The table below
+> is the older amd64 / Go 1.26 run against v1; see
+> [docs/BENCH.md](docs/BENCH.md#json-v2-and-what-json-actually-costs) for the
+> full json/v2 comparison.
+
 | AD host dump | wire | encode | decode | decode allocs |
 | --- | ---: | ---: | ---: | ---: |
 | `encoding/json` | 532 KB | 1.5 ms | 4.9 ms | 15 851 |

--- a/bench/competitor.go
+++ b/bench/competitor.go
@@ -2,6 +2,7 @@ package bench
 
 import (
 	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"testing"
 
 	msgpack "github.com/vmihailenco/msgpack/v5"
@@ -27,6 +28,13 @@ var qdfTiers = []qdfTier{
 func runCodecMatrix[T any](b *testing.B, value T, newOut func() *T) {
 	b.Helper()
 
+	// Three JSON arms, because in Go 1.27 encoding/json IS json/v2 under
+	// DefaultOptionsV1: the v1/v2 gap measures the price of the compatibility
+	// options, not a faster engine. json-v2 runs v2's own defaults (no map-key
+	// sorting, no HTML escaping, [] instead of null for a nil slice — wire
+	// differences, so its size column is not interchangeable with v1's), and
+	// json-v2-compat runs v2 asked for v1 semantics, whose output is
+	// byte-identical to v1.
 	jsonBytes, _ := json.Marshal(value)
 	b.Run("encode/json", func(b *testing.B) {
 		var buf []byte
@@ -44,6 +52,45 @@ func runCodecMatrix[T any](b *testing.B, value T, newOut func() *T) {
 		for i := 0; i < b.N; i++ {
 			out := newOut()
 			_ = json.Unmarshal(jsonBytes, out)
+		}
+	})
+
+	jsonV2Bytes, _ := jsonv2.Marshal(value)
+	b.Run("encode/json-v2", func(b *testing.B) {
+		var buf []byte
+		b.ReportAllocs()
+		b.SetBytes(int64(len(jsonV2Bytes)))
+		for i := 0; i < b.N; i++ {
+			buf, _ = jsonv2.Marshal(value)
+		}
+		_ = buf
+		b.ReportMetric(float64(len(jsonV2Bytes)), "wire-B")
+	})
+	b.Run("decode/json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(jsonV2Bytes)))
+		for i := 0; i < b.N; i++ {
+			out := newOut()
+			_ = jsonv2.Unmarshal(jsonV2Bytes, out)
+		}
+	})
+
+	b.Run("encode/json-v2-compat", func(b *testing.B) {
+		var buf []byte
+		b.ReportAllocs()
+		b.SetBytes(int64(len(jsonBytes)))
+		for i := 0; i < b.N; i++ {
+			buf, _ = jsonv2.Marshal(value, json.DefaultOptionsV1())
+		}
+		_ = buf
+		b.ReportMetric(float64(len(jsonBytes)), "wire-B")
+	})
+	b.Run("decode/json-v2-compat", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(jsonBytes)))
+		for i := 0; i < b.N; i++ {
+			out := newOut()
+			_ = jsonv2.Unmarshal(jsonBytes, out, json.DefaultOptionsV1())
 		}
 	})
 

--- a/bench/floats_test.go
+++ b/bench/floats_test.go
@@ -2,6 +2,7 @@ package bench
 
 import (
 	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"testing"
 
 	msgpack "github.com/vmihailenco/msgpack/v5"
@@ -48,6 +49,14 @@ func BenchmarkEncode_Float32Vec512(b *testing.B) {
 			}
 		}
 	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := jsonv2.Marshal(v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 	b.Run("msgpack", func(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
@@ -72,6 +81,14 @@ func BenchmarkEncode_Float64Vec512(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
 			if _, err := json.Marshal(v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := jsonv2.Marshal(v); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -104,6 +121,15 @@ func BenchmarkDecode_Float32Vec512(b *testing.B) {
 		for b.Loop() {
 			var out Vector
 			if err := json.Unmarshal(jb, &out); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			var out Vector
+			if err := jsonv2.Unmarshal(jb, &out); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/bench/iot_test.go
+++ b/bench/iot_test.go
@@ -19,6 +19,50 @@ func BenchmarkIoT_128x512(b *testing.B) {
 	runCodecMatrix(b, v, func() *IoTBatch { return new(IoTBatch) })
 }
 
+// BenchmarkIoT_JSONText_32x256 measures the hand-written jsontext codec on the
+// same payload the matrix above uses, so its rows can be read beside them.
+//
+// This arm answers "how fast can JSON go on this shape if you remove the
+// reflection entirely" — its honest counterpart is qdf_codegen, not the reflect
+// tiers. The encoder and decoder are reused across iterations, which is the
+// point: a fresh one per message would put back the allocation this exists to
+// remove.
+func BenchmarkIoT_JSONText_32x256(b *testing.B) {
+	v := mkIoTBatch(32, 256)
+
+	enc := newJSONTextEncoder()
+	wire, err := enc.marshalIoTBatch(&v)
+	if err != nil {
+		b.Fatal(err)
+	}
+	size := len(wire)
+	payload := append([]byte(nil), wire...)
+
+	b.Run("encode/jsontext", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(size))
+		e := newJSONTextEncoder()
+		for b.Loop() {
+			if _, err := e.marshalIoTBatch(&v); err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.ReportMetric(float64(size), "wire-B")
+	})
+
+	b.Run("decode/jsontext", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(size))
+		d := newJSONTextDecoder()
+		var out IoTBatch
+		for b.Loop() {
+			if err := d.unmarshalIoTBatch(payload, &out); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
 // TestIoT_Roundtrip verifies that mkIoTBatch payloads survive a
 // Marshal → Unmarshal round-trip under each qdf tier.
 func TestIoT_Roundtrip(t *testing.T) {

--- a/bench/jsontext_codec.go
+++ b/bench/jsontext_codec.go
@@ -358,3 +358,211 @@ func (d *jsontextDecoder) readStringMap() (map[string]string, error) {
 	_, err := d.dec.ReadToken() // }
 	return m, err
 }
+
+// ---- RTB: nested structs, a string slice, and a map per impression ----
+//
+// The shape JSON is most competitive on: mostly strings, so there is little for
+// a binary format's numeric codecs to exploit. It is also the shape where
+// qdf_compression loses encode CPU to json/v2, which makes the ceiling worth
+// knowing precisely.
+
+func (e *jsontextEncoder) writeStringSlice(s []string) error {
+	if s == nil {
+		return e.enc.WriteToken(jsontext.Null)
+	}
+	if err := e.enc.WriteToken(jsontext.BeginArray); err != nil {
+		return err
+	}
+	for _, v := range s {
+		if err := e.enc.WriteToken(jsontext.String(v)); err != nil {
+			return err
+		}
+	}
+	return e.enc.WriteToken(jsontext.EndArray)
+}
+
+// field writes a name token and is the shape every writer below repeats.
+func (e *jsontextEncoder) field(name string) error {
+	return e.enc.WriteToken(jsontext.String(name))
+}
+
+func (e *jsontextEncoder) writeGeo(g *Geo) error {
+	for _, step := range []func() error{
+		func() error { return e.enc.WriteToken(jsontext.BeginObject) },
+		func() error { return e.field("country") },
+		func() error { return e.enc.WriteToken(jsontext.String(g.Country)) },
+		func() error { return e.field("lat") },
+		func() error { return e.enc.WriteToken(jsontext.Float(g.Lat)) },
+		func() error { return e.field("lon") },
+		func() error { return e.enc.WriteToken(jsontext.Float(g.Lon)) },
+		func() error { return e.field("type") },
+		func() error { return e.enc.WriteToken(jsontext.Int(int64(g.Type))) },
+		func() error { return e.enc.WriteToken(jsontext.EndObject) },
+	} {
+		if err := step(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *jsontextEncoder) writeDevice(d *Device) error {
+	if err := e.enc.WriteToken(jsontext.BeginObject); err != nil {
+		return err
+	}
+	if err := e.field("ua"); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.String(d.UA)); err != nil {
+		return err
+	}
+	if err := e.field("ip"); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.String(d.IP)); err != nil {
+		return err
+	}
+	if err := e.field("os"); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.Int(int64(d.OS))); err != nil {
+		return err
+	}
+	if err := e.field("type"); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.Int(int64(d.Type))); err != nil {
+		return err
+	}
+	if err := e.field("geo"); err != nil {
+		return err
+	}
+	if err := e.writeGeo(&d.Geo); err != nil {
+		return err
+	}
+	return e.enc.WriteToken(jsontext.EndObject)
+}
+
+func (e *jsontextEncoder) writeImpression(im *Impression) error {
+	if err := e.enc.WriteToken(jsontext.BeginObject); err != nil {
+		return err
+	}
+	if err := e.field("id"); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.String(im.ID)); err != nil {
+		return err
+	}
+	if err := e.field("bid_floor"); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.Float(im.BidFloor)); err != nil {
+		return err
+	}
+	if err := e.field("w"); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.Int(int64(im.W))); err != nil {
+		return err
+	}
+	if err := e.field("h"); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.Int(int64(im.H))); err != nil {
+		return err
+	}
+	if err := e.field("deal_ids"); err != nil {
+		return err
+	}
+	if err := e.writeStringSlice(im.DealIDs); err != nil {
+		return err
+	}
+	if err := e.field("ext"); err != nil {
+		return err
+	}
+	if err := e.writeStringMapSorted(im.Ext); err != nil {
+		return err
+	}
+	return e.enc.WriteToken(jsontext.EndObject)
+}
+
+func (e *jsontextEncoder) writeBidRequest(r *BidRequest) error {
+	if err := e.enc.WriteToken(jsontext.BeginObject); err != nil {
+		return err
+	}
+	if err := e.field("id"); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.String(r.ID)); err != nil {
+		return err
+	}
+	if err := e.field("at"); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.Int(int64(r.At))); err != nil {
+		return err
+	}
+	if err := e.field("tmax"); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.Int(int64(r.Tmax))); err != nil {
+		return err
+	}
+	if err := e.field("imp"); err != nil {
+		return err
+	}
+	if r.Imp == nil {
+		if err := e.enc.WriteToken(jsontext.Null); err != nil {
+			return err
+		}
+	} else {
+		if err := e.enc.WriteToken(jsontext.BeginArray); err != nil {
+			return err
+		}
+		for i := range r.Imp {
+			if err := e.writeImpression(&r.Imp[i]); err != nil {
+				return err
+			}
+		}
+		if err := e.enc.WriteToken(jsontext.EndArray); err != nil {
+			return err
+		}
+	}
+	if err := e.field("dev"); err != nil {
+		return err
+	}
+	if err := e.writeDevice(&r.Dev); err != nil {
+		return err
+	}
+	if err := e.field("cur"); err != nil {
+		return err
+	}
+	if err := e.writeStringSlice(r.Cur); err != nil {
+		return err
+	}
+	return e.enc.WriteToken(jsontext.EndObject)
+}
+
+// marshalRTBBatch writes a []BidRequest. The returned slice aliases the
+// encoder's buffer, like marshalIoTBatch.
+func (e *jsontextEncoder) marshalRTBBatch(v []BidRequest) ([]byte, error) {
+	e.reset()
+	if v == nil {
+		if err := e.enc.WriteToken(jsontext.Null); err != nil {
+			return nil, err
+		}
+		return bytes.TrimSuffix(e.buf.Bytes(), []byte("\n")), nil
+	}
+	if err := e.enc.WriteToken(jsontext.BeginArray); err != nil {
+		return nil, err
+	}
+	for i := range v {
+		if err := e.writeBidRequest(&v[i]); err != nil {
+			return nil, err
+		}
+	}
+	if err := e.enc.WriteToken(jsontext.EndArray); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSuffix(e.buf.Bytes(), []byte("\n")), nil
+}

--- a/bench/jsontext_codec.go
+++ b/bench/jsontext_codec.go
@@ -1,0 +1,360 @@
+package bench
+
+import (
+	"bytes"
+	"encoding/json/jsontext"
+	"io"
+	"sort"
+)
+
+// Hand-written JSON codecs over encoding/json/jsontext, as the ceiling of what
+// JSON can do on these fixtures.
+//
+// The filename matters: an earlier name for this file was jsontext_arm.go, and
+// _arm is a GOARCH suffix — Go silently excluded the whole file from the build
+// and every check passed while nothing in here compiled.
+//
+// What this arm is: JSON with the reflection removed. jsontext is a token
+// stream, so the struct walk that json.Marshal performs at run time is written
+// out here at compile time, field by field. Nothing is discovered by reflect;
+// the encoder appends tokens into a buffer it keeps between calls.
+//
+// What this arm is NOT: a fair comparison against qdf's *reflect* tiers. Its
+// honest counterpart is qdf_codegen, which is also a compile-time struct walk.
+// Reading it against qdf_speed or qdf_balanced flatters JSON, and the tables say
+// so where they show it.
+//
+// The output is byte-compatible with encoding/json v1 semantics — map keys
+// sorted, nil slices as null — because otherwise the size column would not line
+// up with the v1 row it sits beside. Sorting is the one place this codec does
+// work v2's defaults skip, and it is deliberate: it is what makes the row
+// comparable.
+
+// jsontextEncoder is a reusable encode context. The Encoder and the buffer both
+// survive between calls — that reuse is the point, since a fresh Encoder per
+// message would put allocation back in exactly the place this arm exists to
+// remove.
+type jsontextEncoder struct {
+	buf  bytes.Buffer
+	enc  *jsontext.Encoder
+	keys []string // scratch for sorted map keys
+}
+
+func newJSONTextEncoder() *jsontextEncoder {
+	e := &jsontextEncoder{}
+	e.enc = jsontext.NewEncoder(io.Discard)
+	return e
+}
+
+// reset points the encoder at its own buffer for a fresh message.
+func (e *jsontextEncoder) reset() {
+	e.buf.Reset()
+	e.enc.Reset(&e.buf)
+}
+
+// writeStringMapSorted writes a map[string]string with its keys in sorted order,
+// matching encoding/json v1. The key scratch is reused across calls.
+func (e *jsontextEncoder) writeStringMapSorted(m map[string]string) error {
+	if m == nil {
+		return e.enc.WriteToken(jsontext.Null)
+	}
+	if err := e.enc.WriteToken(jsontext.BeginObject); err != nil {
+		return err
+	}
+	e.keys = e.keys[:0]
+	for k := range m {
+		e.keys = append(e.keys, k)
+	}
+	sort.Strings(e.keys)
+	for _, k := range e.keys {
+		if err := e.enc.WriteToken(jsontext.String(k)); err != nil {
+			return err
+		}
+		if err := e.enc.WriteToken(jsontext.String(m[k])); err != nil {
+			return err
+		}
+	}
+	return e.enc.WriteToken(jsontext.EndObject)
+}
+
+func (e *jsontextEncoder) writeInt64Slice(s []int64) error {
+	if s == nil {
+		return e.enc.WriteToken(jsontext.Null)
+	}
+	if err := e.enc.WriteToken(jsontext.BeginArray); err != nil {
+		return err
+	}
+	for _, v := range s {
+		if err := e.enc.WriteToken(jsontext.Int(v)); err != nil {
+			return err
+		}
+	}
+	return e.enc.WriteToken(jsontext.EndArray)
+}
+
+func (e *jsontextEncoder) writeFloat64Slice(s []float64) error {
+	if s == nil {
+		return e.enc.WriteToken(jsontext.Null)
+	}
+	if err := e.enc.WriteToken(jsontext.BeginArray); err != nil {
+		return err
+	}
+	for _, v := range s {
+		if err := e.enc.WriteToken(jsontext.Float(v)); err != nil {
+			return err
+		}
+	}
+	return e.enc.WriteToken(jsontext.EndArray)
+}
+
+// marshalIoTBatch writes an IoTBatch as JSON without reflecting over it. The
+// returned slice aliases the encoder's buffer and is valid until the next
+// marshal on the same encoder — the caller in a benchmark reads its length and
+// drops it, which is the usage this is shaped for.
+func (e *jsontextEncoder) marshalIoTBatch(v *IoTBatch) ([]byte, error) {
+	e.reset()
+	if err := e.enc.WriteToken(jsontext.BeginObject); err != nil {
+		return nil, err
+	}
+	if err := e.enc.WriteToken(jsontext.String("devices")); err != nil {
+		return nil, err
+	}
+	if v.Devices == nil {
+		if err := e.enc.WriteToken(jsontext.Null); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := e.enc.WriteToken(jsontext.BeginArray); err != nil {
+			return nil, err
+		}
+		for i := range v.Devices {
+			if err := e.writeDeviceReading(&v.Devices[i]); err != nil {
+				return nil, err
+			}
+		}
+		if err := e.enc.WriteToken(jsontext.EndArray); err != nil {
+			return nil, err
+		}
+	}
+	if err := e.enc.WriteToken(jsontext.EndObject); err != nil {
+		return nil, err
+	}
+	// jsontext.Encoder is a stream encoder and terminates a top-level value with
+	// a newline; json.Marshal does not. Trimming it is what makes the two
+	// outputs byte-comparable, and the size column honest — a stray byte per
+	// message is invisible in a log and shows up as a real difference at scale.
+	return bytes.TrimSuffix(e.buf.Bytes(), []byte("\n")), nil
+}
+
+func (e *jsontextEncoder) writeDeviceReading(d *DeviceReading) error {
+	if err := e.enc.WriteToken(jsontext.BeginObject); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.String("device_id")); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.String(d.DeviceID)); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.String("ts")); err != nil {
+		return err
+	}
+	if err := e.writeInt64Slice(d.Ts); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.String("temp")); err != nil {
+		return err
+	}
+	if err := e.writeFloat64Slice(d.Temp); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.String("humidity")); err != nil {
+		return err
+	}
+	if err := e.writeFloat64Slice(d.Humidity); err != nil {
+		return err
+	}
+	if err := e.enc.WriteToken(jsontext.String("tags")); err != nil {
+		return err
+	}
+	if err := e.writeStringMapSorted(d.Tags); err != nil {
+		return err
+	}
+	return e.enc.WriteToken(jsontext.EndObject)
+}
+
+// jsontextDecoder mirrors the encoder: one reusable Decoder, no per-message
+// allocation of the machinery itself.
+type jsontextDecoder struct {
+	dec *jsontext.Decoder
+	rd  bytes.Reader
+}
+
+func newJSONTextDecoder() *jsontextDecoder {
+	d := &jsontextDecoder{}
+	d.dec = jsontext.NewDecoder(bytes.NewReader(nil))
+	return d
+}
+
+func (d *jsontextDecoder) reset(data []byte) {
+	d.rd.Reset(data)
+	d.dec.Reset(&d.rd)
+}
+
+// unmarshalIoTBatch reads what marshalIoTBatch wrote. It reads by position
+// rather than by name: this decoder's whole purpose is to skip the name lookup
+// that reflection cannot avoid, and it is paired with the encoder above, whose
+// field order is fixed.
+func (d *jsontextDecoder) unmarshalIoTBatch(data []byte, out *IoTBatch) error {
+	d.reset(data)
+	if _, err := d.dec.ReadToken(); err != nil { // {
+		return err
+	}
+	if _, err := d.dec.ReadToken(); err != nil { // "devices"
+		return err
+	}
+	if d.dec.PeekKind() == 'n' {
+		if _, err := d.dec.ReadToken(); err != nil {
+			return err
+		}
+		out.Devices = nil
+		return nil
+	}
+	if _, err := d.dec.ReadToken(); err != nil { // [
+		return err
+	}
+	out.Devices = out.Devices[:0]
+	for d.dec.PeekKind() != ']' {
+		var dr DeviceReading
+		if err := d.readDeviceReading(&dr); err != nil {
+			return err
+		}
+		out.Devices = append(out.Devices, dr)
+	}
+	if _, err := d.dec.ReadToken(); err != nil { // ]
+		return err
+	}
+	_, err := d.dec.ReadToken() // }
+	return err
+}
+
+func (d *jsontextDecoder) readDeviceReading(dr *DeviceReading) error {
+	if _, err := d.dec.ReadToken(); err != nil { // {
+		return err
+	}
+	for d.dec.PeekKind() != '}' {
+		nameTok, err := d.dec.ReadToken()
+		if err != nil {
+			return err
+		}
+		switch nameTok.String() {
+		case "device_id":
+			t, err := d.dec.ReadToken()
+			if err != nil {
+				return err
+			}
+			dr.DeviceID = t.String()
+		case "ts":
+			if dr.Ts, err = d.readInt64Slice(dr.Ts); err != nil {
+				return err
+			}
+		case "temp":
+			if dr.Temp, err = d.readFloat64Slice(dr.Temp); err != nil {
+				return err
+			}
+		case "humidity":
+			if dr.Humidity, err = d.readFloat64Slice(dr.Humidity); err != nil {
+				return err
+			}
+		case "tags":
+			if dr.Tags, err = d.readStringMap(); err != nil {
+				return err
+			}
+		default:
+			if err := d.dec.SkipValue(); err != nil {
+				return err
+			}
+		}
+	}
+	_, err := d.dec.ReadToken() // }
+	return err
+}
+
+func (d *jsontextDecoder) readInt64Slice(dst []int64) ([]int64, error) {
+	if d.dec.PeekKind() == 'n' {
+		_, err := d.dec.ReadToken()
+		return nil, err
+	}
+	if _, err := d.dec.ReadToken(); err != nil { // [
+		return nil, err
+	}
+	dst = dst[:0]
+	for d.dec.PeekKind() != ']' {
+		t, err := d.dec.ReadToken()
+		if err != nil {
+			return nil, err
+		}
+		n, err := t.Int()
+		if err != nil {
+			return nil, err
+		}
+		dst = append(dst, n)
+	}
+	_, err := d.dec.ReadToken() // ]
+	return dst, err
+}
+
+func (d *jsontextDecoder) readFloat64Slice(dst []float64) ([]float64, error) {
+	if d.dec.PeekKind() == 'n' {
+		_, err := d.dec.ReadToken()
+		return nil, err
+	}
+	if _, err := d.dec.ReadToken(); err != nil { // [
+		return nil, err
+	}
+	dst = dst[:0]
+	for d.dec.PeekKind() != ']' {
+		t, err := d.dec.ReadToken()
+		if err != nil {
+			return nil, err
+		}
+		f, err := t.Float()
+		if err != nil {
+			return nil, err
+		}
+		dst = append(dst, f)
+	}
+	_, err := d.dec.ReadToken() // ]
+	return dst, err
+}
+
+func (d *jsontextDecoder) readStringMap() (map[string]string, error) {
+	if d.dec.PeekKind() == 'n' {
+		_, err := d.dec.ReadToken()
+		return nil, err
+	}
+	if _, err := d.dec.ReadToken(); err != nil { // {
+		return nil, err
+	}
+	m := make(map[string]string)
+	for d.dec.PeekKind() != '}' {
+		kt, err := d.dec.ReadToken()
+		if err != nil {
+			return nil, err
+		}
+		// The key must be materialised BEFORE the value is read. A Token aliases
+		// the decoder's buffer and is voided by the next Decoder call — reading
+		// the value first and then asking the key for its String panics with
+		// "invalid jsontext.Token; it has been voided by a subsequent
+		// json.Decoder call". That aliasing is what makes the API zero-copy, and
+		// it is the one rule a hand-written codec has to keep.
+		k := kt.String()
+		vt, err := d.dec.ReadToken()
+		if err != nil {
+			return nil, err
+		}
+		m[k] = vt.String()
+	}
+	_, err := d.dec.ReadToken() // }
+	return m, err
+}

--- a/bench/jsontext_codec_test.go
+++ b/bench/jsontext_codec_test.go
@@ -1,0 +1,73 @@
+package bench
+
+import (
+	"encoding/json"
+	jsonv2 "encoding/json/v2"
+	"reflect"
+	"testing"
+)
+
+// TestJSONTextCodecRoundTrips gates the hand-written jsontext codec against the
+// two things that could make its benchmark numbers meaningless.
+//
+// A hand-rolled encoder that drops a field is faster than one that does not, and
+// nothing else in this harness would notice: the benchmark only reads ns/op and
+// the length of the output. So this checks the output against the reflection
+// encoder byte for byte, and checks the hand-written decoder reproduces the
+// value.
+func TestJSONTextCodecRoundTrips(t *testing.T) {
+	for _, n := range []struct {
+		devices, samples int
+	}{{1, 1}, {4, 16}, {32, 256}} {
+		v := mkIoTBatch(n.devices, n.samples)
+
+		enc := newJSONTextEncoder()
+		got, err := enc.marshalIoTBatch(&v)
+		if err != nil {
+			t.Fatalf("%dx%d: marshal: %v", n.devices, n.samples, err)
+		}
+
+		// Byte-for-byte against encoding/json v1. The codec sorts map keys for
+		// exactly this reason: without it the bytes differ by key order and the
+		// size column would not line up with the v1 row it sits beside.
+		want, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("%dx%d: reference marshal: %v", n.devices, n.samples, err)
+		}
+		if string(got) != string(want) {
+			t.Fatalf("%dx%d: jsontext output differs from encoding/json.\n got %d bytes\nwant %d bytes\nfirst divergence at %d",
+				n.devices, n.samples, len(got), len(want), firstDiff(got, want))
+		}
+
+		// The hand-written decoder must reproduce the value, and so must v2's
+		// reflection decoder reading the hand-written bytes — the second check
+		// is what says the output is real JSON rather than something only this
+		// file can read.
+		var back IoTBatch
+		dec := newJSONTextDecoder()
+		if err := dec.unmarshalIoTBatch(got, &back); err != nil {
+			t.Fatalf("%dx%d: jsontext unmarshal: %v", n.devices, n.samples, err)
+		}
+		if !reflect.DeepEqual(back, v) {
+			t.Fatalf("%dx%d: jsontext decoder did not reproduce the value", n.devices, n.samples)
+		}
+
+		var viaV2 IoTBatch
+		if err := jsonv2.Unmarshal(got, &viaV2); err != nil {
+			t.Fatalf("%dx%d: json/v2 could not read the jsontext output: %v", n.devices, n.samples, err)
+		}
+		if !reflect.DeepEqual(viaV2, v) {
+			t.Fatalf("%dx%d: json/v2 read the jsontext output into a different value", n.devices, n.samples)
+		}
+	}
+}
+
+func firstDiff(a, b []byte) int {
+	n := min(len(a), len(b))
+	for i := range n {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return n
+}

--- a/bench/jsontext_codec_test.go
+++ b/bench/jsontext_codec_test.go
@@ -62,6 +62,42 @@ func TestJSONTextCodecRoundTrips(t *testing.T) {
 	}
 }
 
+// TestJSONTextRTBRoundTrips is the same gate for the RTB codec: byte-identical
+// to encoding/json v1, and readable back by json/v2's reflection decoder.
+//
+// There is no hand-written RTB decoder — the encoder is the interesting half
+// here (it is the arm that answers "how fast can JSON encode a string-heavy
+// payload"), and a decoder would double the surface for no extra answer. So the
+// round-trip runs through json/v2 instead.
+func TestJSONTextRTBRoundTrips(t *testing.T) {
+	for _, n := range []int{1, 8, 128} {
+		v := mkRTBBatch(n)
+
+		enc := newJSONTextEncoder()
+		got, err := enc.marshalRTBBatch(v)
+		if err != nil {
+			t.Fatalf("n=%d: marshal: %v", n, err)
+		}
+
+		want, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("n=%d: reference marshal: %v", n, err)
+		}
+		if string(got) != string(want) {
+			t.Fatalf("n=%d: jsontext output differs from encoding/json: got %d bytes, want %d, first divergence at %d",
+				n, len(got), len(want), firstDiff(got, want))
+		}
+
+		var back []BidRequest
+		if err := jsonv2.Unmarshal(got, &back); err != nil {
+			t.Fatalf("n=%d: json/v2 could not read the jsontext output: %v", n, err)
+		}
+		if !reflect.DeepEqual(back, v) {
+			t.Fatalf("n=%d: json/v2 read the jsontext output into a different value", n)
+		}
+	}
+}
+
 func firstDiff(a, b []byte) int {
 	n := min(len(a), len(b))
 	for i := range n {

--- a/bench/largepayload_test.go
+++ b/bench/largepayload_test.go
@@ -2,6 +2,7 @@ package bench
 
 import (
 	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"fmt"
 	"math/rand"
 	"runtime"
@@ -269,6 +270,16 @@ func BenchmarkLargePayload_Encode(b *testing.B) {
 			_, _ = json.Marshal(v)
 		}
 	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		// v2 defaults can differ in length from v1 (key order aside, a nil
+		// slice is [] not null), so this arm measures against its own output.
+		jsonV2Bytes, _ := jsonv2.Marshal(v)
+		b.SetBytes(int64(len(jsonV2Bytes)))
+		for b.Loop() {
+			_, _ = jsonv2.Marshal(v)
+		}
+	})
 	b.Run("msgpack", func(b *testing.B) {
 		b.ReportAllocs()
 		b.SetBytes(int64(len(mb)))
@@ -318,6 +329,14 @@ func BenchmarkLargePayload_Decode(b *testing.B) {
 		for b.Loop() {
 			var out largeBatch
 			_ = json.Unmarshal(jb, &out)
+		}
+	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(jb)))
+		for b.Loop() {
+			var out largeBatch
+			_ = jsonv2.Unmarshal(jb, &out)
 		}
 	})
 	b.Run("msgpack", func(b *testing.B) {

--- a/bench/maps_test.go
+++ b/bench/maps_test.go
@@ -2,6 +2,7 @@ package bench
 
 import (
 	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"strconv"
 	"testing"
 
@@ -46,6 +47,14 @@ func BenchmarkEncode_MapHeavy(b *testing.B) {
 			}
 		}
 	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := jsonv2.Marshal(v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 	b.Run("msgpack", func(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
@@ -82,6 +91,15 @@ func BenchmarkDecode_MapHeavy(b *testing.B) {
 		for b.Loop() {
 			var out Attrs
 			if err := json.Unmarshal(jb, &out); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			var out Attrs
+			if err := jsonv2.Unmarshal(jb, &out); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/bench/memory_test.go
+++ b/bench/memory_test.go
@@ -2,6 +2,7 @@ package bench
 
 import (
 	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"runtime"
 	"strconv"
 	"testing"
@@ -48,6 +49,13 @@ func BenchmarkDecode_MapHeavy_RepeatedKeys(b *testing.B) {
 			_ = json.Unmarshal(jsonBufs[i%N], &out)
 		}
 	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; b.Loop(); i++ {
+			var out map[string]string
+			_ = jsonv2.Unmarshal(jsonBufs[i%N], &out)
+		}
+	})
 	b.Run("msgpack", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; b.Loop(); i++ {
@@ -84,6 +92,20 @@ func BenchmarkMemory_DecodeLogBatch1k_Bytes(b *testing.B) {
 		for range runs {
 			var out LogBatch
 			_ = json.Unmarshal(jsonBytes, &out)
+		}
+		runtime.ReadMemStats(&ms)
+		b.ReportMetric(float64(ms.TotalAlloc-startAllocs)/runs, "B/decode")
+	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		var ms runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&ms)
+		startAllocs := ms.TotalAlloc
+		const runs = 100
+		for range runs {
+			var out LogBatch
+			_ = jsonv2.Unmarshal(jsonBytes, &out)
 		}
 		runtime.ReadMemStats(&ms)
 		b.ReportMetric(float64(ms.TotalAlloc-startAllocs)/runs, "B/decode")
@@ -142,6 +164,13 @@ func BenchmarkDecode_MapStringAny_RepeatedKeys(b *testing.B) {
 		for i := 0; b.Loop(); i++ {
 			var out map[string]any
 			_ = json.Unmarshal(jsonBufs[i%N], &out)
+		}
+	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; b.Loop(); i++ {
+			var out map[string]any
+			_ = jsonv2.Unmarshal(jsonBufs[i%N], &out)
 		}
 	})
 	b.Run("qdf_fast", func(b *testing.B) {

--- a/bench/qpack_test.go
+++ b/bench/qpack_test.go
@@ -2,6 +2,7 @@ package bench
 
 import (
 	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"testing"
 
 	msgpack "github.com/vmihailenco/msgpack/v5"
@@ -50,6 +51,12 @@ func BenchmarkQPack_Encode(b *testing.B) {
 			_, _ = json.Marshal(v)
 		}
 	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_, _ = jsonv2.Marshal(v)
+		}
+	})
 	b.Run("msgpack", func(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
@@ -89,6 +96,13 @@ func BenchmarkQPack_Decode(b *testing.B) {
 		for b.Loop() {
 			var out qpackPayload
 			_ = json.Unmarshal(jb, &out)
+		}
+	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			var out qpackPayload
+			_ = jsonv2.Unmarshal(jb, &out)
 		}
 	})
 	b.Run("msgpack", func(b *testing.B) {

--- a/bench/realistic_decode_test.go
+++ b/bench/realistic_decode_test.go
@@ -2,6 +2,7 @@ package bench
 
 import (
 	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"testing"
 
 	msgpack "github.com/vmihailenco/msgpack/v5"
@@ -33,6 +34,15 @@ func BenchmarkDecode_UniqueLog(b *testing.B) {
 		for i := 0; b.Loop(); i++ {
 			var out LogEntry
 			if err := json.Unmarshal(jsonBufs[i&(N-1)], &out); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; b.Loop(); i++ {
+			var out LogEntry
+			if err := jsonv2.Unmarshal(jsonBufs[i&(N-1)], &out); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -82,6 +92,17 @@ func BenchmarkDecodeParallel_UniqueLog(b *testing.B) {
 			for pb.Next() {
 				var out LogEntry
 				_ = json.Unmarshal(jsonBufs[i&(N-1)], &out)
+				i++
+			}
+		})
+	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		b.RunParallel(func(pb *testing.PB) {
+			i := 0
+			for pb.Next() {
+				var out LogEntry
+				_ = jsonv2.Unmarshal(jsonBufs[i&(N-1)], &out)
 				i++
 			}
 		})

--- a/bench/realistic_test.go
+++ b/bench/realistic_test.go
@@ -2,6 +2,7 @@ package bench
 
 import (
 	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"math/rand/v2"
 	"testing"
 
@@ -52,6 +53,15 @@ func BenchmarkEncode_UniqueLog(b *testing.B) {
 			}
 		}
 	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			v := state.next()
+			if _, err := jsonv2.Marshal(&v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 	b.Run("msgpack", func(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
@@ -93,6 +103,22 @@ func BenchmarkEncode_MixedTypes(b *testing.B) {
 			default:
 				v := state.next()
 				_, _ = json.Marshal(&v)
+			}
+		}
+	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; b.Loop(); i++ {
+			switch i & 3 {
+			case 0:
+				_, _ = jsonv2.Marshal(tiny)
+			case 1:
+				_, _ = jsonv2.Marshal(flat)
+			case 2:
+				_, _ = jsonv2.Marshal(nested)
+			default:
+				v := state.next()
+				_, _ = jsonv2.Marshal(&v)
 			}
 		}
 	})
@@ -145,6 +171,16 @@ func BenchmarkEncode_RandomSize(b *testing.B) {
 			}
 		}
 	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			n := sizes[rng.IntN(len(sizes))]
+			v := MakeWide(n)
+			if _, err := jsonv2.Marshal(v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 	b.Run("msgpack", func(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
@@ -176,6 +212,16 @@ func BenchmarkEncodeParallel_UniqueLog(b *testing.B) {
 			for pb.Next() {
 				v := st.next()
 				_, _ = json.Marshal(&v)
+			}
+		})
+	})
+	b.Run("json-v2", func(b *testing.B) {
+		b.ReportAllocs()
+		b.RunParallel(func(pb *testing.PB) {
+			st := newUniqueState()
+			for pb.Next() {
+				v := st.next()
+				_, _ = jsonv2.Marshal(&v)
 			}
 		})
 	})

--- a/bench/rtb_test.go
+++ b/bench/rtb_test.go
@@ -52,3 +52,32 @@ func TestRTB_Roundtrip(t *testing.T) {
 		})
 	}
 }
+
+// BenchmarkRTB_JSONText_1024 is the encode ceiling for JSON on a string-heavy
+// payload: the struct walk written out by hand, with the encoder and its buffer
+// reused between messages.
+//
+// This is the shape where qdf_compression loses encode CPU to json/v2, so
+// knowing what JSON can actually reach here — rather than what its reflection
+// path happens to cost — is the point of the arm.
+func BenchmarkRTB_JSONText_1024(b *testing.B) {
+	v := mkRTBBatch(1024)
+	enc := newJSONTextEncoder()
+	wire, err := enc.marshalRTBBatch(v)
+	if err != nil {
+		b.Fatal(err)
+	}
+	size := len(wire)
+
+	b.Run("encode/jsontext", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(size))
+		e := newJSONTextEncoder()
+		for b.Loop() {
+			if _, err := e.marshalRTBBatch(v); err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.ReportMetric(float64(size), "wire-B")
+	})
+}

--- a/cmd/qdf-bench/baselines.go
+++ b/cmd/qdf-bench/baselines.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"fmt"
 	"os"
 	"reflect"
@@ -24,7 +25,37 @@ type extCodec struct {
 // dec = "-".
 var baselines = []extCodec{
 	{"json", json.Marshal, json.Unmarshal},
+	{"json-v2", jsonv2Marshal, jsonv2Unmarshal},
+	{"json-v2-compat", jsonv2CompatMarshal, jsonv2CompatUnmarshal},
 	{"msgpack", msgpack.Marshal, msgpack.Unmarshal},
+}
+
+// There are three JSON rows here rather than one, and the third is the reason
+// the other two can be read honestly.
+//
+// In Go 1.27 encoding/json IS json/v2 driven by DefaultOptionsV1 — see
+// $GOROOT/src/encoding/json/v2_encode.go. So the gap between the v1 and v2 rows
+// is not a faster engine; it is the price of the v1 compatibility options. The
+// json-v2-compat row pins that down: v2 asked for v1 semantics costs what v1
+// costs, and its output is byte-identical.
+//
+// v2's defaults are faster because they stop doing three things v1 does: sorting
+// map keys, escaping HTML, and writing null (rather than [] / {}) for a nil
+// slice or map. Those are wire differences, not just speed ones, which is why
+// the size columns for the v1 and v2 rows are not interchangeable.
+//
+// v1 stays because it is what almost every published Go benchmark measures
+// against and what most deployed code runs.
+func jsonv2Marshal(v any) ([]byte, error) { return jsonv2.Marshal(v) }
+
+func jsonv2Unmarshal(data []byte, ptr any) error { return jsonv2.Unmarshal(data, ptr) }
+
+func jsonv2CompatMarshal(v any) ([]byte, error) {
+	return jsonv2.Marshal(v, json.DefaultOptionsV1())
+}
+
+func jsonv2CompatUnmarshal(data []byte, ptr any) error {
+	return jsonv2.Unmarshal(data, ptr, json.DefaultOptionsV1())
 }
 
 // benchExtTyped mirrors benchTyped for an external codec over the typed Info

--- a/diagrams/performance.md
+++ b/diagrams/performance.md
@@ -1,5 +1,15 @@
 # Performance: Algorithmic Wins
 
+> **`json` on this page means `encoding/json` v1**, measured on the amd64 host
+> named in [BENCH.md](../docs/BENCH.md). Go 1.27's `encoding/json/v2` narrows some of
+> these gaps by 0–21% and, on payloads with no maps to sort and no HTML to
+> escape, by nothing at all — the v1/v2 difference is exactly the price of the
+> compatibility options, since in Go 1.27 `encoding/json` *is* json/v2 under
+> `DefaultOptionsV1`. Wire sizes are unaffected except where a nil slice or map
+> is involved. See
+> [BENCH.md](../docs/BENCH.md#json-v2-and-what-json-actually-costs).
+
+
 ## What this shows
 
 The 10 key algorithmic and engineering wins in qdf, grouped by the resource

--- a/docs/ARTICLE.md
+++ b/docs/ARTICLE.md
@@ -1,5 +1,15 @@
 # qdf: a schemaless Go serializer you can run `WHERE` over
 
+> **`json` on this page means `encoding/json` v1**, measured on the amd64 host
+> named in [BENCH.md](BENCH.md). Go 1.27's `encoding/json/v2` narrows some of
+> these gaps by 0–21% and, on payloads with no maps to sort and no HTML to
+> escape, by nothing at all — the v1/v2 difference is exactly the price of the
+> compatibility options, since in Go 1.27 `encoding/json` *is* json/v2 under
+> `DefaultOptionsV1`. Wire sizes are unaffected except where a nil slice or map
+> is involved. See
+> [BENCH.md](BENCH.md#json-v2-and-what-json-actually-costs).
+
+
 *A practical, byte-level deep-dive into a pure-Go binary format that is
 JSON-flexible, protobuf-dense, and lets you filter and project the encoded bytes
 without decoding them — plus a decision guide for picking the right modes, options,

--- a/docs/BENCH.md
+++ b/docs/BENCH.md
@@ -166,6 +166,42 @@ smaller wire.**
 
 3.2× faster encode and 2.8× faster decode than json/v2, at 2.3× less wire.
 
+### Large payload (~150 MiB source value)
+
+This is where v2's real strength shows, and it is memory rather than time.
+
+| codec | encode | allocs | alloc bytes | decode | allocs |
+|---|---|---|---|---|---|
+| `json` v1 | 58.6 ms | 250 124 | 87.3 MB | 144.7 ms | 1 023 820 |
+| `json/v2` | 55.0 ms | **100 003** | **37.0 MB** | 117.8 ms | 1 023 822 |
+| msgpack | 31.2 ms | 100 023 | 65.5 MB | 66.9 ms | 1 425 126 |
+| qdf_fast | **11.7 ms** | 18 | 28.1 MB | 23.4 ms | 875 099 |
+| qdf_dense | 12.8 ms | 20 | **17.5 MB** | **21.2 ms** | 829 782 |
+
+json/v2 cuts encode allocation count by 60% and allocated bytes by 58% against
+v1, at roughly the same time. It is the largest v2 win anywhere in this file, and
+it is the one that matters most in a service under GC pressure.
+
+Against v2: qdf_fast encodes **4.7×** faster, qdf_dense decodes **5.6×** faster
+and holds its encode working set to less than half.
+
+### QPack fixture — numeric slices
+
+| codec | encode | decode |
+|---|---|---|
+| `json` v1 | 17.5 µs | 38.1 µs |
+| `json/v2` | 17.4 µs | 29.3 µs |
+| msgpack | 21.0 µs | 28.0 µs |
+| **qdf_qpack** | **1.4 µs** | **1.5 µs** |
+
+**12.4× faster encode and 19.5× faster decode than json/v2.** This is the shape
+qdf is built for — dense numeric columns where bit-packing and
+frame-of-reference do the work that a text format cannot.
+
+Note that v2 and v1 encode this fixture at the same speed: with no maps to sort
+and no strings to escape, v2's defaults have nothing to skip. That is the
+clearest demonstration of where the v2 win comes from.
+
 **And one place qdf loses.** `qdf_compression` encodes this payload in 1330 µs
 against json/v2's 1242 µs — slower. It buys a 197 KB wire against 546 KB, so the
 trade is a good one when bytes cost more than CPU, but on encode CPU alone the

--- a/docs/BENCH.md
+++ b/docs/BENCH.md
@@ -202,11 +202,39 @@ Note that v2 and v1 encode this fixture at the same speed: with no maps to sort
 and no strings to escape, v2's defaults have nothing to skip. That is the
 clearest demonstration of where the v2 win comes from.
 
-**And one place qdf loses.** `qdf_compression` encodes this payload in 1330 µs
-against json/v2's 1242 µs — slower. It buys a 197 KB wire against 546 KB, so the
-trade is a good one when bytes cost more than CPU, but on encode CPU alone the
-strongest JSON now beats qdf's heaviest tier on a string-shaped payload. That is
-worth knowing before reaching for `OptCompression` on a hot path.
+### The hand-written ceiling is not where I expected it
+
+The IoT numbers say a hand-written codec is the fastest JSON on that shape. On
+RTB it is not — and the reason is worth more than the number.
+
+| RTB encode arm | time | allocs | semantics |
+|---|---|---|---|
+| `json` v1 | 1354 µs | 10 053 | v1 |
+| `json/v2` + `DefaultOptionsV1` | 1348 µs | 10 052 | v1 |
+| `jsontext`, hand-written | **1355 µs** | **0** | v1 |
+| `json/v2` defaults | **1238 µs** | 5 043 | v2 |
+
+The hand-written codec, with the reflection gone and **zero allocations**, lands
+exactly on v1's time — and *behind* v2's defaults. It sorts map keys, because
+that is what makes its bytes comparable with the v1 row; v2's defaults do not.
+
+So on a string-heavy payload the encode cost is the **format plus the v1
+semantics**, and removing reflection buys nothing measurable. "Hand-written is
+the ceiling" holds for v1-compatible output only. It is a useful correction to
+the IoT reading, where the numeric slices gave the hand-written codec something
+real to win.
+
+### And one place qdf loses
+
+`qdf_compression` encodes RTB in 1281 µs against json/v2's 1238 µs — slower. It
+buys a 197 KB wire against 546 KB, so the trade is a good one where bytes cost
+more than CPU, but on encode CPU alone v2's defaults beat qdf's heaviest tier on
+a string-shaped payload. Worth knowing before reaching for `OptCompression` on a
+hot path — and `docs/CHOOSING.md` already gives that advice.
+
+Against the JSON arms that preserve v1 semantics, `qdf_compression` still wins
+(1281 µs against 1348–1355 µs). The loss is specifically to v2's *relaxed*
+defaults.
 
 
 ## Scenario profiles (per-call `Options` recipes)

--- a/docs/BENCH.md
+++ b/docs/BENCH.md
@@ -9,6 +9,14 @@
 Measured on Darwin amd64 / Intel i7-9750H @ 2.6 GHz. Go 1.26.0.
 `go test -bench=. -benchmem -benchtime=2s` in `bench/`.
 
+> **Two different machines live in this file.** Everything below this line, up to
+> the JSON section at the end, was measured on the amd64 host named above against
+> `encoding/json` v1. The **[json/v2 section](#json-v2-and-what-json-actually-costs)**
+> was re-measured on Darwin **arm64** / Apple Silicon, Go **1.27.0**. Absolute
+> ns/op do not transfer between the two; ratios do. The older tables are being
+> re-cut on the new host — until they are, read them for their ratios and not
+> their nanoseconds.
+
 Operating modes compared:
 
 - **qdf_fast** — default build. Reflect-based with specialized fast
@@ -79,6 +87,91 @@ coverage by `TestPool_ConcurrentEncoders` + the full `-race` test sweep.
   **8.5× faster**).
 - All build-tag combinations (default, `qdf_reflect2`, `qdf_simd`,
   both) build, test under -race, and fuzz-pass cleanly.
+
+
+## json/v2, and what JSON actually costs
+
+Go 1.27 ships `encoding/json/v2` and `encoding/json/jsontext` as stable packages
+— no `GOEXPERIMENT`. That makes the JSON side of every comparison here as fast
+as the standard library gets, so it is worth asking plainly whether qdf still
+wins. It does, and by margins that did not move much. But three things turned up
+on the way that are more interesting than the verdict.
+
+Measured on Darwin arm64 / Apple Silicon, Go 1.27.0, `-count=8`, medians.
+Raw output: `docs/superpowers/results/2026-08-22-json-v2/`.
+
+### The v2 win is semantic, not architectural
+
+In Go 1.27 `encoding/json` **is** json/v2 driven by `DefaultOptionsV1()`
+(`$GOROOT/src/encoding/json/v2_encode.go`). So the v1/v2 gap is not a faster
+engine — it is the price of the v1 compatibility options. Ask v2 for v1
+semantics and it costs what v1 costs:
+
+| arm | IoT encode | IoT decode | RTB encode | RTB decode |
+|---|---|---|---|---|
+| `json` (v1) | 679 µs | 1406 µs | 1372 µs | 2854 µs |
+| `json/v2` defaults | 661 µs | 1135 µs | 1242 µs | 2366 µs |
+| `json/v2` + `DefaultOptionsV1` | 663 µs | 1398 µs | 1365 µs | 2903 µs |
+
+v2 is faster only by no longer doing three things v1 does: sorting map keys,
+escaping HTML, and writing `null` rather than `[]` / `{}` for a nil slice or map.
+Those are wire differences too, not only speed ones:
+
+```
+v1          {"s":null,"m":null,"h":"a\u003cb\u0026c\u003ed"}
+v2 defaults {"s":[],"m":{},"h":"a<b&c>d"}
+```
+
+Where v2 does win outright is allocation: 68 encode allocations against v1's 164
+on the IoT batch, 5041 against 10052 on RTB.
+
+### JSON's cost is the format, not the reflection
+
+`bench/jsontext_codec.go` is a hand-written codec over `jsontext` — the struct
+walk that `json.Marshal` performs at run time, written out field by field, with
+the encoder and buffer reused between calls. It is the ceiling of what JSON can
+do on this shape, and its honest counterpart is `qdf_codegen`, not the reflect
+tiers.
+
+It reaches **zero allocations per encode**. And it is only ~1.5% faster than v2's
+reflection on time. Number formatting, escaping and byte-level syntax are what
+that leaves untouched — which is the reason a faster JSON library can only move
+this so far.
+
+### IoT batch — 32 devices × 256 samples
+
+| codec | encode | allocs | decode | allocs | wire |
+|---|---|---|---|---|---|
+| `json` v1 | 679 µs | 164 | 1406 µs | 1063 | 458 KB |
+| `json/v2` | 661 µs | 68 | 1135 µs | 1063 | 458 KB |
+| `jsontext` hand-written | 651 µs | **0** | 1045 µs | 864 | 458 KB |
+| msgpack | 354 µs | 47 | 482 µs | 775 | 219 KB |
+| **qdf_qpack** | **48 µs** | 2 | **38 µs** | 291 | 157 KB |
+| qdf_balanced | 51 µs | 3 | 42 µs | 188 | 155 KB |
+| qdf_compression | 388 µs | 7 | 99 µs | 184 | 126 KB |
+
+Against the **best** JSON can do: **13.5× faster encode, 27× faster decode, 2.9×
+smaller wire.**
+
+### RTB batch — 1024 bid requests
+
+| codec | encode | allocs | decode | allocs | wire |
+|---|---|---|---|---|---|
+| `json` v1 | 1372 µs | 10052 | 2854 µs | 26717 | 546 KB |
+| `json/v2` | 1242 µs | 5041 | 2366 µs | 26710 | 546 KB |
+| msgpack | 900 µs | 6076 | 1738 µs | 34662 | 418 KB |
+| **qdf_speed** | **389 µs** | 3 | 851 µs | 26254 | 426 KB |
+| qdf_balanced | 532 µs | 4 | **833 µs** | 21282 | 239 KB |
+| qdf_compression | 1330 µs | 14 | 1053 µs | 21290 | 197 KB |
+
+3.2× faster encode and 2.8× faster decode than json/v2, at 2.3× less wire.
+
+**And one place qdf loses.** `qdf_compression` encodes this payload in 1330 µs
+against json/v2's 1242 µs — slower. It buys a 197 KB wire against 546 KB, so the
+trade is a good one when bytes cost more than CPU, but on encode CPU alone the
+strongest JSON now beats qdf's heaviest tier on a string-shaped payload. That is
+worth knowing before reaching for `OptCompression` on a hot path.
+
 
 ## Scenario profiles (per-call `Options` recipes)
 

--- a/docs/CHOOSING.md
+++ b/docs/CHOOSING.md
@@ -1,5 +1,17 @@
 # Choosing the right `Options` (and build tags)
 
+> **Every `json` number on this page is `encoding/json` v1, measured on the
+> amd64 host named in [docs/BENCH.md](BENCH.md).** Go 1.27's
+> `encoding/json/v2` narrows some of these gaps and none of them decisively:
+> measured here it gains **0–21% on decode** and **0–9% on encode**, and on a
+> payload with no maps to sort and no HTML to escape it gains **nothing at all**,
+> because in Go 1.27 `encoding/json` *is* json/v2 under `DefaultOptionsV1` and
+> the difference between them is exactly the price of those options. Its real win
+> is allocation — up to 60% fewer on a large payload. The full v1 / v2 /
+> hand-written-`jsontext` comparison is in
+> [BENCH.md](BENCH.md#json-v2-and-what-json-actually-costs).
+
+
 qdf has one encode entry point: `Marshal(v, opts)`. The `opts` bit-mask
 picks which codecs run. This page is a cheatsheet for the choice.
 For the full API reference and data-shape-to-codec mapping see [`docs/USAGE.md`](USAGE.md).

--- a/docs/COMPETITIVE.md
+++ b/docs/COMPETITIVE.md
@@ -1,5 +1,17 @@
 # Competitive benchmarks — qdf vs json / msgpack / protobuf / flatbuffers
 
+> **Every `json` number on this page is `encoding/json` v1, measured on the
+> amd64 host named in [docs/BENCH.md](BENCH.md).** Go 1.27's
+> `encoding/json/v2` narrows some of these gaps and none of them decisively:
+> measured here it gains **0–21% on decode** and **0–9% on encode**, and on a
+> payload with no maps to sort and no HTML to escape it gains **nothing at all**,
+> because in Go 1.27 `encoding/json` *is* json/v2 under `DefaultOptionsV1` and
+> the difference between them is exactly the price of those options. Its real win
+> is allocation — up to 60% fewer on a large payload. The full v1 / v2 /
+> hand-written-`jsontext` comparison is in
+> [BENCH.md](BENCH.md#json-v2-and-what-json-actually-costs).
+
+
 Realistic, batch-shaped payloads encoded by every codec at the **same record
 count**, so wire size and memory are directly comparable.
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1,5 +1,15 @@
 # qdf — developer guide
 
+> **`json` on this page means `encoding/json` v1**, measured on the amd64 host
+> named in [BENCH.md](BENCH.md). Go 1.27's `encoding/json/v2` narrows some of
+> these gaps by 0–21% and, on payloads with no maps to sort and no HTML to
+> escape, by nothing at all — the v1/v2 difference is exactly the price of the
+> compatibility options, since in Go 1.27 `encoding/json` *is* json/v2 under
+> `DefaultOptionsV1`. Wire sizes are unaffected except where a nil slice or map
+> is involved. See
+> [BENCH.md](BENCH.md#json-v2-and-what-json-actually-costs).
+
+
 > **Visual overview:** Mermaid architecture diagrams covering concept,
 > wire layout, codec picker, Dense interning, columnar/selective-decode,
 > and performance wins live in **[`../diagrams/`](../diagrams/README.md)**.


### PR DESCRIPTION
Go 1.27 ships `encoding/json/v2` and `encoding/json/jsontext` as stable packages — no `GOEXPERIMENT`, verified. That makes the JSON side of every comparison in this repo as fast as the standard library gets, so the question "does qdf still win" deserved a real answer rather than a number measured against v1 on a machine nobody here has.

**It does. And two things turned up that are more interesting than the verdict.**

## json/v2's win is semantic, not architectural

In Go 1.27 `encoding/json` **is** json/v2 driven by `DefaultOptionsV1()` (`$GOROOT/src/encoding/json/v2_encode.go`). The v1/v2 gap is therefore the price of the compatibility options, not a better engine — and it can be measured directly:

| arm | IoT encode | RTB encode | bytes |
|---|---|---|---|
| `json` v1 | 679 µs | 1354 µs | baseline |
| `json/v2` defaults | 661 µs | 1238 µs | same length, different key order |
| `json/v2` + `DefaultOptionsV1` | 663 µs | 1348 µs | **byte-identical to v1** |

v2 is faster only by no longer sorting map keys, escaping HTML, or writing `null` for a nil slice — wire differences, not only speed ones. On the QPack fixture, which has neither maps nor escapable strings, v1 and v2 encode at **17.5 vs 17.4 µs**: nothing to skip, nothing gained.

Where it wins outright is allocation. On the large payload: **100 003 encode allocations against v1's 250 124, and 37.0 MB against 87.3 MB** — a 60% cut, at equal speed. That is the v2 change most likely to matter in a service under GC pressure.

Every table keeps all three rows for this reason. Drop the compat row and a reader concludes the standard library got rewritten.

## The hand-written ceiling is not where I expected it

`bench/jsontext_codec.go` writes the struct walk out by hand over `jsontext`, encoder and buffer reused. On the IoT batch it reaches **zero allocations per encode** and is the fastest JSON there.

On RTB it is not:

| RTB encode | time | allocs | semantics |
|---|---|---|---|
| `json` v1 | 1354 µs | 10 053 | v1 |
| `json/v2` + `DefaultOptionsV1` | 1348 µs | 10 052 | v1 |
| `jsontext`, hand-written | **1355 µs** | **0** | v1 |
| `json/v2` defaults | **1238 µs** | 5 043 | v2 |

With reflection gone and zero allocations it lands exactly on v1's time, behind v2's defaults — because it sorts map keys to keep its bytes comparable, and v2's defaults do not. **On a string-heavy payload the encode cost is the format plus the v1 semantics; removing reflection buys nothing measurable.** The IoT reading was not wrong, it was specific: numeric slices gave the hand-written codec something real to win.

I wrote the second codec expecting it to confirm the first. It refuted it, and that is in `BENCH.md` under its own heading.

## The verdict, and where qdf loses

| fixture | qdf | vs best JSON |
|---|---|---|
| IoT 32×256 | qdf_qpack 48 µs / 38 µs | **13.5× encode, 27× decode, 2.9× smaller** |
| RTB 1024 | qdf_speed 387 µs / 851 µs | 3.2× encode, 2.8× decode, 2.3× smaller |
| Large payload | qdf_fast 11.7 ms, qdf_dense 21.2 ms dec | 4.7× encode, 5.6× decode |
| QPack | qdf_qpack 1.4 µs / 1.5 µs | 12.4× encode, 19.5× decode |
| AD host dump | OptBalanced 121 KB / 0.22 ms / 0.17 ms | 4.1× smaller, 4.5× faster decode, ⅕ the allocations |

**And one loss.** `qdf_compression` encodes RTB in 1281 µs against json/v2's 1238 µs. It buys 197 KB against 546 KB, so the trade holds where bytes cost more than CPU — and against every JSON arm that preserves v1 semantics (1348–1355 µs) it still wins. The loss is specifically to v2's relaxed defaults. `docs/CHOOSING.md` already gives the right advice for it ("anything hot path stays on `OptBalanced`"), which I checked rather than assumed.

## What changed

- Three JSON arms in both competitor layers, plus **18 `json-v2` twins** beside every direct `json.Marshal` comparison in `bench/`.
- Two hand-written `jsontext` codecs (IoT, RTB), each gated: byte-identical to `encoding/json` v1, round-tripped, and readable by v2's reflection decoder. Verified non-vacuous — five sabotages across the two, each failing the gate.
- `BENCH.md` carries the re-measured tables; `README.md`'s AD head-to-head has a v2 row; `CHOOSING.md`, `COMPETITIVE.md`, `ARTICLE.md`, `GUIDE.md` and `diagrams/performance.md` now name the JSON version behind their numbers.

## Three traps, recorded where they bit

The codec file was first named `jsontext_arm.go` — **`_arm` is a GOARCH suffix**. Go put it in `IgnoredGoFiles` and build, vet *and* lint all passed while nothing in it compiled. `go list -f '{{.IgnoredGoFiles}}'` is how that becomes visible.

`jsontext.Encoder` terminates a top-level value with a newline and `json.Marshal` does not — one invisible byte per message, which is a real size difference at scale.

A `jsontext.Token` aliases the decoder's buffer and is voided by the next `Decoder` call: reading a map's value before materialising its key panics with *"invalid jsontext.Token; it has been voided by a subsequent json.Decoder call"*. That aliasing **is** the zero-copy, and it is the one rule a hand-written codec must keep.

## Verification

Wire digest unchanged at `4069ebfd…`. Root, bench and all module suites green, `-race` clean, lint zero over the explicit package list and `./...`. Raw benchmark output under `docs/superpowers/results/2026-08-22-json-v2/`.

## Not done

The third planned `jsontext` fixture (the RTB result answered what it was for), and the older per-fixture `BENCH.md` tables, which remain amd64 / Go 1.26 / json v1 — the file header now says so rather than pretending otherwise.

**Stacked on #187**, which is unmerged: this needs Go 1.27.
