### PR TITLE
perf(qdf): one pooled-encoder lifecycle, and a map recycler that stopped allocating its own bookkeeping

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -78,6 +78,12 @@ type Decoder struct {
 	// largest column seen; bounded on return to pool.
 	deltaScratch []uint64
 
+	// recycledMaps is how many pointers the per-type lists hold in total.
+	// dropRecycledMaps keeps the lists (and their capacity) but empties them, so
+	// len(mapFreeList) can no longer answer "is anything recycled?" — the keys
+	// outlive their contents on purpose.
+	recycledMaps int
+
 	i int
 
 	// depth / maxDepth bound recursive decode nesting. The wire dictates
@@ -298,7 +304,7 @@ func (d *Decoder) SetInput(buf []byte) {
 	d.selectFields = nil
 	d.selectKeys = nil
 	d.query = nil
-	clear(d.mapFreeList) // drop recycled maps; keep the backing allocated
+	d.dropRecycledMaps() // drop recycled maps; keep the backing allocated
 	if d.state != nil {
 		d.state.reset()
 	}

--- a/fsst_dict.go
+++ b/fsst_dict.go
@@ -63,15 +63,37 @@ func (d *FSSTDict) AppendMarshal(dst []byte, v any, opts Options) ([]byte, error
 
 // marshalDict is Marshal with an optional pre-trained FSST table (nil = train
 // per batch). Marshal delegates here with a nil dict.
-func marshalDict(v any, opts Options, dict *fsst.SymbolTable) ([]byte, error) {
+// The pooled-encoder lifecycle, shared by the any-taking and the type-parameter
+// entry points.
+//
+// Those two differ in exactly one step — how the value reaches the encoder: the
+// any path unpacks an eface, the typed path hands over a pointer whose type is
+// known at the call site. Everything around that step is identical, and it is the
+// part where a divergence would be a memory bug rather than a cosmetic one: when
+// the caller's backing array may stay aliased in a pooled encoder, and when a
+// spike-sized buffer is handed over rather than copied.
+//
+// It is split into acquire/finish rather than wrapped around a closure so the
+// hot path keeps its shape: a closure passed to a non-inlined helper can escape,
+// and this is the allocation-sensitive path in the library.
+
+// acquireEnc takes a pooled encoder and prepares it for one message.
+func acquireEnc(opts Options, dict *fsst.SymbolTable) *Encoder {
 	enc := encPool.Get().(*Encoder)
 	enc.Reset()
 	enc.applyOpts(opts)
 	enc.fsstDict = dict
-	if err := encodeReflect(enc, v); err != nil {
-		putEnc(enc, &encPool)
-		return nil, err
-	}
+	return enc
+}
+
+// finishMarshal completes a from-scratch encode: it applies the entropy pass,
+// then either hands the encoder's buffer to the caller or clones it, and returns
+// the encoder to the pool.
+//
+// A buffer past marshalDetachThreshold is handed over rather than copied —
+// putEnc would drop one that large anyway, so cloning it would cost a second
+// large allocation for nothing.
+func finishMarshal(enc *Encoder) []byte {
 	enc.maybeApplyRANS(0)
 	var out []byte
 	if cap(enc.buf) > marshalDetachThreshold {
@@ -82,28 +104,50 @@ func marshalDict(v any, opts Options, dict *fsst.SymbolTable) ([]byte, error) {
 		out = slices.Clone(enc.buf)
 	}
 	putEnc(enc, &encPool) // cap a spike-sized buffer / widening scratch before pooling
-	return out, nil
+	return out
 }
 
-// appendMarshalDict is AppendMarshal with an optional pre-trained FSST table.
-func appendMarshalDict(dst []byte, v any, opts Options, dict *fsst.SymbolTable) ([]byte, error) {
-	enc := encPool.Get().(*Encoder)
-	enc.Reset()
-	enc.applyOpts(opts)
-	enc.fsstDict = dict
-	start := len(dst)
-	enc.buf = dst
-	if err := encodeReflect(enc, v); err != nil {
-		// Detach the caller's dst before pooling: putEnc only nils buf past
-		// maxPooledBuf, so a normal-sized dst would stay aliased in the pooled
-		// encoder and the next encode would overwrite the caller's backing array.
-		enc.buf = nil
-		putEnc(enc, &encPool)
-		return dst, err
-	}
+// abortMarshal returns the encoder after a failed from-scratch encode. The
+// buffer is the encoder's own, so there is nothing to detach.
+func abortMarshal(enc *Encoder) { putEnc(enc, &encPool) }
+
+// finishAppend completes an append-to-dst encode. The buffer belongs to the
+// caller, so it is always detached rather than cloned.
+func finishAppend(enc *Encoder, start int) []byte {
 	enc.maybeApplyRANS(start)
 	out := enc.buf
 	enc.buf = nil
 	putEnc(enc, &encPool) // cap a spike-sized widening scratch before pooling
-	return out, nil
+	return out
+}
+
+// abortAppend returns the encoder after a failed append-to-dst encode.
+//
+// Detaching the caller's dst first is load-bearing: putEnc only nils buf past
+// maxPooledBuf, so a normal-sized dst would stay aliased in the pooled encoder
+// and the next encode would overwrite the caller's backing array.
+func abortAppend(enc *Encoder) {
+	enc.buf = nil
+	putEnc(enc, &encPool)
+}
+
+func marshalDict(v any, opts Options, dict *fsst.SymbolTable) ([]byte, error) {
+	enc := acquireEnc(opts, dict)
+	if err := encodeReflect(enc, v); err != nil {
+		abortMarshal(enc)
+		return nil, err
+	}
+	return finishMarshal(enc), nil
+}
+
+// appendMarshalDict is AppendMarshal with an optional pre-trained FSST table.
+func appendMarshalDict(dst []byte, v any, opts Options, dict *fsst.SymbolTable) ([]byte, error) {
+	enc := acquireEnc(opts, dict)
+	start := len(dst)
+	enc.buf = dst
+	if err := encodeReflect(enc, v); err != nil {
+		abortAppend(enc)
+		return dst, err
+	}
+	return finishAppend(enc, start), nil
 }

--- a/qdf.go
+++ b/qdf.go
@@ -669,7 +669,7 @@ func unmarshalQuery(data []byte, out any, qp *queryPlan) error {
 	dec.query = qp
 	dec.noCopy = qp.noCopy
 	dec.arena = qp.arena
-	clear(dec.mapFreeList) // drop maps recycled by a prior decode into a different target
+	dec.dropRecycledMaps() // drop maps recycled by a prior decode into a different target
 	if dec.state != nil {
 		dec.state.reset()
 	}
@@ -706,7 +706,7 @@ func unmarshalKeys(data []byte, out any, keys []string) error {
 	dec.selectFields = nil
 	dec.selectKeys = keys
 	dec.query = nil
-	clear(dec.mapFreeList)
+	dec.dropRecycledMaps()
 	if dec.state != nil {
 		dec.state.reset()
 	}
@@ -732,7 +732,7 @@ func unmarshal(data []byte, out any, fields []string, noCopy bool, arena *Arena)
 	dec.selectFields = fields
 	dec.selectKeys = nil
 	dec.query = nil        // parity with UnmarshalT / SetInput: never inherit a prior query decode's plan from the shared pool
-	clear(dec.mapFreeList) // drop maps recycled by a prior decode into a different target
+	dec.dropRecycledMaps() // drop maps recycled by a prior decode into a different target
 	if dec.state != nil {
 		dec.state.reset()
 	}

--- a/qdf_generic.go
+++ b/qdf_generic.go
@@ -66,7 +66,7 @@ func UnmarshalT[T any](data []byte, out *T) error {
 	dec.selectFields = nil
 	dec.selectKeys = nil
 	dec.query = nil
-	clear(dec.mapFreeList) // drop maps recycled by a prior decode into a different target
+	dec.dropRecycledMaps() // drop maps recycled by a prior decode into a different target
 	if dec.state != nil {
 		dec.state.reset()
 	}

--- a/qdf_generic.go
+++ b/qdf_generic.go
@@ -2,7 +2,6 @@ package qdf
 
 import (
 	"reflect"
-	"slices"
 	"unsafe"
 )
 
@@ -21,49 +20,24 @@ import (
 // call site; opts copies by value, so the call adds zero heap
 // allocations over MarshalT itself.
 func MarshalT[T any](v T, opts Options) ([]byte, error) {
-	enc := encPool.Get().(*Encoder)
-	enc.Reset()
-	enc.applyOpts(opts)
+	enc := acquireEnc(opts, nil)
 	if err := encodeT(enc, &v); err != nil {
-		putEnc(enc, &encPool)
+		abortMarshal(enc)
 		return nil, err
 	}
-	enc.maybeApplyRANS(0)
-	// Mirror marshalDict: hand a spike-sized backing straight to the caller
-	// instead of cloning it (putEnc would drop it past maxPooledBuf anyway), so
-	// MarshalT stays allocation-equivalent to Marshal on large payloads.
-	var out []byte
-	if cap(enc.buf) > marshalDetachThreshold {
-		out = enc.buf
-		enc.noteDetached(out)
-		enc.buf = nil
-	} else {
-		out = slices.Clone(enc.buf)
-	}
-	putEnc(enc, &encPool) // cap a spike-sized buffer / widening scratch before pooling
-	return out, nil
+	return finishMarshal(enc), nil
 }
 
 // AppendMarshalT is the generic equivalent of AppendMarshal.
 func AppendMarshalT[T any](dst []byte, v T, opts Options) ([]byte, error) {
-	enc := encPool.Get().(*Encoder)
-	enc.Reset()
-	enc.applyOpts(opts)
+	enc := acquireEnc(opts, nil)
 	start := len(dst)
 	enc.buf = dst
 	if err := encodeT(enc, &v); err != nil {
-		// Detach the caller's dst before pooling: putEnc only nils buf past
-		// maxPooledBuf, so a normal-sized dst would stay aliased in the pooled
-		// encoder and the next encode would overwrite the caller's backing array.
-		enc.buf = nil
-		putEnc(enc, &encPool)
+		abortAppend(enc)
 		return dst, err
 	}
-	enc.maybeApplyRANS(start)
-	out := enc.buf
-	enc.buf = nil
-	putEnc(enc, &encPool) // cap a spike-sized widening scratch before pooling
-	return out, nil
+	return finishAppend(enc, start), nil
 }
 
 // UnmarshalT is the generic equivalent of Unmarshal. The destination

--- a/reuse.go
+++ b/reuse.go
@@ -146,11 +146,12 @@ func reuseOrMakeMap[K comparable, V any](d *Decoder, p unsafe.Pointer, n int) ma
 	// fresh decode (no reused []struct{map} target to harvest from) skips the
 	// reflect.TypeFor + map lookup entirely, so this path is zero-cost vs a plain
 	// make when no recycling is in play.
-	if len(d.mapFreeList) > 0 {
+	if d.recycledMaps > 0 {
 		t := reflect.TypeFor[map[K]V]()
 		if lst := d.mapFreeList[t]; len(lst) > 0 {
 			ptr := lst[len(lst)-1]
 			d.mapFreeList[t] = lst[:len(lst)-1]
+			d.recycledMaps--
 			// Reconstruct the map header value from its harvested hmap pointer.
 			m := *(*map[K]V)(unsafe.Pointer(&ptr))
 			clear(m)
@@ -166,11 +167,12 @@ func reuseOrMakeMap[K comparable, V any](d *Decoder, p unsafe.Pointer, n int) ma
 // (the caller — decodeAny — returns the map rather than writing through a *map),
 // so it only consults the free-list. Zero-cost when the free-list is empty.
 func popOrMakeMap[K comparable, V any](d *Decoder, n int) map[K]V {
-	if len(d.mapFreeList) > 0 {
+	if d.recycledMaps > 0 {
 		t := reflect.TypeFor[map[K]V]()
 		if lst := d.mapFreeList[t]; len(lst) > 0 {
 			ptr := lst[len(lst)-1]
 			d.mapFreeList[t] = lst[:len(lst)-1]
+			d.recycledMaps--
 			m := *(*map[K]V)(unsafe.Pointer(&ptr))
 			clear(m)
 			return m
@@ -189,10 +191,11 @@ func reuseOrMakeMapReflect(d *Decoder, t reflect.Type, n int, p unsafe.Pointer) 
 		reflect.NewAt(t, p).Elem().Clear() // clear keeps the map, drops entries
 		return
 	}
-	if len(d.mapFreeList) > 0 {
+	if d.recycledMaps > 0 {
 		if lst := d.mapFreeList[t]; len(lst) > 0 {
 			ptr := lst[len(lst)-1]
 			d.mapFreeList[t] = lst[:len(lst)-1]
+			d.recycledMaps--
 			*(*unsafe.Pointer)(p) = ptr        // install the harvested map at p
 			reflect.NewAt(t, p).Elem().Clear() // empty its entries before refill
 			return
@@ -251,6 +254,7 @@ func (d *Decoder) harvestValue(td *typeDesc, p unsafe.Pointer) {
 			}
 			if len(d.mapFreeList[td.rType]) < maxRecycledMaps {
 				d.mapFreeList[td.rType] = append(d.mapFreeList[td.rType], hmap)
+				d.recycledMaps++
 			}
 		}
 	case reflect.Struct:
@@ -264,4 +268,27 @@ func (d *Decoder) harvestValue(td *typeDesc, p unsafe.Pointer) {
 			}
 		}
 	}
+}
+
+// dropRecycledMaps empties the per-type free lists without giving their backing
+// arrays back.
+//
+// clear() on the outer map deletes the keys, and with them the slices held as
+// values — so the next harvest appends to a nil slice and allocates one afresh.
+// Measured at eleven allocations per decode on the telemetry fixture, which is
+// 43% of everything the reuse path still allocates: the machinery that exists to
+// avoid allocation was allocating its own bookkeeping every time.
+//
+// The elements are nilled before the truncation rather than left past len.
+// Keeping stale unsafe.Pointers in the backing array would pin the harvested
+// maps for the GC — trading an allocation for a leak, which is a worse deal than
+// the one being fixed.
+func (d *Decoder) dropRecycledMaps() {
+	for t, lst := range d.mapFreeList {
+		for i := range lst {
+			lst[i] = nil
+		}
+		d.mapFreeList[t] = lst[:0]
+	}
+	d.recycledMaps = 0
 }

--- a/reuse.go
+++ b/reuse.go
@@ -210,6 +210,18 @@ func reuseOrMakeMapReflect(d *Decoder, t reflect.Type, n int, p unsafe.Pointer) 
 // fresh) — a size bound, not a correctness limit.
 const maxRecycledMaps = 1 << 14
 
+// maxRetainedRecycledMaps bounds the free-list capacity a pooled decoder keeps
+// across resets. Below it the backing array survives, so the next harvest
+// appends into it instead of growing a fresh slice; above it the list is
+// released, because a one-off wide decode should not leave its peak footprint on
+// a decoder that returns to the pool.
+//
+// 4096 pointers is 32 KB per map type. It sits between the two numbers that
+// matter: a 1000-row telemetry batch grows its list to 1023, so ordinary batches
+// keep their backing and keep the reuse; maxRecycledMaps lets one list reach
+// 16384 (128 KB), and nothing near that should survive a return to the pool.
+const maxRetainedRecycledMaps = 1 << 12
+
 // typeDescHasMap reports whether a value of type td holds a map at any
 // struct-nesting depth (a map field, or a map reachable through nested struct
 // fields). decodeSlice computes this once per slice type so the per-decode
@@ -287,6 +299,15 @@ func (d *Decoder) dropRecycledMaps() {
 	for t, lst := range d.mapFreeList {
 		for i := range lst {
 			lst[i] = nil
+		}
+		if cap(lst) > maxRetainedRecycledMaps {
+			// A spike-sized list is released rather than kept: maxRecycledMaps
+			// lets one list reach 16384 pointers, and holding that 128 KB on a
+			// pooled decoder for the life of the pool is what the cap above
+			// exists to prevent. Keeping the capacity is an optimisation for the
+			// steady state, not a license to pin the peak.
+			delete(d.mapFreeList, t)
+			continue
 		}
 		d.mapFreeList[t] = lst[:0]
 	}

--- a/reuse_counter_test.go
+++ b/reuse_counter_test.go
@@ -79,3 +79,74 @@ func TestRecycledMapsCounterMatchesLists(t *testing.T) {
 		t.Fatalf("dropRecycledMaps left recycledMaps=%d", dec.recycledMaps)
 	}
 }
+
+// TestRecycledMapsReleasesSpikeCapacity gates the other half of
+// dropRecycledMaps: the backing array survives a reset only while it is small.
+//
+// maxRecycledMaps lets one per-type list reach 16384 pointers — 128 KB — and the
+// whole point of that cap is that a one-off wide decode must not leave its peak
+// on a decoder returning to the pool. Keeping capacity across resets is an
+// optimisation for the steady state; without the release branch it would quietly
+// turn into a permanent retention of the largest decode the process ever did.
+func TestRecycledMapsReleasesSpikeCapacity(t *testing.T) {
+	type row struct {
+		Name string            `qdf:"name"`
+		Tags map[string]string `qdf:"tags"`
+	}
+	mk := func(n int) []byte {
+		src := make([]row, n)
+		for i := range src {
+			src[i] = row{Name: "svc", Tags: map[string]string{"env": "prod"}}
+		}
+		w, err := Marshal(src, OptSpeed)
+		if err != nil {
+			t.Fatalf("marshal %d: %v", n, err)
+		}
+		return w
+	}
+
+	capOf := func(d *Decoder) int {
+		total := 0
+		for _, lst := range d.mapFreeList {
+			total += cap(lst)
+		}
+		return total
+	}
+
+	// Small alternating decodes: the list stays and keeps its capacity, which is
+	// the behavior the allocation win depends on.
+	dec := NewDecoder()
+	var out []row
+	small := [][]byte{mk(64), mk(48)}
+	for i := range 4 {
+		dec.SetInput(small[i%2])
+		if err := decodeReflect(dec, &out); err != nil {
+			t.Fatalf("small decode %d: %v", i, err)
+		}
+	}
+	dec.dropRecycledMaps()
+	if got := capOf(dec); got == 0 {
+		t.Fatal("small decodes released the free-list backing; the steady-state reuse is gone")
+	}
+
+	// A decode wide enough to push one list past the retention bound must release
+	// it rather than pin it for the life of the pooled decoder.
+	wide := maxRetainedRecycledMaps * 4
+	dec2 := NewDecoder()
+	var out2 []row
+	dec2.SetInput(mk(wide))
+	if err := decodeReflect(dec2, &out2); err != nil {
+		t.Fatalf("wide decode: %v", err)
+	}
+	dec2.SetInput(mk(wide / 2)) // shrink: harvests the wide row's maps
+	if err := decodeReflect(dec2, &out2); err != nil {
+		t.Fatalf("shrink decode: %v", err)
+	}
+	if c := capOf(dec2); c <= maxRetainedRecycledMaps {
+		t.Skipf("the wide decode did not grow a list past the bound (cap=%d); nothing to release", c)
+	}
+	dec2.dropRecycledMaps()
+	if got := capOf(dec2); got > maxRetainedRecycledMaps {
+		t.Fatalf("dropRecycledMaps retained %d pointers of capacity, bound is %d", got, maxRetainedRecycledMaps)
+	}
+}

--- a/reuse_counter_test.go
+++ b/reuse_counter_test.go
@@ -1,0 +1,81 @@
+package qdf
+
+import "testing"
+
+// TestRecycledMapsCounterMatchesLists gates the one invariant dropRecycledMaps
+// introduced: d.recycledMaps must equal the total length of the per-type free
+// lists, at every point a decode can observe it.
+//
+// The counter exists because dropRecycledMaps keeps the map's keys (and their
+// slices' capacity) while emptying them, so len(d.mapFreeList) can no longer
+// answer "is anything recycled?" — it stays non-zero over empty lists. Three
+// call sites pop from those lists and one pushes; a future edit that forgets to
+// move the counter would either lose recycling silently (counter too low) or
+// send reuseOrMakeMap hunting through empty lists on every decode (too high).
+// Neither shows up as a failure anywhere else.
+func TestRecycledMapsCounterMatchesLists(t *testing.T) {
+	type row struct {
+		Name string            `qdf:"name"`
+		Tags map[string]string `qdf:"tags"`
+	}
+
+	mk := func(n int) []byte {
+		src := make([]row, n)
+		for i := range src {
+			src[i] = row{
+				Name: "svc",
+				Tags: map[string]string{"env": "prod", "ver": "1.2.3"},
+			}
+		}
+		w, err := Marshal(src, OptSpeed)
+		if err != nil {
+			t.Fatalf("marshal %d: %v", n, err)
+		}
+		return w
+	}
+	// Two lengths, alternated, under OptSpeed. Both details are load-bearing and
+	// both were found by watching the free list stay empty:
+	//
+	// A DIFFERENT length is what makes decode-slice-reuse zero the old elements,
+	// which is the only path that harvests their maps onto the free list. Two
+	// same-length decodes take reuseOrMakeMap's direct-target branch and never
+	// touch the list — the first version of this test did exactly that and
+	// passed with the counter deliberately broken three different ways.
+	//
+	// And OptSpeed keeps the payload on the row-major decoder. Under OptBalanced
+	// this shape goes columnar, which never reaches harvestMaps at all, so the
+	// free list stays empty however the lengths vary.
+	wires := [][]byte{mk(64), mk(48)}
+
+	check := func(d *Decoder, when string) {
+		t.Helper()
+		total := 0
+		for _, lst := range d.mapFreeList {
+			total += len(lst)
+		}
+		if d.recycledMaps != total {
+			t.Fatalf("%s: recycledMaps=%d but the lists hold %d", when, d.recycledMaps, total)
+		}
+	}
+
+	dec := NewDecoder()
+
+	var out []row
+	for i := range 6 {
+		w := wires[i%2]
+		dec.SetInput(w)
+		if err := decodeReflect(dec, &out); err != nil {
+			t.Fatalf("decode %d: %v", i, err)
+		}
+		check(dec, "after decode")
+		if out[0].Tags["env"] != "prod" || out[0].Tags["ver"] != "1.2.3" {
+			t.Fatalf("decode %d: tags did not round-trip: %v", i, out[0].Tags)
+		}
+	}
+	// And after the reset that empties the lists without freeing them.
+	dec.dropRecycledMaps()
+	check(dec, "after dropRecycledMaps")
+	if dec.recycledMaps != 0 {
+		t.Fatalf("dropRecycledMaps left recycledMaps=%d", dec.recycledMaps)
+	}
+}

--- a/stream.go
+++ b/stream.go
@@ -331,7 +331,7 @@ func (s *StreamDecoder) Decode(out any) error {
 	// harvested but did not reuse, so a recycled map never crosses frames. Runs
 	// BEFORE decode, so this frame's own harvest (into the same out — the common
 	// streaming reuse) still recycles normally.
-	clear(s.dec.mapFreeList)
+	s.dec.dropRecycledMaps()
 	start := s.dec.i
 	if err := decodeReflect(s.dec, out); err != nil {
 		// The cursor is left partway through the frame and the dense state is
@@ -433,7 +433,7 @@ func (s *StreamDecoder) Reset(r io.Reader) {
 	s.dec.mode = Fast
 	s.dec.colIndex = false
 	s.dec.colMaxLen = 0
-	clear(s.dec.mapFreeList)
+	s.dec.dropRecycledMaps()
 	// keyIdx keys alias the prior stream's base data (keyTokenAt); clear so a
 	// reused StreamDecoder does not GC-pin it across Reset (mirrors mapFreeList).
 	clear(s.dec.keyIdx)


### PR DESCRIPTION
Three commits, from a deduplication refactor into an allocator finding that only showed up under profiling.

## 1 — one pooled-encoder lifecycle instead of two copies of it

`MarshalT` and `AppendMarshalT` each carried their own copy of the lifecycle `marshalDict` and `appendMarshalDict` already had — **16 identical lines out of 19** in the first pair, **13 of 16** in the second. The duplicated part is the subtle part: when the caller's backing array may stay aliased in a pooled encoder, and when a spike-sized buffer is handed over rather than copied. A divergence there is a memory bug, and there were two places to keep in step.

The paths differ in exactly one step — how the value reaches the encoder. Everything around it is now `acquireEnc` plus `finishMarshal` / `abortMarshal` / `finishAppend` / `abortAppend`.

Split into acquire/finish rather than wrapped around a closure **on purpose**: a closure passed to a non-inlined helper can escape, and this is the allocation-sensitive path in the library.

**This needed no new language feature**, which is worth saying because the work started from Go 1.27's generic methods. A method could not take a type parameter before 1.27, but a plain helper always could — `Marshal`/`MarshalT` are both free functions, and one generic free function could have served both since Go 1.18 (verified by compiling one under `go 1.21`). What generic methods actually unlock is type parameters on the *stateful* types, which is additive API and deliberately not here: a prototype `StreamEncoder.EncodeT[T]` measured −2.74% against the boxed path with the day's A/A noise floor at −1.97%.

## 2 — stop the map recycler from reallocating its own bookkeeping

Go 1.27 ships size-specialized malloc **on by default** (verified: `GOEXPERIMENT=nosizespecializedmalloc` is accepted, and the 1.27 API list adds **zero** symbols to `runtime`, `runtime/debug`, `runtime/metrics`, `sync`, `weak`, `unique`). So the question it raises is not "what do we call" but "where do our allocations sit relative to the 128-byte class it specialised".

Profiling the realistic telemetry fixture answered it, and pointed somewhere else. Encode is already at 3 allocs/op. Decode into a **reused** target was at 31 — and **43% of those came from `harvestValue`**, the machinery that exists to avoid allocation.

`clear(d.mapFreeList)` deletes the outer map's keys, and with them the per-type slices held as values. The comment claimed it kept the backing allocated; true of the outer map, false of the lists. Every harvest then appended to a nil slice and grew a fresh one.

`dropRecycledMaps` empties the lists in place instead. Elements are nilled before truncation rather than left past `len` — keeping stale `unsafe.Pointer`s in the backing array would pin the harvested maps for the GC, trading an allocation for a leak.

That change broke a guard I then had to restore: `reuseOrMakeMap` fast-exits on `len(d.mapFreeList) > 0` so a fresh decode skips `reflect.TypeFor` and a map lookup entirely — documented as "zero-cost when no recycling is in play". Keeping the keys makes that test true over empty lists. A `recycledMaps` counter now answers what the map's length used to.

## 3 — bound the capacity commit 2 started retaining

**Self-review found a regression commit 2 introduced, and the first fix for it silently undid the optimisation.** Both are in the commit message.

`clear()` used to delete the keys, so the lists became garbage and their backing was released. Keeping the keys meant a pooled decoder held that backing for the life of the pool — and `maxRecycledMaps` lets one list reach 16384 pointers, **128 KB per map type**. The comment on that cap says it exists so "a one-off huge `[]struct{map}` decode can't pin unbounded map headers"; retaining the peak defeats exactly that.

The first fix released anything past 256 pointers. Tests passed, gates passed, and benchstat against main came back all `~` — **the win was gone**. A 1000-row telemetry batch grows its list to 1023, so the bound was releasing on every ordinary decode. The number had been picked from nowhere.

Measured what the workload needs (peak capacity **1023**, ~7 KB) and set the bound at 4096 pointers / 32 KB per type: ordinary batches keep their backing, nothing near the 16384 hard cap survives a return to the pool.

## Numbers

Against `origin/main`, n=12 interleaved, Apple M5 Pro / Go 1.27 / darwin-arm64:

| decode, reused target | main | branch | |
|---|---|---|---|
| B/op | 18 390 | **859** | −95.33% (p=0.000) |
| allocs/op | 31 | **20** | −35.48% (p=0.000) |
| sec/op | 188.4 µs | 186.8 µs | ~ (p=0.060) |

The time is unchanged, and that is the honest framing: this is a GC-pressure win, not a latency win. A microbenchmark that never runs under GC pressure will not show it.

Where the remaining allocations live, measured rather than assumed: **strings** (the arena already solves them — on the string-heavy AD fixture it takes decode from **2070 to 21** allocations) and **per-row maps** (only target reuse solves them). The two are disjoint; the arena does almost nothing for telemetry (2023 → 2006) because its cost is maps, not strings.

## On the gates

Getting the counter test to mean anything took three tries, and both details in it are load-bearing:

- Two decodes of the **same length** take `reuseOrMakeMap`'s direct-target branch and never touch the free list. The first version did exactly that and **passed with the counter deliberately broken three different ways**.
- The **shape** decides the path. Under `OptBalanced` a two-field struct goes columnar and never reaches `harvestMaps`; `telemetryEvent`'s ten fields keep it row-major — which is why the profile saw `harvestValue` at 42% while a narrow test fixture saw the free list stay empty. The gate now pins `OptSpeed`.

Both gates are verified non-vacuous: dropping the decrement, the increment, or the counter reset each fails the first; removing the release **or** releasing unconditionally each fails the second.

## Verification

Wire digest unchanged at `4069ebfd…`. All four build configurations green (default, `-race`, `qdf_simd`, `qdf_reflect2`), all five modules green, lint zero on **both** architectures (arm64 and `GOOS=linux GOARCH=amd64`), `FuzzDecoder_NeverPanics` over 11.2M executions with no crashers.

## Not done, deliberately

The map free list does not survive a call to `Unmarshal` — `dropRecycledMaps()` runs at the top of it, so a one-shot caller (`var out []T; Unmarshal(...)`, which is most callers) gets no recycling and pays a map per row. Keeping the list across calls is worth roughly **2000 allocations per telemetry decode**, but the reset is not accidental: a harvested map came from a target the caller overwrote, and handing it to a *different* caller's target is only safe if the first no longer references it. That is a design decision with a correctness argument behind it, not an oversight, and it needs its own investigation rather than a change in passing.
